### PR TITLE
Query string dependent observe.

### DIFF
--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -94,6 +94,7 @@ hnd_get_resource(coap_context_t  *ctx UNUSED_PARAM,
                  coap_session_t *session UNUSED_PARAM,
                  coap_pdu_t *request UNUSED_PARAM,
                  str *token UNUSED_PARAM,
+                 str *query UNUSED_PARAM,
                  coap_pdu_t *response) {
   rd_t *rd = NULL;
   unsigned char buf[3];
@@ -121,6 +122,7 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
                  coap_session_t *session UNUSED_PARAM,
                  coap_pdu_t *request UNUSED_PARAM,
                  str *token UNUSED_PARAM,
+                 str *query UNUSED_PARAM,
                  coap_pdu_t *response) {
 #if 1
   response->hdr->code = COAP_RESPONSE_CODE(501);
@@ -197,6 +199,7 @@ hnd_delete_resource(coap_context_t  *ctx,
                     coap_session_t *session UNUSED_PARAM,
                     coap_pdu_t *request UNUSED_PARAM,
                     str *token UNUSED_PARAM,
+                    str *query UNUSED_PARAM,
                     coap_pdu_t *response) {
   rd_t *rd = NULL;
 
@@ -218,6 +221,7 @@ hnd_get_rd(coap_context_t  *ctx UNUSED_PARAM,
            coap_session_t *session UNUSED_PARAM,
            coap_pdu_t *request UNUSED_PARAM,
            str *token UNUSED_PARAM,
+           str *query UNUSED_PARAM,
            coap_pdu_t *response) {
   unsigned char buf[3];
 
@@ -381,10 +385,9 @@ hnd_post_rd(coap_context_t  *ctx,
             coap_session_t *session,
             coap_pdu_t *request,
             str *token UNUSED_PARAM,
+            str *query UNUSED_PARAM,
             coap_pdu_t *response) {
   coap_resource_t *r;
-  coap_opt_iterator_t opt_iter;
-  coap_opt_t *query;
 #define LOCSIZE 68
   unsigned char *loc;
   size_t loc_size;
@@ -402,16 +405,11 @@ hnd_post_rd(coap_context_t  *ctx,
   loc[loc_size++] = '/';
 
   /* store query parameters for later use */
-  query = coap_check_option(request, COAP_OPTION_URI_QUERY, &opt_iter);
   if (query) {
-    parse_param((unsigned char *)"h", 1,
-    COAP_OPT_VALUE(query), COAP_OPT_LENGTH(query), &h);
-    parse_param((unsigned char *)"ins", 3,
-    COAP_OPT_VALUE(query), COAP_OPT_LENGTH(query), &ins);
-    parse_param((unsigned char *)"lt", 2,
-    COAP_OPT_VALUE(query), COAP_OPT_LENGTH(query), &lt);
-    parse_param((unsigned char *)"rt", 2,
-    COAP_OPT_VALUE(query), COAP_OPT_LENGTH(query), &rt);
+    parse_param((unsigned char *)"h", 1, query->s, query->length, &h);
+    parse_param((unsigned char *)"ins", 3, query->s, query->length, &ins);
+    parse_param((unsigned char *)"lt", 2, query->s, query->length, &lt);
+    parse_param((unsigned char *)"rt", 2, query->s, query->length, &rt);
   }
 
   if (h.length) {   /* client has specified a node name */

--- a/include/coap/resource.h
+++ b/include/coap/resource.h
@@ -44,6 +44,7 @@ typedef void (*coap_method_handler_t)
    coap_session_t *,
    coap_pdu_t *,
    str * /* token */,
+   str * /* query string */,
    coap_pdu_t * /* response */);
 
 #define COAP_ATTR_FLAGS_RELEASE_NAME  0x1
@@ -298,12 +299,15 @@ void coap_hash_request_uri(const coap_pdu_t *request, coap_key_t key);
  * @param resource        The observed resource.
  * @param session         The observer's session
  * @param token           The token that identifies this subscription.
+ * @param query           The query string, if any. subscription will
+                          take ownership of the string.
  * @return                A pointer to the added/updated subscription
  *                        information or @c NULL on error.
  */
 coap_subscription_t *coap_add_observer(coap_resource_t *resource,
                                        coap_session_t *session,
-                                       const str *token);
+                                       const str *token,
+                                       str *query);
 
 /**
  * Returns a subscription object for given @p peer.
@@ -407,5 +411,7 @@ coap_print_status_t coap_print_wellknown(coap_context_t *,
                                          coap_opt_t *);
 
 void coap_handle_failed_notify(coap_context_t *, coap_session_t *, const str *);
+
+int coap_resource_set_dirty(coap_resource_t *r, const str *query);
 
 #endif /* _COAP_RESOURCE_H_ */

--- a/include/coap/subscribe.h
+++ b/include/coap/subscribe.h
@@ -62,6 +62,7 @@ typedef struct coap_subscription_t {
                             *   dirty flag is set too) */
   size_t token_length;     /**< actual length of token */
   unsigned char token[8];  /**< token used for subscription */
+  str *query;              /**< query string used for subscription, if any */
 } coap_subscription_t;
 
 void coap_subscription_init(coap_subscription_t *);

--- a/include/coap/uri.h
+++ b/include/coap/uri.h
@@ -12,6 +12,7 @@
 
 #include "hashkey.h"
 #include "str.h"
+struct coap_pdu_t;
 
 /**
  * The scheme specifiers. Secure schemes have an odd numeric value,
@@ -135,6 +136,13 @@ int coap_split_query(const unsigned char *s,
                      size_t length,
                      unsigned char *buf,
                      size_t *buflen);
+
+/**
+ * Extract query string from request PDU according to escape rules in 6.5.8.
+ * @param request Request PDU.
+ * @return        Reconstructed and escaped query string part.
+ */
+str *coap_get_query(struct coap_pdu_t *request);
 
 /** @} */
 

--- a/libcoap-1.sym
+++ b/libcoap-1.sym
@@ -124,6 +124,7 @@ coap_register_async
 coap_remove_async
 coap_remove_from_queue
 coap_resource_init
+coap_resource_set_dirty
 coap_response_phrase
 coap_retransmit
 coap_run_once


### PR DESCRIPTION
Remember the query string used during the observe request and pass it to the resource handler.
Support partial notification of observers based on the query string.