### PR TITLE
debug: prefix debug message macros with coap_

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -146,7 +146,7 @@ coap_new_request(coap_context_t *ctx,
 
   pdu->hdr->token_length = the_token.length;
   if ( !coap_add_token(pdu, the_token.length, the_token.s)) {
-    debug("cannot add token to request\n");
+    coap_debug("cannot add token to request\n");
   }
 
   coap_show_pdu(pdu);
@@ -245,7 +245,7 @@ clear_obs(coap_context_t *ctx,
     tid = coap_send(ctx, local_interface, remote, pdu);
 
   if (tid == COAP_INVALID_TID) {
-    debug("clear_obs: error sending new request");
+    coap_debug("clear_obs: error sending new request");
     coap_delete_pdu(pdu);
   } else if (pdu->hdr->type != COAP_MESSAGE_CON)
     coap_delete_pdu(pdu);
@@ -330,7 +330,7 @@ message_handler(struct coap_context_t *ctx,
 
 #ifndef NDEBUG
   if (LOG_DEBUG <= coap_get_log_level()) {
-    debug("** process incoming %d.%02d response:\n",
+    coap_debug("** process incoming %d.%02d response:\n",
           (received->hdr->code >> 5), received->hdr->code & 0x1F);
     coap_show_pdu(received);
   }
@@ -346,7 +346,7 @@ message_handler(struct coap_context_t *ctx,
   }
 
   if (received->hdr->type == COAP_MESSAGE_RST) {
-    info("got RST\n");
+    coap_info("got RST\n");
     return;
   }
 
@@ -355,7 +355,7 @@ message_handler(struct coap_context_t *ctx,
 
     /* set obs timer if we have successfully subscribed a resource */
     if (sent && coap_check_option(received, COAP_OPTION_SUBSCRIPTION, &opt_iter)) {
-      debug("observation relationship established, set timeout to %d\n", obs_seconds);
+      coap_debug("observation relationship established, set timeout to %d\n", obs_seconds);
       set_timeout(&obs_wait, obs_seconds);
     }
 
@@ -371,7 +371,7 @@ message_handler(struct coap_context_t *ctx,
 
       if(COAP_OPT_BLOCK_MORE(block_opt)) {
         /* more bit is set */
-        debug("found the M bit, block size is %u, block nr. %u\n",
+        coap_debug("found the M bit, block size is %u, block nr. %u\n",
               COAP_OPT_BLOCK_SZX(block_opt),
               coap_opt_block_num(block_opt));
 
@@ -398,7 +398,7 @@ message_handler(struct coap_context_t *ctx,
 
           /* finally add updated block option from response, clear M bit */
           /* blocknr = (blocknr & 0xfffffff7) + 0x10; */
-          debug("query block %d\n", (coap_opt_block_num(block_opt) + 1));
+          coap_debug("query block %d\n", (coap_opt_block_num(block_opt) + 1));
           coap_add_option(pdu,
                           blktype,
                           coap_encode_var_bytes(buf,
@@ -411,7 +411,7 @@ message_handler(struct coap_context_t *ctx,
             tid = coap_send(ctx, local_interface, remote, pdu);
 
           if (tid == COAP_INVALID_TID) {
-            debug("message_handler: error sending new request");
+            coap_debug("message_handler: error sending new request");
             coap_delete_pdu(pdu);
           } else {
             set_timeout(&max_wait, wait_seconds);
@@ -429,11 +429,11 @@ message_handler(struct coap_context_t *ctx,
         block.szx = COAP_OPT_BLOCK_SZX(block_opt);
         block.num = coap_opt_block_num(block_opt);
 
-        debug("found Block1, block size is %u, block nr. %u\n",
+        coap_debug("found Block1, block size is %u, block nr. %u\n",
         block.szx, block.num);
 
         if (payload.length <= (block.num+1) * (1 << (block.szx + 4))) {
-          debug("upload ready\n");
+          coap_debug("upload ready\n");
           ready = 1;
           return;
         }
@@ -466,7 +466,7 @@ message_handler(struct coap_context_t *ctx,
           block.num++;
           block.m = ((block.num+1) * (1 << (block.szx + 4)) < payload.length);
 
-          debug("send block %d\n", block.num);
+          coap_debug("send block %d\n", block.num);
           coap_add_option(pdu,
                           COAP_OPTION_BLOCK1,
                           coap_encode_var_bytes(buf,
@@ -484,7 +484,7 @@ message_handler(struct coap_context_t *ctx,
             tid = coap_send(ctx, local_interface, remote, pdu);
 
           if (tid == COAP_INVALID_TID) {
-            debug("message_handler: error sending new request");
+            coap_debug("message_handler: error sending new request");
             coap_delete_pdu(pdu);
           } else {
             set_timeout(&max_wait, wait_seconds);
@@ -518,7 +518,7 @@ message_handler(struct coap_context_t *ctx,
 
   /* finally send new request, if needed */
   if (pdu && coap_send(ctx, local_interface, remote, pdu) == COAP_INVALID_TID) {
-    debug("message_handler: error sending response");
+    coap_debug("message_handler: error sending response");
   }
   coap_delete_pdu(pdu);
 
@@ -641,7 +641,7 @@ cmdline_content_type(char *arg, unsigned short key) {
         value[valcnt] = content_types[i].code;
         valcnt++;
       } else {
-        warn("W: unknown content-format '%s'\n",arg);
+        coap_warn("W: unknown content-format '%s'\n",arg);
       }
     }
 
@@ -1190,7 +1190,7 @@ main(int argc, char **argv) {
 
 #ifndef NDEBUG
   if (LOG_DEBUG <= coap_get_log_level()) {
-    debug("sending CoAP request:\n");
+    coap_debug("sending CoAP request:\n");
     coap_show_pdu(pdu);
   }
 #endif
@@ -1204,7 +1204,7 @@ main(int argc, char **argv) {
     coap_delete_pdu(pdu);
 
   set_timeout(&max_wait, wait_seconds);
-  debug("timeout is set to %d seconds\n", wait_seconds);
+  coap_debug("timeout is set to %d seconds\n", wait_seconds);
 
   while ( !(ready && coap_can_exit(ctx)) ) {
     FD_ZERO(&readfds);
@@ -1245,11 +1245,11 @@ main(int argc, char **argv) {
     } else { /* timeout */
       coap_ticks(&now);
       if (max_wait <= now) {
-        info("timeout\n");
+        coap_info("timeout\n");
         break;
       }
       if (obs_wait && obs_wait <= now) {
-        debug("clear observation relationship\n");
+        coap_debug("clear observation relationship\n");
         clear_obs(ctx, ctx->endpoint, &dst); /* FIXME: handle error case COAP_TID_INVALID */
 
         /* make sure that the obs timer does not fire again */

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -153,7 +153,7 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
 
         tmp.s = (unsigned char *)coap_malloc(tmp.length);
         if (!tmp.s) {
-          debug("hnd_put_rd: cannot allocate storage for new rd\n");
+          coap_debug("hnd_put_rd: cannot allocate storage for new rd\n");
           code = COAP_RESPONSE_CODE(503);
           goto finish;
         }
@@ -183,7 +183,7 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
   response = coap_pdu_init(type, code, request->hdr->id, size);
 
   if (!response) {
-    debug("cannot create response for message %d\n", request->hdr->id);
+    coap_debug("cannot create response for message %d\n", request->hdr->id);
     return;
   }
 
@@ -191,7 +191,7 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
     coap_add_token(response, request->hdr->token_length, request->hdr->token);
 
   if (coap_send(ctx, peer, response) == COAP_INVALID_TID) {
-    debug("hnd_get_rd: cannot send response for message %d\n",
+    coap_debug("hnd_get_rd: cannot send response for message %d\n",
     request->hdr->id);
   }
   coap_delete_pdu(response);
@@ -361,14 +361,14 @@ make_rd(coap_address_t *peer UNUSED_PARAM, coap_pdu_t *pdu) {
   rd = rd_new();
 
   if (!rd) {
-    debug("hnd_get_rd: cannot allocate storage for rd\n");
+    coap_debug("hnd_get_rd: cannot allocate storage for rd\n");
     return NULL;
   }
 
   if (coap_get_data(pdu, &rd->data.length, &data)) {
     rd->data.s = (unsigned char *)coap_malloc(rd->data.length);
     if (!rd->data.s) {
-      debug("hnd_get_rd: cannot allocate storage for rd->data\n");
+      coap_debug("hnd_get_rd: cannot allocate storage for rd->data\n");
       rd_delete(rd);
       return NULL;
     }

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -261,7 +261,7 @@ check_async(coap_context_t *ctx,
              : COAP_MESSAGE_NON,
              COAP_RESPONSE_CODE(205), 0, size);
   if (!response) {
-    debug("check_async: insufficient memory, we'll try later\n");
+    coap_debug("check_async: insufficient memory, we'll try later\n");
     async->appdata =
       (void *)((unsigned long)async->appdata + 15 * COAP_TICKS_PER_SECOND);
     return;
@@ -275,7 +275,7 @@ check_async(coap_context_t *ctx,
   coap_add_data(response, 4, (unsigned char *)"done");
 
   if (coap_send(ctx, local_if, &async->peer, response) == COAP_INVALID_TID) {
-    debug("check_async: cannot send response for message %d\n",
+    coap_debug("check_async: cannot send response for message %d\n",
     response->hdr->id);
   }
   coap_delete_pdu(response);

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -348,7 +348,7 @@ hnd_put_test(coap_context_t  *ctx, struct coap_resource_t *resource,
 
   return;
  error:
-  warn("cannot modify resource\n");
+  coap_warn("cannot modify resource\n");
   response->hdr->code = COAP_RESPONSE_CODE(500);
 }
 
@@ -442,7 +442,7 @@ hnd_get_separate(coap_context_t  *ctx, struct coap_resource_t *resource,
       delay = d < COAP_RESOURCE_CHECK_TIME_SEC 
 	? COAP_RESOURCE_CHECK_TIME_SEC
 	: d;
-      debug("set delay to %lu\n", delay);
+      coap_debug("set delay to %lu\n", delay);
       break;
     }
   }
@@ -468,7 +468,7 @@ check_async(coap_context_t  *ctx, coap_tick_t now) {
 			   : COAP_MESSAGE_NON, 
 			   COAP_RESPONSE_CODE(205), 0, size);
   if (!response) {
-    debug("check_async: insufficient memory, we'll try later\n");
+    coap_debug("check_async: insufficient memory, we'll try later\n");
     async->appdata = 
       (void *)((unsigned long)async->appdata + 15 * COAP_TICKS_PER_SECOND);
     return;
@@ -485,7 +485,7 @@ check_async(coap_context_t  *ctx, coap_tick_t now) {
   coap_add_data(response, 4, (unsigned char *)"done");
 
   if (coap_send(ctx, &async->peer, response) == COAP_INVALID_TID) {
-    debug("check_async: cannot send response for message %d\n", 
+    coap_debug("check_async: cannot send response for message %d\n", 
 	  response->hdr->id);
   }
   coap_delete_pdu(response);
@@ -506,7 +506,7 @@ make_large(char *filename) {
 
   /* read from specified input file */
   if (stat(filename, &statbuf) < 0) {
-    warn("cannot stat file %s\n", filename);
+    coap_warn("cannot stat file %s\n", filename);
     return NULL;
   }
 
@@ -516,7 +516,7 @@ make_large(char *filename) {
 
   inputfile = fopen(filename, "r");
   if ( !inputfile ) {
-    warn("cannot read file %s\n", filename);
+    coap_warn("cannot read file %s\n", filename);
     coap_free(payload);
     return NULL;
   }

--- a/include/coap/debug.h
+++ b/include/coap/debug.h
@@ -61,9 +61,9 @@ void coap_log_impl(coap_log_t level, const char *format, ...);
 #ifndef NDEBUG
 
 /* A set of convenience macros for common log levels. */
-#define info(...) coap_log(LOG_INFO, __VA_ARGS__)
-#define warn(...) coap_log(LOG_WARNING, __VA_ARGS__)
-#define debug(...) coap_log(LOG_DEBUG, __VA_ARGS__)
+#define coap_info(...) coap_log(LOG_INFO, __VA_ARGS__)
+#define coap_warn(...) coap_log(LOG_WARNING, __VA_ARGS__)
+#define coap_debug(...) coap_log(LOG_DEBUG, __VA_ARGS__)
 
 #include "pdu.h"
 void coap_show_pdu(const coap_pdu_t *);
@@ -73,9 +73,9 @@ size_t coap_print_addr(const struct coap_address_t *, unsigned char *, size_t);
 
 #else
 
-#define debug(...)
-#define info(...)
-#define warn(...)
+#define coap_debug(...)
+#define coap_info(...)
+#define coap_warn(...)
 
 #define coap_show_pdu(x)
 #define coap_print_addr(...)

--- a/src/async.c
+++ b/src/async.c
@@ -32,7 +32,7 @@ coap_register_async(coap_context_t *context, coap_address_t *peer,
   if (s != NULL) {
     /* We must return NULL here as the caller must know that he is
      * responsible for releasing @p data. */
-    debug("asynchronous state for transaction %d already registered\n", id);
+    coap_debug("asynchronous state for transaction %d already registered\n", id);
     return NULL;
   }
 

--- a/src/block.c
+++ b/src/block.c
@@ -79,7 +79,7 @@ coap_write_block_opt(coap_block_t *block, unsigned short type,
 
   start = block->num << (block->szx + 4);
   if (data_length <= start) {
-    debug("illegal block requested\n");
+    coap_debug("illegal block requested\n");
     return -2;
   }
   
@@ -104,10 +104,10 @@ coap_write_block_opt(coap_block_t *block, unsigned short type,
 
       /* we need to decrease the block size */
       if (avail < 16) { 	/* bad luck, this is the smallest block size */
-	debug("not enough space, even the smallest block does not fit");
+	coap_debug("not enough space, even the smallest block does not fit");
 	return -3;
       }
-      debug("decrease block size for %zu to %d\n", avail, coap_fls(avail) - 5);
+      coap_debug("decrease block size for %zu to %d\n", avail, coap_fls(avail) - 5);
       szx = block->szx;
       block->szx = coap_fls(avail) - 5;
       block->m = 1;

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -181,7 +181,7 @@ coap_new_endpoint(const coap_address_t *addr, int flags) {
     unsigned char addr_str[INET6_ADDRSTRLEN+8];
 
     if (coap_print_addr(&ep->addr, addr_str, INET6_ADDRSTRLEN+8)) {
-      debug("created %sendpoint %s\n", 
+      coap_debug("created %sendpoint %s\n", 
 	    ep->flags & COAP_ENDPOINT_DTLS ? "DTLS " : "",
 	    addr_str);
     }
@@ -422,7 +422,7 @@ coap_network_read(coap_endpoint_t *ep, coap_packet_t **packet) {
   *packet = coap_malloc_packet();
   
   if (!*packet) {
-    warn("coap_network_read: insufficient memory, drop packet\n");
+    coap_warn("coap_network_read: insufficient memory, drop packet\n");
     return -1;
   }
 
@@ -536,7 +536,7 @@ coap_network_read(coap_endpoint_t *ep, coap_packet_t **packet) {
     
     if (len > coap_get_max_packetlength(*packet)) {
       /* FIXME: we might want to send back a response */
-      warn("discarded oversized packet\n");
+      coap_warn("discarded oversized packet\n");
       return -1;
     }
 
@@ -549,7 +549,7 @@ coap_network_read(coap_endpoint_t *ep, coap_packet_t **packet) {
       unsigned char addr_str[INET6_ADDRSTRLEN+8];
       
       if (coap_print_addr(&(*packet)->src, addr_str, INET6_ADDRSTRLEN+8)) {
-	debug("received %zd bytes from %s\n", len, addr_str);
+	coap_debug("received %zd bytes from %s\n", len, addr_str);
       }
     }
 #endif /* NDEBUG */

--- a/src/mem.c
+++ b/src/mem.c
@@ -105,7 +105,7 @@ coap_malloc_type(coap_memory_tag_t type, size_t size) {
   assert(container);
 
   if (size > container->size) {
-    debug("coap_malloc_type: Requested memory exceeds maximum object size\n");
+    coap_debug("coap_malloc_type: Requested memory exceeds maximum object size\n");
     return NULL;
   }
 

--- a/src/option.c
+++ b/src/option.c
@@ -43,7 +43,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
   assert(opt); assert(result);
 
 #define ADVANCE_OPT(o,e,step) if ((e) < step) {			\
-    debug("cannot advance opt past end\n");			\
+    coap_debug("cannot advance opt past end\n");			\
     return 0;							\
   } else {							\
     (e) -= step;						\
@@ -59,7 +59,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
   switch(result->delta) {
   case 15:
     if (*opt != COAP_PAYLOAD_START) {
-      debug("ignored reserved option delta 15\n");
+      coap_debug("ignored reserved option delta 15\n");
     }
     return 0;
   case 14:
@@ -69,7 +69,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
     ADVANCE_OPT(opt,length,1);
     result->delta = ((*opt & 0xff) << 8) + 269;
     if (result->delta < 269) {
-      debug("delta too large\n");
+      coap_debug("delta too large\n");
       return 0;
     }
     /* fall through */
@@ -84,7 +84,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
 
   switch(result->length) {
   case 15:
-    debug("found reserved option length 15\n");
+    coap_debug("found reserved option length 15\n");
     return 0;
   case 14:
     /* Handle two-byte value: First, the MSB + 269 is stored as delta value.
@@ -107,7 +107,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
 
   result->value = (unsigned char *)opt;
   if (length < result->length) {
-    debug("invalid option length\n");
+    coap_debug("invalid option length\n");
     return 0;
   }
 
@@ -226,7 +226,7 @@ coap_opt_delta(const coap_opt_t *opt) {
 
   switch (n) {
   case 15: /* error */
-    warn("coap_opt_delta: illegal option delta\n");
+    coap_warn("coap_opt_delta: illegal option delta\n");
 
     /* This case usually should not happen, hence we do not have a
      * proper way to indicate an error. */
@@ -254,7 +254,7 @@ coap_opt_length(const coap_opt_t *opt) {
   length = *opt & 0x0f;
   switch (*opt & 0xf0) {
   case 0xf0:
-    debug("illegal option delta\n");
+    coap_debug("illegal option delta\n");
     return 0;
   case 0xe0:
     ++opt;
@@ -268,7 +268,7 @@ coap_opt_length(const coap_opt_t *opt) {
 
   switch (length) {
   case 0x0f:
-    debug("illegal option length\n");
+    coap_debug("illegal option length\n");
     return 0;
   case 0x0e:
     length = (*opt++ << 8) + 269;
@@ -288,7 +288,7 @@ coap_opt_value(coap_opt_t *opt) {
 
   switch (*opt & 0xf0) {
   case 0xf0:
-    debug("illegal option delta\n");
+    coap_debug("illegal option delta\n");
     return 0;
   case 0xe0:
     ++ofs;
@@ -302,7 +302,7 @@ coap_opt_value(coap_opt_t *opt) {
 
   switch (*opt & 0x0f) {
   case 0x0f:
-    debug("illegal option length\n");
+    coap_debug("illegal option length\n");
     return 0;
   case 0x0e:
     ++ofs;
@@ -339,7 +339,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[0] = delta << 4;
   } else if (delta < 270) {
     if (maxlen < 2) {
-      debug("insufficient space to encode option delta %d\n", delta);
+      coap_debug("insufficient space to encode option delta %d\n", delta);
       return 0;
     }
 
@@ -347,7 +347,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[++skip] = delta - 13;
   } else {
     if (maxlen < 3) {
-      debug("insufficient space to encode option delta %d\n", delta);
+      coap_debug("insufficient space to encode option delta %d\n", delta);
       return 0;
     }
 
@@ -360,7 +360,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[0] |= length & 0x0f;
   } else if (length < 270) {
     if (maxlen < skip + 2) {
-      debug("insufficient space to encode option length %zu\n", length);
+      coap_debug("insufficient space to encode option length %zu\n", length);
       return 0;
     }
     
@@ -368,7 +368,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[++skip] = length - 13;
   } else {
     if (maxlen < skip + 3) {
-      debug("insufficient space to encode option delta %d\n", delta);
+      coap_debug("insufficient space to encode option delta %d\n", delta);
       return 0;
     }
 
@@ -389,7 +389,7 @@ coap_opt_encode(coap_opt_t *opt, size_t maxlen, unsigned short delta,
   assert(l <= maxlen);
   
   if (!l) {
-    debug("coap_opt_encode: cannot set option header\n");
+    coap_debug("coap_opt_encode: cannot set option header\n");
     return 0;
   }
   
@@ -397,7 +397,7 @@ coap_opt_encode(coap_opt_t *opt, size_t maxlen, unsigned short delta,
   opt += l;
 
   if (maxlen < length) {
-    debug("coap_opt_encode: option too large for buffer\n");
+    coap_debug("coap_opt_encode: option too large for buffer\n");
     return 0;
   }
 

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -176,7 +176,7 @@ coap_add_option(coap_pdu_t *pdu, unsigned short type, unsigned int len, const un
   pdu->data = NULL;
 
   if (type < pdu->max_delta) {
-    warn("coap_add_option: options are not in correct order\n");
+    coap_warn("coap_add_option: options are not in correct order\n");
     return 0;
   }
 
@@ -187,7 +187,7 @@ coap_add_option(coap_pdu_t *pdu, unsigned short type, unsigned int len, const un
 			    type - pdu->max_delta, data, len);
 
   if (!optsize) {
-    warn("coap_add_option: cannot add option\n");
+    coap_warn("coap_add_option: cannot add option\n");
     /* error */
     return 0;
   } else {
@@ -208,7 +208,7 @@ coap_add_option_later(coap_pdu_t *pdu, unsigned short type, unsigned int len) {
   pdu->data = NULL;
 
   if (type < pdu->max_delta) {
-    warn("coap_add_option: options are not in correct order\n");
+    coap_warn("coap_add_option: options are not in correct order\n");
     return NULL;
   }
 
@@ -219,7 +219,7 @@ coap_add_option_later(coap_pdu_t *pdu, unsigned short type, unsigned int len) {
 			    type - pdu->max_delta, NULL, len);
 
   if (!optsize) {
-    warn("coap_add_option: cannot add option\n");
+    coap_warn("coap_add_option: cannot add option\n");
     /* error */
     return NULL;
   } else {
@@ -239,7 +239,7 @@ coap_add_data(coap_pdu_t *pdu, unsigned int len, const unsigned char *data) {
     return 1;
 
   if (pdu->length + len + 1 > pdu->max_size) {
-    warn("coap_add_data: cannot add: data too large for PDU\n");
+    coap_warn("coap_add_data: cannot add: data too large for PDU\n");
     assert(pdu->data == NULL);
     return 0;
   }
@@ -345,12 +345,12 @@ coap_pdu_parse(unsigned char *data, size_t length, coap_pdu_t *pdu) {
   assert(pdu);
 
   if (pdu->max_size < length) {
-    debug("insufficient space to store parsed PDU\n");
+    coap_debug("insufficient space to store parsed PDU\n");
     return 0;
   }
 
   if (length < sizeof(coap_hdr_t)) {
-    debug("discarded invalid PDU\n");
+    coap_debug("discarded invalid PDU\n");
   }
 
 #ifdef WITH_LWIP
@@ -371,14 +371,14 @@ coap_pdu_parse(unsigned char *data, size_t length, coap_pdu_t *pdu) {
   /* sanity checks */
   if (pdu->hdr->code == 0) {
     if (length != sizeof(coap_hdr_t) || pdu->hdr->token_length) {
-      debug("coap_pdu_parse: empty message is not empty\n");
+      coap_debug("coap_pdu_parse: empty message is not empty\n");
       goto discard;
     }
   }
 
   if (length < sizeof(coap_hdr_t) + pdu->hdr->token_length
       || pdu->hdr->token_length > 8) {
-    debug("coap_pdu_parse: invalid Token\n");
+    coap_debug("coap_pdu_parse: invalid Token\n");
     goto discard;
   }
 
@@ -401,7 +401,7 @@ coap_pdu_parse(unsigned char *data, size_t length, coap_pdu_t *pdu) {
 
   while (length && *opt != COAP_PAYLOAD_START) {
     if (!next_option_safe(&opt, (size_t *)&length)) {
-      debug("coap_pdu_parse: drop\n");
+      coap_debug("coap_pdu_parse: drop\n");
       goto discard;
     }
   }
@@ -412,11 +412,11 @@ coap_pdu_parse(unsigned char *data, size_t length, coap_pdu_t *pdu) {
     opt++; length--;
 
     if (!length) {
-      debug("coap_pdu_parse: message ending in payload start marker\n");
+      coap_debug("coap_pdu_parse: message ending in payload start marker\n");
       goto discard;
     }
 
-    debug("set data to %p (pdu ends at %p)\n", (unsigned char *)opt, 
+    coap_debug("set data to %p (pdu ends at %p)\n", (unsigned char *)opt, 
 	  (unsigned char *)pdu->hdr + pdu->length);
     pdu->data = (unsigned char *)opt;
   }

--- a/src/resource.c
+++ b/src/resource.c
@@ -304,7 +304,7 @@ coap_resource_init(const unsigned char *uri, size_t len, int flags) {
 
     r->flags = flags;
   } else {
-    debug("coap_resource_init: no memory left\n");
+    coap_debug("coap_resource_init: no memory left\n");
   }
   
   return r;
@@ -339,7 +339,7 @@ coap_add_attr(coap_resource_t *resource,
     /* add attribute to resource list */
     LL_PREPEND(resource->link_attr, attr);
   } else {
-    debug("coap_add_attr: no memory left\n");
+    coap_debug("coap_add_attr: no memory left\n");
   }
   
   return attr;
@@ -632,14 +632,14 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
       if (!response) {
         obs->dirty = 1;
         r->partiallydirty = 1;
-	debug("coap_check_notify: pdu init failed, resource stays partially dirty\n");
+	coap_debug("coap_check_notify: pdu init failed, resource stays partially dirty\n");
 	continue;
       }
 
       if (!coap_add_token(response, obs->token_length, obs->token)) {
         obs->dirty = 1;
         r->partiallydirty = 1;
-	debug("coap_check_notify: cannot add token, resource stays partially dirty\n");
+	coap_debug("coap_check_notify: cannot add token, resource stays partially dirty\n");
 	coap_delete_pdu(response);
 	continue;
       }
@@ -672,7 +672,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
 	coap_delete_pdu(response);
       if (COAP_INVALID_TID == tid)
       {
-	debug("coap_check_notify: sending failed, resource stays partially dirty\n");
+	coap_debug("coap_check_notify: sending failed, resource stays partially dirty\n");
         obs->dirty = 1;
         r->partiallydirty = 1;
       }
@@ -731,7 +731,7 @@ coap_remove_failed_observers(coap_context_t *context,
 	  unsigned char addr[INET6_ADDRSTRLEN+8];
 
 	  if (coap_print_addr(&obs->subscriber, addr, INET6_ADDRSTRLEN+8))
-	    debug("** removed observer %s\n", addr);
+	    coap_debug("** removed observer %s\n", addr);
 	}
 #endif
 	coap_cancel_all_messages(context, &obs->subscriber, 

--- a/src/uri.c
+++ b/src/uri.c
@@ -269,7 +269,7 @@ make_decoded_option(const unsigned char *s, size_t length,
   size_t written;
 
   if (!buflen) {
-    debug("make_decoded_option(): buflen is 0!\n");
+    coap_debug("make_decoded_option(): buflen is 0!\n");
     return -1;
   }
 
@@ -289,7 +289,7 @@ make_decoded_option(const unsigned char *s, size_t length,
   buflen -= written;
 
   if (buflen < (size_t)res) {
-    debug("buffer too small for option\n");
+    coap_debug("buffer too small for option\n");
     return -1;
   }
 


### PR DESCRIPTION
automated replacement using 

```
sed -i -e 's/\binfo(/coap_info(/g' -e 's/\bwarn(/coap_warn(/g' -e 's/\bdebug(/coap_debug(/g' {include/coap,src,examples}/*.[ch]
```
