### PR TITLE
Enable silent build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,8 @@ AC_C_BIGENDIAN
 # tests needs the static library
 LT_INIT([shared static])
 
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+
 # Setting the libtool versioning
 ###################################################################################
 #                                                                                 #


### PR DESCRIPTION
Silent build makes it much easier to see anomalies such as warnings.
Example output from "make":

 make[2]: Entering directory '/data1/home/davidm/tmp/libcoap/examples'
 CC       client.o
 CCLD     coap-client
 CC       coap-server.o
 CCLD     coap-server
 CC       coap-rd.o
 CCLD     coap-rd

Get the old (verbose) output with "make V=1".