### PR TITLE
Verify tid is not being re-used in a session

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -252,6 +252,14 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
     node->session = NULL;
     node->t = 0;
   } else {
+    coap_queue_t *q = NULL;
+    /* Check that the same tid is not getting re-used in violation of RFC7252 */
+    LL_FOREACH(session->sendqueue, q) {
+      if (q->id == pdu->tid) {
+        coap_log(LOG_ERR, "**  %s tid=%d: already in-use - dropped\n", coap_session_str(session), pdu->tid);
+        return COAP_INVALID_TID;
+      }
+    }
     node = coap_new_node();
     if (node == NULL)
       return COAP_INVALID_TID;


### PR DESCRIPTION
Check that the same tid is not getting re-used in violation of RFC7252
in coap_session_delay_pdu().

To prevent duplication issues highlighted in Issue #163 as per below

`It looks like you are calling coap_send() for the same PDU 3 times - correct?
(sent at 17:09:57, 17:09:59 and 17:10:01)`
