### PR TITLE
coap_openssl.c: client assert error if DTLS error closed socket

### DIFF
--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -123,6 +123,11 @@ static int coap_dgram_write(BIO *a, const char *in, int inl) {
   coap_ssl_data *data = (coap_ssl_data *)BIO_get_data(a);
 
   if (data->session) {
+    if (data->session->sock.flags == COAP_SOCKET_EMPTY && data->session->endpoint == NULL) {
+      /* socket was closed on client due to error */
+      BIO_clear_retry_flags(a);
+      return -1;
+    }
     ret = (int)coap_session_send(data->session, (unsigned char*)in, (size_t)inl);
     BIO_clear_retry_flags(a);
     if (ret <= 0)


### PR DESCRIPTION
For a client, if a DTLS session is closed with ICMP unavailable packet, when
the TLS session is closed in the application with SSL_shutdown(), the OpenSSL
underlying library triggers a BIO_write() which calls coap_dgram_write() which
then 'assert's in coap_session_send().
(sock->flags == COAP_SOCKET_EMPTY && session->endpoint == NULL).

Fix is not to call coap_session_send() from coap_dgram_write() if socket is
closed and this is not an endpoint (not a server).