### PR TITLE
coap-server: Re-order code (move fill_keystore) to support PKI

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -349,6 +349,8 @@ get_context(const char *node, const char *port) {
   if (!ctx) {
     return NULL;
   }
+  /* Need PSK set up before we set up (D)TLS endpoints */
+  fill_keystore(ctx);
 
   memset(&hints, 0, sizeof(struct addrinfo));
   hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
@@ -526,7 +528,6 @@ main(int argc, char **argv) {
   if (!ctx)
     return -1;
 
-  fill_keystore(ctx);
   init_resources(ctx);
 
   /* join multicast group if requested at command line */


### PR DESCRIPTION
fill_keystore() now needs to be before coap_new_endpoint() is called as per

In principle the set-up sequence for CoAP Servers looks like

           coap_new_context()
           coap_context_set_pki() and/or coap_context_set_psk() if encryption is required
           coap_new_endpoint()