### PR TITLE
Add in GNU compiler checking of parameter syntax for coap_log() functions

### DIFF
--- a/include/coap/debug.h
+++ b/include/coap/debug.h
@@ -57,7 +57,12 @@ const char *coap_package_version(void);
  * COAP_DEBUG_FD (for @p level >= @c LOG_WARNING). The text is output only when
  * @p level is below or equal to the log level that set by coap_set_log_level().
  */
+#if (defined(__GNUC__))
+void coap_log_impl(coap_log_t level,
+              const char *format, ...) __attribute__ ((format(printf, 2, 3)));
+#else
 void coap_log_impl(coap_log_t level, const char *format, ...);
+#endif
 
 #ifndef coap_log
 #define coap_log(level, ...) do { if ((level)<=coap_get_log_level()) coap_log_impl((level), __VA_ARGS__); } while(0)

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1169,7 +1169,7 @@ coap_run_once(coap_context_t *ctx, unsigned timeout_ms) {
 #else
     if (errno != EINTR) {
 #endif
-      coap_log(LOG_DEBUG, coap_socket_strerror());
+      coap_log(LOG_DEBUG, "%s", coap_socket_strerror());
       return -1;
     }
   }


### PR DESCRIPTION
Append GNU '__attribute__ ((format(printf, 2, 3))' to the coap_log_impl() function definition.

This then catches an issue in coap_run_once() not being correctly formatted.