### PR TITLE
.gitmodules: Correct URL for tinydtls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ext/tinydtls"]
 	path = ext/tinydtls
-	url = https://git.eclipse.org/r/tinydtls/org.eclipse.tinydtls
+	url = http://git.eclipse.org/gitroot/tinydtls/org.eclipse.tinydtls.git
     ignore = dirty


### PR DESCRIPTION
Correct the URL for getting tinydtls submodule.