### PR TITLE
Fix issues #90, #91 and #92

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -114,10 +114,9 @@ hnd_get_time(coap_context_t  *ctx,
     my_clock_base ? COAP_RESPONSE_CODE(205) : COAP_RESPONSE_CODE(404);
 
   if (coap_find_observer(resource, session, token)) {
-    /* FIXME: need to check for resource->dirty? */
     coap_add_option(response,
                     COAP_OPTION_OBSERVE,
-                    coap_encode_var_bytes(buf, ctx->observe), buf);
+                    coap_encode_var_bytes(buf, resource->observe), buf);
   }
 
   if (my_clock_base)

--- a/examples/contiki/server.c
+++ b/examples/contiki/server.c
@@ -111,9 +111,8 @@ hnd_get_time(coap_context_t  *ctx, struct coap_resource_t *resource,
     my_clock_base ? COAP_RESPONSE_CODE(205) : COAP_RESPONSE_CODE(404);
 
   if (coap_find_observer(resource, peer, token)) {
-    /* FIXME: need to check for resource->dirty? */
     coap_add_option(response, COAP_OPTION_OBSERVE, 
-		    coap_encode_var_bytes(buf, ctx->observe), buf);
+		    coap_encode_var_bytes(buf, resource->observe), buf);
   }
 
   if (my_clock_base)
@@ -218,7 +217,7 @@ PROCESS_THREAD(coap_server_process, ev, data)
       coap_read(coap_context);	/* read received data */
       /* coap_dispatch(coap_context); /\* and dispatch PDUs from receivequeue *\/ */
     } else if (ev == PROCESS_EVENT_TIMER && etimer_expired(&dirty_timer)) {
-      time_resource->dirty = 1;
+      coap_resource_set_dirty(time_resource, NULL);
       etimer_reset(&dirty_timer);
     }
   }

--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -120,12 +120,6 @@ typedef struct coap_context_t {
    */
   uint16_t message_id;
 
-  /**
-   * The next value to be used for Observe. This field is global for all
-   * resources and will be updated when notifications are created.
-   */
-  unsigned int observe;
-
   coap_response_handler_t response_handler;
   coap_nack_handler_t nack_handler;
 

--- a/include/coap/resource.h
+++ b/include/coap/resource.h
@@ -106,6 +106,12 @@ typedef struct coap_resource_t {
   str uri;
   int flags;
 
+  /**
+  * The next value for the Observe option. This field must be increased each
+  * time the resource changes. Only the lower 24 bits are sent.
+  */
+  unsigned int observe;
+
 } coap_resource_t;
 
 /**

--- a/src/resource.c
+++ b/src/resource.c
@@ -720,9 +720,6 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
       }
 
     }
-
-    /* Increment value for next Observe use. */
-    context->observe++;
   }
   r->dirty = 0;
 }
@@ -750,6 +747,10 @@ coap_resource_set_dirty(coap_resource_t *r, const str *query) {
   } else {
     r->dirty = 1;
   }
+
+  /* Increment value for next Observe use. Observe value must be < 2^24 */
+  r->observe = (r->observe + 1) & 0xFFFFFF;
+
   return 1;
 }
 


### PR DESCRIPTION
Changes in resource.c, resource.h:
The value of the observe option is kept for each resource rather than being global to the context.
The value of the observe option must wrap to be stay below 2^24.
The value of the observe option must be different from the initial value when a notification is sent.

Note that the dirty flag must no longer be touched by the application, coap_resource_set_dirty() must be called instead as it takes care of incrementing the observe value. The examples have been updated accordingly