### PR TITLE
resource.h: Introduce new field user_data

### DIFF
--- a/include/coap/resource.h
+++ b/include/coap/resource.h
@@ -112,6 +112,12 @@ typedef struct coap_resource_t {
   */
   unsigned int observe;
 
+  /**
+   * This pointer is under user control. It can be used to store context for
+   * the coap handler.
+   */
+  void *user_data;
+
 } coap_resource_t;
 
 /**
@@ -136,6 +142,32 @@ coap_resource_t *coap_resource_init(const unsigned char *uri,
 COAP_STATIC_INLINE void
 coap_resource_set_mode(coap_resource_t *r, int mode) {
   r->flags = (r->flags & !COAP_RESOURCE_FLAGS_NOTIFY_CON) | mode;
+}
+
+/**
+ * Sets the user_data. The user_data is exclusively used by the library-user
+ * and can be used as context in the handler functions.
+ *
+ * @param r	Resource to attach the data to
+ * @param data	Data to attach to the user_data field. This pointer is only used for
+ *		storage, the data remains under user control
+ */
+COAP_STATIC_INLINE void
+coap_resource_set_userdata(coap_resource_t *r, void *data) {
+  r->user_data = data;
+}
+
+/**
+ * Gets the user_data. The user_data is exclusively used by the library-user
+ * and can be used as context in the handler functions.
+ *
+ * @param r	Resource to retrieve the user_darta from
+ *
+ * @return	The user_data pointer
+ */
+COAP_STATIC_INLINE void *
+coap_resource_get_userdata(coap_resource_t *r) {
+  return r->user_data;
 }
 
 /**


### PR DESCRIPTION
The library API lacks a way to store context for the handlers. A
LED-handler for example needs to now on which pin the specific LED
is connected in order to control it. Or a higher level API would like to save the
object pointer to the object responsible for the resource.

This change will introduce a void pointer for the user to save context.
He can then retrive the context in the handler if needed.