### PR TITLE
Addition of PKI support

### DIFF
--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -185,6 +185,31 @@ coap_session_t *coap_new_client_session_psk(
   unsigned key_len
 );
 
+struct coap_dtls_pki_t;
+
+/**
+* Creates a new client session to the designated server with PKI credentials
+* @param ctx The CoAP context.
+* @param local_if Address of local interface. It is recommended to use NULL to
+*                 let the operating system choose a suitable local interface.
+*                 If an address is specified, the port number should be zero,
+*                 which means that a free port is automatically selected.
+* @param server The server's address. If the port number is zero, the default
+*               port for the protocol will be used.
+* @param proto CoAP Protocol.
+* @param setup_data PKI parameters.
+*
+* @return A new CoAP session or NULL if failed. Call coap_session_release()
+*         to free.
+*/
+coap_session_t *coap_new_client_session_pki(
+  struct coap_context_t *ctx,
+  const coap_address_t *local_if,
+  const coap_address_t *server,
+  coap_proto_t proto,
+  struct coap_dtls_pki_t *setup_data
+);
+
 /**
 * Creates a new server session for the specified endpoint.
 * @param ctx The CoAP context.

--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -234,8 +234,6 @@ int coap_context_set_psk( coap_context_t *context, const char *hint,
  * The Callback is called to set up the appropriate information if set.
  *
  * @param context        The current coap_context_t object.
- * @param setup_callback The callback which is SSL support dependent. Can be
- *                       NULL.
  * @param setup_data     If NULL, PKI authentication will fail. Certificate
  *                       information required.
  *
@@ -243,7 +241,6 @@ int coap_context_set_psk( coap_context_t *context, const char *hint,
  */
 
 int coap_context_set_pki(coap_context_t *context,
-                           coap_dtls_security_setup_t setup_callback,
                            coap_dtls_pki_t* setup_data);
 
 /**

--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -216,13 +216,35 @@ coap_context_t *coap_new_context(const coap_address_t *listen_addr);
  * Set the context's default server PSK hint and/or key.
  * These global defaults are used only no PSK callback is specified.
  *
- * @param hint    The default PSK server hint sent to a client. If NULL, PSK authentication is disabled. Empty string is a valid hint.
+ * @param context The current coap_context_t object.
+ * @param hint    The default PSK server hint sent to a client. If NULL, PSK
+ *                authentication is disabled. Empty string is a valid hint.
  * @param key     The default PSK key. If NULL, PSK authentication will fail.
- * @param key_len The default PSK key's lenght. If 0, PSK authentication will fail.
+ * @param key_len The default PSK key's lenght. If 0, PSK authentication will
+ *                fail.
+ *
+ * @return 1 if successful, else 0
  */
 
-void coap_context_set_psk( coap_context_t *ctx, const char *hint,
+int coap_context_set_psk( coap_context_t *context, const char *hint,
                            const uint8_t *key, size_t key_len );
+
+/**
+ * Set the context's default PKI information.
+ * The Callback is called to set up the appropriate information if set.
+ *
+ * @param context        The current coap_context_t object.
+ * @param setup_callback The callback which is SSL support dependent. Can be
+ *                       NULL.
+ * @param setup_data     If NULL, PKI authentication will fail. Certificate
+ *                       information required.
+ *
+ * @return 1 if successful, else 0
+ */
+
+int coap_context_set_pki(coap_context_t *context,
+                           coap_dtls_security_setup_t setup_callback,
+                           coap_dtls_pki_t* setup_data);
 
 /**
  * Returns a new message id and updates @p context->message_id accordingly. The

--- a/libcoap-1.map
+++ b/libcoap-1.map
@@ -20,6 +20,7 @@ global:
   coap_clear_event_handler;
   coap_clock_init;
   coap_clone_uri;
+  coap_context_set_pki;
   coap_context_set_psk;
   coap_debug_send_packet;
   coap_debug_set_packet_loss;
@@ -34,6 +35,9 @@ global:
   coap_delete_resource;
   coap_delete_string;
   coap_dispatch;
+  coap_dtls_context_check_keys_enabled;
+  coap_dtls_context_set_pki;
+  coap_dtls_context_set_psk;
   coap_dtls_free_context;
   coap_dtls_free_session;
   coap_dtls_get_context_timeout;
@@ -89,6 +93,7 @@ global:
   coap_network_read;
   coap_network_send;
   coap_new_client_session;
+  coap_new_client_session_pki;
   coap_new_client_session_psk;
   coap_new_context;
   coap_new_endpoint;

--- a/libcoap-1.sym
+++ b/libcoap-1.sym
@@ -18,6 +18,7 @@ coap_cleanup
 coap_clear_event_handler
 coap_clock_init
 coap_clone_uri
+coap_context_set_pki
 coap_context_set_psk
 coap_debug_send_packet
 coap_debug_set_packet_loss
@@ -32,6 +33,9 @@ coap_delete_pdu
 coap_delete_resource
 coap_delete_string
 coap_dispatch
+coap_dtls_context_check_keys_enabled
+coap_dtls_context_set_pki
+coap_dtls_context_set_psk
 coap_dtls_free_context
 coap_dtls_free_session
 coap_dtls_get_context_timeout
@@ -87,6 +91,7 @@ coap_mfree_endpoint
 coap_network_read
 coap_network_send
 coap_new_client_session
+coap_new_client_session_pki
 coap_new_client_session_psk
 coap_new_context
 coap_new_endpoint

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -48,7 +48,7 @@
 #include "libcoap.h"
 #include "debug.h"
 #include "mem.h"
-#include "coap_dtls.h"
+#include "net.h"
 #include "coap_io.h"
 #include "pdu.h"
 #include "utlist.h"

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -11,7 +11,7 @@
 
 #if !defined(HAVE_LIBTINYDTLS) && !defined(HAVE_OPENSSL)
 
-#include "coap_dtls.h"
+#include "net.h"
 
 #ifdef __GNUC__
 #define UNUSED __attribute__((unused))
@@ -26,6 +26,25 @@ coap_dtls_is_supported(void) {
 
 int
 coap_tls_is_supported(void) {
+  return 0;
+}
+
+int coap_dtls_context_set_pki( coap_context_t *ctx UNUSED,
+  coap_dtls_security_setup_t setup_callback UNUSED,
+  coap_dtls_pki_t* setup_data UNUSED
+) {
+  return 0;
+}
+
+int coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
+  const char *hint UNUSED,
+  const uint8_t *key UNUSED, size_t key_len UNUSED
+) {
+  return 0;
+}
+
+int coap_dtls_context_check_keys_enabled(coap_context_t *ctx)
+{
   return 0;
 }
 

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -38,7 +38,6 @@ coap_get_tls_library_version(void) {
 }
 
 int coap_dtls_context_set_pki( coap_context_t *ctx UNUSED,
-  coap_dtls_security_setup_t setup_callback UNUSED,
   coap_dtls_pki_t* setup_data UNUSED
 ) {
   return 0;

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1,5 +1,5 @@
 /*
-* coap_tinydtls.c -- Datagram Transport Layer Support for libcoap with openssl
+* coap_openssl.c -- Datagram Transport Layer Support for libcoap with openssl
 *
 * Copyright (C) 2017 Jean-Claude Michelou <jcm@spinetix.com>
 *
@@ -11,7 +11,7 @@
 
 #ifdef HAVE_OPENSSL
 
-#include "coap_dtls.h"
+#include "net.h"
 #include "mem.h"
 #include "debug.h"
 #include "prng.h"
@@ -37,6 +37,7 @@ typedef struct coap_tls_context_t {
 typedef struct coap_openssl_context_t {
   coap_dtls_context_t dtls;
   coap_tls_context_t tls;
+  int psk_pki_enabled;
 } coap_openssl_context_t;
 
 int coap_dtls_is_supported(void) {
@@ -197,17 +198,6 @@ static long coap_dgram_ctrl(BIO *a, int cmd, long num, void *ptr) {
   }
   return ret;
 }
-
-#if 0
-static int coap_dtls_verify_cert(int ok, X509_STORE_CTX *ctx) {
-  (void)ok;
-  (void)ctx;
-
-  if (dtls_log_level >= LOG_WARNING)
-    coap_log(LOG_WARNING, "cannot accept DTLS connection with certificate.\n");
-  return 0;	/* For now, trust no one */
-}
-#endif
 
 static int coap_dtls_generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len) {
   coap_dtls_context_t *dtls = (coap_dtls_context_t *)SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl));
@@ -387,7 +377,6 @@ void *coap_dtls_new_context(struct coap_context_t *coap_context) {
 
   context = (coap_openssl_context_t *)coap_malloc(sizeof(coap_openssl_context_t));
   if (context) {
-    BIO *bio;
     uint8_t cookie_secret[32];
 
     memset(context, 0, sizeof(coap_openssl_context_t));
@@ -412,9 +401,6 @@ void *coap_dtls_new_context(struct coap_context_t *coap_context) {
     SSL_CTX_set_cookie_generate_cb(context->dtls.ctx, coap_dtls_generate_cookie);
     SSL_CTX_set_cookie_verify_cb(context->dtls.ctx, coap_dtls_verify_cookie);
     SSL_CTX_set_info_callback(context->dtls.ctx, coap_dtls_info_callback);
-    SSL_CTX_set_psk_client_callback(context->dtls.ctx, coap_dtls_psk_client_callback);
-    SSL_CTX_set_psk_server_callback(context->dtls.ctx, coap_dtls_psk_server_callback);
-    SSL_CTX_use_psk_identity_hint(context->dtls.ctx, "");
     SSL_CTX_set_options(context->dtls.ctx, SSL_OP_NO_QUERY_MTU);
     context->dtls.meth = BIO_meth_new(BIO_TYPE_DGRAM, "coapdgram");
     if (!context->dtls.meth)
@@ -428,16 +414,6 @@ void *coap_dtls_new_context(struct coap_context_t *coap_context) {
     BIO_meth_set_ctrl(context->dtls.meth, coap_dgram_ctrl);
     BIO_meth_set_create(context->dtls.meth, coap_dgram_create);
     BIO_meth_set_destroy(context->dtls.meth, coap_dgram_destroy);
-    context->dtls.ssl = SSL_new(context->dtls.ctx);
-    if (!context->dtls.ssl)
-      goto error;
-    bio = BIO_new(context->dtls.meth);
-    if (!bio)
-      goto error;
-    SSL_set_bio(context->dtls.ssl, bio, bio);
-    SSL_set_app_data(context->dtls.ssl, NULL);
-    SSL_set_options(context->dtls.ssl, SSL_OP_COOKIE_EXCHANGE);
-    SSL_set_mtu(context->dtls.ssl, COAP_DEFAULT_MTU);
 
     /* Set up TLS context */
     context->tls.ctx = SSL_CTX_new(TLS_method());
@@ -448,9 +424,6 @@ void *coap_dtls_new_context(struct coap_context_t *coap_context) {
     SSL_CTX_set_cipher_list(context->dtls.ctx, "TLSv1.2:TLSv1.0");
     /*SSL_CTX_set_verify(context->tls.ctx, SSL_VERIFY_PEER, coap_dtls_verify_cert);*/
     SSL_CTX_set_info_callback(context->tls.ctx, coap_dtls_info_callback);
-    SSL_CTX_set_psk_client_callback(context->tls.ctx, coap_dtls_psk_client_callback);
-    SSL_CTX_set_psk_server_callback(context->tls.ctx, coap_dtls_psk_server_callback);
-    SSL_CTX_use_psk_identity_hint(context->tls.ctx, "");
     context->tls.meth = BIO_meth_new(BIO_TYPE_SOCKET, "coapsock");
     if (!context->tls.meth)
       goto error;
@@ -468,6 +441,139 @@ error:
   coap_dtls_free_context(context);
   return NULL;
 }
+
+int coap_dtls_context_set_psk(coap_context_t *ctx,
+  const char *hint,
+  const uint8_t *key, size_t key_len
+) {
+  (void)key;
+  (void)key_len;
+  coap_openssl_context_t *context = ((coap_openssl_context_t *)ctx->dtls_context);
+  BIO *bio;
+  SSL_CTX_set_psk_client_callback(context->dtls.ctx, coap_dtls_psk_client_callback);
+  SSL_CTX_set_psk_server_callback(context->dtls.ctx, coap_dtls_psk_server_callback);
+  SSL_CTX_use_psk_identity_hint(context->dtls.ctx, hint ? hint : "");
+  SSL_CTX_set_psk_client_callback(context->tls.ctx, coap_dtls_psk_client_callback);
+  SSL_CTX_set_psk_server_callback(context->tls.ctx, coap_dtls_psk_server_callback);
+  SSL_CTX_use_psk_identity_hint(context->tls.ctx, hint);
+  if (!context->dtls.ssl) {
+    context->dtls.ssl = SSL_new(context->dtls.ctx);
+    if (!context->dtls.ssl)
+      return 0;
+    bio = BIO_new(context->dtls.meth);
+    if (!bio) {
+      SSL_free (context->dtls.ssl);
+      context->dtls.ssl = NULL;
+      return 0;
+    }
+    SSL_set_bio(context->dtls.ssl, bio, bio);
+    SSL_set_app_data(context->dtls.ssl, NULL);
+    SSL_set_options(context->dtls.ssl, SSL_OP_COOKIE_EXCHANGE);
+    SSL_set_mtu(context->dtls.ssl, COAP_DEFAULT_MTU);
+  }
+  context->psk_pki_enabled = 1;
+  return 1;
+}
+
+int coap_dtls_context_set_pki( coap_context_t *ctx,
+  coap_dtls_security_setup_t setup_callback,
+  coap_dtls_pki_t* setup_data
+) {
+  coap_openssl_context_t *context = ((coap_openssl_context_t *)ctx->dtls_context);
+  BIO *bio;
+  if (context->dtls.ctx) {
+    if (setup_data->public_cert && setup_data->public_cert[0]) {
+      if (!(SSL_CTX_use_certificate_file(context->dtls.ctx, setup_data->public_cert, SSL_FILETYPE_PEM))) {
+        coap_log(LOG_WARNING, "*** coap_dtls_context_set_pki: DTLS: %s: Unable to configure Server Certificate\n", setup_data->public_cert);
+        return 0;
+      }
+    }
+    else if (setup_data->asn1_public_cert && setup_data->asn1_public_cert_len > 0) {
+      if (!(SSL_CTX_use_certificate_ASN1(context->dtls.ctx, setup_data->asn1_public_cert_len, setup_data->asn1_public_cert))) {
+        coap_log(LOG_WARNING, "*** coap_dtls_context_set_pki: DTLS: %s: Unable to configure Server Certificate\n", "ASN1");
+        return 0;
+      }
+    }
+    else {
+      coap_log(LOG_ERR, "*** coap_dtls_context_set_pki: DTLS: No Server Certificate defined\n");
+    }
+    if (setup_data->private_key && setup_data->private_key[0]) {
+      if (!(SSL_CTX_use_PrivateKey_file(context->dtls.ctx, setup_data->private_key, SSL_FILETYPE_PEM))) {
+        coap_log(LOG_WARNING, "*** coap_dtls_context_set_pki: DTLS: %s: Unable to configure Server Private Key\n", setup_data->private_key);
+        return 0;
+      }
+    }
+    else if (setup_data->asn1_private_key && setup_data->asn1_private_key_len > 0) {
+      if (!(SSL_CTX_use_PrivateKey_ASN1(setup_data->asn1_private_key_type, context->dtls.ctx, setup_data->asn1_private_key, setup_data->asn1_private_key_len))) {
+        coap_log(LOG_WARNING, "*** coap_dtls_context_set_pki: DTLS: %s: Unable to configure Server Private Key\n", "ASN1");
+        return 0;
+      }
+    }
+    else {
+      coap_log(LOG_ERR, "*** coap_dtls_context_set_pki: DTLS: No Server Private Key defined\n");
+    }
+  }
+  if (context->tls.ctx) {
+    if (setup_data->public_cert && setup_data->public_cert[0]) {
+      if (!(SSL_CTX_use_certificate_file(context->tls.ctx, setup_data->public_cert, SSL_FILETYPE_PEM))) {
+        coap_log(LOG_WARNING, "*** coap_dtls_context_set_pki: TLS: %s: Unable to configure Server Certificate\n", setup_data->public_cert);
+        return 0;
+      }
+    }
+    else if (setup_data->asn1_public_cert && setup_data->asn1_public_cert_len > 0) {
+      if (!(SSL_CTX_use_certificate_ASN1(context->tls.ctx, setup_data->asn1_public_cert_len, setup_data->asn1_public_cert))) {
+        coap_log(LOG_WARNING, "*** coap_dtls_context_set_pki: TLS: %s: Unable to configure Server Certificate\n", "ASN1");
+        return 0;
+      }
+    }
+    else {
+      coap_log(LOG_ERR, "*** coap_dtls_context_set_pki: TLS: No Server Certificate defined\n");
+    }
+    if (setup_data->private_key && setup_data->private_key[0]) {
+      if (!(SSL_CTX_use_PrivateKey_file(context->tls.ctx, setup_data->private_key, SSL_FILETYPE_PEM))) {
+        coap_log(LOG_WARNING, "*** coap_dtls_context_set_pki: TLS: %s: Unable to configure Server Private Key\n", setup_data->private_key);
+        return 0;
+      }
+    }
+    else if (setup_data->asn1_private_key && setup_data->asn1_private_key_len > 0) {
+      if (!(SSL_CTX_use_PrivateKey_ASN1(setup_data->asn1_private_key_type, context->tls.ctx, setup_data->asn1_private_key, setup_data->asn1_private_key_len))) {
+        coap_log(LOG_WARNING, "*** coap_dtls_context_set_pki: TLS: %s: Unable to configure Server Private Key\n", "ASN1");
+        return 0;
+      }
+    }
+    else {
+      coap_log(LOG_ERR, "*** coap_dtls_context_set_pki: TLS: No Server Private Key defined\n");
+    }
+  }
+
+  if (!setup_callback) return 0;
+  if (!setup_callback(context->dtls.ctx, setup_data)) return 0;
+  if (!setup_callback(context->tls.ctx, setup_data)) return 0;;
+  if (!context->dtls.ssl) {
+    context->dtls.ssl = SSL_new(context->dtls.ctx);
+    if (!context->dtls.ssl)
+      return 0;
+    bio = BIO_new(context->dtls.meth);
+    if (!bio) {
+      SSL_free (context->dtls.ssl);
+      context->dtls.ssl = NULL;
+      return 0;
+    }
+    SSL_set_bio(context->dtls.ssl, bio, bio);
+    SSL_set_app_data(context->dtls.ssl, NULL);
+    SSL_set_options(context->dtls.ssl, SSL_OP_COOKIE_EXCHANGE);
+    SSL_set_mtu(context->dtls.ssl, COAP_DEFAULT_MTU);
+  }
+  context->psk_pki_enabled = 1;
+  return 1;
+}
+
+int coap_dtls_context_check_keys_enabled(coap_context_t *ctx)
+{
+  coap_openssl_context_t *context = ((coap_openssl_context_t *)ctx->dtls_context);
+  return context->psk_pki_enabled;
+}
+
 
 void coap_dtls_free_context(void *handle) {
   coap_openssl_context_t *context = (coap_openssl_context_t *)handle;
@@ -547,8 +653,11 @@ void *coap_dtls_new_client_session(coap_session_t *session) {
   SSL *ssl = NULL;
   coap_ssl_data *data;
   int r;
-  coap_dtls_context_t *dtls = &((coap_openssl_context_t *)session->context->dtls_context)->dtls;
+  coap_openssl_context_t *context = ((coap_openssl_context_t *)session->context->dtls_context);
+  coap_dtls_context_t *dtls = &context->dtls;
 
+  if (!context->psk_pki_enabled)
+    goto error;
   ssl = SSL_new(dtls->ctx);
   if (!ssl)
     goto error;
@@ -788,8 +897,11 @@ void *coap_tls_new_client_session(coap_session_t *session, int *connected) {
   BIO *bio = NULL;
   SSL *ssl = NULL;
   int r;
-  coap_tls_context_t *tls = &((coap_openssl_context_t *)session->context->dtls_context)->tls;
+  coap_openssl_context_t *context = ((coap_openssl_context_t *)session->context->dtls_context);
+  coap_tls_context_t *tls = &context->tls;
 
+  if (!context->psk_pki_enabled)
+    goto error;
   *connected = 0;
   ssl = SSL_new(tls->ctx);
   if (!ssl)

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -437,7 +437,7 @@ void *coap_dtls_new_context(struct coap_context_t *coap_context) {
       goto error;
     SSL_CTX_set_app_data(context->tls.ctx, &context->tls);
     SSL_CTX_set_min_proto_version(context->tls.ctx, TLS1_VERSION);
-    SSL_CTX_set_cipher_list(context->dtls.ctx, "TLSv1.2:TLSv1.0");
+    SSL_CTX_set_cipher_list(context->tls.ctx, "TLSv1.2:TLSv1.0");
     /*SSL_CTX_set_verify(context->tls.ctx, SSL_VERIFY_PEER, coap_dtls_verify_cert);*/
     SSL_CTX_set_info_callback(context->tls.ctx, coap_dtls_info_callback);
     context->tls.meth = BIO_meth_new(BIO_TYPE_SOCKET, "coapsock");

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -546,9 +546,10 @@ int coap_dtls_context_set_pki( coap_context_t *ctx,
     }
   }
 
-  if (!setup_callback) return 0;
-  if (!setup_callback(context->dtls.ctx, setup_data)) return 0;
-  if (!setup_callback(context->tls.ctx, setup_data)) return 0;;
+  if (setup_callback) {
+    if (!setup_callback(context->dtls.ctx, setup_data)) return 0;
+    if (!setup_callback(context->tls.ctx, setup_data)) return 0;;
+  }
   if (!context->dtls.ssl) {
     context->dtls.ssl = SSL_new(context->dtls.ctx);
     if (!context->dtls.ssl)

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -12,7 +12,6 @@
 
 #include "coap_config.h"
 #include "coap_io.h"
-#include "coap_dtls.h"
 #include "coap_session.h"
 #include "net.h"
 #include "debug.h"
@@ -568,6 +567,8 @@ coap_session_t *coap_new_client_session_psk(
       session->psk_identity_len = identity_len;
     } else {
       coap_log(LOG_WARNING, "Cannot store session PSK identity");
+      coap_session_release(session);
+      return NULL;
     }
   }
 
@@ -578,12 +579,44 @@ coap_session_t *coap_new_client_session_psk(
       session->psk_key_len = key_len;
     } else {
       coap_log(LOG_WARNING, "Cannot store session PSK key");
+      coap_session_release(session);
+      return NULL;
     }
   }
 
+  if (coap_dtls_is_supported()) {
+    if (!coap_dtls_context_set_psk(ctx, NULL, key, key_len)) {
+      coap_session_release(session);
+      return NULL;
+    }
+  }
   debug("*** %s: new outgoing session\n", coap_session_str(session));
   return coap_session_connect(session);
 }
+
+coap_session_t *coap_new_client_session_pki(
+  struct coap_context_t *ctx,
+  const coap_address_t *local_if,
+  const coap_address_t *server,
+  coap_proto_t proto,
+  coap_dtls_security_setup_t setup_callback,
+  coap_dtls_pki_t* setup_data
+) {
+  coap_session_t *session = coap_session_create_client(ctx, local_if, server, proto);
+
+  if (!session)
+    return NULL;
+
+  if (coap_dtls_is_supported()) {
+    if (!coap_dtls_context_set_pki(ctx, setup_callback, setup_data)) {
+      coap_session_release(session);
+      return NULL;
+    }
+  }
+  debug("*** %s: new outgoing session\n", coap_session_str(session));
+  return coap_session_connect(session);
+}
+
 
 coap_session_t *coap_new_server_session(
   struct coap_context_t *ctx,
@@ -628,6 +661,13 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
   if (proto == COAP_PROTO_TLS && !coap_tls_is_supported()) {
     coap_log(LOG_CRIT, "coap_new_endpoint: TLS not supported\n");
     goto error;
+  }
+
+  if (proto == COAP_PROTO_DTLS || proto == COAP_PROTO_TLS) {
+    if (!coap_dtls_context_check_keys_enabled(context)) {
+      coap_log(LOG_INFO, "coap_new_endpoint: one of coap_dtls_context_set_psk() or coap_dtls_context_set_pki() not called\n");
+      goto error;
+    }
   }
 
   ep = coap_malloc_endpoint();

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -599,7 +599,6 @@ coap_session_t *coap_new_client_session_pki(
   const coap_address_t *local_if,
   const coap_address_t *server,
   coap_proto_t proto,
-  coap_dtls_security_setup_t setup_callback,
   coap_dtls_pki_t* setup_data
 ) {
   coap_session_t *session = coap_session_create_client(ctx, local_if, server, proto);
@@ -608,7 +607,7 @@ coap_session_t *coap_new_client_session_pki(
     return NULL;
 
   if (coap_dtls_is_supported()) {
-    if (!coap_dtls_context_set_pki(ctx, setup_callback, setup_data)) {
+    if (!coap_dtls_context_set_pki(ctx, setup_data)) {
       coap_session_release(session);
       return NULL;
     }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -11,10 +11,10 @@
 
 #ifdef HAVE_LIBTINYDTLS
 
+#include "net.h"
 #include "address.h"
 #include "debug.h"
 #include "mem.h"
-#include "coap_dtls.h"
 
 #include <tinydtls.h>
 #include <dtls.h>
@@ -442,6 +442,25 @@ unsigned int coap_dtls_get_overhead(coap_session_t *session) {
 
 int coap_tls_is_supported(void) {
   return 0;
+}
+
+int coap_dtls_context_set_pki( coap_context_t *ctx UNUSED,
+  coap_dtls_security_setup_t setup_callback UNUSED,
+  coap_dtls_pki_t* setup_data UNUSED
+) {
+  return 0;
+}
+
+int coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
+  const char *hint UNUSED,
+  const uint8_t *key UNUSED, size_t key_len UNUSED
+) {
+  return 1;
+}
+
+int coap_dtls_context_check_keys_enabled(coap_context_t *ctx)
+{
+  return 1;
 }
 
 void *coap_tls_new_client_session(coap_session_t *session UNUSED, int *connected UNUSED) {

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -453,7 +453,6 @@ coap_get_tls_library_version(void) {
 }
 
 int coap_dtls_context_set_pki( coap_context_t *ctx UNUSED,
-  coap_dtls_security_setup_t setup_callback UNUSED,
   coap_dtls_pki_t* setup_data UNUSED
 ) {
   return 0;

--- a/src/net.c
+++ b/src/net.c
@@ -442,11 +442,10 @@ int coap_context_set_psk(coap_context_t *ctx,
 }
 
 int coap_context_set_pki(coap_context_t *ctx,
-  coap_dtls_security_setup_t setup_callback,
   coap_dtls_pki_t* setup_data
 ) {
   if (coap_dtls_is_supported()) {
-    return coap_dtls_context_set_pki(ctx, setup_callback, setup_data);
+    return coap_dtls_context_set_pki(ctx, setup_data);
   }
   return 0;
 }

--- a/src/net.c
+++ b/src/net.c
@@ -42,7 +42,6 @@
 #endif
 
 #include "libcoap.h"
-#include "coap_dtls.h"
 #include "utlist.h"
 #include "debug.h"
 #include "mem.h"
@@ -399,7 +398,7 @@ coap_get_context_server_hint(
   return 0;
 }
 
-void coap_context_set_psk(coap_context_t *ctx,
+int coap_context_set_psk(coap_context_t *ctx,
   const char *hint,
   const uint8_t *key, size_t key_len
 ) {
@@ -417,6 +416,7 @@ void coap_context_set_psk(coap_context_t *ctx,
       ctx->psk_hint_len = hint_len;
     } else {
       coap_log(LOG_ERR, "No memory to store PSK hint");
+      return 0;
     }
   }
 
@@ -432,8 +432,23 @@ void coap_context_set_psk(coap_context_t *ctx,
       ctx->psk_key_len = key_len;
     } else {
       coap_log(LOG_ERR, "No memory to store PSK key");
+      return 0;
     }
   }
+  if (coap_dtls_is_supported()) {
+    return coap_dtls_context_set_psk(ctx, hint, key, key_len);
+  }
+  return 0;
+}
+
+int coap_context_set_pki(coap_context_t *ctx,
+  coap_dtls_security_setup_t setup_callback,
+  coap_dtls_pki_t* setup_data
+) {
+  if (coap_dtls_is_supported()) {
+    return coap_dtls_context_set_pki(ctx, setup_callback, setup_data);
+  }
+  return 0;
 }
 
 coap_context_t *


### PR DESCRIPTION
For the TLS libraries that support it, there is a requirement for PKI support as well as PSK support.

PKI support is a little different from PSK support as the (D)TLS sessions setup is different, and optional callback flexibility needs to get added in.

In principle the set-up sequence for CoAP Servers looks like
----
coap_new_context()
coap_context_set_pki() and/or coap_context_set_psk() if encryption is required
coap_new_endpoint()
----

In principle the set-up sequence for CoAP Clients looks like
----
coap_new_context()
coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk()
----