### PR TITLE
removed un-necessary const cast

### DIFF
--- a/include/coap/block.h
+++ b/include/coap/block.h
@@ -41,7 +41,7 @@ typedef struct {
  * returns @c NULL.
  */
 #define COAP_OPT_BLOCK_LAST(opt) \
-  (coap_opt_length(opt) ? (coap_opt_const_value(opt) + (coap_opt_length(opt)-1)) : 0)
+  (coap_opt_length(opt) ? (coap_opt_value(opt) + (coap_opt_length(opt)-1)) : 0)
 
 /** Returns the value of the More-bit of a Block option @p opt. */
 #define COAP_OPT_BLOCK_MORE(opt) \

--- a/include/coap/option.h
+++ b/include/coap/option.h
@@ -398,12 +398,7 @@ uint16_t coap_opt_length(const coap_opt_t *opt);
  *
  * @return    A pointer to the option value or @c NULL on error.
  */
-uint8_t *coap_opt_value(coap_opt_t *opt);
-
-COAP_STATIC_INLINE const uint8_t *
-coap_opt_const_value( const coap_opt_t *opt ) {
-  return coap_opt_value((coap_opt_t*)opt);
-}
+uint8_t *coap_opt_value(const coap_opt_t *opt);
 
 /** @} */
 

--- a/src/block.c
+++ b/src/block.c
@@ -31,9 +31,9 @@ coap_opt_block_num(const coap_opt_t *block_opt) {
   if (len == 0) {
     return 0;
   }
-  
+
   if (len > 1) {
-    num = coap_decode_var_bytes(coap_opt_const_value(block_opt), 
+    num = coap_decode_var_bytes(coap_opt_value(block_opt),
 				coap_opt_length(block_opt) - 1);
   }
   

--- a/src/option.c
+++ b/src/option.c
@@ -278,7 +278,7 @@ coap_opt_length(const coap_opt_t *opt) {
 }
 
 unsigned char *
-coap_opt_value(coap_opt_t *opt) {
+coap_opt_value(const coap_opt_t *opt) {
   size_t ofs = 1;
 
   switch (*opt & 0xf0) {


### PR DESCRIPTION
It seems that this cast (which generates a build error with some compiler switches, at least a warning) is not necessary since the options are only accessed in read only. I enforced the original function with a 'const' argument passing.

It is the only "dangerous" code within the public interface, otherwise everithing is ok with all the compiler flags turned on. It would be good to have a very strict and compliant interface so that libcoap can be integrated in application environment with very strict compiler flags enabled. 