### PR TITLE
Set relative time 't' to zero when it actually expire

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1998,6 +1998,7 @@ static void coap_retransmittimer_execute(void *arg) {
       break;
     } else {
       elapsed -= nextinqueue->t;
+      nextinqueue->t = 0;
       coap_retransmit(ctx, coap_pop_next(ctx));
       nextinqueue = coap_peek_next(ctx);
     }


### PR DESCRIPTION
Not seting that relative time to zero will only (in the pop process) increase the next node relative time with this one. 
e.g. if node1->t = 1000 (1 sec), and node2->t = 1000 ( + 1 sec),
after 1 sec, we pop node1 and node2 become first with t = 2000 (as pop will do node2->t += node1->t. But in reality, 1 second already elapsed, so node2->t should be 1000 instead.