### PR TITLE
Assorted build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,7 @@ AX_CHECK_COMPILE_FLAG([-Wunused-result], [WARNING_CFLAGS="$WARNING_CFLAGS -Wunus
 
 AC_SUBST([WARNING_CFLAGS])
 
-AX_CHECK_LINK_FLAG([-Wl,--version-script=./libcoap-${LIBCOAP_API_VERSION}.map],
+AX_CHECK_LINK_FLAG([-Wl,--version-script=${srcdir}/libcoap-${LIBCOAP_API_VERSION}.map],
                    [libcoap_SYMBOLS="-Wl,--version-script=\$(srcdir)/libcoap-\$(LIBCOAP_API_VERSION).map"],
                    [libcoap_SYMBOLS="-export-symbols \$(srcdir)/libcoap-\$(LIBCOAP_API_VERSION).sym"])
 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -9,7 +9,9 @@
 if BUILD_EXAMPLES
 
 # picking up the default warning CFLAGS into AM_CFLAGS
-AM_CFLAGS = -isystem$(top_builddir)/include -I$(top_srcdir)/include $(WARNING_CFLAGS) $(DTLS_CFLAGS) -std=c99
+AM_CFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include \
+            -I$(top_srcdir)/include/coap \
+            $(WARNING_CFLAGS) $(DTLS_CFLAGS) -std=c99
 
 # etsi_iot_01 and tiny are missing
 bin_PROGRAMS = coap-client coap-server coap-rd

--- a/libcoap-1.pc.in
+++ b/libcoap-1.pc.in
@@ -7,5 +7,6 @@ Name: @PACKAGE_NAME@
 Description: C-Implementation of CoAP.
 Version: @PACKAGE_VERSION@
 URL: @PACKAGE_URL@
-Libs: -L${libdir} -lcoap-@LIBCOAP_API_VERSION@ @DTLS_LIBS@
-Cflags: -I${includedir} @DTLS_CFLAGS@
+Libs: -L${libdir} -lcoap-@LIBCOAP_API_VERSION@
+Libs.private: @DTLS_LIBS@
+Cflags: -I${includedir}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,7 +9,7 @@
 if HAVE_CUNIT
 
 # picking up the default warning CFLAGS
-AM_CFLAGS = -I$(top_srcdir)/include/coap -I$(top_builddir)/include/coap $(WARNING_CFLAGS) $(CUNIT_CFLAGS) $(DTLS_CFLAGS) -std=c99
+AM_CFLAGS = -I$(top_builddir)/include/coap -I$(top_srcdir)/include/coap $(WARNING_CFLAGS) $(CUNIT_CFLAGS) $(DTLS_CFLAGS) -std=c99
 
 noinst_PROGRAMS = \
  testdriver


### PR DESCRIPTION
I encountered a few issues while building libcoap with DTLS support and I would like to push the fixes.

The first two concern building outside the source tree (for cleaner builds). 

The third one is to avoid exposing the SSL lib via pkg-config to libcoap users when not required as it can create problems in some scenarios.