### PR TITLE
Require support for configuring session recovery parameters

### DIFF
--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -561,6 +561,19 @@ coap_pdu_t *coap_wellknown_response(coap_context_t *context,
                                     coap_session_t *session,
                                     coap_pdu_t *request);
 
-unsigned int calc_timeout(unsigned char r);
+/**
+ * Calculates the initial timeout based on the session CoAP transmission
+ * parameters 'ack_timeout', 'ack_random_factor', and COAP_TICKS_PER_SECOND.
+ * The calculation requires 'ack_timeout' and 'ack_random_factor' to be in
+ * Qx.FRAC_BITS fixed point notation, whereas the passed parameter @p r
+ * is interpreted as the fractional part of a Q0.MAX_BITS random value.
+ *
+ * @param session session timeout is associated with
+ * @param r  random value as fractional part of a Q0.MAX_BITS fixed point
+ *           value
+ * @return   COAP_TICKS_PER_SECOND * 'ack_timeout' *
+ *           (1 + ('ack_random_factor' - 1) * r)
+ */
+unsigned int coap_calc_timeout(coap_session_t *session, unsigned char r);
 
 #endif /* _COAP_NET_H_ */

--- a/libcoap-1.map
+++ b/libcoap-1.map
@@ -148,8 +148,11 @@ global:
   coap_session_delay_pdu;
   coap_session_disconnected;
   coap_session_free;
+  coap_session_get_ack_random_factor;
+  coap_session_get_ack_timeout;
   coap_session_get_app_data;
   coap_session_get_by_peer;
+  coap_session_get_max_transmit;
   coap_session_max_pdu_size;
   coap_session_reference;
   coap_session_release;
@@ -157,7 +160,10 @@ global:
   coap_session_send;
   coap_session_send_csm;
   coap_session_send_pdu;
+  coap_session_set_ack_random_factor;
+  coap_session_set_ack_timeout;
   coap_session_set_app_data;
+  coap_session_set_max_retransmit;
   coap_session_set_mtu;
   coap_session_str;
   coap_session_write;

--- a/libcoap-1.sym
+++ b/libcoap-1.sym
@@ -146,8 +146,11 @@ coap_session_connected
 coap_session_delay_pdu
 coap_session_disconnected
 coap_session_free
+coap_session_get_ack_random_factor
+coap_session_get_ack_timeout
 coap_session_get_app_data
 coap_session_get_by_peer
+coap_session_get_max_transmit
 coap_session_max_pdu_size
 coap_session_reference
 coap_session_release
@@ -155,7 +158,10 @@ coap_session_reset
 coap_session_send
 coap_session_send_csm
 coap_session_send_pdu
+coap_session_set_ack_random_factor
+coap_session_set_ack_timeout
 coap_session_set_app_data
+coap_session_set_max_retransmit
 coap_session_set_mtu
 coap_session_str
 coap_session_write


### PR DESCRIPTION
As per "RFC7252: 4.8.1.  Changing the Parameters", support is required for being able to modify the message transmission parameters.  This change proves the functions to be able to do this, along with the other code changes required to support the per session configuration.