### PR TITLE
Allow client example to not generate Uri-Host and Uri-Port options

### DIFF
--- a/examples/coap-client.txt.in
+++ b/examples/coap-client.txt.in
@@ -105,6 +105,9 @@ OPTIONS
 *-T* token::
    Include the 'token' to the request.
 
+*-U* ::
+   Never include Uri-Host or Uri-Port options.
+
 EXAMPLES
 --------
 * Example


### PR DESCRIPTION
Added a new command line option, -U.

I work with constrained implementations of CoAP, [gcoap](https://github.com/RIOT-OS/RIOT/pull/5598) and [nanocoap](https://github.com/kaspar030/sock/tree/master/nanocoap). I appreciate having the examples in libcoap to test against. However, these constrained implementations have no need for the Uri-Host or Uri-Port options -- there always is a single host and port being served. Since these options are 'critical', the implementation can't ignore them, so I would like the ability to ensure they will not be sent.