### PR TITLE
net.c: use after free in coap_free_context()

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -500,12 +500,12 @@ coap_free_context(coap_context_t *context) {
 
   coap_delete_all_resources(context);
 
-  if (context->dtls_context)
-    coap_dtls_free_context(context->dtls_context);
-
   LL_FOREACH_SAFE(context->endpoint, ep, tmp) {
     coap_free_endpoint(ep);
   }
+
+  if (context->dtls_context)
+    coap_dtls_free_context(context->dtls_context);
 
   if (context->psk_hint)
     coap_free(context->psk_hint);


### PR DESCRIPTION
Because of incorrect free order, if there are open TLS connections when
coap_free_context() is called a use after free will occur as OpenSSL tries to
shutdown the connections.