### PR TITLE
flags option in coap_resource_init documented

### DIFF
--- a/include/coap/resource.h
+++ b/include/coap/resource.h
@@ -102,8 +102,12 @@ typedef struct coap_resource_t {
  *
  * @param uri    The URI path of the new resource.
  * @param len    The length of @p uri.
- * @param flags  Flags for memory management (in particular release of memory).
- *
+ * @param flags  Flags for memory management (in particular release of memory). Possibly values:@n
+ * COAP_RESOURCE_FLAGS_RELEASE_URI If this flag is set, the URI passed to coap_resource_init() is free'd by coap_delete_resource()@n
+ * COAP_RESOURCE_FLAGS_NOTIFY_CON If this flag is set, coap-observe notifications will be sent confirmable by default.@n
+ * COAP_RESOURCE_FLAGS_NOTIFY_NON (default) If this flag is set, coap-observe notifications will be sent non-confirmable by default.@n
+ * If flags is set to 0 then the COAP_RESOURCE_FLAGS_NOTIFY_NON is considered.
+ * 
  * @return       A pointer to the new object or @c NULL on error.
  */
 coap_resource_t *coap_resource_init(const unsigned char *uri,


### PR DESCRIPTION
Possible values of the flags option of the coap_resource_init have been documented. This change also affects the documentation generated by doxygen
