### PR TITLE
TlS: Determine TLS library support

### DIFF
--- a/include/coap/coap_dtls.h
+++ b/include/coap/coap_dtls.h
@@ -27,6 +27,21 @@ int coap_dtls_is_supported(void);
 /** Returns 1 if support for TLS is enabled, or 0 otherwise. */
 int coap_tls_is_supported( void );
 
+#define COAP_TLS_LIBRARY_NOTLS 0
+#define COAP_TLS_LIBRARY_TINYDTLS 1
+#define COAP_TLS_LIBRARY_OPENSSL 2
+#define COAP_TLS_LIBRARY_GNUTLS 3
+
+typedef struct coap_tls_version_t {
+  uint64_t version; /* Library Version */
+  int type; /* One of COAP_TLS_LIBRARY_* */
+} coap_tls_version_t;
+
+/**
+ * Returns the version and type of library libcoap was compiled against
+ */
+coap_tls_version_t *coap_get_tls_library_version(void);
+
 /** Sets the log level to the specified value. */
 void coap_dtls_set_log_level(int level);
 

--- a/libcoap-1.map
+++ b/libcoap-1.map
@@ -73,6 +73,7 @@ global:
   coap_get_log_level;
   coap_get_query;
   coap_get_resource_from_key;
+  coap_get_tls_library_version;
   coap_handle_dgram;
   coap_handle_event;
   coap_handle_failed_notify;

--- a/libcoap-1.sym
+++ b/libcoap-1.sym
@@ -71,6 +71,7 @@ coap_get_data
 coap_get_log_level
 coap_get_query
 coap_get_resource_from_key
+coap_get_tls_library_version
 coap_handle_dgram
 coap_handle_event
 coap_handle_failed_notify

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -29,6 +29,14 @@ coap_tls_is_supported(void) {
   return 0;
 }
 
+coap_tls_version_t *
+coap_get_tls_library_version(void) {
+  static coap_tls_version_t version;
+  version.version = 0;
+  version.type = COAP_TLS_LIBRARY_NOTLS;
+  return &version;
+}
+
 static int dtls_log_level = 0;
 
 void coap_dtls_startup(void) {

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -40,11 +40,27 @@ typedef struct coap_openssl_context_t {
 } coap_openssl_context_t;
 
 int coap_dtls_is_supported(void) {
+  if (SSLeay() < 0x10100000L) {
+    coap_log(LOG_WARNING, "OpenSSL version 1.1.0 or later is required\n");
+    return 0;
+  }
   return 1;
 }
 
 int coap_tls_is_supported(void) {
+  if (SSLeay() < 0x10100000L) {
+    coap_log(LOG_WARNING, "OpenSSL version 1.1.0 or later is required\n");
+    return 0;
+  }
   return 1;
+}
+
+coap_tls_version_t *
+coap_get_tls_library_version(void) {
+  static coap_tls_version_t version;
+  version.version = SSLeay();
+  version.type = COAP_TLS_LIBRARY_OPENSSL;
+  return &version;
 }
 
 void coap_dtls_startup(void) {

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -444,6 +444,14 @@ int coap_tls_is_supported(void) {
   return 0;
 }
 
+coap_tls_version_t *
+coap_get_tls_library_version(void) {
+  static coap_tls_version_t version;
+  version.version = DTLS_VERSION;
+  version.type = COAP_TLS_LIBRARY_TINYDTLS;
+  return &version;
+}
+
 void *coap_tls_new_client_session(coap_session_t *session UNUSED, int *connected UNUSED) {
   return NULL;
 }


### PR DESCRIPTION
Add in support for determining TLS library type that libcoap was built against, as well as the TLS library version.