### PR TITLE
Reverting coap_transaction_id() to work the way it did.

### DIFF
--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -387,11 +387,9 @@ int coap_handle_message(coap_context_t *ctx,
  * @param pdu  The message that initiated the transaction.
  * @param id   Set to the new id.
  */
-#if defined(WITH_POSIX) || defined(WITH_LWIP) || defined(WITH_CONTIKI)
 void coap_transaction_id(const coap_address_t *peer,
                          const coap_pdu_t *pdu,
                          coap_tid_t *id);
-#endif
 
 /**
  * This function removes the element with given @p id from the list given list.

--- a/src/net.c
+++ b/src/net.c
@@ -491,12 +491,9 @@ coap_option_check_critical(coap_context_t *ctx,
   return ok;
 }
 
-#if defined(WITH_POSIX) || defined(WITH_LWIP) || defined(WITH_CONTIKI)
 void
 coap_transaction_id(const coap_address_t *peer, const coap_pdu_t *pdu, 
 		    coap_tid_t *id) {
-  (void)peer;
-
   coap_key_t h;
 
   memset(h, 0, sizeof(coap_key_t));
@@ -531,7 +528,6 @@ coap_transaction_id(const coap_address_t *peer, const coap_pdu_t *pdu,
 
   *id = (((h[0] << 8) | h[1]) ^ ((h[2] << 8) | h[3])) & INT_MAX;
 }
-#endif
 
 coap_tid_t
 coap_send_ack(coap_context_t *context, 


### PR DESCRIPTION
While removing W4 warnings I've accidentally modified coap_transaction_id(), even though it was not necessary.