### PR TITLE
Unused parameter warning

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -104,6 +104,7 @@ hnd_get_time(coap_context_t  *ctx,
   size_t len;
   time_t now;
   coap_tick_t t;
+  (void)request;
 
   /* FIXME: return time, e.g. in human-readable by default and ticks
    * when query ?ticks is given. */

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -217,6 +217,7 @@ void coap_session_connected(coap_session_t *session) {
 }
 
 void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reason) {
+  (void)reason;
   debug("*** %s: session disconnected\n", coap_session_str(session));
   if (session->proto == COAP_PROTO_DTLS && session->tls) {
     coap_dtls_free_session(session);


### PR DESCRIPTION
Remove the two unused parameter warnings I have when compiling.