### PR TITLE
Changes from Iotivity for draft-ietf-core-coap-tcp-tls and cross-platform support

### DIFF
--- a/coap_config.h.contiki
+++ b/coap_config.h.contiki
@@ -121,7 +121,7 @@ typedef void FILE;
 # endif /* UIP_CONF_BYTE_ORDER */
 #endif /* BYTE_ORDER */
 
-/* Define assert() as emtpy directive unless HAVE_ASSERT_H is given. */
+/* Define assert() as empty directive unless HAVE_ASSERT_H is given. */
 #ifndef HAVE_ASSERT_H
 # define assert(x)
 #endif

--- a/coap_config.h.contiki
+++ b/coap_config.h.contiki
@@ -56,6 +56,7 @@
 
 #define HAVE_STRNLEN 1
 #define HAVE_SNPRINTF 1
+#define HAVE_STRINGS_H 1
 
 /* there is no file-oriented output */
 #define COAP_DEBUG_FD NULL

--- a/coap_config.h.windows
+++ b/coap_config.h.windows
@@ -1,24 +1,43 @@
 #ifndef _COAP_CONFIG_H_
 #define _COAP_CONFIG_H_
 
-/* Define to 1 if you have <ws2tcpip.h> header file. */
 #if defined(_WIN32)
+
+/* Define to 1 if you have <ws2tcpip.h> header file. */
 #define HAVE_WS2TCPIP_H 1
-#endif
 
 /* Define to 1 if you have <winsock2.h> header file. */
-#if defined(_WIN32)
 #define HAVE_WINSOCK2_H 1
-#endif
 
 /* Define to 1 if you have <assert.h> header file. */
-#if defined(_WIN32)
 #define HAVE_ASSERT_H 1
+
+/* Define to 1 if you have <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if you have <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have <time.h> header file. */
+#define HAVE_TIME_H 1
+
+/* Define to 1 if you have malloc(). */
+#define HAVE_MALLOC 1
+
+/* Define to 1 if you have vprintf(). */
+#define HAVE_VPRINTF 1
+
+/* Define to 1 if you have strnlen(). */
+#define HAVE_STRNLEN 1
+
+/* Define to 1 if you have snprintf(). */
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
+#define HAVE_SNPRINTF 1
 #endif
 
-#ifdef _WIN32
 #define ssize_t SSIZE_T
 #define in_port_t uint16_t
+
 #endif
 
 /* Define to the full name of this package. */

--- a/coap_config.h.windows
+++ b/coap_config.h.windows
@@ -1,0 +1,37 @@
+#ifndef _COAP_CONFIG_H_
+#define _COAP_CONFIG_H_
+
+/* Define to 1 if you have <Ws2tcpip.h> header file. */
+#if defined(_WIN32)
+#define HAVE_WS2TCPIP_H 1
+#endif
+
+/* Define to 1 if you have <Winsock2.h> header file. */
+#if defined(_WIN32)
+#define HAVE_WINSOCK2_H 1
+#endif
+
+#ifdef _WIN32
+#define ssize_t SSIZE_T
+#define in_port_t uint16_t
+#endif
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "libcoap"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "libcoap 4.1.1"
+
+#ifndef COAP_STATIC_INLINE
+#  if defined(__cplusplus)
+#    define COAP_STATIC_INLINE inline
+#  else
+#    ifdef _MSC_VER
+#      define COAP_STATIC_INLINE static __inline
+#    else
+#      define COAP_STATIC_INLINE static inline
+#    endif
+#  endif
+#endif
+
+#endif /* _COAP_CONFIG_H_ */

--- a/coap_config.h.windows
+++ b/coap_config.h.windows
@@ -1,14 +1,19 @@
 #ifndef _COAP_CONFIG_H_
 #define _COAP_CONFIG_H_
 
-/* Define to 1 if you have <Ws2tcpip.h> header file. */
+/* Define to 1 if you have <ws2tcpip.h> header file. */
 #if defined(_WIN32)
 #define HAVE_WS2TCPIP_H 1
 #endif
 
-/* Define to 1 if you have <Winsock2.h> header file. */
+/* Define to 1 if you have <winsock2.h> header file. */
 #if defined(_WIN32)
 #define HAVE_WINSOCK2_H 1
+#endif
+
+/* Define to 1 if you have <assert.h> header file. */
+#if defined(_WIN32)
+#define HAVE_ASSERT_H 1
 #endif
 
 #ifdef _WIN32

--- a/examples/client.c
+++ b/examples/client.c
@@ -69,7 +69,7 @@ coap_tick_t obs_wait = 0;               /* timeout for current subscription */
 #define UNUSED_PARAM
 #endif /* GCC */
 
-static inline void
+COAP_STATIC_INLINE void
 set_timeout(coap_tick_t *timer, const unsigned int seconds) {
   coap_ticks(timer);
   *timer += seconds * COAP_TICKS_PER_SECOND;
@@ -305,7 +305,7 @@ resolve_address(const str *server, struct sockaddr *dst) {
    ((Pdu)->hdr->code == COAP_RESPONSE_CODE(201) ||                \
     (Pdu)->hdr->code == COAP_RESPONSE_CODE(204)))
 
-static inline int
+COAP_STATIC_INLINE int
 check_token(coap_pdu_t *received) {
   return received->hdr->token_length == the_token.length &&
     memcmp(received->hdr->token, the_token.s, the_token.length) == 0;
@@ -808,7 +808,7 @@ cmdline_proxy(char *arg) {
   return 1;
 }
 
-static inline void
+COAP_STATIC_INLINE void
 cmdline_token(char *arg) {
   strncpy((char *)the_token.s, arg, min(sizeof(_token_data), strlen(arg)));
   the_token.length = strlen(arg);

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -65,7 +65,7 @@ rd_t *resources = NULL;
 #define UNUSED_PARAM
 #endif /* GCC */
 
-static inline rd_t *
+COAP_STATIC_INLINE rd_t *
 rd_new(void) {
   rd_t *rd;
   rd = (rd_t *)coap_malloc(sizeof(rd_t));
@@ -75,7 +75,7 @@ rd_new(void) {
   return rd;
 }
 
-static inline void
+COAP_STATIC_INLINE void
 rd_delete(rd_t *rd) {
   if (rd) {
     coap_free(rd->data.s);

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -88,14 +88,14 @@ coap_new_payload(size_t size) {
   return p;
 }
 
-static inline coap_payload_t *
+COAP_STATIC_INLINE coap_payload_t *
 coap_find_payload(const coap_key_t key) {
   coap_payload_t *p;
   HASH_FIND(hh, test_resources, key, sizeof(coap_key_t), p);
   return p;
 }
 
-static inline void
+COAP_STATIC_INLINE void
 coap_add_payload(const coap_key_t key, coap_payload_t *payload,
 		 coap_dynamic_uri_t *uri) {
   assert(payload);
@@ -109,7 +109,7 @@ coap_add_payload(const coap_key_t key, coap_payload_t *payload,
   }
 }
 
-static inline void
+COAP_STATIC_INLINE void
 coap_delete_payload(coap_payload_t *payload) {
   if (payload) {
     coap_dynamic_uri_t *uri;

--- a/include/coap/address.h
+++ b/include/coap/address.h
@@ -52,7 +52,7 @@ typedef struct coap_address_t {
 #define _coap_is_mcast_impl(Address) uip_is_addr_mcast(&((Address)->addr))
 #endif /* WITH_CONTIKI */
 
-#ifdef WITH_POSIX
+#if !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
 /** multi-purpose address abstraction */
 typedef struct coap_address_t {
   socklen_t size;           /**< size of addr */
@@ -71,7 +71,7 @@ typedef struct coap_address_t {
  */
 int coap_address_equals(const coap_address_t *a, const coap_address_t *b);
 
-static inline int
+COAP_STATIC_INLINE int
 _coap_address_isany_impl(const coap_address_t *a) {
   /* need to compare only relevant parts of sockaddr_in6 */
   switch (a->addr.sa.sa_family) {
@@ -88,7 +88,7 @@ _coap_address_isany_impl(const coap_address_t *a) {
   return 0;
 }
 
-static inline int
+COAP_STATIC_INLINE int
 _coap_is_mcast_impl(const coap_address_t *a) {
   if (!a)
     return 0;
@@ -103,7 +103,7 @@ _coap_is_mcast_impl(const coap_address_t *a) {
   }
  return 0;
 }
-#endif /* WITH_POSIX */
+#endif /* !WITH_LWIP && !WITH_CONTIKI */
 
 /**
  * Resets the given coap_address_t object @p addr to its default values. In
@@ -112,23 +112,23 @@ _coap_is_mcast_impl(const coap_address_t *a) {
  *
  * @param addr The coap_address_t object to initialize.
  */
-static inline void
+COAP_STATIC_INLINE void
 coap_address_init(coap_address_t *addr) {
   assert(addr);
   memset(addr, 0, sizeof(coap_address_t));
-#ifdef WITH_POSIX
+#if defined(WITH_LWIP) || defined(WITH_CONTIKI)
   /* lwip and Contiki have constant address sizes and doesn't need the .size part */
   addr->size = sizeof(addr->addr);
 #endif
 }
 
-#ifndef WITH_POSIX
+#if defined(WITH_LWIP) || defined(WITH_CONTIKI)
 /**
  * Compares given address objects @p a and @p b. This function returns @c 1 if
  * addresses are equal, @c 0 otherwise. The parameters @p a and @p b must not be
  * @c NULL;
  */
-static inline int
+COAP_STATIC_INLINE int
 coap_address_equals(const coap_address_t *a, const coap_address_t *b) {
   assert(a); assert(b);
   return _coap_address_equals_impl(a, b);
@@ -140,7 +140,7 @@ coap_address_equals(const coap_address_t *a, const coap_address_t *b) {
  * function returns @c 1 if this is the case, @c 0 otherwise. The parameters @p
  * a must not be @c NULL;
  */
-static inline int
+COAP_STATIC_INLINE int
 coap_address_isany(const coap_address_t *a) {
   assert(a);
   return _coap_address_isany_impl(a);
@@ -150,7 +150,7 @@ coap_address_isany(const coap_address_t *a) {
  * Checks if given address @p a denotes a multicast address. This function
  * returns @c 1 if @p a is multicast, @c 0 otherwise.
  */
-static inline int
+COAP_STATIC_INLINE int
 coap_is_mcast(const coap_address_t *a) {
   return a && _coap_is_mcast_impl(a);
 }

--- a/include/coap/address.h
+++ b/include/coap/address.h
@@ -15,7 +15,13 @@
 #ifndef _COAP_ADDRESS_H_
 #define _COAP_ADDRESS_H_
 
+#ifdef HAVE_ASSERT_H
 #include <assert.h>
+#else
+#ifndef assert
+#  define assert(x)
+#endif
+#endif
 #include <stdint.h>
 #include <string.h>
 

--- a/include/coap/async.h
+++ b/include/coap/async.h
@@ -136,7 +136,7 @@ coap_async_state_t *coap_find_async(coap_context_t *context, coap_tid_t id);
  *
  * @param s The state object to update.
  */
-static inline void
+COAP_STATIC_INLINE void
 coap_touch_async(coap_async_state_t *s) { coap_ticks(&s->created); }
 
 /** @} */

--- a/include/coap/bits.h
+++ b/include/coap/bits.h
@@ -28,7 +28,7 @@
  *
  * @return     @c -1 if @p bit does not fit into @p vec, @c 1 otherwise.
  */
-inline static int
+COAP_STATIC_INLINE int
 bits_setb(uint8_t *vec, size_t size, uint8_t bit) {
   if (size <= (bit >> 3))
     return -1;
@@ -48,7 +48,7 @@ bits_setb(uint8_t *vec, size_t size, uint8_t bit) {
  *
  * @return     @c -1 if @p bit does not fit into @p vec, @c 1 otherwise.
  */
-inline static int
+COAP_STATIC_INLINE int
 bits_clrb(uint8_t *vec, size_t size, uint8_t bit) {
   if (size <= (bit >> 3))
     return -1;
@@ -67,7 +67,7 @@ bits_clrb(uint8_t *vec, size_t size, uint8_t bit) {
  *
  * @return     @c 1 if the bit is set, @c 0 otherwise.
  */
-inline static int
+COAP_STATIC_INLINE int
 bits_getb(const uint8_t *vec, size_t size, uint8_t bit) {
   if (size <= (bit >> 3))
     return -1;

--- a/include/coap/block.h
+++ b/include/coap/block.h
@@ -61,13 +61,13 @@ unsigned int coap_opt_block_num(const coap_opt_t *block_opt);
  * Checks if more than @p num blocks are required to deliver @p data_len
  * bytes of data for a block size of 1 << (@p szx + 4).
  */
-static inline int
+COAP_STATIC_INLINE int
 coap_more_blocks(size_t data_len, unsigned int num, unsigned short szx) {
   return ((num+1) << (szx + 4)) < data_len;
 }
 
 /** Sets the More-bit in @p block_opt */
-static inline void
+COAP_STATIC_INLINE void
 coap_opt_block_set_m(coap_opt_t *block_opt, int m) {
   if (m)
     *(COAP_OPT_VALUE(block_opt) + (COAP_OPT_LENGTH(block_opt) - 1)) |= 0x08;

--- a/include/coap/coap.h.in
+++ b/include/coap/coap.h.in
@@ -37,6 +37,7 @@ extern "C" {
 #include "bits.h"
 #include "block.h"
 #include "coap_io.h"
+#include "coap_list.h"
 #include "coap_time.h"
 #include "debug.h"
 #include "encode.h"

--- a/include/coap/coap_io.h
+++ b/include/coap/coap_io.h
@@ -33,14 +33,12 @@ struct coap_context_t;
  * tuple (handle, addr) must uniquely identify this endpoint.
  */
 typedef struct coap_endpoint_t {
-#if defined(WITH_POSIX) || defined(WITH_CONTIKI)
+#ifndef WITH_LWIP
   union {
     int fd;       /**< on POSIX systems */
     void *conn;   /**< opaque connection (e.g. uip_conn in Contiki) */
   } handle;       /**< opaque handle to identify this endpoint */
-#endif /* WITH_POSIX or WITH_CONTIKI */
-
-#ifdef WITH_LWIP
+#else
   struct udp_pcb *pcb;
  /**< @FIXME --chrysn
   * this was added in a hurry, not sure it confirms to the overall model */

--- a/include/coap/coap_list.h
+++ b/include/coap/coap_list.h
@@ -1,0 +1,48 @@
+/* -*- Mode: C; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 * -*- */
+
+/* coap_list.h -- CoAP list structures
+ *
+ * Copyright (C) 2010,2011,2015 Olaf Bergmann <bergmann@tzi.org>
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms of
+ * use.
+ */
+
+#ifndef _COAP_LIST_H_
+#define _COAP_LIST_H_
+
+#include "utlist.h"
+
+struct coap_linkedlistnode {
+  struct coap_linkedlistnode *next;
+  void *data;
+
+  /**
+   * Callback function that is called from coap_delete to release
+   * additional memory allocated by data Set to NULL if you do not
+   * need this. Note that data is free'd automatically. */
+  void (*delete_func)(void *);
+};
+
+typedef struct coap_linkedlistnode coap_list_t;
+
+/**
+ * Adds node to given queue, ordered by specified order function. Returns 1
+ * when insert was successful, 0 otherwise.
+ */
+int coap_insert(coap_list_t **queue, coap_list_t *node, int (*order)(void *, void *));
+
+/* destroys specified node */
+int coap_delete(coap_list_t *node);
+
+/* removes all items from given queue and frees the allocated storage */
+void coap_delete_list(coap_list_t *queue);
+
+/**
+ * Creates a new list node and adds the given data object. The memory allocated
+ * by data will be released by coap_delete() with the new node. Returns the
+ * new list node.
+ */
+coap_list_t *coap_new_listnode(void *data, void (*delete_func)(void *));
+
+#endif /* _COAP_LIST_H_ */

--- a/include/coap/coap_time.h
+++ b/include/coap/coap_time.h
@@ -33,17 +33,17 @@ typedef uint32_t coap_tick_t;
 typedef uint32_t coap_time_t;
 typedef int32_t coap_tick_diff_t;
 
-static inline void coap_ticks_impl(coap_tick_t *t) {
+COAP_STATIC_INLINE void coap_ticks_impl(coap_tick_t *t) {
   *t = sys_now();
 }
 
-static inline void coap_clock_init_impl(void) {
+COAP_STATIC_INLINE void coap_clock_init_impl(void) {
 }
 
 #define coap_clock_init coap_clock_init_impl
 #define coap_ticks coap_ticks_impl
 
-static inline coap_time_t coap_ticks_to_rt(coap_tick_t t) {
+COAP_STATIC_INLINE coap_time_t coap_ticks_to_rt(coap_tick_t t) {
   return t / COAP_TICKS_PER_SECOND;
 }
 #endif
@@ -63,20 +63,20 @@ typedef int coap_tick_diff_t;
 
 #define COAP_TICKS_PER_SECOND CLOCK_SECOND
 
-static inline void coap_clock_init(void) {
+COAP_STATIC_INLINE void coap_clock_init(void) {
   clock_init();
 }
 
-static inline void coap_ticks(coap_tick_t *t) {
+COAP_STATIC_INLINE void coap_ticks(coap_tick_t *t) {
   *t = clock_time();
 }
 
-static inline coap_time_t coap_ticks_to_rt(coap_tick_t t) {
+COAP_STATIC_INLINE coap_time_t coap_ticks_to_rt(coap_tick_t t) {
   return t / COAP_TICKS_PER_SECOND;
 }
 #endif /* WITH_CONTIKI */
 
-#ifdef WITH_POSIX
+#if !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
 /**
  * This data type represents internal timer ticks with COAP_TICKS_PER_SECOND
  * resolution.
@@ -119,13 +119,13 @@ void coap_ticks(coap_tick_t *t);
  *          point (seconds since epoch on POSIX).
  */
 coap_time_t coap_ticks_to_rt(coap_tick_t t);
-#endif /* WITH_POSIX */
+#endif /* !WITH_LWIP && !WITH_CONTIKI */
 
 /**
  * Returns @c 1 if and only if @p a is less than @p b where less is defined on a
  * signed data type.
  */
-static inline int coap_time_lt(coap_tick_t a, coap_tick_t b) {
+COAP_STATIC_INLINE int coap_time_lt(coap_tick_t a, coap_tick_t b) {
   return ((coap_tick_diff_t)(a - b)) < 0;
 }
 
@@ -133,7 +133,7 @@ static inline int coap_time_lt(coap_tick_t a, coap_tick_t b) {
  * Returns @c 1 if and only if @p a is less than or equal @p b where less is
  * defined on a signed data type.
  */
-static inline int coap_time_le(coap_tick_t a, coap_tick_t b) {
+COAP_STATIC_INLINE int coap_time_le(coap_tick_t a, coap_tick_t b) {
   return a == b || coap_time_lt(a,b);
 }
 

--- a/include/coap/encode.h
+++ b/include/coap/encode.h
@@ -10,10 +10,10 @@
 #ifndef _COAP_ENCODE_H_
 #define _COAP_ENCODE_H_
 
-#if (BSD >= 199103) || defined(WITH_CONTIKI)
-# include <string.h>
-#else
+#ifdef HAVE_STRINGS_H
 # include <strings.h>
+#else 
+# include <string.h>
 #endif
 
 #define Nn 8  /* duplicate definition of N if built on sky motes */

--- a/include/coap/encode.h
+++ b/include/coap/encode.h
@@ -15,6 +15,9 @@
 #else 
 # include <string.h>
 #endif
+#include <stdbool.h>
+
+#include "option.h"
 
 #define Nn 8  /* duplicate definition of N if built on sky motes */
 #define E 4
@@ -48,5 +51,11 @@ unsigned int coap_decode_var_bytes(unsigned char *buf,unsigned int len);
  * Returns the number of bytes used to encode val or 0 on error.
  */
 unsigned int coap_encode_var_bytes(unsigned char *buf, unsigned int val);
+
+/**
+ * Tests whether the option definition has a type that allows variable byte encoding.
+ * Returns true when supported, false when not supported.
+ */
+bool coap_is_var_bytes(coap_option_def_t* def);
 
 #endif /* _COAP_ENCODE_H_ */

--- a/include/coap/libcoap.h
+++ b/include/coap/libcoap.h
@@ -10,6 +10,8 @@
 #ifndef _LIBCOAP_H_
 #define _LIBCOAP_H_
 
+#include "coap_config.h"
+
 /* The non posix embedded platforms like Contiki, TinyOS, RIOT, ... doesn't have
  * a POSIX compatible header structure so we have to slightly do some platform
  * related things. Currently there is only Contiki available so we check for a
@@ -18,9 +20,14 @@
  *
  * The CONTIKI variable is within the Contiki build environment! */
 
-#if !defined (CONTIKI) 
+#ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#endif
+#ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
-#endif /* CONTIKI */
+#endif
+#ifdef HAVE_WS2TCPIP_H
+#include <ws2tcpip.h>
+#endif
 
 #endif /* _LIBCOAP_H_ */

--- a/include/coap/mem.h
+++ b/include/coap/mem.h
@@ -67,14 +67,14 @@ void coap_free_type(coap_memory_tag_t type, void *p);
 /**
  * Wrapper function to coap_malloc_type() for backwards compatibility.
  */
-static inline void *coap_malloc(size_t size) {
+COAP_STATIC_INLINE void *coap_malloc(size_t size) {
   return coap_malloc_type(COAP_STRING, size);
 }
 
 /**
  * Wrapper function to coap_free_type() for backwards compatibility.
  */
-static inline void coap_free(void *object) {
+COAP_STATIC_INLINE void coap_free(void *object) {
   coap_free_type(COAP_STRING, object);
 }
 
@@ -86,7 +86,7 @@ static inline void coap_free(void *object) {
 
 /* no initialization needed with lwip (or, more precisely: lwip must be
  * completely initialized anyway by the time coap gets active)  */
-static inline void coap_memory_init(void) {}
+COAP_STATIC_INLINE void coap_memory_init(void) {}
 
 /* It would be nice to check that size equals the size given at the memp
  * declaration, but i currently don't see a standard way to check that without
@@ -98,11 +98,11 @@ static inline void coap_memory_init(void) {}
 /* Those are just here to make uri.c happy where string allocation has not been
  * made conditional.
  */
-static inline void *coap_malloc(size_t size) {
+COAP_STATIC_INLINE void *coap_malloc(size_t size) {
   LWIP_ASSERT("coap_malloc must not be used in lwIP", 0);
 }
 
-static inline void coap_free(void *pointer) {
+COAP_STATIC_INLINE void coap_free(void *pointer) {
   LWIP_ASSERT("coap_free must not be used in lwIP", 0);
 }
 

--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -13,7 +13,9 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
+#endif
 #include <time.h>
 
 #ifdef WITH_LWIP
@@ -137,7 +139,7 @@ typedef struct coap_context_t {
  * @param context The context to register the handler for.
  * @param handler The response handler to register.
  */
-static inline void
+COAP_STATIC_INLINE void
 coap_register_response_handler(coap_context_t *context,
                                coap_response_handler_t handler) {
   context->response_handler = handler;
@@ -149,7 +151,7 @@ coap_register_response_handler(coap_context_t *context,
  * @param ctx  The context to use.
  * @param type The option type to register.
  */
-inline static void
+COAP_STATIC_INLINE void
 coap_register_option(coap_context_t *ctx, unsigned char type) {
   coap_option_setb(ctx->known_options, type);
 }
@@ -185,7 +187,7 @@ coap_context_t *coap_new_context(const coap_address_t *listen_addr);
  *
  * @return        Incremented message id in network byte order.
  */
-static inline unsigned short
+COAP_STATIC_INLINE unsigned short
 coap_new_message_id(coap_context_t *context) {
   context->message_id++;
 #ifndef WITH_CONTIKI
@@ -342,7 +344,7 @@ coap_tid_t coap_send_ack(coap_context_t *context,
  * @return                The transaction id if RST was sent or @c
  *                        COAP_INVALID_TID on error.
  */
-static inline coap_tid_t
+COAP_STATIC_INLINE coap_tid_t
 coap_send_rst(coap_context_t *context,
               const coap_endpoint_t *local_interface,
               const coap_address_t *dst,
@@ -420,7 +422,7 @@ int coap_remove_from_queue(coap_queue_t **queue,
  *
  * @return      @c 1 if node was found, removed and destroyed, @c 0 otherwise.
  */
-inline static int
+COAP_STATIC_INLINE int
 coap_remove_transaction(coap_queue_t **queue, coap_tid_t id) {
   coap_queue_t *node;
   if (!coap_remove_from_queue(queue, id, &node))

--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -10,7 +10,14 @@
 #ifndef _COAP_NET_H_
 #define _COAP_NET_H_
 
+#ifdef HAVE_ASSERT_H
 #include <assert.h>
+#else
+#ifndef assert
+#  define assert(x)
+#endif
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #ifdef HAVE_SYS_TIME_H

--- a/include/coap/option.h
+++ b/include/coap/option.h
@@ -291,6 +291,26 @@ coap_opt_iterator_t *coap_option_iterator_init(coap_pdu_t *pdu,
                                                const coap_opt_filter_t filter);
 
 /**
+ * Initializes the given option iterator @p oi to point to the
+ * beginning of the @p pdu's option list. This function returns @p oi
+ * on success, @c NULL otherwise (i.e. when no options exist).
+ * Note that a length check on the option list must be performed before
+ * coap_option_iterator_init() is called.
+ *
+ * @param pdu  The PDU the options of which should be walked through.
+ * @param oi   An iterator object that will be initilized.
+ * @param filter An optional option type filter.
+ *               With @p type != @c COAP_OPT_ALL, coap_option_next()
+ *               will return only options matching this bitmask.
+ *               Fence-post options @c 14, @c 28, @c 42, ... are always
+ *               skipped.
+ *
+ * @return The iterator object @p oi on success, @c NULL otherwise.
+ */
+coap_opt_iterator_t *coap_option_iterator_init2(coap_pdu_t *pdu, coap_opt_iterator_t *oi,
+        const coap_opt_filter_t filter, coap_transport_t transport);
+
+/**
  * Updates the iterator @p oi to point to the next option. This function returns
  * a pointer to that option or @c NULL if no more options exist. The contents of
  * @p oi will be updated. In particular, @c oi->n specifies the current option's

--- a/include/coap/option.h
+++ b/include/coap/option.h
@@ -32,6 +32,17 @@ typedef struct {
   unsigned char *value;
 } coap_option_t;
 
+/** Representation of the association between a CoAP option key and its
+ *  data type and valid data length ranges.
+ */
+typedef struct
+{
+    unsigned short key;     /**< The ID of the option the following values apply to. */
+    unsigned char type;     /**< The type of the option: u=uint, s=string, o=opaque. */
+    unsigned int min;       /**< The minimum number of bytes allowed for the option data */
+    unsigned int max;       /**< The maximum number of bytes allowed for the option data */
+} coap_option_def_t;
+
 /**
  * Parses the option pointed to by @p opt into @p result. This function returns
  * the number of bytes that have been parsed, or @c 0 on error. An error is
@@ -142,7 +153,7 @@ typedef uint16_t coap_opt_filter_t[COAP_OPT_FILTER_SIZE];
  *
  * @param f The filter to clear.
  */
-static inline void
+COAP_STATIC_INLINE void
 coap_option_filter_clear(coap_opt_filter_t f) {
   memset(f, 0, sizeof(coap_opt_filter_t));
 }
@@ -195,7 +206,7 @@ int coap_option_filter_get(const coap_opt_filter_t filter, unsigned short type);
  *
  * @return       @c 1 if bit was set, @c -1 otherwise.
  */
-inline static int
+COAP_STATIC_INLINE int
 coap_option_setb(coap_opt_filter_t filter, unsigned short type) {
   return coap_option_filter_set(filter, type) ? 1 : -1;
 }
@@ -212,7 +223,7 @@ coap_option_setb(coap_opt_filter_t filter, unsigned short type) {
  *
  * @return       @c 1 if bit was set, @c -1 otherwise.
  */
-inline static int
+COAP_STATIC_INLINE int
 coap_option_clrb(coap_opt_filter_t filter, unsigned short type) {
   return coap_option_filter_unset(filter, type) ? 1 : -1;
 }
@@ -229,7 +240,7 @@ coap_option_clrb(coap_opt_filter_t filter, unsigned short type) {
  *
  * @return       @c 1 if bit was set, @c 0 if not, @c -1 on error.
  */
-inline static int
+COAP_STATIC_INLINE int
 coap_option_getb(const coap_opt_filter_t filter, unsigned short type) {
   return coap_option_filter_get(filter, type);
 }
@@ -401,6 +412,16 @@ unsigned short coap_opt_length(const coap_opt_t *opt);
  * @return    A pointer to the option value or @c NULL on error.
  */
 unsigned char *coap_opt_value(coap_opt_t *opt);
+
+/**
+ * Returns a pointer to the coap option range definitions. @key
+ * must be a valid option ID. This function returns @c NULL if
+ * @p key is not a valid option ID.
+ *
+ * @param key The option ID whose definition should be returned.
+ * @return A pointer to the option definition.
+ */
+coap_option_def_t* coap_opt_def(unsigned short key);
 
 /** @deprecated { Use coap_opt_value() instead. } */
 #define COAP_OPT_VALUE(opt) coap_opt_value((coap_opt_t *)opt)

--- a/include/coap/pdu.h
+++ b/include/coap/pdu.h
@@ -21,6 +21,11 @@
 #include <lwip/pbuf.h>
 #endif
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #define COAP_DEFAULT_PORT      5683 /* CoAP default UDP port */
 #define COAP_DEFAULT_MAX_AGE     60 /* default maximum object lifetime in seconds */
 #ifndef COAP_MAX_PDU_SIZE
@@ -53,11 +58,14 @@
 #define COAP_REQUEST_DELETE    4
 
 /* CoAP option types (be sure to update check_critical when adding options */
+/* See http://www.iana.org/assignments/core-parameters/core-parameters.xhtml#option-numbers */
 
 #define COAP_OPTION_IF_MATCH        1 /* C, opaque, 0-8 B, (none) */
 #define COAP_OPTION_URI_HOST        3 /* C, String, 1-255 B, destination address */
 #define COAP_OPTION_ETAG            4 /* E, opaque, 1-8 B, (none) */
 #define COAP_OPTION_IF_NONE_MATCH   5 /* empty, 0 B, (none) */
+#define COAP_OPTION_OBSERVE         6 /* E, empty/uint, 0 B/0-3 B, (none) */
+#define COAP_OPTION_SUBSCRIPTION  COAP_OPTION_OBSERVE
 #define COAP_OPTION_URI_PORT        7 /* C, uint, 0-2 B, destination port */
 #define COAP_OPTION_LOCATION_PATH   8 /* E, String, 0-255 B, - */
 #define COAP_OPTION_URI_PATH       11 /* C, String, 0-255 B, (none) */
@@ -71,15 +79,11 @@
 #define COAP_OPTION_PROXY_SCHEME   39 /* C, String, 1-255 B, (none) */
 #define COAP_OPTION_SIZE1          60 /* E, uint, 0-4 B, (none) */
 
-/* option types from draft-ietf-coap-observe-09 */
+/* selected option types from draft-core-block-21 */
 
-#define COAP_OPTION_OBSERVE         6 /* E, empty/uint, 0 B/0-3 B, (none) */
-#define COAP_OPTION_SUBSCRIPTION  COAP_OPTION_OBSERVE
-
-/* selected option types from draft-core-block-04 */
-
-#define COAP_OPTION_BLOCK2         23 /* C, uint, 0--3 B, (none) */
-#define COAP_OPTION_BLOCK1         27 /* C, uint, 0--3 B, (none) */
+#define COAP_OPTION_BLOCK2         23 /* C, uint, 0-3 B, (none) */
+#define COAP_OPTION_BLOCK1         27 /* C, uint, 0-3 B, (none) */
+#define COAP_OPTION_SIZE2          28 /* E, uint, 0-4 B, (none) */
 
 /* selected option types from draft-tcs-coap-no-response-option-11 */
 
@@ -171,27 +175,91 @@ typedef int coap_tid_t;
  */
 #define COAP_DROPPED_RESPONSE -2
 
+#define COAP_TCP_HEADER_NO_FIELD    2
+#define COAP_TCP_HEADER_8_BIT       3
+#define COAP_TCP_HEADER_16_BIT      4
+#define COAP_TCP_HEADER_32_BIT      6
+
+#define COAP_TCP_LENGTH_FIELD_8_BIT      13
+#define COAP_TCP_LENGTH_FIELD_16_BIT     269
+#define COAP_TCP_LENGTH_FIELD_32_BIT     65805
+
+#define COAP_TCP_LENGTH_LIMIT_8_BIT      13
+#define COAP_TCP_LENGTH_LIMIT_16_BIT     256
+#define COAP_TCP_LENGTH_LIMIT_32_BIT     65536
+
+#define COAP_TCP_LENGTH_FIELD_NUM_8_BIT      13
+#define COAP_TCP_LENGTH_FIELD_NUM_16_BIT     14
+#define COAP_TCP_LENGTH_FIELD_NUM_32_BIT     15
+
+#define COAP_OPTION_FIELD_8_BIT      12
+#define COAP_OPTION_FIELD_16_BIT     256
+#define COAP_OPTION_FIELD_32_BIT     65536
+
+typedef enum {
+    COAP_UDP = 0,
+#ifdef WITH_TCP
+    COAP_TCP,
+    COAP_TCP_8BIT,
+    COAP_TCP_16BIT,
+    COAP_TCP_32BIT
+#endif
+} coap_transport_t;
+
 #ifdef WORDS_BIGENDIAN
 typedef struct {
-  unsigned int version:2;      /* protocol version */
-  unsigned int type:2;         /* type flag */
-  unsigned int token_length:4; /* length of Token */
-  unsigned int code:8;         /* request method (value 1--10) or response
-                                  code (value 40-255) */
-  unsigned short id;           /* message id */
-  unsigned char token[];       /* the actual token, if any */
-} coap_hdr_t;
+  unsigned short version:2;      /* protocol version */
+  unsigned short type:2;         /* type flag */
+  unsigned short token_length:4; /* length of Token */
+  unsigned short code:8;         /* request method (value 1--10) or response
+                                    code (value 40-255) */
+  unsigned short id;             /* message id */
+  unsigned char token[];         /* the actual token, if any */
+} coap_hdr_udp_t;
 #else
 typedef struct {
-  unsigned int token_length:4; /* length of Token */
-  unsigned int type:2;         /* type flag */
-  unsigned int version:2;      /* protocol version */
-  unsigned int code:8;         /* request method (value 1--10) or response
-                                  code (value 40-255) */
-  unsigned short id;           /* transaction id (network byte order!) */
-  unsigned char token[];       /* the actual token, if any */
-} coap_hdr_t;
+  unsigned short token_length:4; /* length of Token */
+  unsigned short type:2;         /* type flag */
+  unsigned short version:2;      /* protocol version */
+  unsigned short code:8;         /* request method (value 1--10) or response
+                                    code (value 40-255) */
+  unsigned short id;             /* transaction id (network byte order!) */
+  unsigned char token[];         /* the actual token, if any */
+} coap_hdr_udp_t;
 #endif
+
+#ifdef WITH_TCP
+typedef struct {
+  unsigned char header_data[COAP_TCP_HEADER_NO_FIELD];
+  unsigned char token[]; /* the actual token, if any */
+} coap_hdr_tcp_t;
+
+typedef struct {
+  unsigned char header_data[COAP_TCP_HEADER_8_BIT];
+  unsigned char token[]; /* the actual token, if any */
+} coap_hdr_tcp_8bit_t;
+
+typedef struct {
+  unsigned char header_data[COAP_TCP_HEADER_16_BIT];
+  unsigned char token[]; /* the actual token, if any */
+} coap_hdr_tcp_16bit_t;
+
+typedef struct {
+  unsigned char header_data[6];
+  unsigned char token[]; /* the actual token, if any */
+} coap_hdr_tcp_32bit_t;
+
+typedef union {
+  coap_hdr_udp_t udp;
+  coap_hdr_tcp_t tcp;  
+  coap_hdr_tcp_8bit_t tcp_8bit;
+  coap_hdr_tcp_16bit_t tcp_16bit;
+  coap_hdr_tcp_32bit_t tcp_32bit;
+} coap_hdr_transport_t;
+#endif /* WITH_TCP */
+
+// Typedef for backwards compatibility.
+typedef coap_hdr_udp_t coap_hdr_t;
 
 #define COAP_MESSAGE_IS_EMPTY(MSG)    ((MSG)->code == 0)
 #define COAP_MESSAGE_IS_REQUEST(MSG)  (!COAP_MESSAGE_IS_EMPTY(MSG) \
@@ -226,10 +294,18 @@ typedef struct {
 
 typedef struct {
   size_t max_size;          /**< allocated storage for options and data */
-  coap_hdr_t *hdr;          /**< Address of the first byte of the CoAP message.
-                             *   This may or may not equal (coap_hdr_t*)(pdu+1)
-                             *   depending on the memory management
-                             *   implementation. */
+  union {
+    coap_hdr_t *hdr;          /**< Address of the first byte of the CoAP message.
+                               *   This may or may not equal (coap_hdr_t*)(pdu+1)
+                               *   depending on the memory management
+                               *   implementation. */
+#ifdef WITH_TCP
+    coap_hdr_transport_t *transport_hdr; /**< Address of the first byte of the CoAP message.
+                                           *   This may or may not equal (coap_hdr_t*)(pdu+1)
+                                           *   depending on the memory management
+                                           *   implementation. */
+#endif
+  };
   unsigned short max_delta; /**< highest option number */
   unsigned short length;    /**< PDU length (including header, options, data) */
   unsigned char *data;      /**< payload */
@@ -308,6 +384,15 @@ void coap_pdu_clear(coap_pdu_t *pdu, size_t size);
  */
 coap_pdu_t *coap_new_pdu(void);
 
+/**
+ * Creates a new CoAP PDU. The object is created on the heap and must be released
+ * using coap_delete_pdu();
+ *
+ * @deprecated This function allocates the maximum storage for each
+ * PDU. Use coap_pdu_init2() instead.
+ */
+coap_pdu_t *coap_new_pdu2(coap_transport_t transport, unsigned int size);
+
 void coap_delete_pdu(coap_pdu_t *);
 
 /**
@@ -327,6 +412,106 @@ int coap_pdu_parse(unsigned char *data,
                    coap_pdu_t *result);
 
 /**
+ * Parses @p data into the CoAP PDU structure given in @p result. This
+ * function returns @c 0 on error or a number greater than zero on
+ * success.
+ *
+ * @param data   The raw data to parse as CoAP PDU
+ * @param length The actual size of @p data
+ * @param result The PDU structure to fill. Note that the structure must
+ *               provide space for at least @p length bytes to hold the
+ *               entire CoAP PDU.
+ * @param transport The transport type.
+ * @return A value greater than zero on success or @c 0 on error.
+ */
+int coap_pdu_parse2(unsigned char *data, size_t length, coap_pdu_t *pdu,
+                    coap_transport_t transport);
+
+#ifdef WITH_TCP
+/**
+ * Get total pdu size including header + option + payload (with marker) from pdu data.
+ *
+ * @param data   The raw data to parse as CoAP PDU.
+ * @param size   payload size of pdu.
+ * @return Total message length.
+ */
+size_t coap_get_total_message_length(const unsigned char *data, size_t size);
+
+/**
+ * Get transport type of coap header for coap over tcp
+ * through payload size(including payload marker) + option size.
+ *
+ * @param size   payload size of pdu.
+ * @return The transport type.
+ */
+coap_transport_t coap_get_tcp_header_type_from_size(unsigned int size);
+
+/**
+ * Get transport type of coap header for coap over tcp
+ * through first nibble(0~E) of init-byte .
+ *
+ * @param legnth   length value of init byte.
+* @return The transport type.
+ */
+coap_transport_t coap_get_tcp_header_type_from_initbyte(unsigned int length);
+
+/**
+ * Add length of option/payload into 'Len+ byte...' field of coap header
+ * for coap over tcp.
+ *
+ * @param pdu  The pdu pointer.
+ * @param transport The transport type.
+ * @param length  length value of init byte.
+ */
+void coap_add_length(const coap_pdu_t *pdu, coap_transport_t transport,
+                     unsigned int length);
+
+/**
+ * Get the length of option/payload field of coap header for coap over tcp.
+ *
+ * @param pdu  The pdu pointer.
+ * @param transport The transport type.
+ * @return length value of init byte.
+ */
+unsigned int coap_get_length(const coap_pdu_t *pdu, coap_transport_t transport);
+
+/**
+ * Get the length of option/payload field of coap header for coap over tcp.
+ *
+ * @param header   The header to parse.
+ * @return transport The transport type.
+ */
+unsigned int coap_get_length_from_header(const unsigned char *header,
+                                         coap_transport_t transport);
+
+/**
+ * Get length of header including len, TKL, Len+bytes, Code, token bytes for coap over tcp.
+ *
+ * @param data   The raw data to parse as CoAP PDU
+ * @return header length + token length
+ */
+unsigned int coap_get_tcp_header_length(unsigned char *data);
+
+/**
+ * Get length of header including len, TKL, Len+bytes, Code
+ * without token bytes for coap over tcp.
+ *
+ * @param transport The transport type.
+ * @return header length.
+ */
+unsigned int coap_get_tcp_header_length_for_transport(coap_transport_t transport);
+
+/**
+ * Get option length.
+ *
+ * @param key      delta of option
+ * @param length   length of option
+ * @return total option length
+ */
+size_t coap_get_opt_header_length(unsigned short key, size_t length);
+#endif /* WITH_TCP */
+
+/**
  * Adds token of length @p len to @p pdu.
  * Adding the token destroys any following contents of the pdu. Hence options
  * and data must be added after coap_add_token() has been called. In @p pdu,
@@ -344,8 +529,23 @@ int coap_add_token(coap_pdu_t *pdu,
                   const unsigned char *data);
 
 /**
- * Adds option of given type to pdu that is passed as first
- * parameter.
+ * Adds token of length @p len to @p pdu. Adding the token destroys
+ * any following contents of the pdu. Hence options and data must be
+ * added after coap_add_token2() has been called. In @p pdu, length is
+ * set to @p len + @c 4, and max_delta is set to @c 0.  This funtion
+ * returns @c 0 on error or a value greater than zero on success.
+ *
+ * @param pdu  The pdu pointer.
+ * @param len  The length of the new token.
+ * @param data The token to add.
+ * @param transport The transport type.
+ * @return A value greater than zero on success, or @c 0 on error.
+ */
+int coap_add_token2(coap_pdu_t *pdu, size_t len, const unsigned char *data,
+                    coap_transport_t transport);
+
+/**
+ * Adds option of given type to pdu that is passed as first parameter.
  * coap_add_option() destroys the PDU's data, so coap_add_data() must be called
  * after all options have been added. As coap_add_token() destroys the options
  * following the token, the token must be added before coap_add_option() is
@@ -355,6 +555,17 @@ size_t coap_add_option(coap_pdu_t *pdu,
                        unsigned short type,
                        unsigned int len,
                        const unsigned char *data);
+
+/**
+ * Adds option of given type to pdu that is passed as first
+ * parameter. coap_add_option2() destroys the PDU's data, so
+ * coap_add_data() must be called after all options have been added.
+ * As coap_add_token2() destroys the options following the token,
+ * the token must be added before coap_add_option2() is called.
+ * This function returns the number of bytes written or @c 0 on error.
+ */
+size_t coap_add_option2(coap_pdu_t *pdu, unsigned short type, unsigned int len,
+                        const unsigned char *data, coap_transport_t transport);
 
 /**
  * Adds option of given type to pdu that is passed as first parameter, but does
@@ -385,4 +596,7 @@ int coap_get_data(coap_pdu_t *pdu,
                   size_t *len,
                   unsigned char **data);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 #endif /* _COAP_PDU_H_ */

--- a/include/coap/prng.h
+++ b/include/coap/prng.h
@@ -20,7 +20,7 @@
  * @{
  */
 
-#if defined(WITH_POSIX) || (defined(WITH_LWIP) && !defined(LWIP_RAND))
+#if !defined(WITH_CONTIKI) && !defined(LWIP_RAND)
 #include <stdlib.h>
 
 /**
@@ -34,9 +34,7 @@ coap_prng_impl(unsigned char *buf, size_t len) {
     *buf++ = rand() & 0xFF;
   return 1;
 }
-#endif /* WITH_POSIX */
-
-#ifdef WITH_CONTIKI
+#else /* WITH_CONTIKI */
 #include <string.h>
 
 /**

--- a/include/coap/prng.h
+++ b/include/coap/prng.h
@@ -28,7 +28,7 @@
  * prng(). You might want to change prng() to use a better PRNG on your specific
  * platform.
  */
-static inline int
+COAP_STATIC_INLINE int
 coap_prng_impl(unsigned char *buf, size_t len) {
   while (len--)
     *buf++ = rand() & 0xFF;
@@ -44,7 +44,7 @@ coap_prng_impl(unsigned char *buf, size_t len) {
  * prng(). You might want to change prng() to use a better PRNG on your specific
  * platform.
  */
-static inline int
+COAP_STATIC_INLINE int
 contiki_prng_impl(unsigned char *buf, size_t len) {
   unsigned short v = random_rand();
   while (len > sizeof(v)) {
@@ -63,7 +63,7 @@ contiki_prng_impl(unsigned char *buf, size_t len) {
 #endif /* WITH_CONTIKI */
 
 #if defined(WITH_LWIP) && defined(LWIP_RAND)
-static inline int
+COAP_STATIC_INLINE int
 lwip_prng_impl(unsigned char *buf, size_t len) {
   u32_t v = LWIP_RAND();
   while (len > sizeof(v)) {

--- a/include/coap/resource.h
+++ b/include/coap/resource.h
@@ -15,7 +15,9 @@
 #ifndef _COAP_RESOURCE_H_
 #define _COAP_RESOURCE_H_
 
+#if defined(HAVE_ASSERT_H) && !defined(assert)
 # include <assert.h>
+#endif
 
 #ifndef COAP_RESOURCE_CHECK_TIME
 /** The interval in seconds to check if resources have changed. */

--- a/include/coap/resource.h
+++ b/include/coap/resource.h
@@ -115,7 +115,7 @@ coap_resource_t *coap_resource_init(const unsigned char *uri,
  * @p mode which must be one of @c COAP_RESOURCE_FLAGS_NOTIFY_NON
  * or @c COAP_RESOURCE_FLAGS_NOTIFY_CON.
  */
-static inline void
+COAP_STATIC_INLINE void
 coap_resource_set_mode(coap_resource_t *r, int mode) {
   r->flags = (r->flags & !COAP_RESOURCE_FLAGS_NOTIFY_CON) | mode;
 }
@@ -244,7 +244,7 @@ coap_print_status_t coap_print_link(const coap_resource_t *resource,
  * @param method   The CoAP request method to handle.
  * @param handler  The handler to register with @p resource.
  */
-static inline void
+COAP_STATIC_INLINE void
 coap_register_handler(coap_resource_t *resource,
                       unsigned char method,
                       coap_method_handler_t handler) {

--- a/include/coap/uri.h
+++ b/include/coap/uri.h
@@ -64,6 +64,60 @@ int coap_hash_path(const unsigned char *path, size_t len, coap_key_t key);
  */
 
 /**
+ * Iterator to for tokenizing a URI path or query. This structure must
+ * be initialized with coap_parse_iterator_init(). Call
+ * coap_parse_next() to walk through the tokens.
+ *
+ * @code
+ * unsigned char *token;
+ * coap_parse_iterator_t pi;
+ * coap_parse_iterator_init(uri.path.s, uri.path.length, "/", "?#", 2, &pi);
+ *
+ * while ((token = coap_parse_next(&pi))) {
+ *   ... do something with token ...
+ * }
+ * @endcode
+ */
+typedef struct
+{
+    size_t n; /**< number of remaining characters in buffer */
+    unsigned char *separator; /**< segment separators */
+    unsigned char *delim; /**< delimiters where to split the string */
+    size_t dlen; /**< length of separator */
+    unsigned char *pos; /**< current position in buffer */
+    size_t segment_length; /**< length of current segment */
+} coap_parse_iterator_t;
+
+/**
+ * Initializes the given iterator @p pi.
+ *
+ * @param s         The string to tokenize.
+ * @param n         The length of @p s.
+ * @param separator The separator character that delimits tokens.
+ * @param delim     A set of characters that delimit @s.
+ * @param dlen      The length of @p delim.
+ * @param pi        The iterator object to initialize.
+ *
+ * @return The initialized iterator object @p pi.
+ */
+coap_parse_iterator_t *
+coap_parse_iterator_init(unsigned char *s, size_t n, unsigned char *separator, unsigned char *delim,
+        size_t dlen, coap_parse_iterator_t *pi);
+
+/**
+ * Updates the iterator @p pi to point to the next token. This
+ * function returns a pointer to that token or @c NULL if no more
+ * tokens exist. The contents of @p pi will be updated. In particular,
+ * @c pi->segment_length specifies the length of the current token, @c
+ * pi->pos points to its beginning.
+ *
+ * @param pi The iterator to update.
+ *
+ * @return The next token or @c NULL if no more tokens exist.
+ */
+unsigned char *coap_parse_next(coap_parse_iterator_t *pi);
+
+/**
  * Parses a given string into URI components. The identified syntactic
  * components are stored in the result parameter @p uri. Optional URI
  * components that are not specified will be set to { 0, 0 }, except for the

--- a/src/address.c
+++ b/src/address.c
@@ -6,10 +6,19 @@
  * README for terms of use.
  */
 
-#ifdef WITH_POSIX
+#include "coap_config.h"
+
+#if !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
 #include <assert.h>
+#ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
+#endif
+#ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
+#endif
+#ifdef HAVE_WS2TCPIP_H
+#include <ws2tcpip.h>
+#endif
 
 #include "address.h"
 
@@ -37,12 +46,11 @@ coap_address_equals(const coap_address_t *a, const coap_address_t *b) {
  return 0;
 }
 
-#else /* WITH_POSIX */
+#else /* WITH_LWIP || WITH_CONTIKI */
 
 /* make compilers happy that do not like empty modules */
-static inline void dummy()
+COAP_STATIC_INLINE void dummy()
 {
 }
 
-#endif /* not WITH_POSIX */
-
+#endif

--- a/src/block.c
+++ b/src/block.c
@@ -19,7 +19,9 @@
 #error "COAP_MAX_BLOCK_SZX too large"
 #endif
 
+#ifndef min
 #define min(a,b) ((a) < (b) ? (a) : (b))
+#endif
 
 #ifndef WITHOUT_BLOCK
 unsigned int
@@ -49,7 +51,7 @@ coap_get_block(coap_pdu_t *pdu, unsigned short type, coap_block_t *block) {
   assert(block);
   memset(block, 0, sizeof(coap_block_t));
 
-  if (pdu && (option = coap_check_option(pdu, type, &opt_iter))) {
+  if (pdu && (option = coap_check_option(pdu, type, &opt_iter)) != NULL) {
     block->szx = COAP_OPT_BLOCK_SZX(option);
     if (COAP_OPT_BLOCK_MORE(option))
       block->m = 1;
@@ -67,6 +69,12 @@ coap_write_block_opt(coap_block_t *block, unsigned short type,
   unsigned char buf[3];
 
   assert(pdu);
+
+  /* Block2 */
+  if (type != COAP_OPTION_BLOCK2) {
+    warn("coap_write_block_opt: skipped unknown option\n");
+    return -1;
+  }
 
   start = block->num << (block->szx + 4);
   if (data_length <= start) {

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -17,9 +17,27 @@
 #endif 
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>
+# define OPTVAL_T(t)         (t)
+# define CLOSE_SOCKET(fd)    close(fd)
+# define COAP_SOCKET_ERROR   (-1)
+# define COAP_INVALID_SOCKET (-1)
+typedef int coap_socket_t;
 #endif
 #ifdef HAVE_NETINET_IN_H
 # include <netinet/in.h>
+#endif
+#ifdef HAVE_WS2TCPIP_H
+# include <ws2tcpip.h>
+# define OPTVAL_T(t)         (const char*)(t)
+# define CLOSE_SOCKET(fd)    { closesocket(fd); WSACleanup(); }
+# define COAP_SOCKET_ERROR   SOCKET_ERROR
+# define COAP_INVALID_SOCKET INVALID_SOCKET
+# undef CMSG_DATA
+# define CMSG_DATA           WSA_CMSG_DATA
+# define CMSG_FIRSTHDR       WSA_CMSG_FIRSTHDR
+# define CMSG_LEN            WSA_CMSG_LEN
+# define CMSG_SPACE          WSA_CMSG_SPACE
+typedef SOCKET coap_socket_t;
 #endif
 #ifdef HAVE_SYS_UIO_H
 # include <sys/uio.h>
@@ -37,12 +55,12 @@
 #include "mem.h"
 #include "coap_io.h"
 
-#ifdef WITH_POSIX
+#if !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
 struct coap_packet_t {
   coap_if_handle_t hnd;	      /**< the interface handle */
   coap_address_t src;	      /**< the packet's source address */
   coap_address_t dst;	      /**< the packet's destination address */
-  const coap_endpoint_t *interface;
+  const coap_endpoint_t *endpoint;
 
   int ifindex;
   void *session;		/**< opaque session data */
@@ -57,7 +75,7 @@ struct coap_packet_t {
 #ifdef WITH_CONTIKI
 static int ep_initialized = 0;
 
-static inline struct coap_endpoint_t *
+COAP_STATIC_INLINE struct coap_endpoint_t *
 coap_malloc_contiki_endpoint() {
   static struct coap_endpoint_t ep;
 
@@ -69,7 +87,7 @@ coap_malloc_contiki_endpoint() {
   }
 }
 
-static inline void
+COAP_STATIC_INLINE void
 coap_free_contiki_endpoint(struct coap_endpoint_t *ep) {
   ep_initialized = 0;
 }
@@ -106,42 +124,52 @@ coap_free_endpoint(coap_endpoint_t *ep) {
 }
 
 #else /* WITH_CONTIKI */
-static inline struct coap_endpoint_t *
+COAP_STATIC_INLINE struct coap_endpoint_t *
 coap_malloc_posix_endpoint(void) {
   return (struct coap_endpoint_t *)coap_malloc(sizeof(struct coap_endpoint_t));
 }
 
-static inline void
+COAP_STATIC_INLINE void
 coap_free_posix_endpoint(struct coap_endpoint_t *ep) {
   coap_free(ep);
 }
 
 coap_endpoint_t *
 coap_new_endpoint(const coap_address_t *addr, int flags) {
-  int sockfd = socket(addr->addr.sa.sa_family, SOCK_DGRAM, 0);
+#ifdef HAVE_WS2TCPIP_H
+  WSADATA Data;
+  if (WSAStartup(MAKEWORD(2, 2), &Data) != NO_ERROR) {
+    coap_log(LOG_WARNING, "coap_new_endpoint: WSAStartup failed");
+    return NULL;
+  }
+#endif
+  coap_socket_t sockfd = socket(addr->addr.sa.sa_family, SOCK_DGRAM, 0);
   int on = 1;
   struct coap_endpoint_t *ep;
 
-  if (sockfd < 0) {
+  if (sockfd == COAP_INVALID_SOCKET) {
+#ifdef HAVE_WS2TCPIP_H
+    WSACleanup();
+#endif
     coap_log(LOG_WARNING, "coap_new_endpoint: socket");
     return NULL;
   }
 
-  if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0)
+  if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
     coap_log(LOG_WARNING, "coap_new_endpoint: setsockopt SO_REUSEADDR");
 
   on = 1;
   switch(addr->addr.sa.sa_family) {
   case AF_INET:
-    if (setsockopt(sockfd, IPPROTO_IP, IP_PKTINFO, &on, sizeof(on)) < 0)
+    if (setsockopt(sockfd, IPPROTO_IP, IP_PKTINFO, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
       coap_log(LOG_ALERT, "coap_new_endpoint: setsockopt IP_PKTINFO\n");
     break;
   case AF_INET6:
 #ifdef IPV6_RECVPKTINFO
-  if (setsockopt(sockfd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &on, sizeof(on)) < 0)
+  if (setsockopt(sockfd, IPPROTO_IPV6, IPV6_RECVPKTINFO, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
     coap_log(LOG_ALERT, "coap_new_endpoint: setsockopt IPV6_RECVPKTINFO\n");
 #else /* IPV6_RECVPKTINFO */
-  if (setsockopt(sockfd, IPPROTO_IPV6, IPV6_PKTINFO, &on, sizeof(on)) < 0)
+  if (setsockopt(sockfd, IPPROTO_IPV6, IPV6_PKTINFO, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
     coap_log(LOG_ALERT, "coap_new_endpoint: setsockopt IPV6_PKTINFO\n");
 #endif /* IPV6_RECVPKTINFO */      
   break;
@@ -149,16 +177,16 @@ coap_new_endpoint(const coap_address_t *addr, int flags) {
     coap_log(LOG_ALERT, "coap_new_endpoint: unsupported sa_family\n");
   }
 
-  if (bind(sockfd, &addr->addr.sa, addr->size) < 0) {
+  if (bind(sockfd, &addr->addr.sa, addr->size) == COAP_SOCKET_ERROR) {
     coap_log(LOG_WARNING, "coap_new_endpoint: bind");
-    close (sockfd);
+    CLOSE_SOCKET(sockfd);
     return NULL;
   }
 
   ep = coap_malloc_posix_endpoint();
   if (!ep) {
     coap_log(LOG_WARNING, "coap_new_endpoint: malloc");
-    close(sockfd);
+    CLOSE_SOCKET(sockfd);
     return NULL;
   }
 
@@ -167,9 +195,9 @@ coap_new_endpoint(const coap_address_t *addr, int flags) {
   ep->flags = flags;
 
   ep->addr.size = addr->size;
-  if (getsockname(sockfd, &ep->addr.addr.sa, &ep->addr.size) < 0) {
+  if (getsockname(sockfd, &ep->addr.addr.sa, &ep->addr.size) == COAP_SOCKET_ERROR) {
     coap_log(LOG_WARNING, "coap_new_endpoint: cannot determine local address");
-    close (sockfd);
+    CLOSE_SOCKET(sockfd);
     return NULL;
   }
 
@@ -193,9 +221,9 @@ coap_new_endpoint(const coap_address_t *addr, int flags) {
 
 void
 coap_free_endpoint(coap_endpoint_t *ep) {
-  if(ep) {
-    if (ep->handle.fd >= 0)
-      close(ep->handle.fd);
+  if (ep) {
+    if (ep->handle.fd != COAP_INVALID_SOCKET)
+      CLOSE_SOCKET(ep->handle.fd);
     coap_free_posix_endpoint((struct coap_endpoint_t *)ep);
   }
 }
@@ -221,8 +249,8 @@ struct in_pktinfo {
 };
 #endif
 
-#if defined(WITH_POSIX) && !defined(SOL_IP)
-/* Solaris expects level IPPROTO_IP for ancillary data. */
+#if !defined(WITH_LWIP) && !defined(WITH_CONTIKI) && !defined(SOL_IP)
+/* Solaris and Windows expect level IPPROTO_IP for ancillary data. */
 #define SOL_IP IPPROTO_IP
 #endif
 
@@ -245,28 +273,43 @@ coap_network_send(struct coap_context_t *context UNUSED_PARAM,
 #ifndef WITH_CONTIKI
   /* a buffer large enough to hold all protocol address types */
   char buf[CMSG_LEN(sizeof(struct sockaddr_storage))];
+  assert(local_interface);
+
+#ifdef WSA_CMSG_SPACE
+  WSAMSG mhdr;
+  WSABUF dataBuf;
+
+  memset(&mhdr, 0, sizeof(mhdr));
+
+  mhdr.name = (PSOCKADDR)&dst->addr.sa;
+  mhdr.lpBuffers = &dataBuf;
+  mhdr.dwBufferCount = 1;
+#else
   struct msghdr mhdr;
   struct iovec iov[1];
-
-  assert(local_interface);
 
   iov[0].iov_base = data;
   iov[0].iov_len = datalen;
 
-  memset(&mhdr, 0, sizeof(struct msghdr));
+  memset(&mhdr, 0, sizeof(mhdr));
   mhdr.msg_name = (void *)&dst->addr;
   mhdr.msg_namelen = dst->size;
 
   mhdr.msg_iov = iov;
   mhdr.msg_iovlen = 1;
+  mhdr.msg_control = buf;
+#endif
 
   switch (dst->addr.sa.sa_family) {
   case AF_INET6: {
     struct cmsghdr *cmsg;
     struct in6_pktinfo *pktinfo;
 
-    mhdr.msg_control = buf;
+#ifdef WSA_CMSG_SPACE
+    mhdr.Control.len = CMSG_SPACE(sizeof(struct in6_pktinfo));
+#else
     mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in6_pktinfo));
+#endif
 
     cmsg = CMSG_FIRSTHDR(&mhdr);
     cmsg->cmsg_level = IPPROTO_IPV6;
@@ -294,8 +337,11 @@ coap_network_send(struct coap_context_t *context UNUSED_PARAM,
     struct cmsghdr *cmsg;
     struct in_pktinfo *pktinfo;
 
-    mhdr.msg_control = buf;
+#ifdef WSA_CMSG_SPACE
+    mhdr.Control.len = CMSG_SPACE(sizeof(struct in_pktinfo));
+#else
     mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in_pktinfo));
+#endif
 
     cmsg = CMSG_FIRSTHDR(&mhdr);
     cmsg->cmsg_level = SOL_IP;
@@ -309,12 +355,30 @@ coap_network_send(struct coap_context_t *context UNUSED_PARAM,
       /* We cannot send with multicast address as source address
        * and hence let the kernel pick the outgoing interface. */
       pktinfo->ipi_ifindex = 0;
+
+#ifdef WSA_CMSG_SPACE
+      /* OS's without ipi_spec_dst put the source address in ipi_addr. */
+      memset(&pktinfo->ipi_addr, 0, sizeof(pktinfo->ipi_addr));
+#else
+      /* OS's with ipi_spec_dst seem to put the source address in ipi_spec_dst
+       * which is apparently a misnomer. */
       memset(&pktinfo->ipi_spec_dst, 0, sizeof(pktinfo->ipi_spec_dst));
+#endif
     } else {
       pktinfo->ipi_ifindex = ep->ifindex;
+
+#ifdef WSA_CMSG_SPACE
+      /* OS's without ipi_spec_dst put the source address in ipi_addr. */
+      memcpy(&pktinfo->ipi_addr,
+	     &local_interface->addr.addr.sin.sin_addr,
+	     local_interface->addr.size);
+#else
+      /* OS's with ipi_spec_dst seem to put the source address in ipi_spec_dst
+       * which is apparently a misnomer. */
       memcpy(&pktinfo->ipi_spec_dst,
 	     &local_interface->addr.addr.sin.sin_addr,
 	     local_interface->addr.size);
+#endif
     }
     break;
   }
@@ -339,8 +403,7 @@ coap_network_send(struct coap_context_t *context UNUSED_PARAM,
 #ifndef CUSTOM_COAP_NETWORK_READ
 
 #define SIN6(A) ((struct sockaddr_in6 *)(A))
-
-#ifdef WITH_POSIX
+#if !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
 static coap_packet_t *
 coap_malloc_packet(void) {
   coap_packet_t *packet;
@@ -359,7 +422,7 @@ coap_free_packet(coap_packet_t *packet) {
 }
 #endif /* WITH_POSIX */
 #ifdef WITH_CONTIKI
-static inline coap_packet_t *
+COAP_STATIC_INLINE coap_packet_t *
 coap_malloc_packet(void) {
   return (coap_packet_t *)coap_malloc_type(COAP_PACKET, 0);
 }
@@ -370,7 +433,7 @@ coap_free_packet(coap_packet_t *packet) {
 }
 #endif /* WITH_CONTIKI */
 
-static inline size_t
+COAP_STATIC_INLINE size_t
 coap_get_max_packetlength(const coap_packet_t *packet UNUSED_PARAM) {
   return COAP_MAX_PDU_SIZE;
 }
@@ -378,7 +441,7 @@ coap_get_max_packetlength(const coap_packet_t *packet UNUSED_PARAM) {
 void
 coap_packet_populate_endpoint(coap_packet_t *packet, coap_endpoint_t *target)
 {
-  target->handle = packet->interface->handle;
+  target->handle = packet->endpoint->handle;
   memcpy(&target->addr, &packet->dst, sizeof(target->addr));
   target->ifindex = packet->ifindex;
   target->flags = 0; /* FIXME */
@@ -400,7 +463,7 @@ coap_packet_get_memmapped(coap_packet_t *packet, unsigned char **address, size_t
  * local interface with address @p local. This function returns @c 1
  * if @p dst is a valid match, and @c 0 otherwise.
  */
-static inline int
+COAP_STATIC_INLINE int
 is_local_if(const coap_address_t *local, const coap_address_t *dst) {
   return coap_address_isany(local) || coap_address_equals(dst, local) ||
     coap_is_mcast(dst);
@@ -457,7 +520,7 @@ coap_network_read(coap_endpoint_t *ep, coap_packet_t **packet) {
 
     /* use getsockname() to get the local port */
     (*packet)->dst.size = sizeof((*packet)->dst.addr);
-    if (getsockname(ep->handle.fd, &(*packet)->dst.addr.sa, &(*packet)->dst.size) < 0) {
+    if (getsockname(ep->handle.fd, &(*packet)->dst.addr.sa, &(*packet)->dst.size) == COAP_SOCKET_ERROR) {
       coap_log(LOG_DEBUG, "cannot determine local port\n");
       goto error;
     }
@@ -565,7 +628,7 @@ coap_network_read(coap_endpoint_t *ep, coap_packet_t **packet) {
 #error "coap_network_read() not implemented on this platform"
 #endif
 
-  (*packet)->interface = ep;
+  (*packet)->endpoint = ep;
 
   return len;
  error:

--- a/src/coap_list.c
+++ b/src/coap_list.c
@@ -1,0 +1,91 @@
+/* -*- Mode: C; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 * -*- */
+
+/* coap_list.c -- CoAP list structures
+ *
+ * Copyright (C) 2010,2011,2015 Olaf Bergmann <bergmann@tzi.org>
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms of
+ * use.
+ */
+
+#include "coap_config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "debug.h"
+#include "mem.h"
+#include "coap_list.h"
+
+int
+coap_insert(coap_list_t **queue, coap_list_t *node, int (*order)(void *, void *node)) {
+  coap_list_t *p, *q;
+  if (!queue || !node)
+    return 0;
+
+  /* set queue head if empty */
+  if (!*queue) {
+    *queue = node;
+    return 1;
+  }
+
+  /* replace queue head if new node has to be added before the existing queue head */
+  q = *queue;
+  if (order(node->data, q->data) < 0) {
+    node->next = q;
+    *queue = node;
+    return 1;
+  }
+
+  /* search for right place to insert */
+  do {
+    p = q;
+    q = q->next;
+  } while (q && order(node->data, q->data) >= 0);
+
+  /* insert new item */
+  node->next = q;
+  p->next = node;
+  return 1;
+}
+
+int
+coap_delete(coap_list_t *node) {
+  if (!node)
+    return 0;
+
+  if (node->delete_func)
+    node->delete_func(node->data);
+  coap_free( node->data);
+  coap_free( node);
+
+  return 1;
+}
+
+void
+coap_delete_list(coap_list_t *queue) {
+  coap_list_t *elt, *tmp;
+
+  if (!queue)
+    return;
+
+  LL_FOREACH_SAFE(queue, elt, tmp) {
+    coap_delete(elt);
+  }
+}
+
+coap_list_t *
+coap_new_listnode(void *data, void (*delete_func)(void *)) {
+  coap_list_t *node = (coap_list_t *)coap_malloc(sizeof(coap_list_t));
+  if (!node) {
+#ifndef NDEBUG
+    coap_log(LOG_CRIT, "coap_new_listnode: malloc\n");
+#endif
+    return NULL;
+  }
+
+  memset(node, 0, sizeof(coap_list_t));
+  node->data = data;
+  node->delete_func = delete_func;
+  return node;
+}

--- a/src/coap_time.c
+++ b/src/coap_time.c
@@ -6,12 +6,13 @@
  * README for terms of use.
  */
 
+#include "coap_config.h"
+
 #ifdef WITH_POSIX
 #include <time.h>
 #include <sys/time.h>
 #include <unistd.h>  /* _POSIX_TIMERS */
 
-#include "coap_config.h"
 #include "coap_time.h"
 
 static coap_time_t coap_clock_offset = 0;
@@ -90,7 +91,7 @@ coap_ticks_to_rt(coap_tick_t t) {
 #else /* WITH_POSIX */
 
 /* make compilers happy that do not like empty modules */
-static inline void dummy()
+COAP_STATIC_INLINE void dummy()
 {
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -7,6 +7,7 @@
  */
 
 #include "coap_config.h"
+#include "coap.h"
 
 #if defined(HAVE_STRNLEN) && defined(__GNUC__) && !defined(_GNU_SOURCE)
 #define _GNU_SOURCE 1
@@ -23,6 +24,12 @@
 
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
+#if defined(__ANDROID__)
+typedef __uint16_t in_port_t;
+#endif
+#endif
+#ifdef HAVE_WS2TCPIP_H
+#include <ws2tcpip.h>
 #endif
 
 #ifdef HAVE_TIME_H
@@ -73,7 +80,7 @@ static char *loglevels[] = {
 
 #ifdef HAVE_TIME_H
 
-static inline size_t
+COAP_STATIC_INLINE size_t
 print_timestamp(char *s, size_t len, coap_tick_t t) {
   struct tm *tmp;
   time_t now = coap_ticks_to_rt(t);
@@ -83,7 +90,7 @@ print_timestamp(char *s, size_t len, coap_tick_t t) {
 
 #else /* alternative implementation: just print the timestamp */
 
-static inline size_t
+COAP_STATIC_INLINE size_t
 print_timestamp(char *s, size_t len, coap_tick_t t) {
 #ifdef HAVE_SNPRINTF
   return snprintf(s, len, "%u.%03u", 
@@ -108,7 +115,7 @@ print_timestamp(char *s, size_t len, coap_tick_t t) {
  * 
  * @return The length of @p s.
  */
-static inline size_t
+COAP_STATIC_INLINE size_t
 strnlen(const char *s, size_t maxlen) {
   size_t n = 0;
   while(*s++ && n < maxlen)
@@ -160,7 +167,7 @@ print_readable( const unsigned char *data, unsigned int len,
 
 size_t
 coap_print_addr(const struct coap_address_t *addr, unsigned char *buf, size_t len) {
-#ifdef HAVE_ARPA_INET_H
+#if defined(HAVE_ARPA_INET_H) || defined(_WIN32)
   const void *addrptr = NULL;
   in_port_t port;
   unsigned char *p = buf;
@@ -362,7 +369,7 @@ print_content_format(unsigned int format_type,
  * to carry binary data. The return value @c 0 hence indicates
  * printable data which is also assumed if @p content_format is @c 01.
  */
-static inline int
+COAP_STATIC_INLINE int
 is_binary(int content_format) {
   return !(content_format == -1 ||
 	   content_format == COAP_MEDIATYPE_TEXT_PLAIN ||

--- a/src/debug.c
+++ b/src/debug.c
@@ -206,7 +206,11 @@ coap_print_addr(const struct coap_address_t *addr, unsigned char *buf, size_t le
       return 0;
   }
 
+#ifdef HAVE_SNPRINTF
   p += snprintf((char *)p, buf + len - p + 1, ":%d", port);
+#else /* HAVE_SNPRINTF */
+    /* @todo manual conversion of port number */
+#endif /* HAVE_SNPRINTF */
 
   return buf + len - p;
 #else /* HAVE_ARPA_INET_H */

--- a/src/encode.c
+++ b/src/encode.c
@@ -13,6 +13,10 @@
 #include "coap_config.h"
 #include "encode.h"
 
+#if defined(HAVE_ASSERT_H) && !defined(assert)
+# include <assert.h>
+#endif
+
 /* Carsten suggested this when fls() is not available: */
 int
 coap_fls(unsigned int i) {
@@ -47,3 +51,13 @@ coap_encode_var_bytes(unsigned char *buf, unsigned int val) {
   return n;
 }
 
+bool
+coap_is_var_bytes(coap_option_def_t* def) {
+  assert (def);
+
+  if ('u' == def->type) {
+    return 1;
+  } else {
+    return 0;
+  }
+}

--- a/src/encode.c
+++ b/src/encode.c
@@ -14,7 +14,8 @@
 #include "encode.h"
 
 /* Carsten suggested this when fls() is not available: */
-int coap_fls(unsigned int i) {
+int
+coap_fls(unsigned int i) {
   int n;
   for (n = 0; i; n++)
     i >>= 1;

--- a/src/net.c
+++ b/src/net.c
@@ -120,7 +120,7 @@
 
 #if !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
 
-time_t clock_offset;
+time_t clock_offset = 0;
 
 COAP_STATIC_INLINE coap_queue_t *
 coap_malloc_node(void) {
@@ -158,7 +158,7 @@ coap_free_node(coap_queue_t *node) {
 #include "mem.h"
 #include "net/ip/uip-debug.h"
 
-clock_time_t clock_offset;
+clock_time_t clock_offset = 0;
 
 #define UIP_IP_BUF   ((struct uip_ip_hdr *)&uip_buf[UIP_LLH_LEN])
 #define UIP_UDP_BUF  ((struct uip_udp_hdr *)&uip_buf[UIP_LLIPH_LEN])
@@ -337,6 +337,11 @@ is_wkc(coap_key_t k) {
 coap_context_t *
 coap_new_context(
   const coap_address_t *listen_addr) {
+  if (!listen_addr) {
+    coap_log(LOG_EMERG, "no listen address specified\n");
+    return NULL;
+  }
+
 #ifndef WITH_CONTIKI
   coap_context_t *c = coap_malloc_type(COAP_CONTEXT, sizeof( coap_context_t ) );
 #endif /* not WITH_CONTIKI */
@@ -346,11 +351,6 @@ coap_new_context(
   if (initialized)
     return NULL;
 #endif /* WITH_CONTIKI */
-
-  if (!listen_addr) {
-    coap_log(LOG_EMERG, "no listen address specified\n");
-    return NULL;
-  }
 
   coap_clock_init();
 #ifdef WITH_LWIP

--- a/src/option.c
+++ b/src/option.c
@@ -143,7 +143,7 @@ coap_option_iterator_init(coap_pdu_t *pdu, coap_opt_iterator_t *oi,
   return oi;
 }
 
-static inline int
+COAP_STATIC_INLINE int
 opt_finished(coap_opt_iterator_t *oi) {
   assert(oi);
 
@@ -420,7 +420,7 @@ typedef struct {
 } opt_filter;
 
 /** Returns true iff @p type denotes an option type larger than 255. */
-static inline int
+COAP_STATIC_INLINE int
 is_long_option(unsigned short type) { return type > 255; }
 
 /** Operation specifiers for coap_filter_op(). */

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -214,19 +214,16 @@ coap_new_pdu2(coap_transport_t transport, unsigned int size) {
 
 void
 coap_delete_pdu(coap_pdu_t *pdu) {
-#if defined(WITH_POSIX) || defined(WITH_CONTIKI)
   if (pdu != NULL) {
+#ifdef WITH_LWIP
+    pbuf_free(pdu->pbuf);
+#else
     if (pdu->hdr != NULL) {
       coap_free_type(COAP_PDU_BUF, pdu->hdr);
     }
+#endif
     coap_free_type(COAP_PDU, pdu);
   }
-#endif
-#ifdef WITH_LWIP
-  if (pdu != NULL) /* accepting double free as the other implementation accept that too */
-    pbuf_free(pdu->pbuf);
-  coap_free_type(COAP_PDU, pdu);
-#endif
 }
 
 #ifdef WITH_TCP

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -85,7 +85,7 @@ coap_pdu_init(unsigned char type, unsigned char code,
     return NULL;
 
   /* size must be large enough for hdr */
-#if defined(WITH_POSIX) || defined(WITH_CONTIKI)
+#if !defined(WITH_LWIP)
   pdu = coap_malloc_type(COAP_PDU, sizeof(coap_pdu_t));
   if (!pdu) return NULL;
   pdu->hdr = coap_malloc_type(COAP_PDU_BUF, size);

--- a/src/resource.c
+++ b/src/resource.c
@@ -29,7 +29,7 @@
 
 #endif
 
-#ifdef WITH_POSIX
+#if !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
 
 #define COAP_MALLOC_TYPE(Type) \
   ((coap_##Type##_t *)coap_malloc(sizeof(coap_##Type##_t)))
@@ -50,19 +50,21 @@ coap_resources_init() {
   memb_init(&subscription_storage);
 }
 
-static inline coap_subscription_t *
+COAP_STATIC_INLINE coap_subscription_t *
 coap_malloc_subscription() {
   return memb_alloc(&subscription_storage);
 }
 
-static inline void
+COAP_STATIC_INLINE void
 coap_free_subscription(coap_subscription_t *subscription) {
   memb_free(&subscription_storage, subscription);
 }
 
 #endif /* WITH_CONTIKI */
 
+#ifndef min
 #define min(a,b) ((a) < (b) ? (a) : (b))
+#endif
 
 /* Helper functions for conditional output of character sequences into
  * a given buffer. The first Offset characters are skipped.

--- a/src/resource.c
+++ b/src/resource.c
@@ -116,7 +116,7 @@ match(const str *text, const str *pattern, int match_prefix, int match_substring
     while (remaining_length) {
       size_t token_length;
       unsigned char *token = next_token;
-      next_token = memchr(token, ' ', remaining_length);
+      next_token = (unsigned char *)memchr(token, ' ', remaining_length);
 
       if (next_token) {
         token_length = next_token - token;

--- a/src/str.c
+++ b/src/str.c
@@ -15,8 +15,8 @@
 #include "str.h"
 
 str *coap_new_string(size_t size) {
-  str *s = coap_malloc(sizeof(str) + size + 1);
-  if ( !s ) {
+  str *s = (str *)coap_malloc(sizeof(str) + size + 1);
+  if (!s) {
 #ifndef NDEBUG
     coap_log(LOG_CRIT, "coap_new_string: malloc\n");
 #endif

--- a/src/uri.c
+++ b/src/uri.c
@@ -414,7 +414,7 @@ coap_uri_t *
 coap_new_uri(const unsigned char *uri, unsigned int length) {
   unsigned char *result;
 
-  result = coap_malloc(length + 1 + sizeof(coap_uri_t));
+  result = (unsigned char *)coap_malloc(length + 1 + sizeof(coap_uri_t));
 
   if (!result)
     return NULL;
@@ -476,7 +476,7 @@ coap_clone_uri(const coap_uri_t *uri) {
  * segment_handler_t hence we use this wrapper as safe typecast. */
 COAP_STATIC_INLINE void
 hash_segment(unsigned char *s, size_t len, void *data) {
-  coap_hash(s, len, data);
+  coap_hash(s, len, (unsigned char *)data);
 }
 
 int
@@ -530,14 +530,14 @@ coap_parse_next(coap_parse_iterator_t *pi) {
 
     /* skip following separator (the first segment might not have one) */
 
-      if (strchr((const char*)s,*(pi->pos))) {
+      if (strchr((const char*)s, *(pi->pos))) {
           ++pi->pos;
           --pi->n;
       }
 
       p = pi->pos;
 
-      while ((pi->segment_length < pi->n) && (!strchr((const char*)s,*p))
+      while ((pi->segment_length < pi->n) && (!strchr((const char*)s, *p))
               && (!strnchr(pi->delim, pi->dlen, *p))) {
           ++p;
           ++pi->segment_length;

--- a/src/uri.c
+++ b/src/uri.c
@@ -33,7 +33,7 @@
  * @return A pointer to the first occurence of @p c, or @c NULL 
  * if not found.
  */
-static inline unsigned char *
+COAP_STATIC_INLINE unsigned char *
 strnchr(unsigned char *s, size_t len, unsigned char c) {
   while (len && *s++ != c)
     --len;
@@ -308,7 +308,7 @@ typedef void (*segment_handler_t)(unsigned char *, size_t, void *);
 /**
  * Checks if path segment @p s consists of one or two dots.
  */
-static inline int
+COAP_STATIC_INLINE int
 dots(unsigned char *s, size_t len) {
   return *s == '.' && (len == 1 || (*(s+1) == '.' && len == 2));
 }
@@ -474,7 +474,7 @@ coap_clone_uri(const coap_uri_t *uri) {
 
 /* The function signature of coap_hash() is different from
  * segment_handler_t hence we use this wrapper as safe typecast. */
-static inline void
+COAP_STATIC_INLINE void
 hash_segment(unsigned char *s, size_t len, void *data) {
   coap_hash(s, len, data);
 }


### PR DESCRIPTION
These changes were already in the Iotivity code base, and we're trying to unfork libcoap and have iotivity just use the regular libcoap library.   These changes include support for draft-ietf-core-coap-tcp-tls and some cross-platform fixes (e.g., to also run on Windows).