### PR TITLE
Add handler for lost CON messages.

### DIFF
--- a/include/coap/coap_io.h
+++ b/include/coap/coap_io.h
@@ -166,4 +166,11 @@ struct coap_packet_t {
 #endif
 typedef struct coap_packet_t coap_packet_t;
 
+typedef enum {
+  COAP_NACK_TOO_MANY_RETRIES,
+  COAP_NACK_NOT_DELIVERABLE,
+  COAP_NACK_RST,
+  COAP_NACK_TLS_FAILED
+} coap_nack_reason_t;
+
 #endif /* _COAP_IO_H_ */

--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -67,6 +67,7 @@ typedef struct coap_session_t {
   size_t psk_identity_len;
   uint8_t *psk_key;
   size_t psk_key_len;
+  void *app;                    /**< application-specific data */
 } coap_session_t;
 
 /**
@@ -87,11 +88,24 @@ coap_session_t *coap_session_reference(coap_session_t *session);
 void coap_session_release(coap_session_t *session);
 
 /**
+* Stores @p data with the given session. This function overwrites any value
+* that has previously been stored with @p session.
+*/
+void coap_session_set_app_data(coap_session_t *session, void *data);
+
+/**
+* Returns any application-specific data that has been stored with @p
+* session using the function coap_session_set_app_data(). This function will
+* return @c NULL if no data has been stored.
+*/
+void *coap_session_get_app_data(const coap_session_t *session);
+
+/**
 * Notify session that it has failed connecting or has been disconnected.
 *
 * @param session The CoAP session.
 */
-void coap_session_disconnected(coap_session_t *session);
+void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reason);
 
 /**
 * Notify session that the remote peer is no longer listening.

--- a/libcoap-1.sym
+++ b/libcoap-1.sym
@@ -135,12 +135,14 @@ coap_session_connected
 coap_session_delay_pdu
 coap_session_disconnected
 coap_session_free
+coap_session_get_app_data
 coap_session_get_by_peer
 coap_session_max_pdu_size
 coap_session_reference
 coap_session_release
 coap_session_reset
 coap_session_send
+coap_session_set_app_data
 coap_session_set_mtu
 coap_session_str
 coap_set_app_data

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -509,7 +509,7 @@ int coap_dtls_send(coap_session_t *session,
   if (dtls_event >= 0) {
     coap_handle_event(session->context, dtls_event, session);
     if (dtls_event == COAP_EVENT_DTLS_ERROR || dtls_event == COAP_EVENT_DTLS_CLOSED) {
-      coap_session_disconnected(session);
+      coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
       r = -1;
     }
   }
@@ -540,8 +540,8 @@ void coap_dtls_handle_timeout(coap_session_t *session) {
 
   assert(ssl != NULL);
   if (DTLSv1_handle_timeout(ssl) < 0) {
-    /* Too may retries */
-    coap_session_disconnected(session);
+    /* Too many retries */
+    coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
   }
 }
 
@@ -607,7 +607,7 @@ int coap_dtls_receive(coap_session_t *session,
     if (dtls_event >= 0) {
       coap_handle_event(session->context, dtls_event, session);
       if (dtls_event == COAP_EVENT_DTLS_ERROR || dtls_event == COAP_EVENT_DTLS_CLOSED) {
-	coap_session_disconnected(session);
+	coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
 	r = -1;
       }
     }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -354,7 +354,7 @@ coap_dtls_send(coap_session_t *session,
     if (coap_event_dtls == COAP_EVENT_DTLS_CONNECTED)
       coap_session_connected(session);
     else if (coap_event_dtls == DTLS_ALERT_CLOSE_NOTIFY || coap_event_dtls == COAP_EVENT_DTLS_ERROR)
-      coap_session_disconnected(session);
+      coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
   }
 
   return res;
@@ -400,7 +400,7 @@ coap_dtls_receive(coap_session_t *session,
     if (coap_event_dtls == COAP_EVENT_DTLS_CONNECTED)
       coap_session_connected(session);
     else if (coap_event_dtls == DTLS_ALERT_CLOSE_NOTIFY || coap_event_dtls == COAP_EVENT_DTLS_ERROR)
-      coap_session_disconnected(session);
+      coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
   }
 
   return res;

--- a/src/net.c
+++ b/src/net.c
@@ -520,7 +520,7 @@ coap_set_app_data(coap_context_t *ctx, void *app_data) {
 }
 
 void *
-coap_get_app_data(coap_context_t *ctx) {
+coap_get_app_data(const coap_context_t *ctx) {
   assert(ctx);
   return ctx->app;
 }
@@ -896,6 +896,8 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
 #endif /* WITHOUT_OBSERVE */
 
   /* And finally delete the node */
+  if (node->pdu->hdr->type == COAP_MESSAGE_CON && context->nack_handler)
+    context->nack_handler(context, node->session, node->pdu, COAP_NACK_TOO_MANY_RETRIES, node->id);
   coap_delete_node(node);
   return COAP_INVALID_TID;
 }
@@ -1019,8 +1021,12 @@ coap_read(coap_context_t *ctx, coap_tick_t now) {
   }
 
   LL_FOREACH_SAFE(ctx->sessions, s, tmp_s) {
-    if ((s->sock.flags & COAP_SOCKET_HAS_DATA) != 0)
+    if ((s->sock.flags & COAP_SOCKET_HAS_DATA) != 0) {
+      /* Make sure the session object is not deleted in one of the callbacks  */
+      coap_session_reference(s);
       coap_read_session(ctx, s, now);
+	  coap_session_release(s);
+	}
   }
 
 }
@@ -1152,13 +1158,16 @@ token_match(const unsigned char *a, size_t alen,
 }
 
 void
-coap_cancel_session_messages(coap_context_t *context, coap_session_t *session) {
+coap_cancel_session_messages(coap_context_t *context, coap_session_t *session,
+  coap_nack_reason_t reason) {
   coap_queue_t *p, *q;
 
   while (context->sendqueue && context->sendqueue->session == session) {
     q = context->sendqueue;
     context->sendqueue = q->next;
     debug("** %s tid=%d: removed\n", coap_session_str(session), q->id);
+    if (q->pdu->hdr->type == COAP_MESSAGE_CON && context->nack_handler)
+      context->nack_handler(context, session, q->pdu, reason, q->id);
     coap_delete_node(q);
   }
 
@@ -1172,6 +1181,8 @@ coap_cancel_session_messages(coap_context_t *context, coap_session_t *session) {
     if (q->session == session) {
       p->next = q->next;
       debug("** %s tid=%d: removed\n", coap_session_str(session), q->id);
+      if (q->pdu->hdr->type == COAP_MESSAGE_CON && context->nack_handler)
+        context->nack_handler(context, session, q->pdu, reason, q->id);
       coap_delete_node(q);
       q = p->next;
     } else {
@@ -1184,7 +1195,7 @@ coap_cancel_session_messages(coap_context_t *context, coap_session_t *session) {
 void
 coap_cancel_all_messages(coap_context_t *context, coap_session_t *session,
   const unsigned char *token, size_t token_length) {
-  /* cancel all messages in sendqueue that are for dst
+  /* cancel all messages in sendqueue that belong to session
    * and use the specified token */
   coap_queue_t *p, *q;
 
@@ -1810,6 +1821,10 @@ coap_dispatch(coap_context_t *context, coap_queue_t *rcvd) {
 
       if (sent)
 	coap_cancel(context, sent);
+
+      if(sent->pdu->hdr->type==COAP_MESSAGE_CON && context->nack_handler)
+	context->nack_handler(context, sent->session, sent->pdu, COAP_NACK_RST, sent->id);
+
       goto cleanup;
 
     case COAP_MESSAGE_NON:	/* check for unknown critical options */


### PR DESCRIPTION
Add a new handler callback to notify the application when libcoap bails out on sending a confirmable message.
