### PR TITLE
Fixing coap_remove_failed_observers() loop.

### DIFF
--- a/src/resource.c
+++ b/src/resource.c
@@ -739,8 +739,8 @@ coap_remove_failed_observers(coap_context_t *context,
 
 	COAP_FREE_TYPE(subscription, obs);
       }
+      break;			/* break loop if observer was found */
     }
-    break;			/* break loop if observer was found */
   }
 }
 


### PR DESCRIPTION
The loop was always exiting after analysing the first observer,
so in case there were more and the first one on the list of
observers didn't match the one we wanted to remove, the
observer never got removed.

Signed-off-by: Pawel Winogrodzki <pawelwi@microsoft.com>