### PR TITLE
coap_io.c: Fix file descriptor leaks when "connections" fail

### DIFF
--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -852,7 +852,6 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
 #endif
         /* client-side ICMP destination unreachable, ignore it */
         coap_log(LOG_WARNING, "coap_network_read: unreachable\n");
-        coap_socket_close(sock);
         return -2;
       }
       coap_log(LOG_WARNING, "coap_network_read: %s\n", coap_socket_strerror());

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -315,7 +315,7 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
       return 1;
     }
     coap_log(LOG_WARNING, "coap_socket_connect_tcp1: connect: %s\n", coap_socket_strerror());
-    return 0;
+    goto error;
   }
 
   if (getsockname(sock->fd, &local_addr->addr.sa, &local_addr->size) == COAP_SOCKET_ERROR) {
@@ -850,9 +850,10 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
 #else
       if (errno == ECONNREFUSED) {
 #endif
-	/* client-side ICMP destination unreachable, ignore it */
-	coap_log(LOG_WARNING, "coap_network_read: unreachable\n");
-	return -2;
+        /* client-side ICMP destination unreachable, ignore it */
+        coap_log(LOG_WARNING, "coap_network_read: unreachable\n");
+        coap_socket_close(sock);
+        return -2;
       }
       coap_log(LOG_WARNING, "coap_network_read: %s\n", coap_socket_strerror());
       goto error;


### PR DESCRIPTION
If a TCP connection connection fails, or a an ICMP Unreachable is received
for a UDP packet, then the file descriptor is not closed off.  Eventually
all fails when no more file descriptors are allowed.