### PR TITLE
Add missing LOG_ERR log level

### DIFF
--- a/include/coap/debug.h
+++ b/include/coap/debug.h
@@ -27,6 +27,7 @@ typedef enum {
   LOG_EMERG=0,
   LOG_ALERT,
   LOG_CRIT,
+  LOG_ERR,
   LOG_WARNING,
   LOG_NOTICE,
   LOG_INFO,


### PR DESCRIPTION
The fallback used when &lt;syslog.h&gt; is not available was missing the error level.