### PR TITLE
dtls branch - ignored some generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ include/coap/coap.h
 tests/.deps
 tests/testdriver
 tests/*.o
+
+# ctags - Sublime plugin
+tags
+.tags*

--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,11 @@ stamp-h1
 .libs/
 libcoap*.la
 libcoap*.pc
-src/.deps/
-src/.dirstamp
-src/.libs/
-src/*.o
-src/*.lo
+src/**/.deps/
+src/**/.dirstamp
+src/**/.libs/
+src/**/*.o
+src/**/*.lo
 
 # the doc/ folder
 doc/Doxyfile

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ext/tinydtls"]
 	path = ext/tinydtls
 	url = https://git.eclipse.org/r/tinydtls/org.eclipse.tinydtls
+    ignore = dirty


### PR DESCRIPTION
If we compile in this branch with
```
./autogen.sh
./configure --disable-shared
make
```
some files will be generated that we don't need to track.

- updated .gitignore file to ignore the *.o *.lo .deps/ .dirstamp .libs/ in the subfolders of src/ as well.
- updated .gitmodules to ignore the untracked changes in the 'tinydtls' submodules.