### PR TITLE
net.c: correct brackets in if-statement

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1255,8 +1255,7 @@ coap_wellknown_response(coap_context_t *context, coap_pdu_t *request) {
   }
   
   unsigned int new_resp_length = resp->length + COAP_PRINT_OUTPUT_LENGTH(result);
-  if (new_resp_length > USHRT_MAX)
-  {
+  if (new_resp_length > USHRT_MAX) {
       debug("coap_print_wellknown failed - print result too large\n");
       goto error;
   }

--- a/src/resource.c
+++ b/src/resource.c
@@ -282,8 +282,7 @@ coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen
   *buflen = written;
   output_length = p - buf;
 
-  if (output_length > COAP_PRINT_STATUS_MAX)
-  {
+  if (output_length > COAP_PRINT_STATUS_MAX) {
     return COAP_PRINT_STATUS_ERROR;
   }
 
@@ -525,8 +524,7 @@ coap_print_link(const coap_resource_t *resource,
 
   output_length = p - buf;
 
-  if (output_length > COAP_PRINT_STATUS_MAX)
-  {
+  if (output_length > COAP_PRINT_STATUS_MAX) {
     return COAP_PRINT_STATUS_ERROR;
   }
 
@@ -690,8 +688,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
 
       if (COAP_INVALID_TID == tid || response->hdr->type != COAP_MESSAGE_CON)
 	coap_delete_pdu(response);
-      if (COAP_INVALID_TID == tid)
-      {
+      if (COAP_INVALID_TID == tid) {
 	debug("coap_check_notify: sending failed, resource stays partially dirty\n");
         obs->dirty = 1;
         r->partiallydirty = 1;


### PR DESCRIPTION
Making sure that "if" statements have opening brackets
on the same line to fit with the rest of the code.