### PR TITLE
Move handling of CoAP Options into libcoap, instead of it all being held in coap-client

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -632,6 +632,7 @@ man/coap_attribute.txt
 man/coap_context.txt
 man/coap_handler.txt
 man/coap_observe.txt
+man/coap_pdu_setup.txt
 man/coap_recovery.txt
 man/coap_resource.txt
 man/coap_tls_library.txt

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -16,7 +16,7 @@ AM_CFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include \
 # etsi_iot_01 and tiny are missing
 bin_PROGRAMS = coap-client coap-server coap-rd
 
-coap_client_SOURCES = client.c coap_list.c
+coap_client_SOURCES = client.c
 coap_client_LDADD =  $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
 
 coap_server_SOURCES = coap-server.c

--- a/examples/client.c
+++ b/examples/client.c
@@ -27,8 +27,6 @@
 #endif
 
 #include <coap/coap.h>
-#include <coap/coap_dtls.h>
-#include "coap_list.h"
 
 #define MAX_USER 128 /* Maximum length of a user name (i.e., PSK
                       * identity) in bytes. */
@@ -41,7 +39,7 @@ str the_token = { 0, _token_data };
 
 #define FLAGS_BLOCK 0x01
 
-static coap_list_t *optlist = NULL;
+static coap_optlist_t *optlist = NULL;
 /* Request URI.
  * TODO: associate the resources with transaction id and make it expireable */
 static coap_uri_t uri;
@@ -127,30 +125,14 @@ close_output(void) {
   }
 }
 
-static int
-order_opts(void *a, void *b) {
-  coap_option *o1, *o2;
-
-  if (!a || !b)
-    return a < b ? -1 : 1;
-
-  o1 = (coap_option *)(((coap_list_t *)a)->data);
-  o2 = (coap_option *)(((coap_list_t *)b)->data);
-
-  return (COAP_OPTION_KEY(*o1) < COAP_OPTION_KEY(*o2))
-    ? -1
-    : (COAP_OPTION_KEY(*o1) != COAP_OPTION_KEY(*o2));
-}
-
 static coap_pdu_t *
 coap_new_request(coap_context_t *ctx,
                  coap_session_t *session,
                  method_t m,
-                 coap_list_t **options,
+                 coap_optlist_t **options,
                  unsigned char *data,
                  size_t length) {
   coap_pdu_t *pdu;
-  coap_list_t *opt;
   (void)ctx;
 
   if (!(pdu = coap_new_pdu(session)))
@@ -160,23 +142,12 @@ coap_new_request(coap_context_t *ctx,
   pdu->tid = coap_new_message_id(session);
   pdu->code = m;
 
-  pdu->token_length = (uint8_t)the_token.length;
   if ( !coap_add_token(pdu, the_token.length, the_token.s)) {
-    debug("cannot add token to request\n");
+    coap_log(LOG_DEBUG, "cannot add token to request\n");
   }
 
-  if (options) {
-    /* sort options for delta encoding */
-    LL_SORT((*options), order_opts);
-
-    LL_FOREACH((*options), opt) {
-      coap_option *o = (coap_option *)(opt->data);
-      coap_add_option(pdu,
-                      COAP_OPTION_KEY(*o),
-                      COAP_OPTION_LENGTH(*o),
-                      COAP_OPTION_DATA(*o));
-    }
-  }
+  if (options)
+    coap_add_optlist_pdu(pdu, *options);
 
   if (length) {
     if ((flags & FLAGS_BLOCK) == 0)
@@ -191,7 +162,7 @@ coap_new_request(coap_context_t *ctx,
 static coap_tid_t
 clear_obs(coap_context_t *ctx, coap_session_t *session) {
   coap_pdu_t *pdu;
-  coap_list_t *option;
+  coap_optlist_t *option;
   coap_tid_t tid = COAP_INVALID_TID;
   unsigned char buf[2];
   (void)ctx;
@@ -207,17 +178,14 @@ clear_obs(coap_context_t *ctx, coap_session_t *session) {
   }
 
   if (!coap_add_token(pdu, the_token.length, the_token.s)) {
-    coap_log(LOG_CRIT, "cannot add token");
+    coap_log(LOG_CRIT, "cannot add token\n");
     goto error;
   }
 
   for (option = optlist; option; option = option->next ) {
-    coap_option *o = (coap_option *)(option->data);
-    if (COAP_OPTION_KEY(*o) == COAP_OPTION_URI_HOST) {
-      if (!coap_add_option(pdu,
-          COAP_OPTION_KEY(*o),
-          COAP_OPTION_LENGTH(*o),
-          COAP_OPTION_DATA(*o))) {
+    if (option->number == COAP_OPTION_URI_HOST) {
+      if (!coap_add_option(pdu, option->number, option->length,
+                           option->data)) {
         goto error;
       }
       break;
@@ -228,20 +196,17 @@ clear_obs(coap_context_t *ctx, coap_session_t *session) {
       COAP_OPTION_OBSERVE,
       coap_encode_var_bytes(buf, COAP_OBSERVE_CANCEL),
       buf)) {
-    coap_log(LOG_CRIT, "cannot add option Observe: %u", COAP_OBSERVE_CANCEL);
+    coap_log(LOG_CRIT, "cannot add option Observe: %u\n", COAP_OBSERVE_CANCEL);
     goto error;
   }
 
   for (option = optlist; option; option = option->next ) {
-    coap_option *o = (coap_option *)(option->data);
-    switch (COAP_OPTION_KEY(*o)) {
+    switch (option->number) {
     case COAP_OPTION_URI_PORT :
     case COAP_OPTION_URI_PATH :
     case COAP_OPTION_URI_QUERY :
-      if (!coap_add_option (pdu,
-                            COAP_OPTION_KEY(*o),
-                            COAP_OPTION_LENGTH(*o),
-                            COAP_OPTION_DATA(*o))) {
+      if (!coap_add_option(pdu, option->number, option->length,
+                           option->data)) {
         goto error;
       }
       break;
@@ -250,12 +215,13 @@ clear_obs(coap_context_t *ctx, coap_session_t *session) {
     }
   }
 
-  coap_show_pdu(pdu);
+  if (LOG_INFO <= coap_get_log_level())
+    coap_show_pdu(pdu);
 
   tid = coap_send(session, pdu);
 
   if (tid == COAP_INVALID_TID)
-    debug("clear_obs: error sending new request");
+    coap_log(LOG_DEBUG, "clear_obs: error sending new request\n");
 
   return tid;
  error:
@@ -329,14 +295,14 @@ message_handler(struct coap_context_t *ctx,
   coap_opt_t *block_opt;
   coap_opt_iterator_t opt_iter;
   unsigned char buf[4];
-  coap_list_t *option;
+  coap_optlist_t *option;
   size_t len;
   unsigned char *databuf;
   coap_tid_t tid;
 
 #ifndef NDEBUG
   if (LOG_INFO <= coap_get_log_level()) {
-    debug("** process incoming %d.%02d response:\n",
+    coap_log(LOG_DEBUG, "** process incoming %d.%02d response:\n",
           (received->code >> 5), received->code & 0x1F);
     coap_show_pdu(received);
   }
@@ -361,7 +327,9 @@ message_handler(struct coap_context_t *ctx,
 
     /* set obs timer if we have successfully subscribed a resource */
     if (!obs_started && coap_check_option(received, COAP_OPTION_OBSERVE, &opt_iter)) {
-      debug("observation relationship established, set timeout to %d\n", obs_seconds);
+      coap_log(LOG_DEBUG,
+               "observation relationship established, set timeout to %d\n",
+               obs_seconds);
       obs_started = 1;
       obs_ms = obs_seconds * 1000;
       obs_ms_reset = 1;
@@ -379,7 +347,7 @@ message_handler(struct coap_context_t *ctx,
 
       if(COAP_OPT_BLOCK_MORE(block_opt)) {
         /* more bit is set */
-        debug("found the M bit, block size is %u, block nr. %u\n",
+        coap_log(LOG_DEBUG, "found the M bit, block size is %u, block nr. %u\n",
               COAP_OPT_BLOCK_SZX(block_opt),
               coap_opt_block_num(block_opt));
 
@@ -388,16 +356,13 @@ message_handler(struct coap_context_t *ctx,
         if ( pdu ) {
           /* add URI components from optlist */
           for (option = optlist; option; option = option->next ) {
-            coap_option *o = (coap_option *)(option->data);
-            switch (COAP_OPTION_KEY(*o)) {
+            switch (option->number) {
               case COAP_OPTION_URI_HOST :
               case COAP_OPTION_URI_PORT :
               case COAP_OPTION_URI_PATH :
               case COAP_OPTION_URI_QUERY :
-                coap_add_option (pdu,
-                                 COAP_OPTION_KEY(*o),
-                                 COAP_OPTION_LENGTH(*o),
-                                 COAP_OPTION_DATA(*o));
+                coap_add_option(pdu, option->number, option->length,
+                                option->data);
                 break;
               default:
                 ;     /* skip other options */
@@ -406,7 +371,8 @@ message_handler(struct coap_context_t *ctx,
 
           /* finally add updated block option from response, clear M bit */
           /* blocknr = (blocknr & 0xfffffff7) + 0x10; */
-          debug("query block %d\n", (coap_opt_block_num(block_opt) + 1));
+          coap_log(LOG_DEBUG, "query block %d\n",
+                   (coap_opt_block_num(block_opt) + 1));
           coap_add_option(pdu,
                           blktype,
                           coap_encode_var_bytes(buf,
@@ -416,7 +382,7 @@ message_handler(struct coap_context_t *ctx,
           tid = coap_send(session, pdu);
 
           if (tid == COAP_INVALID_TID) {
-            debug("message_handler: error sending new request");
+            coap_log(LOG_DEBUG, "message_handler: error sending new request\n");
           } else {
 	    wait_ms = wait_seconds * 1000;
 	    wait_ms_reset = 1;
@@ -431,16 +397,20 @@ message_handler(struct coap_context_t *ctx,
       if (block_opt) { /* handle Block1 */
         unsigned int szx = COAP_OPT_BLOCK_SZX(block_opt);
         unsigned int num = coap_opt_block_num(block_opt);
-        debug("found Block1 option, block size is %u, block nr. %u\n", szx, num);
+        coap_log(LOG_DEBUG,
+                 "found Block1 option, block size is %u, block nr. %u\n",
+                 szx, num);
         if (szx != block.szx) {
           unsigned int bytes_sent = ((block.num + 1) << (block.szx + 4));
           if (bytes_sent % (1 << (szx + 4)) == 0) {
             /* Recompute the block number of the previous packet given the new block size */
             block.num = (bytes_sent >> (szx + 4)) - 1;
             block.szx = szx;
-            debug("new Block1 size is %u, block number %u completed\n", (1 << (block.szx + 4)), block.num);
+            coap_log(LOG_DEBUG,
+                     "new Block1 size is %u, block number %u completed\n",
+                     (1 << (block.szx + 4)), block.num);
           } else {
-            debug("ignoring request to increase Block1 size, "
+            coap_log(LOG_DEBUG, "ignoring request to increase Block1 size, "
             "next block is not aligned on requested block size boundary. "
             "(%u x %u mod %u = %u != 0)\n",
                   block.num + 1, (1 << (block.szx + 4)), (1 << (szx + 4)),
@@ -449,7 +419,7 @@ message_handler(struct coap_context_t *ctx,
         }
 
         if (payload.length <= (block.num+1) * (1 << (block.szx + 4))) {
-          debug("upload ready\n");
+          coap_log(LOG_DEBUG, "upload ready\n");
           ready = 1;
           return;
         }
@@ -460,17 +430,14 @@ message_handler(struct coap_context_t *ctx,
 
           /* add URI components from optlist */
           for (option = optlist; option; option = option->next ) {
-            coap_option *o = (coap_option *)(option->data);
-            switch (COAP_OPTION_KEY(*o)) {
+            switch (option->number) {
               case COAP_OPTION_URI_HOST :
               case COAP_OPTION_URI_PORT :
               case COAP_OPTION_URI_PATH :
               case COAP_OPTION_CONTENT_FORMAT :
               case COAP_OPTION_URI_QUERY :
-                coap_add_option (pdu,
-                                 COAP_OPTION_KEY(*o),
-                                 COAP_OPTION_LENGTH(*o),
-                                 COAP_OPTION_DATA(*o));
+                coap_add_option(pdu, option->number, option->length,
+                                option->data);
                 break;
               default:
               ;     /* skip other options */
@@ -482,7 +449,7 @@ message_handler(struct coap_context_t *ctx,
           block.num++;
           block.m = ((block.num+1) * (1 << (block.szx + 4)) < payload.length);
 
-          debug("send block %d\n", block.num);
+          coap_log(LOG_DEBUG, "send block %d\n", block.num);
           coap_add_option(pdu,
                           COAP_OPTION_BLOCK1,
                           coap_encode_var_bytes(buf,
@@ -498,7 +465,7 @@ message_handler(struct coap_context_t *ctx,
 	  tid = coap_send(session, pdu);
 
           if (tid == COAP_INVALID_TID) {
-            debug("message_handler: error sending new request");
+            coap_log(LOG_DEBUG, "message_handler: error sending new request\n");
           } else {
 	    wait_ms = wait_seconds * 1000;
 	    wait_ms_reset = 1;
@@ -509,7 +476,7 @@ message_handler(struct coap_context_t *ctx,
       } else {
         /* There is no block option set, just read the data and we are done. */
         if (coap_get_data(received, &len, &databuf))
-        append_to_output(databuf, len);
+          append_to_output(databuf, len);
       }
     }
   } else {      /* no 2.05 */
@@ -580,7 +547,7 @@ usage( const char *program, const char *version) {
      "\t-U\t\tnever include Uri-Host or Uri-Port options\n"
      "\t-r\t\tUse reliable protocol (TCP or TLS)\n"
      "\t-l list\t\tFail to send some datagram specified by a comma separated list of number or number intervals(for debugging only)\n"
-     "\t-l loss%%\t\tRandmoly fail to send datagrams with the specified probability(for debugging only)\n"
+     "\t-l loss%%\tRandomly fail to send datagrams with the specified probability(for debugging only)\n"
      "\n"
      "examples:\n"
      "\tcoap-client -m get coap://[::1]/\n"
@@ -588,25 +555,6 @@ usage( const char *program, const char *version) {
      "\tcoap-client -m get -T cafe coap://[::1]/time\n"
      "\techo 1000 | coap-client -m put -T cafe coap://[::1]/time -f -\n"
      ,program, version, program, wait_seconds);
-}
-
-static coap_list_t *
-new_option_node(uint16_t key, size_t length, unsigned char *data) {
-  coap_list_t *node;
-
-  node = coap_malloc(sizeof(coap_list_t) + sizeof(coap_option) + length);
-
-  if (node) {
-    coap_option *option;
-    option = (coap_option *)(node->data);
-    COAP_OPTION_KEY(*option) = key;
-    COAP_OPTION_LENGTH(*option) = length;
-    memcpy(COAP_OPTION_DATA(*option), data, length);
-  } else {
-    coap_log(LOG_DEBUG, "new_option_node: malloc\n");
-  }
-
-  return node;
 }
 
 typedef struct {
@@ -635,7 +583,7 @@ cmdline_content_type(char *arg, uint16_t key) {
     { 60, "application/cbor" },
     { 255, NULL }
   };
-  coap_list_t *node;
+  coap_optlist_t *node;
   unsigned char i, value[10];
   int valcnt = 0;
   unsigned char buf[2];
@@ -659,7 +607,7 @@ cmdline_content_type(char *arg, uint16_t key) {
         value[valcnt] = content_types[i].code;
         valcnt++;
       } else {
-        warn("W: unknown content-format '%s'\n",arg);
+        coap_log(LOG_WARNING, "W: unknown content-format '%s'\n",arg);
       }
     }
 
@@ -670,9 +618,9 @@ cmdline_content_type(char *arg, uint16_t key) {
   }
 
   for (i = 0; i < valcnt; ++i) {
-    node = new_option_node(key, coap_encode_var_bytes(buf, value[i]), buf);
+    node = coap_new_optlist(key, coap_encode_var_bytes(buf, value[i]), buf);
     if (node) {
-      LL_PREPEND(optlist, node);
+      coap_insert_optlist(&optlist, node);
     }
   }
 }
@@ -703,8 +651,8 @@ cmdline_uri(char *arg, int create_uri_opts) {
   if (proxy.length) {   /* create Proxy-Uri from argument */
     size_t len = strlen(arg);
     while (len > 270) {
-      coap_insert(&optlist,
-                  new_option_node(COAP_OPTION_PROXY_URI,
+      coap_insert_optlist(&optlist,
+                  coap_new_optlist(COAP_OPTION_PROXY_URI,
                   270,
                   (unsigned char *)arg));
 
@@ -712,8 +660,8 @@ cmdline_uri(char *arg, int create_uri_opts) {
       arg += 270;
     }
 
-    coap_insert(&optlist,
-                new_option_node(COAP_OPTION_PROXY_URI,
+    coap_insert_optlist(&optlist,
+                coap_new_optlist(COAP_OPTION_PROXY_URI,
                 len,
                 (unsigned char *)arg));
 
@@ -724,18 +672,20 @@ cmdline_uri(char *arg, int create_uri_opts) {
     }
 
     if (uri.scheme==COAP_URI_SCHEME_COAPS && !reliable && !coap_dtls_is_supported()) {
-      coap_log(LOG_EMERG, "coaps URI scheme not supported in this version of libcoap\n");
+      coap_log(LOG_EMERG,
+               "coaps URI scheme not supported in this version of libcoap\n");
       return -1;
     }
 
     if ((uri.scheme==COAP_URI_SCHEME_COAPS_TCP || (uri.scheme==COAP_URI_SCHEME_COAPS && reliable)) && !coap_tls_is_supported()) {
-      coap_log(LOG_EMERG, "coaps+tcp URI scheme not supported in this version of libcoap\n");
+      coap_log(LOG_EMERG,
+            "coaps+tcp URI scheme not supported in this version of libcoap\n");
       return -1;
     }
 
     if (uri.port != get_default_port(&uri) && create_uri_opts) {
-      coap_insert(&optlist,
-                  new_option_node(COAP_OPTION_URI_PORT,
+      coap_insert_optlist(&optlist,
+                  coap_new_optlist(COAP_OPTION_URI_PORT,
                   coap_encode_var_bytes(portbuf, uri.port),
                   portbuf));
     }
@@ -745,8 +695,8 @@ cmdline_uri(char *arg, int create_uri_opts) {
       res = coap_split_path(uri.path.s, uri.path.length, buf, &buflen);
 
       while (res--) {
-        coap_insert(&optlist,
-                    new_option_node(COAP_OPTION_URI_PATH,
+        coap_insert_optlist(&optlist,
+                    coap_new_optlist(COAP_OPTION_URI_PATH,
                     coap_opt_length(buf),
                     coap_opt_value(buf)));
 
@@ -760,8 +710,8 @@ cmdline_uri(char *arg, int create_uri_opts) {
       res = coap_split_query(uri.query.s, uri.query.length, buf, &buflen);
 
       while (res--) {
-        coap_insert(&optlist,
-                    new_option_node(COAP_OPTION_URI_QUERY,
+        coap_insert_optlist(&optlist,
+                    coap_new_optlist(COAP_OPTION_URI_QUERY,
                     coap_opt_length(buf),
                     coap_opt_value(buf)));
 
@@ -812,14 +762,15 @@ set_blocksize(void) {
     opt_length = coap_encode_var_bytes(buf,
           (block.num << 4 | block.m << 3 | block.szx));
 
-    coap_insert(&optlist, new_option_node(opt, opt_length, buf));
+    coap_insert_optlist(&optlist, coap_new_optlist(opt, opt_length, buf));
   }
 }
 
 static void
 cmdline_subscribe(char *arg) {
   obs_seconds = atoi(arg);
-  coap_insert(&optlist, new_option_node(COAP_OPTION_OBSERVE, 0, NULL));
+  coap_insert_optlist(&optlist, coap_new_optlist(COAP_OPTION_OBSERVE,
+                      COAP_OBSERVE_ESTABLISH, NULL));
 }
 
 static int
@@ -872,8 +823,8 @@ cmdline_option(char *arg) {
   if (*arg == ',')
     ++arg;
 
-  coap_insert(&optlist,
-              new_option_node(num, strlen(arg), (unsigned char *)arg));
+  coap_insert_optlist(&optlist,
+              coap_new_optlist(num, strlen(arg), (unsigned char *)arg));
 }
 
 /**
@@ -1298,8 +1249,8 @@ main(int argc, char **argv) {
       && create_uri_opts) {
         /* add Uri-Host */
 
-        coap_insert(&optlist,
-                    new_option_node(COAP_OPTION_URI_HOST,
+        coap_insert_optlist(&optlist,
+                    coap_new_optlist(COAP_OPTION_URI_HOST,
                     uri.host.length,
                     uri.host.s));
   }
@@ -1314,7 +1265,7 @@ main(int argc, char **argv) {
 
 #ifndef NDEBUG
   if (LOG_INFO <= coap_get_log_level()) {
-    debug("sending CoAP request:\n");
+    coap_log(LOG_DEBUG, "sending CoAP request:\n");
     coap_show_pdu(pdu);
   }
 #endif
@@ -1322,7 +1273,7 @@ main(int argc, char **argv) {
   coap_send(session, pdu);
 
   wait_ms = wait_seconds * 1000;
-  debug("timeout is set to %u seconds\n", wait_seconds);
+  coap_log(LOG_DEBUG, "timeout is set to %u seconds\n", wait_seconds);
 
   while ( !(ready && coap_can_exit(ctx)) ) {
 
@@ -1341,7 +1292,7 @@ main(int argc, char **argv) {
       }
       if ( obs_ms > 0 && !obs_ms_reset ) {
 	if ( (unsigned)result >= obs_ms ) {
-	  debug( "clear observation relationship\n" );
+	  coap_log(LOG_DEBUG, "clear observation relationship\n" );
 	  clear_obs( ctx, session ); /* FIXME: handle error case COAP_TID_INVALID */
 
 	  /* make sure that the obs timer does not fire again */
@@ -1360,7 +1311,7 @@ main(int argc, char **argv) {
 
  finish:
 
-  coap_delete_list(optlist);
+  coap_delete_optlist(optlist);
   coap_session_release( session );
   coap_free_context( ctx );
   coap_cleanup();

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -149,7 +149,8 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
 
         tmp.s = (unsigned char *)coap_malloc(tmp.length);
         if (!tmp.s) {
-          debug("hnd_put_rd: cannot allocate storage for new rd\n");
+          coap_log(LOG_DEBUG,
+                   "hnd_put_rd: cannot allocate storage for new rd\n");
           code = COAP_RESPONSE_CODE(503);
           goto finish;
         }
@@ -179,7 +180,8 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
   response = coap_pdu_init(type, code, request->hdr->id, size);
 
   if (!response) {
-    debug("cannot create response for message %d\n", request->hdr->id);
+    coap_log(LOG_DEBUG, "cannot create response for message %d\n",
+             request->hdr->id);
     return;
   }
 
@@ -187,7 +189,7 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
     coap_add_token(response, request->hdr->token_length, request->hdr->token);
 
   if (coap_send(ctx, peer, response) == COAP_INVALID_TID) {
-    debug("hnd_get_rd: cannot send response for message %d\n",
+    coap_log(LOG_DEBUG, "hnd_get_rd: cannot send response for message %d\n",
     request->hdr->id);
   }
 #endif
@@ -356,14 +358,14 @@ make_rd(coap_pdu_t *pdu) {
   rd = rd_new();
 
   if (!rd) {
-    debug("hnd_get_rd: cannot allocate storage for rd\n");
+    coap_log(LOG_DEBUG, "hnd_get_rd: cannot allocate storage for rd\n");
     return NULL;
   }
 
   if (coap_get_data(pdu, &rd->data.length, &data)) {
     rd->data.s = (unsigned char *)coap_malloc(rd->data.length);
     if (!rd->data.s) {
-      debug("hnd_get_rd: cannot allocate storage for rd->data\n");
+      coap_log(LOG_DEBUG, "hnd_get_rd: cannot allocate storage for rd->data\n");
       rd_delete(rd);
       return NULL;
     }

--- a/examples/coap_list.c
+++ b/examples/coap_list.c
@@ -8,6 +8,23 @@
  * use.
  */
 
+/*
+ * examples/coap_list.[ch] are DEPRECATED.  You should be using
+ * struct coap_optlist_t instead with the following functions which are a part
+ * of libcoap.
+ *
+ * coap_new_optlist()
+ * coap_insert_optlist()
+ * coap_delete_optlist()
+ * coap_add_optlist_pdu()
+ *
+ * See 'man coap_pdu_setup' for further information.
+ *
+ * examples/coap_list.[ch] files will be removed in a future release
+ * They are left here to support building backward compatability of old versions
+ * of coap-client
+ */
+
 /* #include "coap_config.h" */
 
 #include <stdio.h>

--- a/examples/coap_list.h
+++ b/examples/coap_list.h
@@ -8,6 +8,23 @@
  * use.
  */
 
+/*
+ * examples/coap_list.[ch] are DEPRECATED.  You should be using
+ * struct coap_optlist_t instead with the following functions which are a part
+ * of libcoap.
+ *
+ * coap_new_optlist()
+ * coap_insert_optlist()
+ * coap_delete_optlist()
+ * coap_add_optlist_pdu()
+ *
+ * See 'man coap_pdu_setup' for further information.
+ *
+ * examples/coap_list.[ch] files will be removed in a future release
+ * They are left here to support building backward compatability of old versions
+ * of coap-client
+ */
+
 #ifndef _COAP_LIST_H_
 #define _COAP_LIST_H_
 

--- a/include/coap/coap.h.in
+++ b/include/coap/coap.h.in
@@ -51,8 +51,6 @@ extern "C" {
 #include "str.h"
 #include "subscribe.h"
 #include "uri.h"
-#include "uthash.h"
-#include "utlist.h"
 
 #ifdef __cplusplus
 }

--- a/include/coap/debug.h
+++ b/include/coap/debug.h
@@ -65,7 +65,7 @@ void coap_log_impl(coap_log_t level, const char *format, ...);
 #endif
 
 #ifndef coap_log
-#define coap_log(level, ...) do { if ((level)<=coap_get_log_level()) coap_log_impl((level), __VA_ARGS__); } while(0)
+#define coap_log(level, ...) do { if ((level)<=(int)coap_get_log_level()) coap_log_impl((level), __VA_ARGS__); } while(0)
 #endif
 
 /* A set of convenience macros for common log levels. */

--- a/include/coap/mem.h
+++ b/include/coap/mem.h
@@ -42,6 +42,7 @@ typedef enum {
   COAP_DTLS_SESSION,
 #endif
   COAP_SESSION,
+  COAP_OPTLIST,
 } coap_memory_tag_t;
 
 #ifndef WITH_LWIP

--- a/include/coap/option.h
+++ b/include/coap/option.h
@@ -25,7 +25,9 @@
 typedef uint8_t coap_opt_t;
 #define PCHAR(p) ((coap_opt_t *)(p))
 
-/** Representation of CoAP options. */
+/**
+ * Representation of CoAP options.
+ */
 typedef struct {
   uint16_t delta;
   size_t length;
@@ -406,5 +408,74 @@ coap_opt_const_value( const coap_opt_t *opt ) {
 }
 
 /** @} */
+
+/**
+ * Representation of chained list of CoAP options to install.
+ *
+ * @code
+ * coap_optlist_t *optlist_chain = NULL;
+ * coap_pdu_t *pdu = coap_new_pdu(session);
+ *
+ * ... other set up code ...
+ * coap_insert_optlist(&optlist_chain, coap_new_optlist(COAP_OPTION_OBSERVE,
+ *                    COAP_OBSERVE_ESTABLISH, NULL));
+ *
+ * coap_add_optlist_pdu(pdu, *optlist_chain);
+ * ... other code ...
+ * coap_delete_optlist(optlist_chain);
+ * @endcode
+ */
+typedef struct coap_optlist_t {
+  struct coap_optlist_t *next;  /**< next entry in the optlist chain */
+  uint16_t number;              /**< the option number (no delta coding) */
+  size_t length;                /**< the option value length */
+  uint8_t data[];               /**< the option data */
+} coap_optlist_t;
+
+/**
+ * Create a new optlist entry.
+ *
+ * @param number    The option number (COAP_OPTION_*)
+ * @param length    The option length
+ * @param data      The option value data
+ *
+ * @return          A pointer to the new optlist entry, or @c NULL if error
+ */
+coap_optlist_t *coap_new_optlist(uint16_t number,
+                                 size_t length,
+                                 const uint8_t *data);
+
+/**
+ * The current optlist of @p optlist_chain is first sorted (as per RFC7272
+ * ordering requirements) and then added to the @pdu.
+ *
+ * @param pdu  The pdu to add the options to from the chain list
+ * @param optlist_chain The chained list of optlist to add to the pdu
+ *
+ * @return     @c 1 if succesful or @c 0 if failure;
+ */
+int coap_add_optlist_pdu(coap_pdu_t *pdu, coap_optlist_t* optlist_chain);
+
+/**
+ * Adds @p optlist to the given @p optlist_chain. The optlist_chain variable
+ * be set to NULL before the initial call to coap_insert_optlist().
+ * The optlist_chain will need to be deleted using coap_delete_optlist()
+ * when no longer required.
+ *
+ * @param optlist_chain The chain to add optlist to
+ * @param optlist  The optlist to add to the queue
+ *
+ * @return         @c 1 if successful, @c 0 otherwise.
+ */
+int coap_insert_optlist(coap_optlist_t **optlist_chain,
+                        coap_optlist_t *optlist);
+
+/**
+ * Removes all entries from the @p optlist_chain, freeing off their
+ * memory usage.
+ *
+ * @param optlist_chain The optlist chain to remove all the entries from
+ */
+void coap_delete_optlist(coap_optlist_t *optlist_chain);
 
 #endif /* _OPTION_H_ */

--- a/include/coap/pdu.h
+++ b/include/coap/pdu.h
@@ -234,6 +234,8 @@ typedef int coap_tid_t;
 #define COAP_PAYLOAD_START 0xFF /* payload marker */
 
 /**
+ * DEPRECATED.  Use coap_optlist_t instead.
+ *
  * Structures for more convenient handling of options. (To be used with ordered
  * coap_list_t.) The option's data will be added to the end of the coap_option
  * structure (see macro COAP_OPTION_DATA).

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -7,6 +7,7 @@ global:
   coap_add_observer;
   coap_add_option;
   coap_add_option_later;
+  coap_add_optlist_pdu;
   coap_add_resource;
   coap_address_equals;
   coap_add_token;
@@ -32,6 +33,7 @@ global:
   coap_delete_node;
   coap_delete_observer;
   coap_delete_observers;
+  coap_delete_optlist;
   coap_delete_pdu;
   coap_delete_resource;
   coap_delete_string;
@@ -66,6 +68,7 @@ global:
   coap_handle_event;
   coap_handle_failed_notify;
   coap_insert_node;
+  coap_insert_optlist;
   coap_is_mcast;
   coap_log_impl;
   coap_malloc_endpoint;
@@ -81,6 +84,7 @@ global:
   coap_new_endpoint;
   coap_new_error_response;
   coap_new_node;
+  coap_new_optlist;
   coap_new_pdu;
   coap_new_server_session;
   coap_new_string;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -5,6 +5,7 @@ coap_add_data_after
 coap_add_observer
 coap_add_option
 coap_add_option_later
+coap_add_optlist_pdu
 coap_add_resource
 coap_address_equals
 coap_add_token
@@ -30,6 +31,7 @@ coap_delete_attr
 coap_delete_node
 coap_delete_observer
 coap_delete_observers
+coap_delete_optlist
 coap_delete_pdu
 coap_delete_resource
 coap_delete_string
@@ -64,6 +66,7 @@ coap_handle_dgram
 coap_handle_event
 coap_handle_failed_notify
 coap_insert_node
+coap_insert_optlist
 coap_is_mcast
 coap_log_impl
 coap_malloc_endpoint
@@ -79,6 +82,7 @@ coap_new_context
 coap_new_endpoint
 coap_new_error_response
 coap_new_node
+coap_new_optlist
 coap_new_pdu
 coap_new_server_session
 coap_new_string

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -14,6 +14,7 @@ TXT3 = coap_attribute.txt \
 	coap_context.txt \
 	coap_handler.txt \
 	coap_observe.txt \
+	coap_pdu_setup.txt \
 	coap_recovery.txt \
 	coap_resource.txt \
 	coap_tls_library.txt
@@ -45,7 +46,16 @@ man7_MANS = $(MAN7)
 .txt.7:
 	$(A2X) --doctype manpage --format manpage $<
 
+# We are limited to 10 names, but synopsis can cover more
 install-man: install-man3 install-man5 install-man7
+	@/bin/cp -f coap_context.3 coap_free_endpoint.3
+	@/bin/cp -f coap_context.3 coap_endpoint_set_default_mtu.3
+	@/bin/cp -f coap_context.3 coap_session_reference.3
+	@/bin/cp -f coap_context.3 coap_session_release.3
+	@/bin/cp -f coap_context.3 coap_session_set_mtu.3
+	@/bin/cp -f coap_pdu_setup.3 coap_encode_var_bytes.3
+	@/bin/cp -f coap_pdu_setup.3 coap_split_path.3
+	@/bin/cp -f coap_pdu_setup.3 coap_split_query.3
 	$(INSTALL_DATA) *.3 "$(DESTDIR)$(man3dir)"
 
 CLEANFILES = *.3 *.5 *.7 *.xml

--- a/man/coap.txt.in
+++ b/man/coap.txt.in
@@ -35,7 +35,8 @@ examples directory.
 SEE ALSO
 --------
 *coap_attribute*(3), *coap_context*(3), *coap_handler*(3), *coap_observe*(3), 
-*coap_recovery*(3), *coap_resource*(3) and *coap_tls_library*(3)
+*coap_pdu_setup*(3), *coap_recovery*(3), *coap_resource*(3) 
+and *coap_tls_library*(3)
 
 For example executables, see *coap-client*(5), *coap-rd*(5) and *coap-server*(5)
 

--- a/man/coap_attribute.txt.in
+++ b/man/coap_attribute.txt.in
@@ -24,7 +24,9 @@ int _flags_);*
 *coap_attr_t *coap_find_attr(coap_resource_t *_resource_, const unsigned 
 char *_name_, size_t _nlen_);*
 
-Link with -lcoap-@LIBCOAP_API_VERSION@.
+Link with -lcoap-@LIBCOAP_API_VERSION@, -lcoap-@LIBCOAP_API_VERSION@-openssl
+or -lcoap-@LIBCOAP_API_VERSION@-tinydtls depending on your (D)TLS library
+type.
 
 DESCRIPTION
 -----------
@@ -51,6 +53,7 @@ to be internally freed off when the attribute is deleted with
 It is imperative that _name_ and _value_ point to data that is valid during 
 the lifetime of the attribute.
 
+[horizontal]
 *COAP_ATTR_FLAGS_RELEASE_NAME*::
 Free off _name_ when attribute is deleted with *coap_delete_resource*().
 

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -10,11 +10,10 @@ coap_context(3)
 
 NAME
 ----
-coap_context, coap_new_context, 
+coap_context, coap_new_context, coap_free_context,
 coap_context_set_pki, coap_context_set_psk, coap_new_endpoint, 
 coap_new_client_session, 
-coap_new_client_session_pki, coap_new_client_session_psk, 
-coap_get_tls_library_version
+coap_new_client_session_pki, coap_new_client_session_psk
 - work with CoAP contexts
 
 SYNOPSIS
@@ -59,7 +58,9 @@ _proto_, coap_dtls_pki_t *_setup_data_);*
 
 *void coap_session_set_mtu(coap_session_t *_session_, unsigned _mtu_);*
 
-Link with -lcoap-@LIBCOAP_API_VERSION@.
+Link with -lcoap-@LIBCOAP_API_VERSION@, -lcoap-@LIBCOAP_API_VERSION@-openssl
+or -lcoap-@LIBCOAP_API_VERSION@-tinydtls depending on your (D)TLS library
+type.
 
 DESCRIPTION
 -----------
@@ -352,7 +353,7 @@ const char *private_key_file, const char *ca_file) {
 
   coap_address_init(&listen_addr);
   listen_addr.addr.sa.sa_family = AF_INET;
-  listen_addr.addr.sin.sin_port = htons (5683);
+  listen_addr.addr.sin.sin_port = htons (5684);
 
   endpoint = coap_new_endpoint(context, &listen_addr, COAP_PROTO_DTLS);
   if (!endpoint) {
@@ -433,7 +434,7 @@ uint8_t *key, unsigned key_len) {
 
   coap_address_init(&listen_addr);
   listen_addr.addr.sa.sa_family = AF_INET;
-  listen_addr.addr.sin.sin_port = htons (5683);
+  listen_addr.addr.sin.sin_port = htons (5684);
 
   endpoint = coap_new_endpoint(context, &listen_addr, COAP_PROTO_DTLS);
   if (!endpoint) {
@@ -503,7 +504,7 @@ const char *ca_file) {
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
   server.addr.sin.sin_addr = ip_address;
-  server.addr.sin.sin_port = htons (5683);
+  server.addr.sin.sin_port = htons (5684);
 
   memset (&dtls_pki, 0, sizeof (dtls_pki));
 
@@ -513,7 +514,7 @@ const char *ca_file) {
   dtls_pki.call_back   = NULL;
 
   session = coap_new_client_session_pki(context, NULL, &server, 
-                                        COAP_PROTO_UDP, &dtls_pki);
+                                        COAP_PROTO_DTLS, &dtls_pki);
   if (!session) {
     coap_free_context(context);
     return NULL;
@@ -544,10 +545,10 @@ const char *identity, const uint8_t *key, unsigned key_len) {
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
   server.addr.sin.sin_addr = ip_address;
-  server.addr.sin.sin_port = htons (5683);
+  server.addr.sin.sin_port = htons (5684);
 
   session = coap_new_client_session_psk(context, NULL, &server, 
-                                        COAP_PROTO_UDP, identity, key, key_len);
+                                        COAP_PROTO_DTLS, identity, key, key_len);
   if (!session) {
     coap_free_context(context);
     return NULL;

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -34,7 +34,9 @@ coap_ping_handler_t _handler_)*;
 *void coap_register_pong_handler(coap_context_t *_context_, 
 coap_pong_handler_t _handler_)*;
 
-Link with -lcoap-@LIBCOAP_API_VERSION@.
+Link with -lcoap-@LIBCOAP_API_VERSION@, -lcoap-@LIBCOAP_API_VERSION@-openssl
+or -lcoap-@LIBCOAP_API_VERSION@-tinydtls depending on your (D)TLS library
+type.
 
 DESCRIPTION
 -----------

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -28,7 +28,9 @@ const str *_query_);*
 *coap_subscription_t *coap_find_observer(coap_resource_t *_resource_, 
 coap_session_t *_session_, const str *_token_);*
 
-Link with -lcoap-@LIBCOAP_API_VERSION@.
+Link with -lcoap-@LIBCOAP_API_VERSION@, -lcoap-@LIBCOAP_API_VERSION@-openssl
+or -lcoap-@LIBCOAP_API_VERSION@-tinydtls depending on your (D)TLS library
+type.
 
 DESCRIPTION
 -----------
@@ -143,6 +145,11 @@ coap_pdu_t *response) {
   /* Define what the response code is going to be */
   response->code = COAP_RESPONSE_CODE(205);
 
+  /*
+   * Note that the following coap_add_option MUST be defined with numerically
+   * incrementing COAP_OPTION_ options
+   */
+
   /* If the resource is being Observed, return with Observe set */
   if (coap_find_observer(resource, session, token)) {
     coap_add_option(response,
@@ -244,118 +251,72 @@ int main(int argc, char *argv[]){
 --
 #include <coap/coap.h>
 
-unsigned char msgtype = COAP_MESSAGE_CON; /* usually, requests are sent confirmable */
+/* usually, requests are sent confirmable */
 
-typedef struct coap_list_t {
-  struct coap_list_t *next;
-  char data[];
-} coap_list_t;
+static unsigned char msgtype = COAP_MESSAGE_CON;
 
-static int coap_insert(coap_list_t **head, coap_list_t *node) {
-
-  if (!node) {
-    coap_log(LOG_WARNING, "node not specified\n");
-  } else {
-    /* must append at the list end to avoid re-ordering of
-     * options during sort */
-    LL_APPEND((*head), node);
-  } 
-  
-  return node != NULL;
-
-}
-
-static coap_list_t * new_option_node(uint16_t key, size_t length,
-unsigned char *data) {
-
-  coap_list_t *node;
-
-  node = coap_malloc(sizeof(coap_list_t) + sizeof(coap_option) + length);
-
-  if (node) {
-    coap_option *option;
-    option = (coap_option *)(node->data);
-    COAP_OPTION_KEY(*option) = key;
-    COAP_OPTION_LENGTH(*option) = length;
-    memcpy(COAP_OPTION_DATA(*option), data, length);
-  } else {
-    coap_log(LOG_DEBUG, "new_option_node: malloc\n");
-  }
-
-  return node;
-
-}
-
-static int order_opts(void *a, void *b) {
-
-  coap_option *o1, *o2;
-
-  if (!a || !b)
-    return a < b ? -1 : 1;
-
-  o1 = (coap_option *)(((coap_list_t *)a)->data);
-  o2 = (coap_option *)(((coap_list_t *)b)->data);
-
-  return (COAP_OPTION_KEY(*o1) < COAP_OPTION_KEY(*o2))
-    ? -1
-    : (COAP_OPTION_KEY(*o1) != COAP_OPTION_KEY(*o2));
-
-}
+static unsigned int token = 0;
 
 static coap_pdu_t *
-coap_new_request(coap_context_t *ctx, coap_session_t *session, char m,
-coap_list_t **options, unsigned char *data, size_t length, int observe) {
+coap_new_request(coap_context_t *context, coap_session_t *session, char request_code,
+coap_optlist_t **options, unsigned char *data, size_t length, int observe) {
 
-  static unsigned int token = 0;
   coap_pdu_t *pdu;
-  coap_list_t *opt;
-  (void)ctx;
+  coap_optlist_t *opt;
+  (void)context;
 
-  if (!(pdu = coap_new_pdu(session)))
+  /* Create the pdu with the apropriate options */
+  pdu = coap_pdu_init(msgtype, request_code, coap_new_message_id(session),
+                      coap_session_max_pdu_size(session));
+  if (!pdu)
     return NULL;
 
-  pdu->type = msgtype;
-  pdu->tid = coap_new_message_id(session);
-  pdu->code = m;
-
-  /* Create uniqueness for this request */
+  /*
+   * Create uniqueness token for this request for handling unsolicited /
+   * delayed responses
+   */
   token++;
   if (!coap_add_token(pdu, sizeof(token), (unsigned char*)&token)) {
     coap_log(LOG_DEBUG, "cannot add token to request\n");
+    goto error;
   }
 
-  if (m == COAP_REQUEST_GET && observe) {
+
+  if (request_code == COAP_REQUEST_GET && observe) {
     /* Indicate that we want to observe this resource */
-    coap_insert(options, new_option_node(COAP_OPTION_OBSERVE,
-                                         COAP_OBSERVE_ESTABLISH, NULL));
+    if (!coap_insert_optlist(options, 
+                             coap_new_optlist(COAP_OPTION_OBSERVE,
+                                         COAP_OBSERVE_ESTABLISH, NULL)))
+      goto error;
   }
 
-  if (options) {
-    /* sort options for delta encoding */
-    LL_SORT((*options), order_opts);
 
-    LL_FOREACH((*options), opt) {
-      coap_option *o = (coap_option *)(opt->data);
-      coap_add_option(pdu,
-                      COAP_OPTION_KEY(*o),
-                      COAP_OPTION_LENGTH(*o),
-                      COAP_OPTION_DATA(*o));
-    }
-  }
+  /* ... Other code / options etc. ... */
 
-  if (length) {
-    coap_add_data(pdu, length, data);
+  /* Add in all the options (after internal sorting) to the pdu */
+  if (!coap_add_optlist_pdu(pdu, *options))
+    goto error;
+
+  if (data && length) {
+    /* Add in the specified data */
+    if (!coap_add_data(pdu, length, data))
+      goto error;
   }
 
   return pdu;
+
+error:
+
+  coap_delete_pdu(pdu);
+  return NULL;
 
 }
 --
 
 SEE ALSO
 --------
-*coap_attribute*(3), *coap_context*(3), *coap_handler*(3) and 
-*coap_resource*(3)
+*coap_attribute*(3), *coap_context*(3), *coap_handler*(3), *coap_pdu_setup*(3)
+and *coap_resource*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -1,0 +1,394 @@
+// -*- mode:doc; -*-
+// vim: set syntax=asciidoc,tw=0:
+
+coap_pdu_setup(3)
+=================
+:doctype: manpage
+:man source:   coap_pdu_setup
+:man version:  @PACKAGE_VERSION@
+:man manual:   libcoap Manual
+
+NAME
+----
+coap_pdu_setup, coap_pdu_init, coap_add_token, coap_new_optlist, 
+coap_insert_optlist, coap_delete_optlist, coap_add_optlist_pdu,
+coap_add_option, coap_add_data - work with CoAP PDUs
+
+SYNOPSIS
+--------
+*#include <coap/coap.h>*
+
+*coap_pdu_t *coap_pdu_init(uint8_t _type_, uint8_t _code_,
+uint16_t _message_id_, size_t _max_size_);*
+
+*int coap_add_token(coap_pdu_t *_pdu_, size_t _length_, 
+const uint8_t *_data_);*
+
+*coap_optlist_t *coap_new_optlist(uint16_t _number_, size_t _length_,
+const uint8_t *_data_);*
+
+*int coap_insert_optlist(coap_optlist_t *_optlist_chain_,
+coap_optlist_t *_optlist_);*
+
+*void coap_delete_optlist(coap_optlist_t *_optlist_chain_);*
+
+*int coap_add_optlist_pdu(coap_pdu_t *_pdu_, coap_optlist_t *_optlist_chain_);*
+
+*size_t coap_add_option(coap_pdu_t *_pdu_, uint16_t _number_, size_t _length_,
+const uint8_t *_data_);*
+
+*int coap_add_data(coap_pdu_t *_pdu_, size_t _length_, const uint8_t *_data_);*
+
+*unsigned int coap_encode_var_bytes(uint8_t *_buffer_, unsigned int _value_);*
+
+*int coap_split_path(const uint8_t *_path_, size_t _length_, uint8_t *_buffer_,
+size_t *_buflen_);*
+
+*int coap_split_query(const uint8_t *_query_, size_t _length_, uint8_t *_buffer_,
+size_t *_buflen_);*
+
+Link with -lcoap-@LIBCOAP_API_VERSION@, -lcoap-@LIBCOAP_API_VERSION@-openssl
+or -lcoap-@LIBCOAP_API_VERSION@-tinydtls depending on your (D)TLS library
+type.
+
+DESCRIPTION
+-----------
+The CoAP PDU is of the form
+
+--header--|--optional token--|--optional options--|--optional payload--
+
+The PDU must be built in the correct order, from left to right.  In particular,
+the options need to be added in the correct numerical option order as they are 
+stored in the PDU using relative numeric offsets from the previous option 
+number.
+
+There are option list functions available where options can be added to a 
+chained list of options and then the chain list is sorted and then be added to 
+the PDU.
+
+Typically for clients, when creating a request, the PDU needs to be created 
+before filling it with the appropriate information.
+
+Typically with a server, the response PDU, with the optional token already added
+in, will already be created before the response handler is called, and the 
+response PDU will need to be updated as appropriate starting with the optional 
+options.  Note that updating the response pdu's code variable will cause the 
+response pdu to get transmitted.  If code does not get updated, then the 
+response pdu is freed off by the underlying library.
+
+The *coap_pdu_init*() function returns a newly created _PDU_ of type 
+_coap_pdu_t_*.  _type_ is one of the following
+
+[horizontal]
+*COAP_MESSAGE_CON*::
+Set the _PDU_ to be of type confirmable.
+*COAP_MESSAGE_NON*::
+Set the _PDU_ to be of type non-confirmable.
+*COAP_MESSAGE_ACK*::
+Set the _PDU_ to be of type acknowledge (for internal use).
+*COAP_MESSAGE_RST*::
+Set the _PDU_ to be of type reset.
+
+The _code_ is one of the following
+
+[horizontal]
+*COAP_REQUEST_GET*::
+Set the _PDU_ request to be of type GET.
+*COAP_REQUEST_POST*::
+Set the _PDU_ request to be of type POST.
+*COAP_REQUEST_PUT*::
+Set the _PDU_ request to be of type PUT.
+*COAP_REQUEST_DELETE*::
+Set the _PDU_ request to be of type DELETE.
+*COAP_REQUEST_FETCH*::
+Set the _PDU_ request to be of type FETCH.
+*COAP_REQUEST_PATCH*::
+Set the _PDU_ request to be of type PATCH.
+*COAP_REQUEST_IPATCH*::
+Set the _PDU_ request to be of type IPATCH.
+
+The _message_id_ must be unique per request (which is not the same as the
+token), and must not be reused within EXCHANGE_LIFETIME (usually 247 seconds).
+To automate this, the function coap_new_message_id(session) should be called.
+
+The _max_size_ parameter defines the maximum size of a _PDU_ and is usually 
+determined by calling coap_session_max_pdu_size(session); 
+
+The *coap_add_token*() function adds in the specified token's _data_ of length 
+_length_ to the PDU _pdu_.  The maximum length of the token is 8 bytes.
+Adding the token must be done before any options or data are added. 
+This function must only be called once per _pdu_, and must not be called
+in the appropriate response handler.
+
+The *coap_new_optlist*() function returns a newly created _optlist_ entry of
+type _coap_optlist_t_*.  The _number_ specifies which CoAP option is to be 
+used, and is one of the COAP_OPTION_* definitions.  The _length_ is the length 
+of the data of the option, and _data_ points to the content of the option.
+
+The following is the current list of options with their numeric value
+----
+#define COAP_OPTION_IF_MATCH        1 /* opaque, 0-8 B */
+#define COAP_OPTION_URI_HOST        3 /* String, 1-255 B */
+#define COAP_OPTION_ETAG            4 /* opaque, 1-8 B */
+#define COAP_OPTION_IF_NONE_MATCH   5 /* empty,  0 B */
+#define COAP_OPTION_OBSERVE         6 /* empty/uint, 0 B/0-3 B */
+#define COAP_OPTION_URI_PORT        7 /* uint, 0-2 B */
+#define COAP_OPTION_LOCATION_PATH   8 /* String, 0-255 B */
+#define COAP_OPTION_URI_PATH       11 /* String, 0-255 B */
+#define COAP_OPTION_CONTENT_FORMAT 12 /* uint, 0-2 B */
+#define COAP_OPTION_MAXAGE         14 /* uint, 0-4 B, default 60 Seconds */
+#define COAP_OPTION_URI_QUERY      15 /* String, 1-255 B */
+#define COAP_OPTION_ACCEPT         17 /* uint, 0-2 B */
+#define COAP_OPTION_LOCATION_QUERY 20 /* String, 0-255 B */
+#define COAP_OPTION_BLOCK2         23 /* uint, 0-3 B */
+#define COAP_OPTION_BLOCK1         27 /* uint, 0-3 B */
+#define COAP_OPTION_PROXY_URI      35 /* String, 1-1034 B */
+#define COAP_OPTION_PROXY_SCHEME   39 /* String, 1-255 B */
+#define COAP_OPTION_SIZE1          60 /* uint, 0-4 B */
+#define COAP_OPTION_NORESPONSE    258 /* uint, 0-1 B */
+----
+See FURTHER INFORMATION as to how to get the latest list.
+
+The *coap_insert_optlist*() function adds the _optlist_ entry onto the 
+_optlist_chain_ and then sorts the _optlist_chain_ before returning.
+The initial _optlist_chain_ entry needs to be set to NULL before this function
+is first called.  The coap_delete_optlist() function has to be called to free
+off all the _optlist_chain_ entries.
+
+The *coap_delete_optlist*() function deletes and frees off all the optlist 
+entries in the _optlist_chain_.
+
+The *coap_add_optlist_pdu*() function sorts all of the entries in 
+_optlist_chain_ into ascending option numeric order and adds all the entries 
+to the _pdu_.  This function does not free off the entries in _optlist_chain_.
+This function must be called after adding any token and before adding in the
+payload data.
+
+The *coap_add_option*() function adds in the specified option of type _number_ 
+with _data_ of length _length_ to the PDU _pdu_.
+It is critical that options are added to the _pdu_ with _number_ either
+being the same or greater than the previous option _number_ that was added.
+
+The *coap_add_data*() function added in the specified payload _data_ of length
+_length_ to the PDU _pdu_. Adding the payload data must be done after any
+token or options are added.  This function must only be called once per _pdu_.
+
+The *coap_encode_var_bytes*() function encodes _value_ into _buffer_.  
+_buffer_ needs to be dimensioned to be at least the sizeof(int) to prevent
+any _buffer_ overflows.
+
+The *coap_split_path*() function splits up _path_ of length _length_ and 
+places the result in _buffer_ which has a size of _buflen_.  _buflen_ needs
+to be preset with the size of _buffer_ before the function call, and then
+_buflen_ is updated whith the actual size of _buffer_ used.
+
+The *coap_split_query*() function splits up _query_ of length _length_ and 
+places the result in _buffer_ which has a size of _buflen_.  _buflen_ needs
+to be preset with the size of _buffer_ before the function call, and then
+_buflen_ is updated whith the actual size of _buffer_ used.
+
+RETURN VALUES
+-------------
+The *coap_pdu_init*() function returns a newly created _PDU_ or NULL if there 
+is a malloc or parameter failure. 
+
+The *coap_new_optlist*() function returns a newly created _optlist_ or NULL
+if there is a malloc failure. 
+
+The *coap_add_token*(), *coap_insert_optlist*(), *coap_delete_optlist*(),
+*coap_add_optlist_pdu*() and *coap_add_data*()
+functions return 0 on failure, 1 on success.
+
+The *coap_add_optlist*() function returns either the length of the option
+or 0 on failure.
+
+The *coap_encode_var_bytes*() function returns either the length of bytes
+encoded or 0 on failure.
+
+EXAMPLES
+--------
+*Setup PDU and Transmit*
+
+[source, c]
+--
+#include <coap/coap.h>
+
+static int token = 0;
+
+int
+build_send_pdu(coap_context_t *context, coap_session_t *session, 
+uint8_t msgtype, uint8_t request_code, const char *uri, const char *query, 
+unsigned char *data, size_t length, int observe) {
+
+  coap_pdu_t *pdu;
+  (void)context;
+  char buf[1024];
+  size_t buflen;
+  char *sbuf = buf;
+  int res;
+  coap_optlist_t *optlist_chain = NULL;
+
+  /* Create the pdu with the apropriate options */
+  pdu = coap_pdu_init(msgtype, request_code, coap_new_message_id(session),
+                      coap_session_max_pdu_size(session));
+  if (!pdu)
+    return 0;
+
+  /*
+   * Create uniqueness token for this request for handling unsolicited /
+   * delayed responses
+   */
+  token++;
+  if (!coap_add_token(pdu, sizeof(token), (unsigned char*)&token)) {
+    coap_log(LOG_DEBUG, "cannot add token to request\n");
+    goto error;
+  }
+
+  if (uri) {
+    /* Add in the URI options */
+    buflen = sizeof(buf);
+    res = coap_split_path((const uint8_t*)uri, strlen(uri), sbuf, &buflen);
+    while (res--) {
+      if (!coap_insert_optlist(&optlist_chain, 
+                               coap_new_optlist(COAP_OPTION_URI_PATH,
+                        coap_opt_length(sbuf), coap_opt_value(sbuf))))
+        goto error;
+      sbuf += coap_opt_size(sbuf);
+    }
+  }
+
+  if (query) {
+    /* Add in the QUERY options */
+    buflen = sizeof(buf);
+    res = coap_split_query((const uint8_t*)query, strlen(query), sbuf, &buflen);
+    while (res--) {
+      if (!coap_insert_optlist(&optlist_chain, 
+                               coap_new_optlist(COAP_OPTION_URI_QUERY,
+                        coap_opt_length(sbuf), coap_opt_value(sbuf))))
+        goto error;
+      sbuf += coap_opt_size(sbuf);
+    }
+  }
+
+  if (request_code == COAP_REQUEST_GET && observe) {
+    /* Indicate that we want to observe this resource */
+    if (!coap_insert_optlist(&optlist_chain, 
+                             coap_new_optlist(COAP_OPTION_OBSERVE,
+                                         COAP_OBSERVE_ESTABLISH, NULL)))
+      goto error;
+  }
+
+  /* ... Other code / options etc. ... */
+
+  /* Add in all the options (after internal sorting) to the pdu */
+  if (!coap_add_optlist_pdu(pdu, optlist_chain))
+    goto error;
+
+  if (data && length) {
+    /* Add in the specified data */
+    if (!coap_add_data(pdu, length, data))
+      goto error;
+  }
+
+  if (coap_send(session, pdu) == COAP_INVALID_TID)
+    goto error;
+  return 1;
+
+error:
+
+  if (pdu)
+    coap_pdu_delete(pdu);
+  return 0;
+
+}
+--
+
+*Resource Handler Response PDU Update*
+
+[source, c]
+--
+#include <coap/coap.h>
+
+static void 
+hnd_get_time(coap_context_t *context, coap_resource_t *resource, 
+coap_session_t *session, coap_pdu_t *request, str *token, str *query, 
+coap_pdu_t *response) {
+
+  unsigned char buf[40];
+  size_t len;
+  time_t now;
+  coap_tick_t t;
+
+  /* ... Additional analysis code for resource, request pdu etc.  ... */
+
+  /* After analysis, generate a suitable response */
+
+  /* Define what the response code is going to be */
+  response->code = COAP_RESPONSE_CODE(205);
+
+  /* Note that token, if set, is already in the response pdu */
+
+  /*
+   * Note that the following coap_add_option MUST be defined with numerically
+   * incrementing COAP_OPTION_ options
+   */
+
+  /* If the resource is being Observed, return with Observe set */
+  if (coap_find_observer(resource, session, token)) {
+    coap_add_option(response,
+                    COAP_OPTION_OBSERVE,
+                    coap_encode_var_bytes(buf, resource->observe), buf);
+  }
+
+  /* Response is in plain text format */
+  coap_add_option(response,
+                    COAP_OPTION_CONTENT_FORMAT,
+                    coap_encode_var_bytes(buf, COAP_MEDIATYPE_TEXT_PLAIN), buf);
+
+  /* Report on how long this response is valid for (1 second in this case)*/
+  coap_add_option(response,
+                  COAP_OPTION_MAXAGE,
+                  coap_encode_var_bytes(buf, 0x01), buf);
+
+  now = time(NULL);
+
+  if (query != NULL && memcmp(query->s, "secs", min(4, query->length)) == 0) {
+    /* Output secs since Jan 1 1970 */
+    len = snprintf((char *)buf, sizeof(buf), "%lu", now);
+    coap_add_data(response, len, buf);
+  } else {
+    /* Output human-readable time */
+    struct tm *tmp;
+    tmp = gmtime(&now);
+    len = strftime((char *)buf, sizeof(buf), "%b %d %H:%M:%S", tmp);
+    coap_add_data(response, len, buf);
+  }
+
+  /*
+   * As resource->code has been updated, the response pdu will be transmitted
+   * by the underlying library
+   */
+
+}
+
+--
+
+SEE ALSO
+--------
+*coap_observe*(3), *coap_resource*(3)
+
+FURTHER INFORMATION
+-------------------
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further 
+information.
+See https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#option-numbers
+for the current set of defined CoAP Options.
+
+BUGS
+----
+Please report bugs on the mailing list for libcoap:
+libcoap-developers@lists.sourceforge.net
+
+AUTHORS
+-------
+The libcoap project <libcoap-developers@lists.sourceforge.net>

--- a/man/coap_recovery.txt.in
+++ b/man/coap_recovery.txt.in
@@ -38,7 +38,9 @@ coap_fixed_point_t _value_)*;
 
 *int coap_debug_set_packet_loss(const char *_loss_level_)*;
 
-Link with -lcoap-@LIBCOAP_API_VERSION@.
+Link with -lcoap-@LIBCOAP_API_VERSION@, -lcoap-@LIBCOAP_API_VERSION@-openssl
+or -lcoap-@LIBCOAP_API_VERSION@-tinydtls depending on your (D)TLS library
+type.
 
 DESCRIPTION
 -----------
@@ -61,6 +63,24 @@ typedef struct coap_fixed_point_t {
                                1/1000 (3 points) precision */
 } coap_fixed_point_t;
 ----
+
+The CoAP message retry rules are (with the default values to compute the time)
+----
+1st retransmit after 1 * ack_timeout * ack_random factor (3 seconds)
+2nd retransmit after 2 * ack_timeout * ack_random factor (6 seconds)
+3rd retransmit after 3 * ack_timeout * ack_random factor (12 seconds)
+4th retransmit after 4 * ack_timeout * ack_random factor (24 seconds)
+5th retransmit after 5 * ack_timeout * ack_random factor (48 seconds)
+
+As max_transmit (by default) is 4, then the 5th retransmit does not get sent,
+but at that point COAP_NACK_TOO_MANY_RETRIES gets raised in the nack_handler
+(if defined). Note that the sum of the seconds is 93 matching RFC7252.
+----
+
+It should be noted that these retries are seperate from the DTLS or TLS
+encrypted session setup retry timeouts. For DTLS, the initial requesting
+packet will get sent max_retransmit times before reporting failure.
+For TLS the initial TCP connection will timeout before reporting failure.
 
 It is also possible to set up packet losses, for both confirmable, and 
 non-confirmable messages.  This can be used for stress testing packet 

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -34,7 +34,9 @@ coap_resource_t _resource_);*
 
 *void coap_resource_set_mode(coap_resource_t *_resource_, int _mode_);*
 
-Link with -lcoap-@LIBCOAP_API_VERSION@.
+Link with -lcoap-@LIBCOAP_API_VERSION@, -lcoap-@LIBCOAP_API_VERSION@-openssl
+or -lcoap-@LIBCOAP_API_VERSION@-tinydtls depending on your (D)TLS library
+type.
 
 DESCRIPTION
 -----------
@@ -76,6 +78,7 @@ or'ed together.
 It is imperative that _uri_path_ points to data that is valid during the 
 lifetime of the resource.
 
+[horizontal]
 *COAP_RESOURCE_FLAGS_NOTIFY_NON*::
 Set the notification message type to non-confirmable.
 

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -24,7 +24,9 @@ SYNOPSIS
 
 *coap_tls_version_t *coap_get_tls_library_version(void);*
 
-Link with -lcoap-@LIBCOAP_API_VERSION@.
+Link with -lcoap-@LIBCOAP_API_VERSION@, -lcoap-@LIBCOAP_API_VERSION@-openssl
+or -lcoap-@LIBCOAP_API_VERSION@-tinydtls depending on your (D)TLS library
+type.
 
 DESCRIPTION
 -----------
@@ -59,10 +61,10 @@ type and library version in a coap_tls_version_t* structure.
 
 [source, c]
 ----
-#define COAP_TLS_LIBRARY_NOTLS 0
+#define COAP_TLS_LIBRARY_NOTLS    0
 #define COAP_TLS_LIBRARY_TINYDTLS 1
-#define COAP_TLS_LIBRARY_OPENSSL 2
-#define COAP_TLS_LIBRARY_GNUTLS 3
+#define COAP_TLS_LIBRARY_OPENSSL  2
+#define COAP_TLS_LIBRARY_GNUTLS   3
 
 typedef struct coap_tls_version_t {
   uint64_t version; /* Library Version as returned by the TLS library */

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -50,7 +50,7 @@ int coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
   return 0;
 }
 
-int coap_dtls_context_check_keys_enabled(coap_context_t *ctx)
+int coap_dtls_context_check_keys_enabled(coap_context_t *ctx UNUSED)
 {
   return 0;
 }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -465,7 +465,7 @@ int coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
   return 1;
 }
 
-int coap_dtls_context_check_keys_enabled(coap_context_t *ctx)
+int coap_dtls_context_check_keys_enabled(coap_context_t *ctx UNUSED)
 {
   return 1;
 }

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -205,6 +205,11 @@ coap_add_token(coap_pdu_t *pdu, size_t len, const uint8_t *data) {
   if (!pdu || len > 8)
     return 0;
 
+  if (pdu->used_size) {
+    coap_log(LOG_WARNING,
+             "coap_add_token: The token must defined first. Token ignored\n");
+    return 0;
+  }
   if (!coap_pdu_check_resize(pdu, len))
     return 0;
   pdu->token_length = (uint8_t)len;

--- a/win32/coap-client/coap-client.vcxproj
+++ b/win32/coap-client/coap-client.vcxproj
@@ -334,10 +334,6 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\examples\client.c" />
-    <ClCompile Include="..\..\examples\coap_list.c" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\..\examples\coap_list.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libcoap.vcxproj">

--- a/win32/coap-client/coap-client.vcxproj.filters
+++ b/win32/coap-client/coap-client.vcxproj.filters
@@ -15,16 +15,8 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\examples\coap_list.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\examples\client.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\..\examples\coap_list.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Anyone building a coap client will need to copy a lot of the code for handling CoAP Options from examples/client.c (see Issue #154 ).  This Pull Request moves the code into libcoap with the definitions of a new structure coap_optlist_t and a set of coap_optlist_* functions.  These new functions simplify the setting up of PDUs etc.  

coap_list_t was not moved into libcoap as it is likely that this structure has been copied into many clients.

The new functions are
coap_new_optlist()
coap_insert_optlist()
coap_add_optlist_pdu()
coap_delete_optlist()

At the same time, the example executables have been cleaned up to remove compiler warnings, the logging macros debug() and warn() has been replaced with coap_logging() as well as all the logging messages now have a trailing \n.

The local variable index compiler warning clash with the string function index has been fixed whilst working in src/option.c to add in the new functions.


Should coap_list.[ch] be left in the examples directory for backward comparability.  I think no, but.....