### PR TITLE
Fixed coap_send_impl()'s scope for portability.

### DIFF
--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -263,6 +263,12 @@ coap_pdu_t *coap_new_error_response(coap_pdu_t *request,
                                     unsigned char code,
                                     coap_opt_filter_t opts);
 
+coap_tid_t
+coap_send_impl(coap_context_t *context,
+	       const coap_endpoint_t *local_interface,
+	       const coap_address_t *dst,
+	       coap_pdu_t *pdu);
+
 /**
  * Sends a non-confirmed CoAP message to given destination. The memory that is
  * allocated by pdu will not be released by coap_send().


### PR DESCRIPTION
Hi,

I'm trying to port libcoap to my own embedded OS that is different from Contiki.
So I made my own `coap_send_impl()`. But compiler said a warning of 'implicit declaration of `coap_send_impl()`' when compiling net.c.
I think adding declaration of `coap_send_impl()` at net.h may be good for more portability.

Regards,
Jongsoo
