### PR TITLE
DTLS session setup retries to establish DTLS many times before failure

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -1326,7 +1326,9 @@ main(int argc, char **argv) {
 
   while ( !(ready && coap_can_exit(ctx)) ) {
 
-    result = coap_run_once( ctx, wait_ms == 0 ? obs_ms : obs_ms == 0 ? wait_ms : min( wait_ms, obs_ms ) );
+    result = coap_run_once( ctx, wait_ms == 0 ?
+                                 obs_ms : obs_ms == 0 ?
+                                 min(wait_ms, 1000) : min( wait_ms, obs_ms ) );
 
     if ( result >= 0 ) {
       if ( wait_ms > 0 && !wait_ms_reset ) {

--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -83,6 +83,7 @@ typedef struct coap_session_t {
   unsigned int max_retransmit;          /**< maximum re-transmit count (default 4) */
   coap_fixed_point_t ack_timeout;       /**< timeout waiting for ack (default 2 secs) */
   coap_fixed_point_t ack_random_factor; /**< ack random factor backoff (default 1.5) */
+  unsigned int dtls_timeout_count;      /**<dtls setup retry counter */
 } coap_session_t;
 
 /**


### PR DESCRIPTION
Make use of the MAX-RETRANSMIT parameter value (default 4) to limit the number of DTLS setup retries before raising COAP_NACK_TLS_FAILED as a session failure.