### PR TITLE
Add a log handler callback.

### DIFF
--- a/include/coap/debug.h
+++ b/include/coap/debug.h
@@ -41,6 +41,11 @@ coap_log_t coap_get_log_level(void);
 /** Sets the log level to the specified value. */
 void coap_set_log_level(coap_log_t level);
 
+typedef void (*coap_log_handler_t) (coap_log_t level, const char *message);
+
+/** Add a custom log callback, use NULL to reset default handler */
+void coap_set_log_handler(coap_log_handler_t handler);
+
 /** Returns a zero-terminated string with the name of this library. */
 const char *coap_package_name(void);
 

--- a/libcoap-1.sym
+++ b/libcoap-1.sym
@@ -145,6 +145,7 @@ coap_session_set_mtu
 coap_session_str
 coap_set_app_data
 coap_set_event_handler
+coap_set_log_handler
 coap_set_log_level
 coap_show_pdu
 coap_socket_bind_udp


### PR DESCRIPTION
In some applications having libcoap write to stdout is not what you want, a global log handler allows the application to push libcoap messages into its own logs instead.