### PR TITLE
Deprecate coap_encode_var_bytes() and add safer coap_encode_var_bytes2()

### DIFF
--- a/include/coap/encode.h
+++ b/include/coap/encode.h
@@ -50,10 +50,22 @@ extern int coap_flsll(long long i);
 unsigned int coap_decode_var_bytes(unsigned char *buf,unsigned int len);
 
 /**
- * Encodes multiple-length byte sequences. buf points to an output buffer of
- * sufficient length to store the encoded bytes. val is the value to encode.
- * Returns the number of bytes used to encode val or 0 on error.
+ * DEPRECATED. Encodes multiple-length byte sequences. buf points to
+ * an output buffer of sufficient length to store the encoded
+ * bytes. val is the value to encode.  Returns the number of bytes
+ * used to encode val or 0 on error.
+ * Please use coap_encode_var_bytes2() instead.
  */
 unsigned int coap_encode_var_bytes(unsigned char *buf, unsigned int val);
+
+/**
+ * Encodes multiple-length byte sequences. buf points to an output
+ * buffer of buf_len bytes to store the encoded bytes. val is the
+ * value to encode.  Returns the number of bytes used to encode val or
+ * 0 on error.  This includes the case where val requires more than
+ * buf_len bytes.
+ */
+unsigned int coap_encode_var_bytes2(unsigned char *buf, unsigned int len,
+				    unsigned int val);
 
 #endif /* _COAP_ENCODE_H_ */

--- a/libcoap-1.map
+++ b/libcoap-1.map
@@ -27,6 +27,7 @@ global:
   coap_delete_string;
   coap_dispatch;
   coap_encode_var_bytes;
+  coap_encode_var_bytes2;
   coap_find_async;
   coap_find_attr;
   coap_find_observer;

--- a/libcoap-1.sym
+++ b/libcoap-1.sym
@@ -25,6 +25,7 @@ coap_delete_resource
 coap_delete_string
 coap_dispatch
 coap_encode_var_bytes
+coap_encode_var_bytes2
 coap_find_async
 coap_find_attr
 coap_find_observer

--- a/src/block.c
+++ b/src/block.c
@@ -118,9 +118,10 @@ coap_write_block_opt(coap_block_t *block, unsigned short type,
   }
 
   /* to re-encode the block option */
-  coap_add_option(pdu, type, coap_encode_var_bytes(buf, ((block->num << 4) | 
-							 (block->m << 3) | 
-							 block->szx)), 
+  coap_add_option(pdu, type, coap_encode_var_bytes2(buf, sizeof(buf),
+						    ((block->num << 4) |
+						     (block->m << 3) |
+						     block->szx)),
 		  buf);
 
   return 1;

--- a/src/encode.c
+++ b/src/encode.c
@@ -55,3 +55,22 @@ coap_encode_var_bytes(unsigned char *buf, unsigned int val) {
   return n;
 }
 
+unsigned int
+coap_encode_var_bytes2(unsigned char *buf, unsigned int buf_len,
+		       unsigned int val) {
+  unsigned int n, i;
+
+  /* count how many bytes are needed to store value: */
+  for (n = 0, i = val; i && n < sizeof(val); ++n)
+    i >>= 8;
+
+  if (n > buf_len)
+    return 0;
+
+  i = n;
+  while (i--) {
+    buf[i] = val & 0xff;
+    val >>= 8;
+  }
+  return n;
+}

--- a/src/net.c
+++ b/src/net.c
@@ -1205,7 +1205,7 @@ coap_wellknown_response(coap_context_t *context, coap_pdu_t *request) {
 
   /* Add Content-Format. As we have checked for available storage,
    * nothing should go wrong here. */
-  assert(coap_encode_var_bytes(buf, 
+  assert(coap_encode_var_bytes2(buf, sizeof(buf),
 		    COAP_MEDIATYPE_APPLICATION_LINK_FORMAT) == 1);
   coap_add_option(resp, COAP_OPTION_CONTENT_FORMAT,
 		  coap_encode_var_bytes(buf, 

--- a/tests/test_wellknown.c
+++ b/tests/test_wellknown.c
@@ -187,9 +187,10 @@ t_wellknown5(void) {
   unsigned char buf[3];
 
   if (!coap_add_option(pdu, COAP_OPTION_BLOCK2,
-		       coap_encode_var_bytes(buf, ((inblock.num << 4) |
-						   (inblock.m << 3) |
-						   inblock.szx)), buf)) {
+		       coap_encode_var_bytes2(buf, sizeof(buf),
+					      ((inblock.num << 4) |
+					       (inblock.m << 3) |
+					       inblock.szx)), buf)) {
     CU_FAIL("cannot add Block2 option");
     return;
   }
@@ -225,7 +226,7 @@ t_wellknown6(void) {
     CU_ASSERT_PTR_NOT_NULL(pdu);
 
     if (!pdu || !coap_add_option(pdu, COAP_OPTION_BLOCK2,
-				 coap_encode_var_bytes(buf,
+				 coap_encode_var_bytes2(buf, sizeof(buf),
 				       ((block.num << 4) | block.szx)), buf)) {
       CU_FAIL("cannot create request");
       return;


### PR DESCRIPTION
coap_encode_var_bytes() will silently overwrite memory if the buffer
passed to it is too small.  coap_encode_var_bytes2() will instead
fails with a return value of 0.