### PR TITLE
coap_io_lwip.c: fix typos in comments

### DIFF
--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -44,7 +44,7 @@ struct pbuf *coap_packet_extract_pbuf(coap_packet_t *packet)
 
 /** Callback from lwIP when a package was received.
  *
- * The current implemntation deals this to coap_handle_message immedately, but
+ * The current implementation deals this to coap_handle_message immediately, but
  * other mechanisms (as storing the package in a queue and later fetching it
  * when coap_read is called) can be envisioned.
  *
@@ -59,7 +59,7 @@ static void coap_recv(void *arg, struct udp_pcb *upcb, struct pbuf *p, const ip_
 	packet->pbuf = p;
 	packet->srcport = port;
 
-	/** FIXME derive the context without changing endopint definition */
+	/** FIXME derive the context without changing endpoint definition */
 	coap_handle_message(ep->context, packet);
 
 	coap_free_packet(packet);


### PR DESCRIPTION
Few typos are fixed.