### PR TITLE
Fix typo in the attribute parameter to the right format "core.rd". (Update coap-rd.c)

### DIFF
--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -545,7 +545,7 @@ init_resources(coap_context_t *ctx) {
   coap_register_handler(r, COAP_REQUEST_POST, hnd_post_rd);
 
   coap_add_attr(r, (unsigned char *)"ct", 2, (unsigned char *)"40", 2, 0);
-  coap_add_attr(r, (unsigned char *)"rt", 2, (unsigned char *)"\"core-rd\"", 9, 0);
+  coap_add_attr(r, (unsigned char *)"rt", 2, (unsigned char *)"\"core.rd\"", 9, 0);
   coap_add_attr(r, (unsigned char *)"ins", 2, (unsigned char *)"\"default\"", 9, 0);
 
   coap_add_resource(ctx, r);


### PR DESCRIPTION
According to the Core Resource directory draft [1]. The discovery of the registration should be done using the /.well-known/core and including a Resource Type (rt) with the value "core.rd". Like that:
GET /.well-known/core?rt=core.rd
There is a typo in the libcoap which accept the "core-rd" instead of the "core.rd" parameter. Fixing that in this version.

[1] - https://tools.ietf.org/html/draft-ietf-core-resource-directory-05#section-5.1