### PR TITLE
Ping Pong handlers: Need for applications to see ping requests / pong responses

### DIFF
--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -76,6 +76,18 @@ typedef void (*coap_nack_handler_t)(struct coap_context_t *,
                                     coap_nack_reason_t reason,
                                     const coap_tid_t id);
 
+/** Message handler that is used as call-back in coap_context_t */
+typedef void (*coap_ping_handler_t)(struct coap_context_t *,
+                                        coap_session_t *session,
+                                        coap_pdu_t *received,
+                                        const coap_tid_t id);
+
+/** Message handler that is used as call-back in coap_context_t */
+typedef void (*coap_pong_handler_t)(struct coap_context_t *,
+				  	coap_session_t *session,
+					coap_pdu_t *received,
+					const coap_tid_t id);
+
 #define COAP_MID_CACHE_SIZE 3
 typedef struct {
   unsigned char flags[COAP_MID_CACHE_SIZE];
@@ -122,6 +134,8 @@ typedef struct coap_context_t {
 
   coap_response_handler_t response_handler;
   coap_nack_handler_t nack_handler;
+  coap_ping_handler_t ping_handler;
+  coap_pong_handler_t pong_handler;
 
   /**
    * Callback function that is used to signal events to the
@@ -178,6 +192,31 @@ coap_register_nack_handler(coap_context_t *context,
   context->nack_handler = handler;
 }
 
+/**
+ * Registers a new message handler that is called whenever a CoAP Ping
+ * message is received.
+ *
+ * @param context The context to register the handler for.
+ * @param handler The ping handler to register.
+ */
+COAP_STATIC_INLINE void
+coap_register_ping_handler(coap_context_t *context,
+                           coap_ping_handler_t handler) {
+  context->ping_handler = handler;
+}
+
+/**
+ * Registers a new message handler that is called whenever a CoAP Pong
+ * message is received.
+ *
+ * @param context The context to register the handler for.
+ * @param handler The pong handler to register.
+ */
+COAP_STATIC_INLINE void
+coap_register_pong_handler(coap_context_t *context,
+                           coap_pong_handler_t handler) {
+  context->pong_handler = handler;
+}
 
 /**
  * Registers the option type @p type with the given context object @p ctx.

--- a/src/net.c
+++ b/src/net.c
@@ -2006,14 +2006,17 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
       coap_session_connected(session);
   } else if (pdu->code == COAP_SIGNALING_PING) {
     coap_pdu_t *pong = coap_pdu_init(COAP_MESSAGE_CON, COAP_SIGNALING_PONG, 0, 1);
+    if (context->ping_handler) {
+      context->ping_handler(context, session, pdu, pdu->tid);
+    }
     if (pong) {
       coap_add_option(pong, COAP_SIGNALING_OPTION_CUSTODY, 0, NULL);
       coap_send(session, pong);
     }
   } else if (pdu->code == COAP_SIGNALING_PONG) {
-      if (context->pong_handler) {
-        context->pong_handler(context, session, pdu, pdu->tid);
-      }
+    if (context->pong_handler) {
+      context->pong_handler(context, session, pdu, pdu->tid);
+    }
   } else if (pdu->code == COAP_SIGNALING_RELEASE
           || pdu->code == COAP_SIGNALING_ABORT) {
     coap_session_disconnected(session, COAP_NACK_RST);

--- a/src/net.c
+++ b/src/net.c
@@ -2010,6 +2010,10 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
       coap_add_option(pong, COAP_SIGNALING_OPTION_CUSTODY, 0, NULL);
       coap_send(session, pong);
     }
+  } else if (pdu->code == COAP_SIGNALING_PONG) {
+      if (context->pong_handler) {
+        context->pong_handler(context, session, pdu, pdu->tid);
+      }
   } else if (pdu->code == COAP_SIGNALING_RELEASE
           || pdu->code == COAP_SIGNALING_ABORT) {
     coap_session_disconnected(session, COAP_NACK_RST);
@@ -2112,6 +2116,12 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
   else if (COAP_PDU_IS_RESPONSE(pdu))
     handle_response(context, session, sent ? sent->pdu : NULL, pdu);
   else {
+    if (COAP_PDU_IS_EMPTY(pdu)) {
+      if (context->ping_handler) {
+        context->ping_handler(context, session,
+          pdu, pdu->tid);
+      }
+    }
     debug("dropped message with invalid code (%d.%02d)\n",
       COAP_RESPONSE_CLASS(pdu->code),
       pdu->code & 0x1f);


### PR DESCRIPTION
This change provides the ability to define ping or pong handlers, so that an application can intercept the traffic and handle, for example, missing pings.