### PR TITLE
coap_io.c: Set COAP_SOCKET_CONNECTED before connect() for TCP

### DIFF
--- a/examples/coap-client.txt.in
+++ b/examples/coap-client.txt.in
@@ -23,9 +23,9 @@ DESCRIPTION
 -----------
 *coap-client* is a CoAP client to communicate with 6LoWPAN devices via
 the protocol CoAP (RFC 7252) using the URI given as argument on the
-command line. The URI must have the scheme 'coap' (or 'coaps' when
-coap-client was built with support for secure communication). The URI's
-host part may be a DNS name or a literal IP address. Note that, for
+command line. The URI must have the scheme 'coap', 'coap+tcp', 'coaps' or
+'coaps+tcp' when coap-client was built with support for secure communication.
+The URI's host part may be a DNS name or a literal IP address. Note that, for
 IPv6 address references, angle brackets are required (c.f. EXAMPLES).
 
 

--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -64,6 +64,7 @@ typedef struct coap_session_t {
   size_t partial_read;            /**< if > 0 indicates number of bytes already read for an incoming message */
   coap_pdu_t *partial_pdu;        /**< incomplete incoming pdu */
   coap_tick_t last_rx_tx;
+  coap_tick_t last_tx_rst;
   uint8_t *psk_identity;
   size_t psk_identity_len;
   uint8_t *psk_key;

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -312,7 +312,12 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
 #else
     if (errno == EINPROGRESS) {
 #endif
-      sock->flags |= COAP_SOCKET_WANT_CONNECT;
+      /*
+       * COAP_SOCKET_CONNECTED needs to be set here as there will be reads/writes
+       * by underlying TLS libraries during connect() and we do not want to
+       * assert() in coap_read_session() or coap_write_session() when called by coap_read()
+       */
+      sock->flags |= COAP_SOCKET_WANT_CONNECT | COAP_SOCKET_CONNECTED;
       return 1;
     }
     coap_log(LOG_WARNING, "coap_socket_connect_tcp1: connect: %s\n", coap_socket_strerror());


### PR DESCRIPTION
If COAP_SOCKET_CONNECTED is not set whilst establishing a TLS based
TCP sesson, coap_read_session() will assert while reading the underlying TLS
packets during PKI exchange.