### PR TITLE
Fixing /W4 warnings for Windows builds.

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -587,7 +587,7 @@ usage( const char *program, const char *version) {
 }
 
 static coap_list_t *
-new_option_node(unsigned short key, unsigned int length, unsigned char *data) {
+new_option_node(unsigned short key, size_t length, unsigned char *data) {
   coap_list_t *node;
 
   node = coap_malloc(sizeof(coap_list_t) + sizeof(coap_option) + length);

--- a/include/coap/coap_io.h
+++ b/include/coap/coap_io.h
@@ -15,6 +15,12 @@
 
 #include "address.h"
 
+#ifdef HAVE_WS2TCPIP_H
+typedef SOCKET coap_socket_t;
+#else
+typedef int coap_socket_t;
+#endif
+
 /**
  * Abstract handle that is used to identify a local network interface.
  */
@@ -35,9 +41,9 @@ struct coap_context_t;
 typedef struct coap_endpoint_t {
 #if defined(WITH_POSIX) || defined(WITH_CONTIKI)
   union {
-    int fd;       /**< on POSIX systems */
-    void *conn;   /**< opaque connection (e.g. uip_conn in Contiki) */
-  } handle;       /**< opaque handle to identify this endpoint */
+    coap_socket_t fd; /**< on POSIX, Contiki and Windows systems */
+    void *conn;       /**< opaque connection (e.g. uip_conn in Contiki) */
+  } handle;           /**< opaque handle to identify this endpoint */
 #endif /* WITH_POSIX or WITH_CONTIKI */
 
 #ifdef WITH_LWIP

--- a/include/coap/encode.h
+++ b/include/coap/encode.h
@@ -32,6 +32,13 @@ extern int coap_fls(unsigned int i);
 #define coap_fls(i) fls(i)
 #endif
 
+#ifndef HAVE_FLSLL
+ /* include this only if flsll() is not available */
+extern int coap_flsll(long long i);
+#else
+#define coap_flsll(i) flsll(i)
+#endif
+
 /* ls and s must be integer variables */
 #define COAP_PSEUDOFP_ENCODE_8_4_DOWN(v,ls) (v < HIBIT ? v : (ls = coap_fls(v) - Nn, (v >> ls) & MMASK) + ls)
 #define COAP_PSEUDOFP_ENCODE_8_4_UP(v,ls,s) (v < HIBIT ? v : (ls = coap_fls(v) - Nn, (s = (((v + ((1<<ENCODE_HEADER_SIZE<<ls)-1)) >> ls) & MMASK)), s == 0 ? HIBIT + ls + 1 : s + ls))

--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -387,9 +387,11 @@ int coap_handle_message(coap_context_t *ctx,
  * @param pdu  The message that initiated the transaction.
  * @param id   Set to the new id.
  */
+#if defined(WITH_POSIX) || defined(WITH_LWIP) || defined(WITH_CONTIKI)
 void coap_transaction_id(const coap_address_t *peer,
                          const coap_pdu_t *pdu,
                          coap_tid_t *id);
+#endif
 
 /**
  * This function removes the element with given @p id from the list given list.

--- a/src/block.c
+++ b/src/block.c
@@ -84,7 +84,7 @@ coap_write_block_opt(coap_block_t *block, unsigned short type,
   }
   
   avail = pdu->max_size - pdu->length - 4;
-  want = 1 << (block->szx + 4);
+  want = (size_t)1 << (block->szx + 4);
 
   /* check if entire block fits in message */
   if (want <= avail) {
@@ -100,16 +100,18 @@ coap_write_block_opt(coap_block_t *block, unsigned short type,
       /* it's the final block and everything fits in the message */
       block->m = 0;
     } else {
-      unsigned char szx;
+      unsigned int szx;
+      int newBlockSize;
 
       /* we need to decrease the block size */
       if (avail < 16) { 	/* bad luck, this is the smallest block size */
-	debug("not enough space, even the smallest block does not fit");
-	return -3;
+        debug("not enough space, even the smallest block does not fit");
+        return -3;
       }
-      debug("decrease block size for %zu to %d\n", avail, coap_fls(avail) - 5);
+      newBlockSize = coap_flsll((long long)avail) - 5;
+      debug("decrease block size for %zu to %d\n", avail, newBlockSize);
       szx = block->szx;
-      block->szx = coap_fls(avail) - 5;
+      block->szx = newBlockSize;
       block->m = 1;
       block->num <<= szx - block->szx;
     }
@@ -127,14 +129,14 @@ coap_write_block_opt(coap_block_t *block, unsigned short type,
 int 
 coap_add_block(coap_pdu_t *pdu, unsigned int len, const unsigned char *data,
 	       unsigned int block_num, unsigned char block_szx) {
-  size_t start;
+  unsigned int start;
   start = block_num << (block_szx + 4);
 
   if (len <= start)
     return 0;
   
   return coap_add_data(pdu, 
-		       min(len - start, (unsigned int)(1 << (block_szx + 4))),
+		       min(len - start, (1U << (block_szx + 4))),
 		       data + start);
 }
 #endif /* WITHOUT_BLOCK  */

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -258,6 +258,11 @@ coap_network_send(struct coap_context_t *context UNUSED_PARAM,
 #ifndef WITH_CONTIKI
   /* a buffer large enough to hold all protocol address types */
   char buf[CMSG_LEN(sizeof(struct sockaddr_storage))];
+  (void)datalen;
+  (void)data;
+  (void)context;
+
+  mhdr.Control.buf = buf;
   struct msghdr mhdr;
   struct iovec iov[1];
 
@@ -387,6 +392,7 @@ coap_free_packet(coap_packet_t *packet) {
 
 static inline size_t
 coap_get_max_packetlength(const coap_packet_t *packet UNUSED_PARAM) {
+  (void)packet;
   return COAP_MAX_PDU_SIZE;
 }
 
@@ -610,10 +616,12 @@ coap_network_read(coap_endpoint_t *ep, coap_packet_t **packet) {
   (*packet)->interface = ep;
 
   return len;
+#if defined(WITH_POSIX) || defined(WITH_CONTIKI)
  error:
   coap_free_packet(*packet);
   *packet = NULL;
   return -1;
+#endif
 }
 
 #undef SIN6

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -258,8 +258,6 @@ coap_network_send(struct coap_context_t *context UNUSED_PARAM,
 #ifndef WITH_CONTIKI
   /* a buffer large enough to hold all protocol address types */
   char buf[CMSG_LEN(sizeof(struct sockaddr_storage))];
-  (void)datalen;
-  (void)data;
   (void)context;
 
   struct msghdr mhdr;
@@ -347,6 +345,8 @@ coap_network_send(struct coap_context_t *context UNUSED_PARAM,
 #else /* WITH_CONTIKI */
   /* FIXME: untested */
   /* FIXME: is there a way to check if send was successful? */
+  (void)datalen;
+  (void)data;
   uip_udp_packet_sendto((struct uip_udp_conn *)ep->handle.conn, data, datalen, 
 			&dst->addr, dst->port);
   return datalen;
@@ -390,7 +390,7 @@ coap_free_packet(coap_packet_t *packet) {
 #endif /* WITH_CONTIKI */
 
 static inline size_t
-coap_get_max_packetlength(const coap_packet_t *packet UNUSED_PARAM) {
+coap_get_max_packetlength(const coap_packet_t *packet) {
   (void)packet;
   return COAP_MAX_PDU_SIZE;
 }

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -262,7 +262,6 @@ coap_network_send(struct coap_context_t *context UNUSED_PARAM,
   (void)data;
   (void)context;
 
-  mhdr.Control.buf = buf;
   struct msghdr mhdr;
   struct iovec iov[1];
 

--- a/src/coap_time.c
+++ b/src/coap_time.c
@@ -47,7 +47,7 @@ coap_clock_init(void) {
 
 void
 coap_ticks(coap_tick_t *t) {
-  coap_tick_t tmp;
+  unsigned long tmp;
 
 #ifdef COAP_CLOCK
   struct timespec tv;

--- a/src/coap_time.c
+++ b/src/coap_time.c
@@ -14,7 +14,7 @@
 #include "coap_config.h"
 #include "coap_time.h"
 
-static coap_time_t coap_clock_offset = 0;
+static coap_tick_t coap_clock_offset = 0;
 
 #if _POSIX_TIMERS && !defined(__APPLE__)
   /* _POSIX_TIMERS is > 0 when clock_gettime() is available */
@@ -23,6 +23,7 @@ static coap_time_t coap_clock_offset = 0;
 #define COAP_CLOCK CLOCK_REALTIME
 #endif
 
+  (void)tzp;
 void
 coap_clock_init(void) {
 #ifdef COAP_CLOCK
@@ -47,7 +48,7 @@ coap_clock_init(void) {
 
 void
 coap_ticks(coap_tick_t *t) {
-  unsigned long tmp;
+  coap_tick_t tmp;
 
 #ifdef COAP_CLOCK
   struct timespec tv;

--- a/src/coap_time.c
+++ b/src/coap_time.c
@@ -23,7 +23,6 @@ static coap_tick_t coap_clock_offset = 0;
 #define COAP_CLOCK CLOCK_REALTIME
 #endif
 
-  (void)tzp;
 void
 coap_clock_init(void) {
 #ifdef COAP_CLOCK

--- a/src/debug.c
+++ b/src/debug.c
@@ -117,11 +117,11 @@ strnlen(const char *s, size_t maxlen) {
 }
 #endif /* HAVE_STRNLEN */
 
-static unsigned int
-print_readable( const unsigned char *data, unsigned int len,
-		unsigned char *result, unsigned int buflen, int encode_always ) {
+static size_t
+print_readable( const unsigned char *data, size_t len,
+		unsigned char *result, size_t buflen, int encode_always ) {
   const unsigned char hex[] = "0123456789ABCDEF";
-  unsigned int cnt = 0;
+  size_t cnt = 0;
   assert(data || len == 0);
 
   if (buflen == 0) { /* there is nothing we can do here but return */
@@ -185,7 +185,8 @@ coap_print_addr(const struct coap_address_t *addr, unsigned char *buf, size_t le
     return min(22, len);
   }
 
-  if (inet_ntop(addr->addr.sa.sa_family, addrptr, (char *)p, len) == 0) {
+  /* Cast needed for Windows, since it doesn't have the correct API signature. */
+  if (inet_ntop(addr->addr.sa.sa_family, (void*)addrptr, (char *)p, len) == 0) {
     perror("coap_print_addr");
     return 0;
   }
@@ -261,7 +262,7 @@ coap_print_addr(const struct coap_address_t *addr, unsigned char *buf, size_t le
 
 /** Returns a textual description of the message type @p t. */
 static const char *
-msg_type_string(uint8_t t) {
+msg_type_string(unsigned short t) {
   static char *types[] = { "CON", "NON", "ACK", "RST", "???" };
 
   return types[min(t, sizeof(types)/sizeof(char *) - 1)];
@@ -269,7 +270,7 @@ msg_type_string(uint8_t t) {
 
 /** Returns a textual description of the method or response code. */
 static const char *
-msg_code_string(uint8_t c) {
+msg_code_string(unsigned short c) {
   static char *methods[] = { "0.00", "GET", "POST", "PUT", "DELETE", "PATCH" };
   static char buf[5];
 

--- a/src/encode.c
+++ b/src/encode.c
@@ -14,12 +14,21 @@
 #include "encode.h"
 
 /* Carsten suggested this when fls() is not available: */
+#ifndef HAVE_FLS
 int coap_fls(unsigned int i) {
+  return coap_flsll(i);
+}
+#endif
+
+#ifndef HAVE_FLSLL
+int coap_flsll(long long i)
+{
   int n;
   for (n = 0; i; n++)
     i >>= 1;
   return n;
 }
+#endif
 
 unsigned int
 coap_decode_var_bytes(unsigned char *buf,unsigned int len) {

--- a/src/mem.c
+++ b/src/mem.c
@@ -32,11 +32,13 @@ coap_memory_init(void) {
 
 void *
 coap_malloc_type(coap_memory_tag_t type UNUSED_PARAM, size_t size) {
+  (void)type;
   return malloc(size);
 }
 
 void
 coap_free_type(coap_memory_tag_t type UNUSED_PARAM, void *p) {
+  (void)type;
   free(p);
 }
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -31,13 +31,13 @@ coap_memory_init(void) {
 #endif /* __GNUC__ */
 
 void *
-coap_malloc_type(coap_memory_tag_t type UNUSED_PARAM, size_t size) {
+coap_malloc_type(coap_memory_tag_t type, size_t size) {
   (void)type;
   return malloc(size);
 }
 
 void
-coap_free_type(coap_memory_tag_t type UNUSED_PARAM, void *p) {
+coap_free_type(coap_memory_tag_t type, void *p) {
   (void)type;
   free(p);
 }

--- a/src/net.c
+++ b/src/net.c
@@ -494,6 +494,10 @@ coap_option_check_critical(coap_context_t *ctx,
 void
 coap_transaction_id(const coap_address_t *peer, const coap_pdu_t *pdu, 
 		    coap_tid_t *id) {
+#if !defined(WITH_POSIX) && !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
+  (void)peer;
+#endif
+
   coap_key_t h;
 
   memset(h, 0, sizeof(coap_key_t));
@@ -793,7 +797,7 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
   /* no more retransmissions, remove node from system */
 
 #ifndef WITH_CONTIKI
-  debug("** removed transaction %d\n", ntohs(node->id));
+  debug("** removed transaction %d\n", ntohl(node->id));
 #endif
 
 #ifndef WITHOUT_OBSERVE
@@ -1030,7 +1034,7 @@ coap_new_error_response(coap_pdu_t *request, unsigned char code,
   coap_opt_iterator_t opt_iter;
   coap_pdu_t *response;
   size_t size = sizeof(coap_hdr_t) + request->hdr->token_length;
-  int type; 
+  unsigned char type;
   coap_opt_t *option;
   unsigned short opt_type = 0;	/* used for calculating delta-storage */
 
@@ -1102,15 +1106,16 @@ coap_new_error_response(coap_pdu_t *request, unsigned char code,
 
     /* copy all options */
     coap_option_iterator_init(request, &opt_iter, opts);
-    while((option = coap_option_next(&opt_iter)))
-      coap_add_option(response, opt_iter.type, 
-		      COAP_OPT_LENGTH(option),
-		      COAP_OPT_VALUE(option));
+    while ((option = coap_option_next(&opt_iter))) {
+      coap_add_option(response, opt_iter.type,
+                      COAP_OPT_LENGTH(option),
+                      COAP_OPT_VALUE(option));
+    }
 
 #if COAP_ERROR_PHRASE_LENGTH > 0
     /* note that diagnostic messages do not need a Content-Format option. */
     if (phrase)
-      coap_add_data(response, strlen(phrase), (unsigned char *)phrase);
+      coap_add_data(response, (unsigned int)strlen(phrase), (unsigned char *)phrase);
 #endif
   }
 
@@ -1187,7 +1192,7 @@ coap_wellknown_response(coap_context_t *context, coap_pdu_t *request) {
       return resp;
     } else if (block.szx > COAP_MAX_BLOCK_SZX) {
       block.szx = COAP_MAX_BLOCK_SZX;
-      block.num = offset >> (block.szx + 4);
+      block.num = (unsigned int)(offset >> (block.szx + 4));
     }
 
     need_block2 = 1;
@@ -1251,9 +1256,16 @@ coap_wellknown_response(coap_context_t *context, coap_pdu_t *request) {
   if ((result & COAP_PRINT_STATUS_ERROR) != 0) {
     debug("coap_print_wellknown failed\n");
     goto error;
-  } 
+  }
   
-  resp->length += COAP_PRINT_OUTPUT_LENGTH(result);
+  unsigned int new_resp_length = resp->length + COAP_PRINT_OUTPUT_LENGTH(result);
+  if (new_resp_length > USHRT_MAX)
+  {
+      debug("coap_print_wellknown failed - print result too large\n");
+      goto error;
+  }
+
+  resp->length = (unsigned short)new_resp_length;
   return resp;
 
  error:
@@ -1334,7 +1346,7 @@ static enum respond_t
 no_response(coap_pdu_t *request, coap_pdu_t *response) {
   coap_opt_t *nores;
   coap_opt_iterator_t opt_iter;
-  uint8_t val = 0;
+  unsigned int val = 0;
 
   assert(request);
   assert(response);
@@ -1557,6 +1569,8 @@ handle_locally(coap_context_t *context __attribute__ ((unused)),
 handle_locally(coap_context_t *context, coap_queue_t *node) {
 #endif /* GCC */
   /* this function can be used to check if node->pdu is really for us */
+  (void)context;
+  (void)node;
   return 1;
 }
 
@@ -1590,9 +1604,9 @@ coap_dispatch(coap_context_t *context, coap_queue_t *rcvd) {
        * notification. Then, we must flag the observer to be alive
        * by setting obs->fail_cnt = 0. */
       if (sent && COAP_RESPONSE_CLASS(sent->pdu->hdr->code) == 2) {
-	const str token = 
-	  { sent->pdu->hdr->token_length, sent->pdu->hdr->token };
-	coap_touch_observer(context, &sent->remote, &token);
+        const str token =
+          {sent->pdu->hdr->token_length, sent->pdu->hdr->token};
+        coap_touch_observer(context, &sent->remote, &token);
       }
       break;
 

--- a/src/option.c
+++ b/src/option.c
@@ -336,7 +336,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     return 0;
 
   if (delta < 13) {
-    opt[0] = delta << 4;
+    opt[0] = (coap_opt_t)(delta << 4);
   } else if (delta < 269) {
     if (maxlen < 2) {
       debug("insufficient space to encode option delta %d\n", delta);
@@ -344,7 +344,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     }
 
     opt[0] = 0xd0;
-    opt[++skip] = delta - 13;
+    opt[++skip] = (coap_opt_t)(delta - 13);
   } else {
     if (maxlen < 3) {
       debug("insufficient space to encode option delta %d\n", delta);
@@ -353,7 +353,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
 
     opt[0] = 0xe0;
     opt[++skip] = ((delta - 269) >> 8) & 0xff;
-    opt[++skip] = (delta - 269) & 0xff;    
+    opt[++skip] = (delta - 269) & 0xff;
   }
     
   if (length < 13) {
@@ -365,7 +365,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     }
     
     opt[0] |= 0x0d;
-    opt[++skip] = length - 13;
+    opt[++skip] = (coap_opt_t)(length - 13);
   } else {
     if (maxlen < skip + 3) {
       debug("insufficient space to encode option delta %d\n", delta);
@@ -374,7 +374,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
 
     opt[0] |= 0x0e;
     opt[++skip] = ((length - 269) >> 8) & 0xff;
-    opt[++skip] = (length - 269) & 0xff;    
+    opt[++skip] = (length - 269) & 0xff;
   }
 
   return skip + 1;
@@ -497,7 +497,7 @@ coap_option_filter_op(coap_opt_filter_t filter,
   if (is_long_option(type)) {
     of->long_opts[index - 1] = type;
   } else {
-    of->short_opts[index - COAP_OPT_FILTER_LONG - 1] = type;
+    of->short_opts[index - COAP_OPT_FILTER_LONG - 1] = (uint8_t)type;
   }
 
   of->mask |= 1 << (index - 1);

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -12,7 +12,10 @@
 # include <assert.h>
 #endif
 
+#if defined(HAVE_LIMITS_H)
 #include <limits.h>
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -124,7 +124,7 @@ coap_new_pdu(void) {
   coap_pdu_t *pdu;
   
 #ifndef WITH_CONTIKI
-  pdu = coap_pdu_init(0, 0, ntohs((u_short)COAP_INVALID_TID), COAP_MAX_PDU_SIZE);
+  pdu = coap_pdu_init(0, 0, ntohs((uint16_t)COAP_INVALID_TID), COAP_MAX_PDU_SIZE);
 #else /* WITH_CONTIKI */
   pdu = coap_pdu_init(0, 0, uip_ntohs(COAP_INVALID_TID), COAP_MAX_PDU_SIZE);
 #endif /* WITH_CONTIKI */

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -12,6 +12,7 @@
 # include <assert.h>
 #endif
 
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/resource.c
+++ b/src/resource.c
@@ -62,6 +62,8 @@ coap_free_subscription(coap_subscription_t *subscription) {
 
 #endif /* WITH_CONTIKI */
 
+#define COAP_PRINT_STATUS_MAX (~COAP_PRINT_STATUS_MASK)
+
 #define min(a,b) ((a) < (b) ? (a) : (b))
 
 /* Helper functions for conditional output of character sequences into
@@ -167,6 +169,7 @@ coap_print_status_t
 coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen,
 		size_t offset, coap_opt_t *query_filter) {
 #endif /* GCC */
+  size_t output_length = 0;
   unsigned char *p = buf;
   const unsigned char *bufend = buf + *buflen;
   size_t left, written = 0;
@@ -277,7 +280,15 @@ coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen
   }
 
   *buflen = written;
-  result = p - buf;
+  output_length = p - buf;
+
+  if (output_length > COAP_PRINT_STATUS_MAX)
+  {
+    return COAP_PRINT_STATUS_ERROR;
+  }
+
+  result = (coap_print_status_t)output_length;
+
   if (result + old_offset - offset < *buflen) {
     result |= COAP_PRINT_STATUS_TRUNC;
   }
@@ -481,6 +492,7 @@ coap_print_link(const coap_resource_t *resource,
   const unsigned char *bufend = buf + *len;
   coap_attr_t *attr;
   coap_print_status_t result = 0;
+  size_t output_length = 0;
   const size_t old_offset = *offset;
   
   *len = 0;
@@ -511,7 +523,15 @@ coap_print_link(const coap_resource_t *resource,
     COPY_COND_WITH_OFFSET(p, bufend, *offset, ";obs", 4, *len);
   }
 
-  result = p - buf;
+  output_length = p - buf;
+
+  if (output_length > COAP_PRINT_STATUS_MAX)
+  {
+    return COAP_PRINT_STATUS_ERROR;
+  }
+
+  result = (coap_print_status_t)output_length;
+
   if (result + old_offset - *offset < *len) {
     result |= COAP_PRINT_STATUS_TRUNC;
   }

--- a/src/uri.c
+++ b/src/uri.c
@@ -12,6 +12,10 @@
 # include <assert.h>
 #endif
 
+#if defined(HAVE_LIMITS_H)
+#include <limits.h>
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>

--- a/src/uri.c
+++ b/src/uri.c
@@ -47,7 +47,7 @@ strnchr(unsigned char *s, size_t len, unsigned char c) {
 int
 coap_split_uri(const unsigned char *str_var, size_t len, coap_uri_t *uri) {
   const unsigned char *p, *q;
-  int secure = 0, res = 0;
+  int res = 0;
 
   if (!str_var || !uri)
     return -1;
@@ -75,7 +75,7 @@ coap_split_uri(const unsigned char *str_var, size_t len, coap_uri_t *uri) {
   }
 
   /* There might be an additional 's', indicating the secure version: */
-  if (len && (secure = *p == 's')) {
+  if (len && (*p == 's')) {
     ++p; --len;
   }
 
@@ -133,15 +133,15 @@ coap_split_uri(const unsigned char *str_var, size_t len, coap_uri_t *uri) {
       int uri_port = 0;
     
       while (p < q)
-	uri_port = uri_port * 10 + (*p++ - '0');
+	      uri_port = uri_port * 10 + (*p++ - '0');
 
       /* check if port number is in allowed range */
       if (uri_port > 65535) {
-	res = -4;
-	goto error;
+	      res = -4;
+	      goto error;
       }
 
-      uri->port = uri_port;
+      uri->port = (unsigned short)uri_port;
     } 
   }
   
@@ -220,18 +220,17 @@ decode_segment(const unsigned char *seg, size_t length, unsigned char *buf) {
 
 /**
  * Runs through the given path (or query) segment and checks if
- * percent-encodings are correct. This function returns @c -1 on error
- * or the length of @p s when decoded.
+ * percent-encodings are correct. This function returns @c 0 on success
+ * and @c -1 on error.
  */
 static int
-check_segment(const unsigned char *s, size_t length) {
-
+check_segment(const unsigned char *s, size_t length, size_t *segment_size) {
   size_t n = 0;
 
   while (length) {
     if (*s == '%') {
       if (length < 2 || !(isxdigit(s[1]) && isxdigit(s[2])))
-	return -1;
+	      return -1;
       
       s += 2;
       length -= 2;
@@ -240,7 +239,9 @@ check_segment(const unsigned char *s, size_t length) {
     ++s; ++n; --length;
   }
   
-  return n;
+  *segment_size = n;
+
+  return 0;
 }
 	 
 /** 
@@ -248,24 +249,26 @@ check_segment(const unsigned char *s, size_t length) {
  * point to a (percent-encoded) path or query segment of a coap_uri_t
  * object.  The created option will have type @c 0, and the length
  * parameter will be set according to the size of the decoded string.
- * On success, this function returns the option's size, or a value
- * less than zero on error. This function must be called from
- * coap_split_path_impl() only.
+ * On success, this function returns @c 0 and sets @p optionsize to the option's
+ * size. On error the function returns a value less than zero. This function
+ * must be called from coap_split_path_impl() only.
  * 
- * @param s       The string to decode.
- * @param length  The size of the percent-encoded string @p s.
- * @param buf     The buffer to store the new coap option.
- * @param buflen  The maximum size of @p buf.
+ * @param s           The string to decode.
+ * @param length      The size of the percent-encoded string @p s.
+ * @param buf         The buffer to store the new coap option.
+ * @param buflen      The maximum size of @p buf.
+ * @param optionsize  The option's size.
  * 
- * @return The option's size, or @c -1 on error.
+ * @return @c 0 on success and @c -1 on error.
  *
  * @bug This function does not split segments that are bigger than 270
  * bytes.
  */
 static int
 make_decoded_option(const unsigned char *s, size_t length, 
-		    unsigned char *buf, size_t buflen) {
+		    unsigned char *buf, size_t buflen, size_t* optionsize) {
   int res;
+  size_t segmentlen;
   size_t written;
 
   if (!buflen) {
@@ -273,12 +276,12 @@ make_decoded_option(const unsigned char *s, size_t length,
     return -1;
   }
 
-  res = check_segment(s, length);
+  res = check_segment(s, length, &segmentlen);
   if (res < 0)
     return -1;
 
   /* write option header using delta 0 and length res */
-  written = coap_opt_setheader(buf, buflen, 0, res);
+  written = coap_opt_setheader(buf, buflen, 0, segmentlen);
 
   assert(written <= buflen);
 
@@ -288,14 +291,16 @@ make_decoded_option(const unsigned char *s, size_t length,
   buf += written;		/* advance past option type/length */
   buflen -= written;
 
-  if (buflen < (size_t)res) {
+  if (buflen < segmentlen) {
     debug("buffer too small for option\n");
     return -1;
   }
 
   decode_segment(s, length, buf);
 
-  return written + res;
+  *optionsize = written + segmentlen;
+
+  return 0;
 }
 
 
@@ -362,12 +367,13 @@ static void
 write_option(unsigned char *s, size_t len, void *data) {
   struct cnt_str *state = (struct cnt_str *)data;
   int res;
+  size_t optionsize;
   assert(state);
 
-  res = make_decoded_option(s, len, state->buf.s, state->buf.length);
-  if (res > 0) {
-    state->buf.s += res;
-    state->buf.length -= res;
+  res = make_decoded_option(s, len, state->buf.s, state->buf.length, &optionsize);
+  if (res == 0) {
+    state->buf.s += optionsize;
+    state->buf.length -= optionsize;
     state->n++;
   }
 }
@@ -476,7 +482,8 @@ coap_clone_uri(const coap_uri_t *uri) {
  * segment_handler_t hence we use this wrapper as safe typecast. */
 static inline void
 hash_segment(unsigned char *s, size_t len, void *data) {
-  coap_hash(s, len, data);
+  assert(len <= UINT_MAX);
+  coap_hash(s, (unsigned int)len, (unsigned char *)data);
 }
 
 int


### PR DESCRIPTION
Removing all of the /W4 level warnings from the code.
No functional changes.

A side effect of fixing the warnings is also making sure all
length/size casts don't end up with data loss.

Signed-off-by: Pawel Winogrodzki <pawelwi@microsoft.com>