### PR TITLE
coap_openssl tidy up, fix first PSK fails if both PSK and PKI are enabled on server

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -138,6 +138,7 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_LDFLAGS =					\
 CTAGS_IGNORE=-I " \
 coap_dtls_context_check_keys_enabled \
 coap_dtls_context_set_pki \
+coap_dtls_context_set_pki_root_cas \
 coap_dtls_context_set_psk \
 coap_dtls_free_context \
 coap_dtls_free_session \
@@ -154,6 +155,7 @@ coap_dtls_receive \
 coap_dtls_send \
 coap_dtls_session_update_mtu \
 coap_dtls_startup \
+coap_endpoint_new_dtls_session \
 coap_packet_extract_pbuf \
 coap_pdu_from_pbuf \
 coap_socket_accept_tcp \

--- a/configure.ac
+++ b/configure.ac
@@ -632,11 +632,13 @@ include/coap/coap.h
 man/coap.txt
 man/coap_attribute.txt
 man/coap_context.txt
+man/coap_encryption.txt
 man/coap_handler.txt
 man/coap_observe.txt
 man/coap_pdu_setup.txt
 man/coap_recovery.txt
 man/coap_resource.txt
+man/coap_session.txt
 man/coap_tls_library.txt
 man/coap-client.txt
 man/coap-server.txt

--- a/include/coap/coap_dtls.h
+++ b/include/coap/coap_dtls.h
@@ -24,14 +24,14 @@
 /**
  * Check whether DTLS is available.
  * 
- * @return 1 if support for DTLS is enabled, or 0 otherwise.
+ * @return @c 1 if support for DTLS is enabled, or @c 0 otherwise.
  */
 int coap_dtls_is_supported(void);
 
 /**
  * Check whether TLS is available.
  *
- * @return 1 if support for TLS is enabled, or 0 otherwise.
+ * @return @c 1 if support for TLS is enabled, or @c 0 otherwise.
  */
 int coap_tls_is_supported(void);
 
@@ -40,6 +40,10 @@ int coap_tls_is_supported(void);
 #define COAP_TLS_LIBRARY_OPENSSL 2 /**< Using OpenSSL library */
 #define COAP_TLS_LIBRARY_GNUTLS 3 /**< Using GnuTLS library */
 
+/**
+ * The structure used for returning the underlying (D)TLS library
+ * information.
+ */
 typedef struct coap_tls_version_t {
   uint64_t version; /**< (D)TLS Library Version */
   int type; /**< Library type. One of COAP_TLS_LIBRARY_* */
@@ -53,8 +57,8 @@ typedef struct coap_tls_version_t {
 coap_tls_version_t *coap_get_tls_library_version(void);
 
 /**
- * Sets the (D)TLS logging level to the specified value.
- * Note: coap_log_level() will influence output if at a lower level 
+ * Sets the (D)TLS logging level to the specified @p level.
+ * Note: coap_log_level() will influence output if at a specified level. 
  *
  * @param level The logging level to use - LOG_*
  */
@@ -70,202 +74,423 @@ int coap_dtls_get_log_level(void);
 struct coap_dtls_pki_t;
 
 /**
- * Security setup handler that is used as call-back in coap_context_set_pki().
+ * Security setup handler that can be used as application call-back in
+ * coap_context_set_pki().
  * Typically, this will be calling additonal functions like
  * SSL_CTX_set_tlsext_servername_callback() etc.
  *
- * @param context The security context definition - e.g. SSL_CTX * for OpenSSL. 
- *              This will be dependent on the underlying TLS library
- *              - see coap_get_tls_library_version()
+ * @param tls_context The security context definition - e.g. SSL_CTX * for
+ *                    OpenSSL. This will be dependent on the underlying TLS
+ *                    library - see coap_get_tls_library_version()
+ * @param tls_session The security session definition - e.g. SSL * for OpenSSL.
+ *                    NULL if server call-back.
+ *                    This will be dependent on the underlying TLS library -
+ *                    see coap_get_tls_library_version()
  * @param setup_data A structure containing setup data originally passed into
- *                  coap_context_set_pki() or coap_new_client_session_pki().
+ *                   coap_context_set_pki() or coap_new_client_session_pki().
  *
- * @return 1 if successful, else 0.
+ * @return @c 1 if successful, else @c 0.
  */
-typedef int (*coap_dtls_security_setup_t)(void *context,
+typedef int (*coap_dtls_security_setup_t)(void *tls_context, void* tls_session,
                                         struct coap_dtls_pki_t *setup_data);
 
+/**
+ * CN Validation call-back that can be set up by coap_context_set_pki().
+ * Invoked when libcoap has done the validation checks at the TLS level,
+ * but the application needs to check that the CN is allowed.
+ * CN is the SubjectAltName in the cert, if not present, then the leftmost
+ * Common Name (CN) component of the subject name.
+ *
+ * @param cn  The determined CN from the certificate
+ * @param asn1_public_cert  The ASN.1 DER encoded X.509 certificate
+ * @param asn1_length  The ASN.1 length
+ * @param coap_session  The CoAP session associated with the certificate update
+ * @param depth  Depth in cert chain.  If 0, then client cert, else a CA
+ * @param validated  TLS layer can find no issues if 1
+ * @param arg  The same as was passed into coap_context_set_pki()
+ *             in setup_data->cn_call_back_arg
+ *
+ * @return @c 1 if accepted, else @c 0 if to be rejected.
+ */
+typedef int (*coap_dtls_cn_callback_t)(const char *cn,
+             const uint8_t *asn1_public_cert,
+             size_t asn1_length,
+             coap_session_t *coap_session,
+             unsigned depth,
+             int validated,
+             void *arg);
+
+/**
+ * The enum used for determining the provided PKI ASN.1 (DER) Private Key
+ * formats.
+ */
 typedef enum coap_asn1_privatekey_type_t {
-  COAP_ASN1_PKEY_NONE,
-  COAP_ASN1_PKEY_RSA,
-  COAP_ASN1_PKEY_RSA2,
-  COAP_ASN1_PKEY_DSA,
-  COAP_ASN1_PKEY_DSA1,
-  COAP_ASN1_PKEY_DSA2,
-  COAP_ASN1_PKEY_DSA3,
-  COAP_ASN1_PKEY_DSA4,
-  COAP_ASN1_PKEY_DH,
-  COAP_ASN1_PKEY_DHX,
-  COAP_ASN1_PKEY_EC,
-  COAP_ASN1_PKEY_HMAC,
-  COAP_ASN1_PKEY_CMAC,
-  COAP_ASN1_PKEY_TLS1_PRF,
-  COAP_ASN1_PKEY_HKDF
+  COAP_ASN1_PKEY_NONE,     /**< NONE */
+  COAP_ASN1_PKEY_RSA,      /**< RSA type */
+  COAP_ASN1_PKEY_RSA2,     /**< RSA2 type */
+  COAP_ASN1_PKEY_DSA,      /**< DSA type */
+  COAP_ASN1_PKEY_DSA1,     /**< DSA1 type */
+  COAP_ASN1_PKEY_DSA2,     /**< DSA2 type */
+  COAP_ASN1_PKEY_DSA3,     /**< DSA3 type */
+  COAP_ASN1_PKEY_DSA4,     /**< DSA4 type */
+  COAP_ASN1_PKEY_DH,       /**< DH type */
+  COAP_ASN1_PKEY_DHX,      /**< DHX type */
+  COAP_ASN1_PKEY_EC,       /**< EC type */
+  COAP_ASN1_PKEY_HMAC,     /**< HMAC type */
+  COAP_ASN1_PKEY_CMAC,     /**< CMAC type */
+  COAP_ASN1_PKEY_TLS1_PRF, /**< TLS1_PRF type */
+  COAP_ASN1_PKEY_HKDF      /**< HKDF type */
 } coap_asn1_privatekey_type_t;
 
-/** The structure used for defining the PKI setup data to be used */
+/**
+ * The enum used for determining the PKI key formats.
+ */
+typedef enum coap_pki_key_t {
+  COAP_PKI_KEY_PEM,      /**< The PKI key type is PEM */
+  COAP_PKI_KEY_ASN1,      /**< The PKI key type is ASN.1 (DER) */
+} coap_pki_key_t;
+
+/**
+ * The structure that holds the PKI PEM definitions.
+ */
+typedef struct coap_pki_key_pem_t {
+  const char *ca_file;       /**< File location of Common CA in PEM format */
+  const char *public_cert;   /**< File location of Public Cert in PEM format */
+  const char *private_key;   /**< File location of Private Key in PEM format */
+} coap_pki_key_pem_t;
+
+/**
+ * The structure that holds the PKI ASN.1 (DER) definitions.
+ */
+typedef struct coap_pki_key_asn1_t {
+  const uint8_t *ca_cert;     /**< ASN1 (DER) Common CA Cert */
+  const uint8_t *public_cert; /**< ASN1 (DER) Public Cert */
+  const uint8_t *private_key; /**< ASN1 (DER) Private Key */
+  size_t ca_cert_len;         /**< ASN1 CA Cert length */
+  size_t public_cert_len;     /**< ASN1 Public Cert length */
+  size_t private_key_len;     /**< ASN1 Private Key length */
+  coap_asn1_privatekey_type_t private_key_type; /**< Private Key Type */
+} coap_pki_key_asn1_t;
+
+/**
+ * The structure that holds the PKI key information.
+ */
+typedef struct coap_dtls_key_t {
+  coap_pki_key_t key_type;          /**< key format type */
+  union {
+    coap_pki_key_pem_t pem;         /**< for PEM keys */
+    coap_pki_key_asn1_t asn1;       /**< for ASN.1 (DER) keys */
+  } key;
+} coap_dtls_key_t;
+
+/**
+ * Server Name Indication (SNI) Validation call-back that can be set up by
+ * coap_context_set_pki().
+ * Invoked if the SNI is not previously seen and prior to sending a certificate
+ * set back to the client so that the appropriate certificate set can be used
+ * based on the requesting SNI.
+ *
+ * @param sni  The requested SNI
+ * @param arg  The same as was passed into coap_context_set_pki()
+ *             in setup_data->sni_call_back_arg
+ *
+ * @return New set of certificates to use, or @c NULL if SNI is to be rejected.
+ */
+typedef coap_dtls_key_t *(*coap_dtls_sni_callback_t)(const char *sni,
+             void* arg);
+
+
+#define COAP_DTLS_PKI_SETUP_VERSION 1 /**< Latest PKI setup version */
+
+/**
+ * The structure used for defining the PKI setup data to be used.
+ */
 typedef struct coap_dtls_pki_t {
-  /* Optional CallBack for additional setup */
-  coap_dtls_security_setup_t call_back;
-  /* Alternative 1: Name of file on disk */
-  const char *ca_file;
-  const char *public_cert;
-  const char *private_key;
-  /* Alternative 2: ASN1 version */
-  const uint8_t *asn1_ca_file;
-  const uint8_t *asn1_public_cert;
-  const uint8_t *asn1_private_key;
-  int asn1_ca_file_len;
-  int asn1_public_cert_len;
-  int asn1_private_key_len;
-  coap_asn1_privatekey_type_t asn1_private_key_type;
+  uint8_t version; /** Set to 1 to support this version of the struct */
+
+  /* Options to enable different TLS functionality in libcoap */
+  uint8_t verify_peer_cert;        /**< 1 if peer cert is to be verified */
+  uint8_t require_peer_cert;       /**< 1 if peer cert is required */
+  uint8_t allow_self_signed;       /**< 1 if self signed certs are allowed */
+  uint8_t allow_expired_certs;     /**< 1 if expired certs are allowed */
+  uint8_t cert_chain_validation;   /**< 1 if to check cert_chain_verify_depth */
+  uint8_t cert_chain_verify_depth; /**< recommended depth is 3 */
+  uint8_t check_cert_revocation;   /**< 1 if revocation checks wanted */
+  uint8_t allow_no_crl;            /**< 1 ignore if CRL not there */
+  uint8_t allow_expired_crl;       /**< 1 if expired crl is allowed */
+  uint8_t reserved[6];             /**< Reserved - must be set to 0 for
+                                        future compatability */
+                                   /* Size of 6 chosen to align to next
+                                    * parameter, so if newly defined option
+                                    * it can use one of the reserverd slot so
+                                    * no need to change
+                                    * COAP_DTLS_PKI_SETUP_VERSION and just
+                                    * decrement the reserved[] count.
+                                    */
+ 
+  /** CN check call-back function.
+   * If not NULL, is called when the TLS connection has passed the configured
+   * TLS options above for the application to verify if the CN is valid.
+   */
+  coap_dtls_cn_callback_t validate_cn_call_back;
+  void *cn_call_back_arg;  /**< Passed in to the CN call-back function */
+ 
+  /** SNI check call-back function.
+   * If not @p NULL, called if the SNI is not previously seen and prior to
+   * sending a certificate set back to the client so that the appropriate
+   * certificate set can be used based on the requesting SNI.
+   */
+  coap_dtls_sni_callback_t validate_sni_call_back;
+  void *sni_call_back_arg;  /**< Passed in to the sni call-back function */
+
+  /** Application Setup call-back definition, overriding libcoap's TLS call-backs.
+   * If not @p NULL, then application is handling the characteristics of the TLS
+   * connection setup in the defined call-back handler.  If set, then none of
+   * the options or call-backs above are acted on. 
+   * Otherwise, libcoap internally based on the selected options handles the 
+   * TLS connection setup.
+   */
+  coap_dtls_security_setup_t app_override_tls_setup_call_back;
+ 
+  char* client_sni;    /**<  If not NULL, SNI to use in client TLS setup.
+                             Owned by the client app and must remain valid
+                             during the call to coap_new_client_session_pki() */
+
+  coap_dtls_key_t pki_key;  /**< PKI key definition */
 } coap_dtls_pki_t;
+
+/** @} */
+
+/**
+ * @defgroup dtls_internal DTLS Support (Internal)
+ * Internal API functions for interfacing with DTLS libraries.
+ * @{
+ */
 
 /**
  * Creates a new DTLS context for the given @p coap_context. This function
- * returns a pointer to a new DTLS context object or NULL on error.
+ * returns a pointer to a new DTLS context object or @c NULL on error.
+ *
+ * Internal function.
  *
  * @param coap_context The CoAP context where the DTLS object shall be used.
  *
- * @return A DTLS context object or NULL on error.
+ * @return A DTLS context object or @c NULL on error.
  */
 void *
 coap_dtls_new_context(struct coap_context_t *coap_context);
 
+#define COAP_DTLS_ROLE_CLIENT  0 /**< Internal function invoked for client */
+#define COAP_DTLS_ROLE_SERVER  1 /**< Internal function invoked for server */
+
 /**
- * Set the DTLS context's default server PSK hint and/or key.
- * This does the PSK specifics for coap_dtls_new_context()
+ * Set the DTLS context's default PSK information.
+ * This does the PSK specifics following coap_dtls_new_context(). 
+ * If @p COAP_DTLS_ROLE_SERVER, then identity hint will also get set.
+ * If @p COAP_DTLS_ROLE_SERVER, then the information will get put into the 
+ * TLS library's context (from which sessions are derived).
+ * If @p COAP_DTLS_ROLE_CLIENT, then the information will get put into the 
+ * TLS library's session.
  *
- * @param ctx The CoAP context.
- * @param hint    The default PSK server hint sent to a client. If NULL, PSK
- *                authentication is disabled. Empty string is a valid hint.
- * @param key     The default PSK key. If NULL, PSK authentication will fail.
- * @param key_len The default PSK key's length. If 0, PSK authentication will
- *                fail.
+ * Internal function.
  *
- * @return 1 if successful, else 0.
+ * @param coap_context The CoAP context.
+ * @param identity_hint The default PSK server identity hint sent to a client.
+ *                      Required parameter.  If @p NULL, will be set to "".
+ *                      Empty string is a valid hint.
+ *                      This parameter is ignored if COAP_DTLS_ROLE_CLIENT
+ * @param role  One of @p COAP_DTLS_ROLE_CLIENT or @p COAP_DTLS_ROLE_SERVER
+ *
+ * @return @c 1 if successful, else @c 0.
  */
 
-int coap_dtls_context_set_psk(struct coap_context_t *ctx, const char *hint,
-                           const uint8_t *key, size_t key_len );
+int
+coap_dtls_context_set_psk(struct coap_context_t *coap_context,
+                          const char *identity_hint,
+                          int role);
 
 /**
  * Set the DTLS context's default server PKI information.
- * This does the PKI specifics for coap_dtls_new_context()
- * The Callback is called to set up the appropriate information.
+ * This does the PKI specifics following coap_dtls_new_context().
+ * If @p COAP_DTLS_ROLE_SERVER, then the information will get put into the 
+ * TLS library's context (from which sessions are derived).
+ * If @p COAP_DTLS_ROLE_CLIENT, then the information will get put into the 
+ * TLS library's session.
  *
- * @param ctx The CoAP context.
- * @param setup_data     If NULL, PKI authentication will fail. Certificate
- *                       information required.
+ * Internal function.
  *
- * @return 1 if successful, else 0.
+ * @param coap_context The CoAP context.
+ * @param setup_data     Setup information defining how PKI is to be setup.
+ *                       Required parameter.  If @p NULL, PKI will not be
+ *                       set up.
+ * @param role  One of @p COAP_DTLS_ROLE_CLIENT or @p COAP_DTLS_ROLE_SERVER
+ *
+ * @return @c 1 if successful, else @c 0.
  */
 
-int coap_dtls_context_set_pki(struct coap_context_t *ctx,
-                           coap_dtls_pki_t* setup_data);
+int
+coap_dtls_context_set_pki(struct coap_context_t *coap_context,
+                          coap_dtls_pki_t *setup_data,
+                          int role);
 
 /**
- * Check whether one of the coap_dtls_context_set_*() functions have been
- * called.
+ * Set the dtls context's default Root CA information for a client or server.
  *
- * @return 1 if coap_dtls_context_set_*() called, else 0.
+ * Internal function.
+ *
+ * @param coap_context   The current coap_context_t object.
+ * @param ca_file        If not @p NULL, is the full path name of a PEM encoded
+ *                       file containing all the Root CAs to be used.
+ * @param ca_dir         If not @p NULL, points to a directory containing PEM
+ *                       encoded files containing all the Root CAs to be used.
+ *
+ * @return @c 1 if successful, else @c 0.
  */
 
-int coap_dtls_context_check_keys_enabled(struct coap_context_t *ctx);
+int
+coap_dtls_context_set_pki_root_cas(struct coap_context_t *coap_context,
+                                   const char *ca_file,
+                                   const char *ca_dir);
 
-/** Releases the storage allocated for @p dtls_context. */
+/**
+ * Check whether one of the coap_dtls_context_set_{psk|pki}() functions have
+ * been called.
+ *
+ * Internal function.
+ *
+ * @param coap_context The current coap_context_t object.
+ *
+ * @return @c 1 if coap_dtls_context_set_{psk|pki}() called, else @c 0.
+ */
+
+int coap_dtls_context_check_keys_enabled(struct coap_context_t *coap_context);
+
+/**
+ * Releases the storage allocated for @p dtls_context.
+ *
+ * Internal function.
+ *
+ * @param dtls_context The DTLS context as returned by coap_dtls_new_context().
+ */
 void coap_dtls_free_context(void *dtls_context);
 
 /**
  * Create a new client-side session. This should send a HELLO to the server.
  *
- * @param session   The CoAP session.
+ * Internal function.
+ *
+ * @param coap_session   The CoAP session.
  *
  * @return Opaque handle to underlying TLS library object containing security
- * parameters for the session.
+ *         parameters for the session.
 */
-void *coap_dtls_new_client_session(coap_session_t *session);
+void *coap_dtls_new_client_session(coap_session_t *coap_session);
 
 /**
- * Create a new server-side session.
- * Called after coap_dtls_hello() has returned 1, signalling that a validated HELLO was received from a client.
+ * Create a new DTLS server-side session.
+ * Called after coap_dtls_hello() has returned @c 1, signalling that a validated
+ * HELLO was received from a client.
  * This should send a HELLO to the server.
  *
- * @param session   The CoAP session.
+ * Internal function.
  *
- * @return Opaque handle to underlying TLS library object containing security parameters for the session.
+ * @param coap_session   The CoAP session.
+ *
+ * @return Opaque handle to underlying TLS library object containing security
+ *         parameters for the DTLS session.
  */
-void *coap_dtls_new_server_session(coap_session_t *session);
+void *coap_dtls_new_server_session(coap_session_t *coap_session);
 
 /**
- * Terminates the DTLS session (may send an ALERT if necessary) then frees the underlying TLS library object containing security parameters for the session.
+ * Terminates the DTLS session (may send an ALERT if necessary) then frees the
+ * underlying TLS library object containing security parameters for the session.
  *
- * @param session   The CoAP session.
+ * Internal function.
+ *
+ * @param coap_session   The CoAP session.
  */
-void coap_dtls_free_session(coap_session_t *session);
+void coap_dtls_free_session(coap_session_t *coap_session);
 
 /**
- * Notify of a change in the session's MTU, e.g. after a PMTU update.
+ * Notify of a change in the CoAP session's MTU, for example after
+ * a PMTU update.
  *
- * @param session   The CoAP session.
+ * Internal function.
+ *
+ * @param coap_session   The CoAP session.
  */
-void coap_dtls_session_update_mtu(coap_session_t *session);
+void coap_dtls_session_update_mtu(coap_session_t *coap_session);
 
 /**
  * Send data to a DTLS peer.
  *
- * @param session   The CoAP session.
+ * Internal function.
+ *
+ * @param coap_session The CoAP session.
  * @param data      pointer to data.
  * @param data_len  Number of bytes to send.
  *
- * @return 0 if this would be blocking, -1 if there is an error or the number of cleartext bytes sent
+ * @return @c 0 if this would be blocking, @c -1 if there is an error or the
+ *         number of cleartext bytes sent.
  */
-int coap_dtls_send(coap_session_t *session,
+int coap_dtls_send(coap_session_t *coap_session,
                    const uint8_t *data,
                    size_t data_len);
 
 /**
- * Check if timeout is handled per session or per context.
+ * Check if timeout is handled per CoAP session or per CoAP context.
  *
- * @return 1 of timeout and retransmit is per context, 0 if it is per session.
+ * Internal function.
+ *
+ * @return @c 1 of timeout and retransmit is per context, @c 0 if it is
+ *         per session.
  */
 int coap_dtls_is_context_timeout(void);
 
 /**
  * Do all pending retransmits and get next timeout
+ *
+ * Internal function.
  * 
  * @param dtls_context The DTLS context.
  *
- * @return 0 If no event is pending or date of the next retransmit.
+ * @return @c 0 if no event is pending or date of the next retransmit.
  */
 coap_tick_t coap_dtls_get_context_timeout(void *dtls_context);
 
 /**
  * Get next timeout for this session.
  *
- * @param session The CoAP session.
+ * Internal function.
  *
- * @return 0 If no event is pending or date of the next retransmit.
+ * @param coap_session The CoAP session.
+ *
+ * @return @c 0 If no event is pending or date of the next retransmit.
  */
-coap_tick_t coap_dtls_get_timeout(coap_session_t *session);
+coap_tick_t coap_dtls_get_timeout(coap_session_t *coap_session);
 
 /**
  * Handle a DTLS timeout expiration.
  *
- * @param session The CoAP session.
+ * Internal function.
+ *
+ * @param coap_session The CoAP session.
  */
-void coap_dtls_handle_timeout(coap_session_t *session);
+void coap_dtls_handle_timeout(coap_session_t *coap_session);
 
 /**
  * Handling incoming data from a DTLS peer.
  *
- * @param session   The CoAP session.
+ * Internal function.
+ *
+ * @param coap_session The CoAP session.
  * @param data      Encrypted datagram.
  * @param data_len  Encrypted datagram size.
  *
- * @return result of coap_handle_dgram on the decrypted CoAP PDU or -1 for error.
+ * @return Result of coap_handle_dgram on the decrypted CoAP PDU
+ *         or @c -1 for error.
  */
-int coap_dtls_receive(coap_session_t *session,
+int coap_dtls_receive(coap_session_t *coap_session,
                       const uint8_t *data,
                       size_t data_len);
 
@@ -273,69 +498,82 @@ int coap_dtls_receive(coap_session_t *session,
  * Handling client HELLO messages from a new candiate peer.
  * Note that session->tls is empty.
  *
- * @param session   The CoAP session.
+ * Internal function.
+ *
+ * @param coap_session The CoAP session.
  * @param data      Encrypted datagram.
  * @param data_len  Encrypted datagram size.
  *
- * @return 0 if a cookie verification message has been sent, 1 if the HELLO
-          contains a valid cookie and a server session should be created,
-          -1 if the message is invalid.
+ * @return @c 0 if a cookie verification message has been sent, @c 1 if the
+ *        HELLO contains a valid cookie and a server session should be created,
+ *        @c -1 if the message is invalid.
  */
-int coap_dtls_hello(coap_session_t *session,
+int coap_dtls_hello(coap_session_t *coap_session,
                     const uint8_t *data,
                     size_t data_len);
 
 /**
  * Get DTLS overhead over cleartext PDUs.
  *
- * @param session   The CoAP session
+ * Internal function.
  *
- * @return maximum number of bytes added by DTLS layer.
+ * @param coap_session The CoAP session.
+ *
+ * @return Maximum number of bytes added by DTLS layer.
  */
-
-unsigned int coap_dtls_get_overhead(coap_session_t *session);
+unsigned int coap_dtls_get_overhead(coap_session_t *coap_session);
 
 /**
  * Create a new TLS client-side session.
  *
- * @param session   The CoAP session.
- * @param connected Updated with  whether the connection is connected yet or not
- *                  0 is not connected.
+ * Internal function.
  *
- * @return Opaque handle to underlying TLS library object containing security parameters for the session.
+ * @param coap_session The CoAP session.
+ * @param connected Updated with whether the connection is connected yet or not.
+ *                  @c 0 is not connected, @c 1 is connected.
+ *
+ * @return Opaque handle to underlying TLS library object containing security
+ *         parameters for the session.
 */
-void *coap_tls_new_client_session(coap_session_t *session, int *connected);
+void *coap_tls_new_client_session(coap_session_t *coap_session, int *connected);
 
 /**
  * Create a TLS new server-side session.
  *
- * @param session   The CoAP session.
- * @param connected Updated with  whether the connection is connected yet or not
- *                  0 is not connected.
+ * Internal function.
  *
- * @return Opaque handle to underlying TLS library object containing security parameters for the session.
+ * @param coap_session The CoAP session.
+ * @param connected Updated with whether the connection is connected yet or not.
+ *                  @c 0 is not connected, @c 1 is connected.
+ *
+ * @return Opaque handle to underlying TLS library object containing security
+ *         parameters for the session.
  */
-void *coap_tls_new_server_session(coap_session_t *session, int *connected);
+void *coap_tls_new_server_session(coap_session_t *coap_session, int *connected);
 
 /**
  * Terminates the TLS session (may send an ALERT if necessary) then frees the
  * underlying TLS library object containing security parameters for the session.
  *
- * @param session   The CoAP session
+ * Internal function.
+ *
+ * @param coap_session The CoAP session.
  */
-void coap_tls_free_session( coap_session_t *session );
+void coap_tls_free_session( coap_session_t *coap_session );
 
 /**
  * Send data to a TLS peer, with implicit flush.
  *
- * @param session   The CoAP session.
+ * Internal function.
+ *
+ * @param coap_session The CoAP session.
  * @param data      Pointer to data.
  * @param data_len  Number of bytes to send.
  *
- * @return          0 if this should be retried, -1 if there is an error or
- *                  the number of cleartext bytes sent.
+ * @return          @c 0 if this should be retried, @c -1 if there is an error
+ *                  or the number of cleartext bytes sent.
  */
-ssize_t coap_tls_write(coap_session_t *session,
+ssize_t coap_tls_write(coap_session_t *coap_session,
                        const uint8_t *data,
                        size_t data_len
                        );
@@ -343,20 +581,29 @@ ssize_t coap_tls_write(coap_session_t *session,
 /**
  * Read some data from a TLS peer.
  *
- * @param session   The CoAP session.
+ * Internal function.
+ *
+ * @param coap_session The CoAP session.
  * @param data      Pointer to data.
  * @param data_len  Maximum number of bytes to read.
  *
- * @return          0 if this should be retried, -1 if there is an error or
- *                  the number of cleartext bytes read.
+ * @return          @c 0 if this should be retried, @c -1 if there is an error
+ *                  or the number of cleartext bytes read.
  */
-ssize_t coap_tls_read(coap_session_t *session,
+ssize_t coap_tls_read(coap_session_t *coap_session,
                       uint8_t *data,
                       size_t data_len
                       );
 
+/**
+ * Initialize the underlying (D)TLS Library layer.
+ *
+ * Internal function.
+ *
+ */
+void coap_dtls_startup(void);
+
 /** @} */
 
-void coap_dtls_startup( void );
 
 #endif /* COAP_DTLS_H */

--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -351,6 +351,17 @@ const char *coap_endpoint_str(const coap_endpoint_t *endpoint);
 coap_session_t *coap_endpoint_get_session(coap_endpoint_t *endpoint,
   const struct coap_packet_t *packet, coap_tick_t now);
 
+/**   
+ * Create a new DTLS session for the @p endpoint.
+ *    
+ * @ingroup dtls_internal
+ *  
+ * @param endpoint  Endpoint to add DTLS session to
+ * @param packet    Received packet information to base session on.
+ * @param now       The current time in ticks.
+ *
+ * @return Created CoAP session or @c NULL if error. 
+ */
 coap_session_t *coap_endpoint_new_dtls_session(coap_endpoint_t *endpoint,
   const struct coap_packet_t *packet, coap_tick_t now);
 

--- a/include/coap/debug.h
+++ b/include/coap/debug.h
@@ -78,7 +78,7 @@ void coap_log_impl(coap_log_t level, const char *format, ...);
 /**
  * Defines the output mode for the coap_show_pdu() function.
  *
- * @param use_printf  1 if the output is to use fprintf() (the default)
+ * @param use_fprintf  1 if the output is to use fprintf() (the default)
  *                    0 if the output is to use coap_log()
  */
 void coap_set_show_pdu_output(int use_fprintf);

--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -33,6 +33,9 @@
 
 struct coap_queue_t;
 
+/**
+ * Queue entry
+ */
 typedef struct coap_queue_t {
   struct coap_queue_t *next;
   coap_tick_t t;                /**< when to send PDU for the next time */
@@ -44,16 +47,37 @@ typedef struct coap_queue_t {
   coap_pdu_t *pdu;              /**< the CoAP PDU to send */
 } coap_queue_t;
 
-/** Adds node to given queue, ordered by node->t. */
+/**
+ * Adds @p node to given @p queue, ordered by variable t in @p node.
+ *
+ * @param queue Queue to add to.
+ * @param node Node entry to add to Queue.
+ *
+ * @return @c 1 added to queue, @c 0 failure.
+ */
 int coap_insert_node(coap_queue_t **queue, coap_queue_t *node);
 
-/** Destroys specified node. */
+/**
+ * Destroys specified @p node.
+ *
+ * @param node Node entry to remove.
+ *
+ * @return @c 1 node deleted from queue, @c 0 failure.
+ */
 int coap_delete_node(coap_queue_t *node);
 
-/** Removes all items from given queue and frees the allocated storage. */
+/**
+ * Removes all items from given @p queue and frees the allocated storage.
+ *
+ * @param queue The queue to delete.
+ */
 void coap_delete_all(coap_queue_t *queue);
 
-/** Creates a new node suitable for adding to the CoAP sendqueue. */
+/**
+ * Creates a new node suitable for adding to the CoAP sendqueue.
+ *
+ * @return New node entry, or @c NULL if failure.
+ */
 coap_queue_t *coap_new_node(void);
 
 struct coap_resource_t;
@@ -62,33 +86,65 @@ struct coap_context_t;
 struct coap_async_state_t;
 #endif
 
-/** Message handler that is used as call-back in coap_context_t */
-typedef void (*coap_response_handler_t)(struct coap_context_t *,
+/**
+ * Response handler that is used as call-back in coap_context_t.
+ *
+ * @param context CoAP session.
+ * @param session CoAP session.
+ * @param sent The PDU that was transmitted.
+ * @param received The PDU that was received.
+ * @param id CoAP transaction ID.
+ */
+typedef void (*coap_response_handler_t)(struct coap_context_t *context,
                                         coap_session_t *session,
                                         coap_pdu_t *sent,
                                         coap_pdu_t *received,
                                         const coap_tid_t id);
 
-/** Message handler that is used as call-back in coap_context_t */
-typedef void (*coap_nack_handler_t)(struct coap_context_t *,
+/**
+ * Negative Acknowedge handler that is used as call-back in coap_context_t.
+ *
+ * @param context CoAP session.
+ * @param session CoAP session.
+ * @param sent The PDU that was transmitted.
+ * @param reason The reason for the NACK.
+ * @param id CoAP transaction ID.
+ */
+typedef void (*coap_nack_handler_t)(struct coap_context_t *context,
                                     coap_session_t *session,
                                     coap_pdu_t *sent,
                                     coap_nack_reason_t reason,
                                     const coap_tid_t id);
 
-/** Message handler that is used as call-back in coap_context_t */
-typedef void (*coap_ping_handler_t)(struct coap_context_t *,
+/**
+ * Recieved Ping handler that is used as call-back in coap_context_t.
+ *
+ * @param context CoAP session.
+ * @param session CoAP session.
+ * @param received The PDU that was received.
+ * @param id CoAP transaction ID.
+ */
+typedef void (*coap_ping_handler_t)(struct coap_context_t *context,
                                         coap_session_t *session,
                                         coap_pdu_t *received,
                                         const coap_tid_t id);
 
-/** Message handler that is used as call-back in coap_context_t */
-typedef void (*coap_pong_handler_t)(struct coap_context_t *,
+/**
+ * Recieved Pong handler that is used as call-back in coap_context_t.
+ *
+ * @param context CoAP session.
+ * @param session CoAP session.
+ * @param received The PDU that was received.
+ * @param id CoAP transaction ID.
+ */
+typedef void (*coap_pong_handler_t)(struct coap_context_t *context,
 				  	coap_session_t *session,
 					coap_pdu_t *received,
 					const coap_tid_t id);
 
-/** The CoAP stack's global state is stored in a coap_context_t object */
+/**
+ * The CoAP stack's global state is stored in a coap_context_t object.
+ */
 typedef struct coap_context_t {
   coap_opt_filter_t known_options;
   struct coap_resource_t *resources; /**< hash table or list of known
@@ -249,35 +305,48 @@ coap_queue_t *coap_pop_next( coap_context_t *context );
 coap_context_t *coap_new_context(const coap_address_t *listen_addr);
 
 /**
- * Set the context's default server PSK hint and/or key.
- * These global defaults are used only no PSK callback is specified.
+ * Set the context's default PSK hint and/or key for a server.
  *
  * @param context The current coap_context_t object.
- * @param hint    The default PSK server hint sent to a client. If NULL, PSK
+ * @param hint    The default PSK server hint sent to a client. If @p NULL, PSK
  *                authentication is disabled. Empty string is a valid hint.
- * @param key     The default PSK key. If NULL, PSK authentication will fail.
- * @param key_len The default PSK key's lenght. If 0, PSK authentication will
+ * @param key     The default PSK key. If @p NULL, PSK authentication will fail.
+ * @param key_len The default PSK key's length. If @p 0, PSK authentication will
  *                fail.
  *
- * @return 1 if successful, else 0
+ * @return @c 1 if successful, else @c 0.
  */
-
 int coap_context_set_psk( coap_context_t *context, const char *hint,
                            const uint8_t *key, size_t key_len );
 
 /**
- * Set the context's default PKI information.
- * The Callback is called to set up the appropriate information if set.
+ * Set the context's default PKI information for a server.
  *
  * @param context        The current coap_context_t object.
- * @param setup_data     If NULL, PKI authentication will fail. Certificate
+ * @param setup_data     If @p NULL, PKI authentication will fail. Certificate
  *                       information required.
  *
- * @return 1 if successful, else 0
+ * @return @c 1 if successful, else @c 0.
  */
+int
+coap_context_set_pki(coap_context_t *context,
+                     coap_dtls_pki_t *setup_data);
 
-int coap_context_set_pki(coap_context_t *context,
-                           coap_dtls_pki_t* setup_data);
+/**
+ * Set the context's default Root CA information for a client or server.
+ *
+ * @param context        The current coap_context_t object.
+ * @param ca_file        If not @p NULL, is the full path name of a PEM encoded
+ *                       file containing all the Root CAs to be used.
+ * @param ca_dir         If not @p NULL, points to a directory containing PEM
+ *                       encoded files containing all the Root CAs to be used.
+ *
+ * @return @c 1 if successful, else @c 0.
+ */
+int
+coap_context_set_pki_root_cas(coap_context_t *context,
+                              const char *ca_file,
+                              const char *ca_dir);
 
 /**
  * Returns a new message id and updates @p session->tx_mid accordingly. The
@@ -298,6 +367,8 @@ coap_new_message_id(coap_session_t *session) {
  * clears all entries from the receive queue and send queue and deletes the
  * resources that have been registered with @p context, and frees the attached
  * endpoints.
+ *
+ * @param context The current coap_context_t object to free off.
  */
 void coap_free_context(coap_context_t *context);
 
@@ -305,6 +376,10 @@ void coap_free_context(coap_context_t *context);
  * Stores @p data with the given CoAP context. This function
  * overwrites any value that has previously been stored with @p
  * context.
+ *
+ * @param context The CoAP context.
+ * @param data The data to store with wih the context. Note that this data
+ *             must be valid during the lifetime of @p context.
  */
 void coap_set_app_data(coap_context_t *context, void *data);
 
@@ -312,6 +387,10 @@ void coap_set_app_data(coap_context_t *context, void *data);
  * Returns any application-specific data that has been stored with @p
  * context using the function coap_set_app_data(). This function will
  * return @c NULL if no data has been stored.
+ *
+ * @param context The CoAP context.
+ *
+ * @return The data previously stored or @c NULL if not data stored.
  */
 void *coap_get_app_data(const coap_context_t *context);
 
@@ -414,6 +493,12 @@ coap_tid_t coap_send( coap_session_t *session, coap_pdu_t *pdu );
 
 /**
  * Handles retransmissions of confirmable messages
+ *
+ * @param context      The CoAP context.
+ * @param node         The node to retransmit.
+ *
+ * @return             The message id of the sent message or @c
+ *                     COAP_INVALID_TID on error.
  */
 coap_tid_t coap_retransmit(coap_context_t *context, coap_queue_t *node);
 
@@ -433,6 +518,7 @@ coap_tid_t coap_retransmit(coap_context_t *context, coap_queue_t *node);
 * @param max_sockets size of socket array.
 * @param num_sockets pointer to the number of valid entries in the socket arrays on output
 * @param now Current time.
+*
 * @return timeout as maxmimum number of milliseconds that the application should wait for network events or 0 if the application should wait forever.
 */
 
@@ -458,7 +544,7 @@ void coap_read(coap_context_t *ctx, coap_tick_t now);
  * @param ctx The CoAP context
  * @param timeout_ms Minimum number of milliseconds to wait for new messages before returning. If zero the call will block until at least one packet is sent or received.
  *
- * @return number of milliseconds spent or -1 if there was an error
+ * @return number of milliseconds spent or @c -1 if there was an error
  */
 
 int coap_run_once( coap_context_t *ctx, unsigned int timeout_ms );
@@ -523,7 +609,7 @@ coap_wait_ack( coap_context_t *context, coap_session_t *session,
  * @param session The session to find.
  * @param id    The transaction id to find.
  *
- * @return      A pointer to the transaction object or NULL if not found.
+ * @return      A pointer to the transaction object or @c NULL if not found.
  */
 coap_queue_t *coap_find_transaction(coap_queue_t *queue, coap_session_t *session, coap_tid_t id);
 
@@ -592,7 +678,7 @@ void coap_ticks(coap_tick_t *);
       }
     }
   }
- * @endcode
+   @endcode
  *
  * @param ctx      The context where all known options are registered.
  * @param pdu      The PDU to check.

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -23,6 +23,7 @@ global:
   coap_clock_init;
   coap_clone_uri;
   coap_context_set_pki;
+  coap_context_set_pki_root_cas;
   coap_context_set_psk;
   coap_debug_send_packet;
   coap_debug_set_packet_loss;
@@ -44,7 +45,6 @@ global:
   coap_dtls_set_log_level;
   coap_encode_var_safe;
   coap_endpoint_get_session;
-  coap_endpoint_new_dtls_session;
   coap_endpoint_set_default_mtu;
   coap_endpoint_str;
   coap_find_async;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -21,6 +21,7 @@ coap_clear_event_handler
 coap_clock_init
 coap_clone_uri
 coap_context_set_pki
+coap_context_set_pki_root_cas
 coap_context_set_psk
 coap_debug_send_packet
 coap_debug_set_packet_loss
@@ -42,7 +43,6 @@ coap_dtls_is_supported
 coap_dtls_set_log_level
 coap_encode_var_safe
 coap_endpoint_get_session
-coap_endpoint_new_dtls_session
 coap_endpoint_set_default_mtu
 coap_endpoint_str
 coap_find_async

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -12,11 +12,13 @@ if BUILD_MANPAGES
 
 TXT3 = coap_attribute.txt \
 	coap_context.txt \
+	coap_encryption.txt \
 	coap_handler.txt \
 	coap_observe.txt \
 	coap_pdu_setup.txt \
 	coap_recovery.txt \
 	coap_resource.txt \
+	coap_session.txt \
 	coap_tls_library.txt
 
 MAN3 = $(TXT3:%.txt=%.3)
@@ -48,14 +50,12 @@ man7_MANS = $(MAN7)
 
 # We are limited to 10 names, but synopsis can cover more
 install-man: install-man3 install-man5 install-man7
-	@echo ".so man3/coap_context.3" > coap_free_endpoint.3
-	@echo ".so man3/coap_context.3" > coap_endpoint_set_default_mtu.3
-	@echo ".so man3/coap_context.3" > coap_session_reference.3
-	@echo ".so man3/coap_context.3" > coap_session_release.3
-	@echo ".so man3/coap_context.3" > coap_session_set_mtu.3
-	@echo ".so man3/coap_pdu_setup.3" > coap_encode_var_safe.3
+	@echo ".so man3/coap_context.3" > coap_context_set_pki_root_cas.3
+	@echo ".so man3/coap_pdu_setup.3" > coap_encode_var_bytes.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_split_path.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_split_query.3
+	@echo ".so man3/coap_session.3" > coap_session_get_app_data.3
+	@echo ".so man3/coap_session.3" > coap_session_set_app_data.3
 	$(INSTALL_DATA) *.3 "$(DESTDIR)$(man3dir)"
 
 CLEANFILES = *.3 *.5 *.7 *.xml

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -17,8 +17,9 @@ SYNOPSIS
 *coap-client* [*-a* addr] [*-b* [num,]size] [*-c* certfile] [*-e* text]
               [*-f* file] [*-k* key] [*-l* loss] [*-m* method] [*-o* file]
               [*-p* port] [*-r*] [*-s* duration] [*-t* type]  [*-u* user]
-              [*-v* num] [*-A* type] [*-B* seconds] [*-N*]
-              [*-O* num,text] [*-P* addr[:port]] [*-T* token] [*-U*] URI
+              [*-v* num] [*-A* type] [*-B* seconds] [*-C* cafile] [*-N*]
+              [*-O* num,text] [*-P* addr[:port]] [*-R* root_cafile]
+              [*-T* token] [*-U*] URI
 
 DESCRIPTION
 -----------
@@ -118,6 +119,14 @@ OPTIONS
 *-B* seconds::
    Break operation after waiting given seconds (default is 90).
 
+*-C* cafile::
+  PEM file containing the CA Certificate that was used to sign the certfile
+  defined using *-c certfile*.
+  This will trigger the validation of the server certificate.
+  If certfile is self-signed (as defined by *-c certfile*), then you need to
+  have on the command line the same filename for both the certfile and cafile
+  (as in  *-c certfile -C certfile*) to trigger validation.
+
 *-N* ::
    Send NON-confirmable message. If option *-N* is not specified, a
    confirmable message will be sent.
@@ -128,6 +137,12 @@ OPTIONS
 *-P* addr[:port]::
    Address (and port) for proxy to use (automatically adds Proxy-Uri option
    to request).
+
+*-R* root_cafile::
+  PEM file containing the set of trusted root CAs that are to be used to
+  validate the server certificate.  The '-C cafile' does not have to be in
+  this list and is 'trusted' for the verification.
+  Alternatively, this can point to a directory containing a set of CA PEM files.
 
 *-T* token::
    Include the 'token' to the request.

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -15,7 +15,8 @@ coap-server - CoAP Server based on libcoap
 SYNOPSIS
 --------
 *coap-server* [*-A* addr] [*-g* group] [*-p* port] [*-l* loss]
-              [*-k* key] [*-h* hint] [*-c* certfile] [*-v* num]
+              [*-k* key] [*-h* hint] [*-c* certfile] [*-C* cafile]
+              [*-R* root_cafile] [*-v* num]
 
 DESCRIPTION
 -----------
@@ -39,6 +40,23 @@ OPTIONS
    Use the specified PEM file which contains the CERTIFICATE and PRIVATE
    KEY information. This argument requires (D)TLS with PKI to be available.
 
+*-C* cafile::
+  PEM file containing the CA Certificate that was used to sign the certfile
+  defined using *-c certfile*.
+  If defined, then the client will be given this CA Certificate during the
+  TLS set up.  Furthermore, this will also trigger the validation of the client
+  provided certificate against this cafile or using the CAs defined by
+  *-R root_cafile*.
+  If certfile is self-signed (as defined by *-c certfile*), then you need to
+  have on the command line the same filename for both the certfile and cafile
+  (as in  *-c certfile -C certfile*) to trigger validation.
+
+*-R* root_cafile::
+  PEM file containing the set of trusted root CAs that are to be used to
+  validate the client certificate.  The '-C cafile' does not have to be in
+  this list and is 'trusted' for the verification.
+  Alternatively, this can point to a directory containing a set of CA PEM files.
+
 *-k* key::
    Pre-shared key to use for inbound connections. This cannot be empty if defined.
    This argument requires (D)TLS with PSK to be available.
@@ -51,7 +69,7 @@ OPTIONS
 
 *-l* list::
    Fail to send some datagrams specified by a comma separated list of
-   numbers or number intervals (debugging only).
+   numbers or number ranges (debugging only).
 
 *-l* loss%::
    Randomly failed to send datagams with the specified probability - 100%

--- a/man/coap.txt.in
+++ b/man/coap.txt.in
@@ -15,34 +15,34 @@ coap - overview of the libcoap library
 DESCRIPTION
 -----------
 
-libcoap is a C implementation of a lightweight application-protocol for 
-devices that are constrained by their resources such as computing power, RF 
-range, memory, bandwith, or network packet sizes. This protocol, CoAP, is 
-standardized by the IETF as RFC 7252. For further information related to 
+libcoap is a C implementation of a lightweight application-protocol for
+devices that are constrained by their resources such as computing power, RF
+range, memory, bandwith, or network packet sizes. This protocol, CoAP, is
+standardized by the IETF as RFC 7252. For further information related to
 CoAP, see http://coap.technology.
 
-Documentation for the specific library calls with examples can be found in the 
+Documentation for the specific library calls with examples can be found in the
 man pages referred to in SEE ALSO.
 
-Further information can be found in the include header files with example 
+Further information can be found in the include header files with example
 code provided in the examples directory.
 
-*NOTE:* This documentation is a work in progress.  Any missing information can 
-be found in the include header files along with example code provided in the 
+*NOTE:* This documentation is a work in progress.  Any missing information can
+be found in the include header files along with example code provided in the
 examples directory.
 
 
 SEE ALSO
 --------
-*coap_attribute*(3), *coap_context*(3), *coap_handler*(3), *coap_observe*(3), 
-*coap_pdu_setup*(3), *coap_recovery*(3), *coap_resource*(3) 
-and *coap_tls_library*(3)
+*coap_attribute*(3), *coap_context*(3), *coap_encryption*(3), *coap_handler*(3),
+*coap_observe*(3), *coap_pdu_setup*(3), *coap_session*(3), *coap_recovery*(3),
+*coap_resource*(3) and *coap_tls_library*(3)
 
 For example executables, see *coap-client*(5), *coap-rd*(5) and *coap-server*(5)
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further 
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further
 information.
 
 BUGS

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -11,9 +11,8 @@ coap_context(3)
 NAME
 ----
 coap_context, coap_new_context, coap_free_context,
-coap_context_set_pki, coap_context_set_psk, coap_new_endpoint, 
-coap_new_client_session, 
-coap_new_client_session_pki, coap_new_client_session_psk
+coap_context_set_pki, coap_context_set_psk, coap_new_endpoint,
+coap_free_endpoint, coap_endpoint_set_default_mtu, coap_endpoint_str
 - work with CoAP contexts
 
 SYNOPSIS
@@ -24,39 +23,24 @@ SYNOPSIS
 
 *void coap_free_context(coap_context_t *_context_);*
 
-*int coap_context_set_pki(coap_context_t *_context_, 
+*int coap_context_set_pki(coap_context_t *_context_,
 coap_dtls_pki_t *_setup_data_);*
 
-*int coap_context_set_psk(coap_context_t *_context_, const char *_hint_, 
+*int coap_context_set_pki_root_cas(coap_context_t *_context_,
+const char *_ca_file_, const char *_ca_dir_);*
+
+*int coap_context_set_psk(coap_context_t *_context_, const char *_hint_,
 const uint8_t *_key_, size_t _key_len_);*
 
-*coap_endpoint_t *coap_new_endpoint(coap_context_t *_context_, 
+*coap_endpoint_t *coap_new_endpoint(coap_context_t *_context_,
 const coap_address_t *_listen_addr_, coap_proto_t _proto_);*
 
 *void coap_free_endpoint(coap_endpoint_t *_endpoint_);*
 
-*void coap_endpoint_set_default_mtu(coap_endpoint_t *_endpoint_, 
+*void coap_endpoint_set_default_mtu(coap_endpoint_t *_endpoint_,
 unsigned _mtu_);*
 
 *const char *coap_endpoint_str(const coap_endpoint_t *_endpoint_);*
-
-*coap_session_t *coap_new_client_session(coap_context_t *_context_, 
-const coap_address_t *_local_if_, const coap_address_t *_server_, 
-coap_proto_t _proto_);*
-
-*coap_session_t *coap_new_client_session_psk(coap_context_t *_context_, 
-const coap_address_t *_local_if_, const coap_address_t *_server_, coap_proto_t 
-_proto_, const char *_identity_, const uint8_t *_key_, unsigned _key_len_);*
-
-*coap_session_t *coap_new_client_session_pki(coap_context_t *_context_, 
-const coap_address_t *_local_if_, const coap_address_t *_server_, coap_proto_t 
-_proto_, coap_dtls_pki_t *_setup_data_);*
-
-*coap_session_t *coap_session_reference(coap_session_t *_session_);*
-
-*void coap_session_release(coap_session_t *_session_);*
-
-*void coap_session_set_mtu(coap_session_t *_session_, unsigned _mtu_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
 or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
@@ -64,138 +48,89 @@ type.
 
 DESCRIPTION
 -----------
+This man page focuses on the CoAP Context.
+
 The CoAP stack's global state is stored in a coap_context_t Context object.
-Resources, Endpoints and Sessions are associated with this context object.  
-There can be more than one coap_context_t object per application, it is up to 
+Resources, Endpoints and Sessions are associated with this context object.
+There can be more than one coap_context_t object per application, it is up to
 the application to manage each one accordingly.
 
-Network traffic can be encrypted or un-encrypted.
+The Session network traffic can be encrypted or un-encrypted if there is an
+underlying TLS library.
 
-If TLS is going to be used for encrypting the network traffic, then the TLS 
-information for Pre-Shared Keys (PSK) or Public Key Infrastructure (PKI) needs 
-to be configured before any network traffic starts to flow. For Servers, this 
-has to be done before the Endpoint is created, for Clients, this is done 
+If TLS is going to be used for encrypting the network traffic, then the TLS
+information for Pre-Shared Keys (PSK) or Public Key Infrastructure (PKI) needs
+to be configured before any network traffic starts to flow. For Servers, this
+has to be done before the Endpoint is created, for Clients, this is done
 during the Client Session set up.
 
-For Servers, all the encryption information is held internally by the TLS 
-Context level and the CoAP Context level as the Server is listening for new 
-incoming traffic.  The TLS and CoAP session will not get built until the new 
-traffic starts, which is done by the libcoap library, with the session having 
-a reference count of 1.
+For Servers, all the encryption information is held internally by the TLS
+Context level and the CoAP Context level as the Server is listening for new
+incoming traffic based on the Endpoint definition.  The TLS and CoAP session
+will not get built until the new traffic starts, which is done by the libcoap
+library, with the session having a reference count of 1.
 
-For Clients, all the encryption information can be held at the TLS Context and 
-CoAP Context levels, or at the TLS Session and CoAP Session levels.  If 
-defined at the Context level, then when Sessions are created, they will 
-inherit the Context definitions, unless they have separately been defined for 
-the Session level, in which case the Session version will get used. 
-Typically the information will be at the Session level for Clients.
+For Clients, all the encryption information can be held at the TLS Context and
+CoAP Context levels, or at the TLS Session and CoAP Session levels.  If
+defined at the Context level, then when Sessions are created, they will
+inherit the Context definitions, unless they have separately been defined for
+the Session level, in which case the Session version will get used.
+Typically the information will be configured at the Session level for Clients.
 
 In principle the set-up sequence for CoAP Servers looks like
 ----
 coap_new_context()
-coap_context_set_psk() and/or coap_context_set_pki() if encryption is required
+coap_context_set_pki_root_cas() - if the root CAs need to be updated and PKI
+coap_context_set_pki() and/or coap_context_set_psk() - if encryption is required
 coap_new_endpoint()
 ----
-*NOTE:* coap_context_set_psk() should be called before coap_context_set_pki() to
-make sure that the PSK ciphers are in place for the first PSK incoming
-connection if both PSK and PKI are to be hosted.
 
-Multiple endpoints can be set up per Context, each listening for a new traffic 
-flow with different TCP/UDP protocols, TLS protocols, port numbers etc. When a 
-new traffic flow is started, then the CoAP library will create and start a new 
+Multiple endpoints can be set up per Context, each listening for a new traffic
+flow with different TCP/UDP protocols, TLS protocols, port numbers etc. When a
+new traffic flow is started, then the CoAP library will create and start a new
 server session.
 
 In principle the set-up sequence for CoAP Clients looks like
 ----
 coap_new_context()
+coap_context_set_pki_root_cas() if the root CAs need to be updated and PKI
 coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk()
 ----
 
 Multiple client sessions are supported per Context.
 
-Due to the nature of TLS, there can be Callbacks that are invoked as the TLS 
-session negotiates encryption algorithms, encryption keys etc.
-Where possible, by default, the CoAP layer handles all this automatically.  
-However, there is the flexibility of the Callbacks for imposing additional 
-security checks etc. when PKI is being used.
-
-These Callbacks will be different (different structures etc.) depending on 
-the TLS implementation type. See coap_tls_library(3) for more information.
-To determine the TLS implementation type to use within the Callback, use the 
-function coap_get_tls_library_version().
-
-The *coap_new_context*() function creates a new Context that is then used 
+The *coap_new_context*() function creates a new Context that is then used
 to keep all the CoAP Resources, Endpoints and Sessions information.
-The optional _listen_addr_ parameter, if set for a CoAP server, creates an 
-Endpoint that is added to the _context_ that is listening for un-encrypted 
+The optional _listen_addr_ parameter, if set for a CoAP server, creates an
+Endpoint that is added to the _context_ that is listening for un-encrypted
 traffic on the IP address and port number defined by _listen_addr_.
 
-The *coap_free_context*() function must be used to release the CoAP stack 
-context.  It clears all entries from the receive queue and send queue and 
-deletes the Resources that have been registered with _context_, and frees the 
+The *coap_free_context*() function must be used to release the CoAP stack
+context.  It clears all entries from the receive queue and send queue and
+deletes the Resources that have been registered with _context_, and frees the
 attached Sessions and Endpoints.
 
-The *coap_context_set_pki*() function, for a specific _context_, is used to 
-configure the TLS context using the _setup_data_ variables as defined in the 
-coap_dtls_pki_t structure below which includes an optional callback 
-function _call_back_ which will get called from within this function. 
-coap_context_set_pki() will always add _public_cert_ and _private_key_ from 
-one of the 2 alternatives provided in _setup_data_, Alternative 1 taking 
-precedence, to the TLS Context.  Any CA file updates have to be done in the 
-_call_back_ function defined in _setup_data_, which can be used as well to set up
-additional callbacks (e.g. for determining whether incoming connection is PSK
-or PKI).
-Set _call_back_ in _setup_data_ to NULL if this callback is not required.
-This function can be used for both Clients and Servers.
+The *coap_context_set_pki*() function, for a specific _context_, is used to
+configure the TLS context using the _setup_data_ variables as defined in the
+coap_dtls_pki_t structure  - see *coap_encrytion(*3).
 
-[source, c]
-----
-typedef struct coap_dtls_pki_t {
-  /* Optional CallBack for additional setup */
-  coap_dtls_security_setup_t call_back;
-  /* Alternative 1: Name of file on disk */
-  const char *ca_file;
-  const char *public_cert;
-  const char *private_key;
-  /* Alternative 2: ASN1 version */
-  const uint8_t *asn1_ca_file;
-  const uint8_t *asn1_public_cert;
-  const uint8_t *asn1_private_key;
-  int asn1_ca_file_len;
-  int asn1_public_cert_len;
-  int asn1_private_key_len;
-  coap_asn1_privatekey_type_t asn1_private_key_type;
-} coap_dtls_pki_t;
+The *coap_context_set_pki_root_cas*() function is used to define a set of
+root CAs to be used instead of the default set of root CAs provided as a part
+of the TLS library.  _ca_file_ points to a PEM encoded file containing the
+list of CAs.  _ca_file can be NULL.  _ca_dir_ points to a directory
+containing a set of PEM encoded files containing rootCAs.  _ca_dir_ can be
+NULL. One or both of _ca_file_ and _ca_dir_ must be set.
 
-typedef enum coap_asn1_privatekey_type_t {
-  COAP_ASN1_PKEY_NONE,
-  COAP_ASN1_PKEY_RSA,
-  COAP_ASN1_PKEY_RSA2,
-  COAP_ASN1_PKEY_DSA,
-  COAP_ASN1_PKEY_DSA1,
-  COAP_ASN1_PKEY_DSA2,
-  COAP_ASN1_PKEY_DSA3,
-  COAP_ASN1_PKEY_DSA4,
-  COAP_ASN1_PKEY_DH,
-  COAP_ASN1_PKEY_DHX,
-  COAP_ASN1_PKEY_EC,
-  COAP_ASN1_PKEY_HMAC,
-  COAP_ASN1_PKEY_CMAC,
-  COAP_ASN1_PKEY_TLS1_PRF,
-  COAP_ASN1_PKEY_HKDF
-} coap_asn1_privatekey_type_t;
-----
-
-The *coap_context_set_psk*() function is used to configure the TLS context 
-using the server _hint_, PreShared Key _key_ with length _key_len_.  
-All parameters must be defined, NULL is not valid.  An empty string is valid 
-for _hint_.  _key_len_ must be greater than 0.  This function can only be used 
+The *coap_context_set_psk*() function is used to configure the TLS context
+using the server _hint_, PreShared Key _key_ with length _key_len_.
+All parameters must be defined, NULL is not valid.  An empty string is valid
+for _hint_.  _key_len_ must be greater than 0.  This function can only be used
 for Servers as it provides a _hint_, not an _identity_.
 
-The *coap_new_endpoint*() function creates a new endpoint for _context_ that 
-is listening for new traffic on the IP address and port number defined by 
+The *coap_new_endpoint*() function creates a new endpoint for _context_ that
+is listening for new traffic on the IP address and port number defined by
 _listen_addr_.
-Different CoAP protocols can be defined for _proto_ - the current supported 
+Different CoAP protocols can be defined for _proto_ - the current supported
 list is:
 
 [source, c]
@@ -206,94 +141,40 @@ COAP_PROTO_TCP
 COAP_PROTO_TLS
 ----
 
-The *coap_free_endpoint*() function must be used to free off the _endpoint_. 
-It clears out all the sessions associated with this endpoint. 
+The *coap_free_endpoint*() function must be used to free off the _endpoint_.
+It clears out all the sessions associated with this endpoint.
 
-The *coap_endpoint_set_default_mtu*() function is used to set the MTU size 
-(the maximum message size) of the data in a packet, excluding any IP or 
+The *coap_endpoint_set_default_mtu*() function is used to set the MTU size
+(the maximum message size) of the data in a packet, excluding any IP or
 TCP/UDP overhead to _mtu_ for the _endpoint_.  A sensible default is 1280.
 
-The *coap_endpoint_str*() function returns a description string of the 
+The *coap_endpoint_str*() function returns a description string of the
 _endpoint_.
-
-The *coap_new_client_session*() function initiates a new client session 
-associated with _context_ to the specified _server_ using the CoAP protocol 
-_proto_.  If the port is not specified in _server_, then the default CoAP 
-port is used.  Normally _local_if_ would be set to NULL, but by specifying 
-_local_if_ the source of the network session can be bound to a specific IP 
-address or port.  The session will initially have a reference count of 1.
-
-The *coap_new_client_session_pki*() function, for a specific _context_, is 
-used to configure the TLS context using the _setup_data_ variables as defined 
-in the coap_dtls_pki_t structure above, which includes an optional callback 
-function _call_back_ which will get called from within this function. 
-coap_new_client_session_pki() will always add _public_cert_ and _private_key_ 
-from one of the 2 alternatives provided in the structure, Alternative 1 taking 
-precedence, to the TLS Context.  Any CA setup functions will have to be done in 
-the _call_back_ function, which can be used as well to set up other additional 
-callbacks.
-Set _call_back_ to NULL if this callback is not required.
-This function also includes the _server_ to connect to, optionally the 
-local interface _local_if_ to bind to and the CoAP protocol _proto_ to use.  
-The session will initially have a reference count of 1.
-
-The *coap_new_client_session_psk*() function, for a specific _context_, is 
-used to configure the TLS context using the client _identity_, Pre-Shared Key 
-_key_ with length _key_len_.  All 3 parameters must be defined, NULL is not 
-valid.  An empty string is valid for _identity_.  _key_len_ must be greater 
-than 0.  This function also includes the _server_ to connect to, 
-optionally the local interface _local_if_ to bind to and the CoAP protocol 
-_proto_ to use.  The session will initially have a reference count of 1.
-
-The *coap_session_reference*() is used to increment the reference count of 
-the _session_.  Incrementing the reference count by an application means that 
-the library will not inadvertently remove the session when it has finished 
-processing the session.
-
-The *coap_session_release*() function must be used to decrement the _session_ 
-reference count, which when it gets to 0, will free off the session if this is 
-a Client,   which then clears all entries from the receive queue and send 
-queue.  If the reference count goes to 0 for a Server, then the _session_ is 
-added to a free pool ready for subsequent re-use. If the Server _session_ is 
-not used for 5 minutes, then it will get completely freed off.
-
-The *coap_sesson_set_default_mtu*() function is used to set the MTU size 
-(the maximum message size) of the data in a packet, excluding any IP or 
-TCP/UDP overhead to _mtu_ for the _session_.
 
 RETURN VALUES
 -------------
-*coap_new_context*() function returns a newly created context or 
-NULL if there is a creation failure. 
+*coap_new_context*() function returns a newly created context or
+NULL if there is a creation failure.
 
-*coap_new_endpoint*() function returns a newly created endpoint or 
-NULL if there is a creation failure. 
+*coap_context_set_pki*(), *coap_context_set_pki_root_cas*() and
+*coap_context_set_psk*() functions return 1 on success, 0 on failure.
 
-*coap_new_client_session*(), *coap_new_client_session_psk*(), 
-*coap_new_client_session_pki*() functions returns a newly created client 
-session or NULL if there is a creation failure. 
+*coap_new_endpoint*() function returns a newly created endpoint or
+NULL if there is a creation failure.
 
-*coap_session_reference*() function returns a pointer to the session.
-
-*coap_endpoint_str*() function returns a description string of the 
+*coap_endpoint_str*() function returns a description string of the
 _endpoint_.
-
-*coap_dtls_is_supported*(), *coap_tls_is_supported*(), *coap_context_set_pki*() *coap_context_set_psk*() functions
-return 0 on failure, 1 on success.
-
-*coap_get_tls_library_version*() function returns the TLS implementation type 
-and library version in a coap_tls_version_t* structure.
 
 EXAMPLES
 --------
 *CoAP Server Non-Encrypted Setup*
 
 [source, c]
---
+----
 #include <coap/coap.h>
 
-static coap_context_t *setup_server_context (void) { 
-
+static coap_context_t *
+setup_server_context (void) {
   coap_endpoint_t *endpoint;
   coap_address_t listen_addr;
   coap_context_t *context = coap_new_context(NULL);
@@ -315,23 +196,88 @@ static coap_context_t *setup_server_context (void) {
   init_resources(context);
 
   return context;
-
 }
---
+----
 
 *CoAP Server DTLS PKI Setup*
 [source, c]
---
+----
 #include <coap/coap.h>
 
-static coap_context_t *setup_server_context_pki (const char *public_cert_file, 
-const char *private_key_file, const char *ca_file) { 
+typedef struct valid_cns_t {
+  int count;
+  char **cn_list;
+} valid_cns_t;
 
+/*
+ * Common Name (CN) Callback verifier
+ */
+static int
+verify_cn_callback(const char *cn,
+                   const uint8_t *asn1_public_cert,
+                   size_t asn1_length,
+                   coap_session_t *session,
+                   unsigned depth,
+                   int validated,
+                   void *arg
+) {
+  valid_cns_t *valid_cn_list = ( valid_cns_t*)arg;
+  int i;
+
+  /* Check that the CN is valid */
+  for (i = 0; i < valid_cn_list->count; i++) {
+    if (!strcasecmp(cn, valid_cn_list->cn_list[i])) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+typedef struct sni_def_t {
+  char* sni;
+  coap_dtls_key_t key;
+} sni_def_t;
+
+typedef struct valid_snis_t {
+  int count;
+  sni_def_t *sni_list;
+} valid_snis_t;
+
+/*
+ * Subject Name Identifier (SNI) callback verifier
+ */
+static coap_dtls_key_t *
+verify_sni_callback(const char *sni,
+                    void *arg
+) {
+  valid_snis_t *valid_sni_list = (valid_snis_t *)arg;
+  int i;
+
+  /* Check that the SNI is valid */
+  for (i = 0; i < valid_sni_list->count; i++) {
+    if (!strcasecmp(sni, valid_sni_list->sni_list[i].sni)) {
+      return &valid_sni_list->sni_list[i].key;
+    }
+  }
+  return NULL;
+}
+
+/*
+ * Set up PKI encryption information
+ */
+static coap_context_t *
+setup_server_context_pki (const char *public_cert_file,
+                          const char *private_key_file,
+                          const char *ca_file,
+                          valid_cns_t *valid_cn_list,
+                          valid_snis_t *valid_sni_list
+) {
   coap_endpoint_t *endpoint;
   coap_address_t listen_addr;
   coap_dtls_pki_t dtls_pki;
   coap_context_t *context;
 
+  /* See coap_tls_library(3) */
   if (!coap_dtls_is_supported())
     return NULL;
 
@@ -341,10 +287,27 @@ const char *private_key_file, const char *ca_file) {
 
   memset (&dtls_pki, 0, sizeof (dtls_pki));
 
-  dtls_pki.ca_file     = ca_file;
-  dtls_pki.public_cert = public_cert_file;
-  dtls_pki.private_key = private_key_file;
-  dtls_pki.call_back   = setup_callback;
+  /* see coap_encryption(3) */
+  dtls_pki.version                 = COAP_DTLS_PKI_SETUP_VERSION;
+  dtls_pki.verify_peer_cert        = 1;
+  dtls_pki.require_peer_cert       = 1;
+  dtls_pki.allow_self_signed       = 1;
+  dtls_pki.allow_expired_certs     = 1;
+  dtls_pki.cert_chain_validation   = 1;
+  dtls_pki.cert_chain_verify_depth = 1;
+  dtls_pki.check_cert_revocation   = 1;
+  dtls_pki.allow_no_crl            = 1;
+  dtls_pki.allow_expired_crl       = 1;
+  dtls_pki.validate_cn_call_back   = verify_cn_callback;
+  dtls_pki.cn_call_back_arg        = valid_cn_list;
+  dtls_pki.validate_sni_call_back  = verify_sni_callback;
+  dtls_pki.sni_call_back_arg       = valid_sni_list;
+  dtls_pki.app_override_tls_setup_call_back = NULL;
+  dtls_pki.client_sni              = NULL;
+  dtls_pki.pki_key.key_type        = COAP_PKI_KEY_PEM;
+  dtls_pki.pki_key.key.pem.ca_file = ca_file;
+  dtls_pki.pki_key.key.pem.public_cert = public_cert_file;
+  dtls_pki.pki_key.key.pem.private_key = private_key_file;
 
   if (coap_context_set_pki(context, &dtls_pki)) {
     coap_free_context(context);
@@ -365,61 +328,24 @@ const char *private_key_file, const char *ca_file) {
   init_resources(context);
 
   return context;
-
 }
---
-
-*CoAP Server OpenSSL DTLS Setup Callback*
-[source, c]
---
-#include <coap/coap.h>
-
-#include <openssl/ssl.h>
-
- /*
-  * Callback function for coap_context_set_pki()
-  *
-  * parameter tls_context for OpenSSL is SSL_CTX*
-  * parameter setup_data is a pointer to coap_dtls_pki_t structure
-  */
-
-int setup_callback(void *tls_context, coap_dtls_pki_t *setup_data) {
-
-  SSL_CTX *ctx = (SSL_CTX *)tls_context;
-
-  /*
-   * Load in the CA file list
-   */
-  if (setup_data->ca_file && setup_data->ca_file[0]) {
-    SSL_CTX_set_client_CA_list(ctx, SSL_load_client_CA_file(setup_data->ca_file));
-    if (!(SSL_CTX_load_verify_locations(ctx, setup_data->ca_file, 0))) {
-      coap_log(LOG_ERR, "Unable to process CA file '%s'\n", setup_data->ca_file);
-      return 0;
-    }
-  }
-  /*
-   * Add in an additional callback which gets called during
-   * TLS Session Callback
-   */
-  SSL_CTX_set_tlsext_servername_callback(ctx, tls_server_name_callback);
-
-  return 1;
-
-}
---
+----
 
 *CoAP Server DTLS PSK Setup*
 [source, c]
---
+----
 #include <coap/coap.h>
 
-static coap_context_t *setup_server_context_psk (const char *hint, const 
-uint8_t *key, unsigned key_len) { 
-
+static coap_context_t *
+setup_server_context_psk (const char *hint,
+                          const uint8_t *key,
+                          unsigned key_len
+) {
   coap_endpoint_t *endpoint;
   coap_address_t listen_addr;
   coap_context_t *context;
 
+  /* See coap_tls_library(3) */
   if (!coap_dtls_is_supported())
     return NULL;
 
@@ -446,126 +372,16 @@ uint8_t *key, unsigned key_len) {
   init_resources(context);
 
   return context;
-
 }
---
-
-*CoAP Client Non-Encrypted Setup*
-[source, c]
---
-#include <coap/coap.h>
-
-#include <netinet/in.h>
-
-static coap_session_t *setup_client_session (struct in_addr ip_address) { 
-
-  coap_session_t *session;
-  coap_address_t server;
-  coap_context_t *context = coap_new_context(NULL);
-
-  if (!context)
-    return NULL;
-
-  coap_address_init(&server);
-  server.addr.sa.sa_family = AF_INET;
-  server.addr.sin.sin_addr = ip_address;
-  server.addr.sin.sin_port = htons (5683);
-
-  session = coap_new_client_session(context, NULL, &server, COAP_PROTO_UDP);
-  if (!session) {
-    coap_free_context(context);
-    return NULL;
-  }
-  /* The context is in session->context */
-  return session;
-
-}
---
-
-*CoAP Client PKI Setup*
-[source, c]
---
-#include <coap/coap.h>
-
-#include <netinet/in.h>
-
-static coap_session_t *setup_client_session_pki (struct in_addr ip_address, 
-const char *public_cert_file, const char *private_key_file, 
-const char *ca_file) { 
-
-  coap_session_t *session;
-  coap_address_t server;
-  coap_dtls_pki_t dtls_pki;
-  coap_context_t *context = coap_new_context(NULL);
-
-  if (!context)
-    return NULL;
-
-  coap_address_init(&server);
-  server.addr.sa.sa_family = AF_INET;
-  server.addr.sin.sin_addr = ip_address;
-  server.addr.sin.sin_port = htons (5684);
-
-  memset (&dtls_pki, 0, sizeof (dtls_pki));
-
-  dtls_pki.ca_file     = ca_file;
-  dtls_pki.public_cert = public_cert_file;
-  dtls_pki.private_key = private_key_file;
-  dtls_pki.call_back   = NULL;
-
-  session = coap_new_client_session_pki(context, NULL, &server, 
-                                        COAP_PROTO_DTLS, &dtls_pki);
-  if (!session) {
-    coap_free_context(context);
-    return NULL;
-  }
-  /* The context is in session->context */
-  return session;
-
-}
---
-
-*CoAP Client PSK Setup*
-[source, c]
---
-#include <coap/coap.h>
-
-#include <netinet/in.h>
-
-static coap_session_t *setup_client_session_psk (struct in_addr ip_address, 
-const char *identity, const uint8_t *key, unsigned key_len) { 
-
-  coap_session_t *session;
-  coap_address_t server;
-  coap_context_t *context = coap_new_context(NULL);
-
-  if (!context)
-    return NULL;
-
-  coap_address_init(&server);
-  server.addr.sa.sa_family = AF_INET;
-  server.addr.sin.sin_addr = ip_address;
-  server.addr.sin.sin_port = htons (5684);
-
-  session = coap_new_client_session_psk(context, NULL, &server, 
-                                        COAP_PROTO_DTLS, identity, key, key_len);
-  if (!session) {
-    coap_free_context(context);
-    return NULL;
-  }
-  /* The context is in session->context */
-  return session;
-
-}
---
+----
 
 SEE ALSO
 --------
-*coap_resource*(3) and *coap_tls_library*(3)
+*coap_encryption*(3), *coap_resource*(3), *coap_session*(3) and *coap_tls_library*(3)
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further 
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further
 information.
 
 BUGS

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -1,0 +1,641 @@
+// -*- mode:doc; -*-
+// vim: set syntax=asciidoc,tw=0:
+
+coap_encryption(3)
+===================
+:doctype: manpage
+:man source:   coap_encryption
+:man version:  @PACKAGE_VERSION@
+:man manual:   libcoap Manual
+
+NAME
+----
+coap_encryption, coap_dtls_pki_t
+- work with CoAP tls/dtls
+
+SYNOPSIS
+--------
+*#include <coap/coap.h>*
+
+*struct coap_dtls_pki_t*
+
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+type.
+
+DESCRIPTION
+-----------
+This man page focuses on setting up CoAP to use encryption.
+
+When the libcoap library was built, it will have been compiled using a
+specific underlying TLS implementation type (e.g. OpenSSL, GnuTLS, TinyDTLS or
+noTLS).  When the libcoap library is linked into an application, it is possible
+that the application needs to dynamically determine whether DTLS or TLS is
+supported, what type of TLS implementation libcoap was compiled with, as well
+as detect what is the version of the currently loaded TLS library.
+
+*NOTE:* If OpenSSL is being used, then the minimum supported OpenSSL library
+version is 1.1.0.
+
+Network traffic can be encrypted or un-encrypted with libcoap if there is an
+underlying TLS library.
+
+If TLS is going to be used for encrypting the network traffic, then the TLS
+information for Pre-Shared Keys (PSK) or Public Key Infrastructure (PKI) needs
+to be configured before any network traffic starts to flow. For Servers, this
+has to be done before the Endpoint is created, for Clients, this is done
+during the Client Session set up.
+
+For Servers, all the encryption information is held internally by the TLS
+Context level and the CoAP Context level as the Server is listening for new
+incoming traffic based on the Endpoint definition.  The TLS and CoAP session
+will not get built until the new traffic starts, which is done by the libcoap
+library, with the session having a reference count of 1.
+
+For Clients, all the encryption information can be held at the TLS Context and
+CoAP Context levels, or at the TLS Session and CoAP Session levels.  If
+defined at the Context level, then when Sessions are created, they will
+inherit the Context definitions, unless they have separately been defined for
+the Session level, in which case the Session version will get used.
+Typically the information will be configured at the Session level for Clients.
+
+In principle the set-up sequence for CoAP Servers looks like
+----
+coap_new_context()
+coap_context_set_pki_root_cas() - if the root CAs need to be updated and PKI
+coap_context_set_pki() and/or coap_context_set_psk() - if encryption is required
+coap_new_endpoint()
+----
+
+Multiple endpoints can be set up per Context, each listening for a new traffic
+flow with different TCP/UDP protocols, TLS protocols, port numbers etc. When a
+new traffic flow is started, then the CoAP library will create and start a new
+server session.
+
+In principle the set-up sequence for CoAP Clients looks like
+----
+coap_new_context()
+coap_context_set_pki_root_cas() - if the root CAs need to be updated and PKI
+coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk()
+----
+
+Multiple client sessions are supported per Context.
+
+Due to the nature of TLS, there are Callbacks that are invoked as the TLS
+session negotiates encryption algorithms, encryption keys etc.
+Where possible, the CoAP layer handles all this automatically based on
+different configuration options passed in by the coap_*_pki() functions.
+
+For PSK setup, the required information needs to be provided in the setup
+calls with no application Callbacks required. Both the Client and Server have
+to provide a PSK.  The Server must have a Hint defined and the Client must
+have an Identity defined.
+
+For PKI setup, if the libcoap PKI configuration options do not handle a specific
+requirement, then an application defined Callback can called to do the
+specific checks.  If Application Callback is defined, then none of the libcoap
+layer Callback checking takes place and it is the responsibility
+of the Application Callback to do all of the checks.
+
+The information passed to this Application Callback will be the TLS context and
+TLS session (as well the configuration information), but the structures
+containing this information will be different as they will be based on the
+underlying TLS library type. coap_get_tls_library_version() is provided to help
+here.
+
+Whether Application Callback is defined or not, libcoap will add in the defined
+Certificate, Private Key and CA Certificate into the TLS environment.  The CA
+Certificate is also added in to the list of valid CAs for Certificate checking.
+
+Then either Application Callback is called or the internal libcoap Callbacks are
+called.  The internal Callbacks (if no Application Callback) will then check the
+required information as defined in the coap_dtls_pki_t described below.
+
+[source, c]
+----
+typedef struct coap_dtls_pki_t {
+  uint8_t version;            /* COAP_DTLS_PKI_SETUP_VERSION */
+
+  /* Options to enable different TLS functionality in libcoap */
+  uint8_t verify_peer_cert;         /* 1 if peer cert is to be verified */
+  uint8_t require_peer_cert;        /* 1 if peer cert is required */
+  uint8_t allow_self_signed;        /* 1 if self signed certs are allowed */
+  uint8_t allow_expired_certs;      /* 1 if expired certs are allowed */
+  uint8_t cert_chain_validation;    /* 1 if to check cert_chain_verify_depth */
+  uint8_t cert_chain_verify_depth;  /* recommended depth is 3 */
+  uint8_t check_cert_revocation;    /* 1 if revocation checks wanted */
+  uint8_t allow_no_crl;             /* 1 ignore if CRL not there */
+  uint8_t allow_expired_crl;        /* 1 if expired crl is allowed */
+  uint8_t reserved[6];              /* Reserved - must be set to 0 for
+                                       future compatability */
+
+  /** CN check call-back function
+   * If not NULL, is called when the TLS connection has passed the configured
+   * TLS options above for the application to verify if the CN is valid.
+   */
+  coap_dtls_cn_callback_t validate_cn_call_back;
+  void *cn_call_back_arg;  /* Passed in to the CN call-back function */
+
+  /** SNI check call-back function
+   * If not NULL, called if the SNI is not previously seen and prior to sending
+   * a certificate set back to the client so that the appropriate certificate set
+   * can be used based on the requesting SNI.
+   */
+  coap_dtls_sni_callback_t validate_sni_call_back;
+  void *sni_call_back_arg;  /* Passed in to the sni call-back function */
+
+  /** Application Setup call-back definition
+   * If not NULL, then application is handling the characteristics of the TLS
+   * connection setup in the defined call-back handler.  If set, then none of
+   * the options or call-backs above are acted on. */
+  coap_dtls_security_setup_t app_override_tls_setup_call_back;
+
+  char* client_sni;       /* If not NULL, SNI to use in client TLS setup.
+                             Owned by the client app and must remain valid
+                             during the call to coap_new_client_session_pki() */
+
+  coap_dtls_key_t pki_key; /* PKI key definition */
+} coap_dtls_pki_t;
+----
+
+More detailed explanation of the coap_dtls_pki_t structure follows.
+
+*WARNING*: All the parameter definitions that are pointers to other locations,
+these locations must remain valid during the lifetime of all the underlying TLS
+sessions that are, or will get created based on this PKI definition.
+
+The first parameter in each subsection enables/disables the functionality, the
+remaining parameter(s) control control what happens when the functionality is
+enabled.
+
+*SECTION: coap_dtls_pki_t Version*
+[source, c]
+----
+#define COAP_DTLS_PKI_SETUP_VERSION 1
+----
+
+*version* is set to COAP_DTLS_PKI_SETUP_VERSION.  This will then allow support
+different for different versions of the coap_dtls_pki_t structure in the future.
+
+*SECTION: Peer Certificate Checking*
+
+*verify_peer_cert* Set to 1 to check that the peer's certificate is valid if
+provided, else 0.
+
+*require_peer_cert* Set to 1 to enforce that the peer provides a certificate,
+else 0.  If the Server, this initates a request for the peer certificate.
+
+*allow_self_signed* Set to 1 to allow the peer (or any certificate in the
+certificate chain) to be a self-signed certificate, else 0.
+
+*allow_expired_certs* Set to 1 to allow certificates that have either expired,
+or are not yet valid to be allowed, else 0.
+
+*SECTION: Certificate Chain Validation*
+
+*cert_chain_validation* Set to 1 to check that the certificate chain is valid,
+else 0.
+
+*cert_chain_verify_depth* Set to the chain depth that is to be checked. This
+is the number of intermediate CAs in the chain. If set to 0, then there can be
+no intermediate CA in the chain.
+
+*SECTION: Certificate Revocation*
+
+*check_cert_revocation* Set to 1 to check whether any certificate in the chain
+has been revoked, else 0.
+
+*allow_no_crl* Set to 1 to not check any certificate that does not have a CRL.
+
+*allow_expired_crl* Set to 1 to allow an certificate that has an expired CRL
+definition to be valid, else 0.
+
+*SECTION: Reserved*
+
+*reserved* Must be set to 0.  Future functionality updates will make use of
+these reserved definitions.
+
+*SECTION: Common Name (CN) Callback*
+[source, c]
+----
+/**
+ * CN Validation call-back that can be set up by coap_context_set_pki().
+ * Invoked when libcoap has done the validation checks at the TLS level,
+ * but the application needs to check that the CN is allowed.
+ * CN is the SubjectAltName in the cert, if not present, then the leftmost
+ * Common Name (CN) component of the subject name
+ *
+ * @param cn  The determined CN from the certificate
+ * @param asn1_public_cert  The ASN.1 encoded (DER) X.509 certificate
+ * @param asn1_length  The ASN.1 length
+ * @param session  The coap session associated with the certificate update
+ * @param depth  Depth in cert chain.  If 0, then client cert, else a CA
+ * @param validated  TLS can find no issues if 1
+ * @param arg  The same as was passed into coap_context_set_pki()
+ *             in setup_data->cn_call_back_arg
+ *
+ * @return 1 if accepted, else 0 if to be rejected
+ */
+typedef int (*coap_dtls_cn_callback_t)(const char *cn,
+             const uint8_t *asn1_public_cert,
+             size_t asn1_length,
+             coap_session_t *session,
+             unsigned depth,
+             int validated,
+             void *arg);
+----
+
+*validate_cn_call_back* points to an application provided CN callback
+checking function or NULL. The application can make use of this CN information
+to decide, for example, that the CN is valid coming from a particular peer.
+The Callback returns 1 on success, 0 if the TLS connection is to be aborted.
+
+*cn_call_back_arg* points to a user defined set of data that will get  passed
+in to the validate_cn_call_back() function and can be used by that function.
+An example would be a set of CNs that are allowed.
+
+*SECTION: Subject Name Identifier (SNI) Callback*
+[source, c]
+----
+typedef struct coap_dtls_key_t {
+  coap_pki_key_t key_type;          /* key format type */
+  union {
+    coap_pki_key_pem_t pem;         /* for PEM keys */
+    coap_pki_key_asn1_t asn1;       /* for ASN.1 (DER) keys */
+  } key;
+} coap_dtls_key_t;
+
+/**
+ * SNI Validation call-back that can be set up by coap_context_set_pki().
+ * Invoked if the SNI is not previously seen and prior to sending a certificate
+ * set back to the client so that the appropriate certificate set can be used
+ * based on the requesting SNI.
+ *
+ * @param sni  The requested SNI
+ * @param arg  The same as was passed into coap_context_set_pki()
+ *             in setup_data->sni_call_back_arg
+ *
+ * @return new set of certificates to use, or NULL if SNI is to be rejected.
+ */
+typedef coap_dtls_key_t *(*coap_dtls_sni_callback_t)(const char *sni,
+             void* arg);
+----
+
+*validate_sni_call_back* points to an application provided SNI callback
+checking function or NULL. The application can make use of this SNI information
+to decide whether the SNI is valid, and what set of certificates to give to the
+client.  Thus it is possible for the coap server to host multiple domains with
+different certificates allocated to each domain.
+The Callback returns a pointer to the certificates to use for this SNI, or NULL
+if the connection it to get rejected.  libcoap remembers the association
+between the SNI and Certificate set and will only invoke this callback if the
+SNI is unknown.
+
+*sni_call_back_arg* points to a user defined set of data that will get  passed
+in to the validate_sni_call_back() function and can be used by that function.
+An example would be a set of SNIs that are allowed with their matching
+certificate sets.
+
+*SECTION: Application Setup Callback*
+[source, c]
+----
+/**
+ * Security setup handler that is used as an application call-back in
+ * coap_context_set_pki().
+ * Typically, this will be calling additonal functions like
+ * SSL_CTX_set_tlsext_servername_callback() etc.
+ *
+ * @param context The security context definition - e.g. SSL_CTX * for OpenSSL.
+ *                This will be dependent on the underlying TLS library
+ *                - see coap_get_tls_library_version()
+ * @param session The security session definition - e.g. SSL * for OpenSSL.
+ *                NULL if server call-back.
+ *                This will be dependent on the underlying TLS library
+ *                - see coap_get_tls_library_version()
+ * @param setup_data A structure containing setup data originally passed into
+ *                   coap_context_set_pki() or coap_new_client_session_pki().
+ * @return 1 if successful, else 0
+ */
+typedef int (*coap_dtls_security_setup_t)(void *context, void* session,
+                                        struct coap_dtls_pki_t *setup_data);
+----
+
+*app_override_tls_setup_call_back* points to an application provided callback
+function that will do all of the TLS callback checking, or NULL. If not NULL,
+then all of the checking defined by the parameters / callbacks above will not
+take place in libcoap.
+
+*SECTION: Subject Name Indicator (SNI) Definition*
+
+*client_sni* points to the SNI name that will be added in as a TLS extension,
+or set NULL.  This typically is the DNS name of the server that the client is
+trying to contact.  This is only used by a client application and the server
+is then able to decide, based on the name in the SNI extension, whether, for
+example, a different certificate should be provided.
+
+*SECTION: Key Type Definition*
+[source, c]
+----
+typedef enum coap_pki_key_t {
+  COAP_PKI_KEY_PEM,    /* PEM type informaiton */
+  COAP_PKI_KEY_ASN1,   /* ASN1 type information */
+} coap_pki_key_t;
+----
+
+*key_type* defines the format that the certificates / keys are provided in.
+This can be COAP_PKI_KEY_PEM or COAP_PKI_KEY_ASN1.
+
+*SECTION: PEM Key Definitions*
+[source, c]
+----
+typedef struct coap_pki_key_pem_t {
+  const char *ca_file;       /* File location of Common CA in PEM format */
+  const char *public_cert;   /* File location of Public Cert in PEM format */
+  const char *private_key;   /* File location of Private Key in PEM format */
+} coap_pki_key_pem_t;
+----
+
+*key.pem.ca_file* points to the CA File location on disk which will be in
+PEM format, or NULL. This file should only contain 1 CA (who signed the
+Public Certificate) as this is passed from the server to the client when
+requesting the client's certificate. This certificate is also added into
+the valid root CAs list if not already present.
+
+*key.pem.public_cert* points to the Public Certificate location on disk
+which will be in PEM format.
+
+*key.pem.private_key* points to the Private Key location on disk which
+will be in PEM format.  This file cannot be password protected.
+
+*SECTION: ASN1 Key Definitions*
+[source, c]
+----
+typedef struct coap_pki_key_asn1_t {
+  const uint8_t *ca_cert;     /* ASN1 Common CA Certificate */
+  const uint8_t *public_cert; /* ASN1 Public Certificate */
+  const uint8_t *private_key; /* ASN1 Private Key */
+  int ca_cert_len;            /* ASN1 CA Certificate length */
+  int public_cert_len;        /* ASN1 Public Certificate length */
+  int private_key_len;        /* ASN1 Private Key length */
+  coap_asn1_privatekey_type_t private_key_type; /* Private Key Type
+                                                   COAP_ASN1_PKEY_* */
+} coap_pki_key_asn1_t;
+
+typedef enum coap_asn1_privatekey_type_t {
+  COAP_ASN1_PKEY_NONE,
+  COAP_ASN1_PKEY_RSA,
+  COAP_ASN1_PKEY_RSA2,
+  COAP_ASN1_PKEY_DSA,
+  COAP_ASN1_PKEY_DSA1,
+  COAP_ASN1_PKEY_DSA2,
+  COAP_ASN1_PKEY_DSA3,
+  COAP_ASN1_PKEY_DSA4,
+  COAP_ASN1_PKEY_DH,
+  COAP_ASN1_PKEY_DHX,
+  COAP_ASN1_PKEY_EC,
+  COAP_ASN1_PKEY_HMAC,
+  COAP_ASN1_PKEY_CMAC,
+  COAP_ASN1_PKEY_TLS1_PRF,
+  COAP_ASN1_PKEY_HKDF
+} coap_asn1_privatekey_type_t;
+----
+
+*key.asn1.ca_cert* points to a DER encoded ASN.1 definition of the CA
+Certificate, or NULL.  This certificate is passed from the server to the client
+when requesting the client's certificate. This certificate is also added into
+the valid root CAs list if not already present.
+
+*key.asn1.public_cert* points to a DER encoded ASN.1 definition of the
+Public Certificate.
+
+*key.asn1.private_key* points to DER encoded ASN.1 definition of the
+Private Key.
+
+*key.asn1.ca_cert_len* is the length of the DER encoded ASN.1 definition of
+the CA Certificate.
+
+*key.asn1.public_cert_len* is the length of the DER encoded ASN.1 definition
+of the Public Certificate.
+
+*key.asn1.private_key_len* is the length of the DER encoded ASN.1 definition
+of the Private Key.
+
+*key.asn1.private_key_type* is the encoding type of the DER encoded ASN.1
+definition of the Private Key.  This will be one of the COAP_ASN1_PKEY_*
+definitions.
+
+EXAMPLES
+--------
+*CoAP Server DTLS PKI Setup*
+[source, c]
+----
+#include <coap/coap.h>
+
+typedef struct valid_cns_t {
+  int count;
+  char **cn_list;
+} valid_cns_t;
+
+/**
+ * CN Validation call-back that is set up by coap_context_set_pki().
+ * Invoked when libcoap has done the validation checks at the TLS level,
+ * but the application needs to check that the CN is allowed.
+ * CN is the SubjectAltName in the cert, if not present, then the leftmost
+ * Common Name (CN) component of the subject name
+ *
+ * @param cn  The determined CN from the certificate
+ * @param asn1_public_cert  The ASN.1 encoded (DER) X.509 certificate
+ * @param asn1_length  The ASN.1 length
+ * @param session  The coap session associated with the certificate update
+ * @param depth  Depth in cert chain.  If 0, then client cert, else a CA
+ * @param validated  TLS can find no issues if 1
+ * @param arg  The same as was passed into coap_context_set_pki()
+ *             in setup_data->cn_call_back_arg
+ *
+ * @return 1 if accepted, else 0 if to be rejected
+ */
+static int
+verify_cn_callback(const char *cn,
+                   const uint8_t *asn1_public_cert,
+                   size_t asn1_length,
+                   coap_session_t *session,
+                   unsigned depth,
+                   int validated,
+                   void *arg
+) {
+  valid_cns_t *valid_cn_list = ( valid_cns_t*)arg;
+  int i;
+
+  /* Check that the CN is valid */
+  for (i = 0; i < valid_cn_list->count; i++) {
+    if (!strcasecmp(cn, valid_cn_list->cn_list[i])) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+typedef struct sni_def_t {
+  char* sni;
+  coap_dtls_key_t key;
+} sni_def_t;
+
+typedef struct valid_snis_t {
+  int count;
+  sni_def_t *sni_list;
+} valid_snis_t;
+
+/**
+ * SNI Validation call-back that is set up by coap_context_set_pki().
+ * Invoked if the SNI is not previously seen and prior to sending a certificate
+ * set back to the client so that the appropriate certificate set can be used
+ * based on the requesting SNI.
+ *
+ * @param sni  The requested SNI
+ * @param arg  The same as was passed into coap_context_set_pki()
+ *             in setup_data->sni_call_back_arg
+ *
+ * @return new set of certificates to use, or NULL if SNI is to be rejected.
+ */
+static coap_dtls_key_t *
+verify_sni_callback(const char *sni,
+                    void *arg
+) {
+  valid_snis_t *valid_sni_list = (valid_snis_t *)arg;
+  int i;
+
+  /* Check that the SNI is valid */
+  for (i = 0; i < valid_sni_list->count; i++) {
+    if (!strcasecmp(sni, valid_sni_list->sni_list[i].sni)) {
+      return &valid_sni_list->sni_list[i].key;
+    }
+  }
+  return NULL;
+}
+
+/*
+ * Set up PKI encryption information
+ */
+static coap_context_t *
+setup_server_context_pki (const char *public_cert_file,
+                          const char *private_key_file,
+                          const char *ca_file,
+                          valid_cns_t *valid_cn_list,
+                          valid_snis_t *valid_sni_list
+) {
+  coap_endpoint_t *endpoint;
+  coap_address_t listen_addr;
+  coap_dtls_pki_t dtls_pki;
+  coap_context_t *context;
+
+  /* See coap_tls_library(3) */
+  if (!coap_dtls_is_supported())
+    return NULL;
+
+  /* See coap_context(3) */
+  context = coap_new_context(NULL);
+  if (!context)
+    return NULL;
+
+  memset (&dtls_pki, 0, sizeof (dtls_pki));
+
+  dtls_pki.version                 = COAP_DTLS_PKI_SETUP_VERSION;
+  dtls_pki.verify_peer_cert        = 1;
+  dtls_pki.require_peer_cert       = 1;
+  dtls_pki.allow_self_signed       = 1;
+  dtls_pki.allow_expired_certs     = 1;
+  dtls_pki.cert_chain_validation   = 1;
+  dtls_pki.cert_chain_verify_depth = 1;
+  dtls_pki.check_cert_revocation   = 1;
+  dtls_pki.allow_no_crl            = 1;
+  dtls_pki.allow_expired_crl       = 1;
+  dtls_pki.validate_cn_call_back   = verify_cn_callback;
+  dtls_pki.cn_call_back_arg        = valid_cn_list;
+  dtls_pki.validate_sni_call_back  = verify_sni_callback;
+  dtls_pki.sni_call_back_arg       = valid_sni_list;
+  dtls_pki.app_override_tls_setup_call_back = NULL;
+  dtls_pki.sni                     = NULL;
+  dtls_pki.pki_key.key_type        = COAP_PKI_KEY_PEM;
+  dtls_pki.pki_key.key.pem.ca_file = ca_file;
+  dtls_pki.pki_key.key.pem.public_cert = public_cert_file;
+  dtls_pki.pki_key.key.pem.private_key = private_key_file;
+
+  /* See coap_context(3) */
+  if (coap_context_set_pki(context, &dtls_pki)) {
+    coap_free_context(context);
+    return NULL;
+  }
+
+  coap_address_init(&listen_addr);
+  listen_addr.addr.sa.sa_family = AF_INET;
+  listen_addr.addr.sin.sin_port = htons (5684);
+
+  /* See coap_context(3) */
+  endpoint = coap_new_endpoint(context, &listen_addr, COAP_PROTO_DTLS);
+  if (!endpoint) {
+    coap_free_context(context);
+    return NULL;
+  }
+
+  /* See coap_resource(3) */
+  init_resources(context);
+
+  return context;
+}
+----
+
+*CoAP Server OpenSSL Application Setup Callback*
+[source, c]
+----
+#include <coap/coap.h>
+
+#include <openssl/ssl.h>
+
+ /*
+  * Application Callback function for coap_context_set_pki()
+  *
+  * It is the responsibilty of the application to do all of the certificate
+  * checking if used
+  *
+  * parameter tls_context for OpenSSL is SSL_CTX*
+  * parameter tls_session for OpenSSL is SSL_* (NULL for server application)
+  * parameter setup_data is a pointer to coap_dtls_pki_t structure
+  */
+
+int
+application_setup_callback(void *tls_context,
+                    void* tls_session,
+                    coap_dtls_pki_t *setup_data
+) {
+  SSL_CTX *ctx = (SSL_CTX *)tls_context;
+
+  /* Other code */
+
+  /*
+   * Add in an additional callback which gets called during
+   * TLS Session Callback
+   */
+  SSL_CTX_set_tlsext_servername_callback(ctx, tls_server_name_callback);
+
+  return 1;
+}
+----
+
+SEE ALSO
+--------
+*coap_context*(3), *coap_resource*(3), *coap_session*(3) and
+*coap_tls_library*(3).
+
+FURTHER INFORMATION
+-------------------
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further
+information.
+
+BUGS
+----
+Please report bugs on the mailing list for libcoap:
+libcoap-developers@lists.sourceforge.net
+
+AUTHORS
+-------
+The libcoap project <libcoap-developers@lists.sourceforge.net>

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -1,0 +1,386 @@
+// -*- mode:doc; -*-
+// vim: set syntax=asciidoc,tw=0:
+
+coap_session(3)
+=================
+:doctype: manpage
+:man source:   coap_session
+:man version:  @PACKAGE_VERSION@
+:man manual:   libcoap Manual
+
+NAME
+----
+coap_session,
+coap_new_client_session,
+coap_new_client_session_psk,
+coap_new_client_session_pki,
+coap_session_reference,
+coap_session_release,
+coap_session_set_mtu,
+coap_session_max_pdu_size,
+coap_session_str - work with CoAP sessions
+
+SYNOPSIS
+--------
+*#include <coap/coap.h>*
+
+*coap_session_t *coap_new_client_session(coap_context_t *_context_,
+const coap_address_t *_local_if_, const coap_address_t *_server_,
+coap_proto_t _proto_);*
+
+*coap_session_t *coap_new_client_session_psk(coap_context_t *_context_,
+const coap_address_t *_local_if_, const coap_address_t *_server_, coap_proto_t
+_proto_, const char *_identity_, const uint8_t *_key_, unsigned _key_len_);*
+
+*coap_session_t *coap_new_client_session_pki(coap_context_t *_context_,
+const coap_address_t *_local_if_, const coap_address_t *_server_, coap_proto_t
+_proto_, coap_dtls_pki_t *_setup_data_);*
+
+*coap_session_t *coap_session_reference(coap_session_t *_session_);*
+
+*void coap_session_release(coap_session_t *_session_);*
+
+*void coap_session_set_mtu(coap_session_t *_session_, unsigned _mtu_);*
+
+*size_t coap_session_max_pdu_size(coap_session_t *_session_);*
+
+*void coap_session_set_app_data(coap_session_t *_session_, void *_data_);*
+
+*void *coap_session_get_app_data(const coap_session_t *_session_);*
+
+*const char *coap_session_str(const coap_session_t *_session_);*
+
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+type.
+
+DESCRIPTION
+-----------
+This man page focuses on the CoAP Session.
+
+The CoAP stack's global state is stored in a coap_context_t Context object.
+Resources, Endpoints and Sessions are associated with this context object.
+There can be more than one coap_context_t object per application, it is up to
+the application to manage each one accordingly.
+
+A CoAP Session maintains the state of an ongoing connection between a Client
+and Server which is stored in a coap_session_t Session object.
+
+The Session network traffic can be encrypted or un-encrypted if there is an
+underlying TLS library.
+
+If TLS is going to be used for encrypting the network traffic, then the TLS
+information for Pre-Shared Keys (PSK) or Public Key Infrastructure (PKI) needs
+to be configured before any network traffic starts to flow. For Servers, this
+has to be done before the Endpoint is created, for Clients, this is done
+during the Client Session set up.
+
+For Servers, all the encryption information is held internally by the TLS
+Context level and the CoAP Context level as the Server is listening for new
+incoming traffic based on the Endpoint definition.  The TLS and CoAP session
+will not get built until the new traffic starts, which is done by the libcoap
+library, with the session having a reference count of 1.
+
+For Clients, all the encryption information can be held at the TLS Context and
+CoAP Context levels, or at the TLS Session and CoAP Session levels.  If
+defined at the Context level, then when Sessions are created, they will
+inherit the Context definitions, unless they have separately been defined for
+the Session level, in which case the Session version will get used.
+Typically the information will be configured at the Session level for Clients.
+
+In principle the set-up sequence for CoAP Servers looks like
+(see coap_context(3) for further information on the functions)
+----
+coap_new_context()
+coap_context_set_pki_root_cas() - if the root CAs need to be updated and PKI
+coap_context_set_pki() and/or coap_context_set_psk() - if encryption is required
+coap_new_endpoint()
+----
+
+Multiple endpoints can be set up per Context, each listening for a new traffic
+flow with different TCP/UDP protocols, TLS protocols, port numbers etc. When a
+new traffic flow is started, then the CoAP library will create and start a new
+server session.
+
+In principle the set-up sequence for CoAP Clients looks like
+----
+coap_new_context()
+coap_context_set_pki_root_cas() if the root CAs need to be updated and PKI
+coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk()
+----
+
+Multiple client sessions are supported per Context.
+
+Different CoAP protocols can be defined for _proto_ - the current supported
+list is:
+
+[source, c]
+----
+COAP_PROTO_UDP
+COAP_PROTO_DTLS
+COAP_PROTO_TCP
+COAP_PROTO_TLS
+----
+
+The *coap_new_client_session*() function initiates a new client session
+associated with _context_ to the specified _server_ using the CoAP protocol
+_proto_.  If the port is not specified in _server_, then the default CoAP
+port is used.  Normally _local_if_ would be set to NULL, but by specifying
+_local_if_ the source of the network session can be bound to a specific IP
+address or port.  The session will initially have a reference count of 1.
+
+The *coap_new_client_session_pki*() function, for a specific _context_, is
+used to configure the TLS context using the _setup_data_ variables as defined
+in the coap_dtls_pki_t structure - see *coap_encrytion(*3).
+The session will initially have a reference count of 1.
+
+The *coap_new_client_session_psk*() function, for a specific _context_, is
+used to configure the TLS context using the client _identity_, Pre-Shared Key
+_key_ with length _key_len_.  All 3 parameters must be defined, NULL is not
+valid.  An empty string is not valid for _identity_.  _key_len_ must be greater
+than 0.  This function also includes the _server_ to connect to,
+optionally the local interface _local_if_ to bind to and the CoAP protocol
+_proto_ to use.  The session will initially have a reference count of 1.
+
+The *coap_session_reference*() is used to increment the reference count of
+the _session_.  Incrementing the reference count by an application means that
+the library will not inadvertently remove the session when it has finished
+processing the session.
+
+The *coap_session_release*() function must be used to decrement the _session_
+reference count, which when it gets to 0, will free off the session if this is
+a Client, which then clears all entries from the receive queue and send
+queue.  If the reference count goes to 0 for a Server, then the _session_ is
+added to a free pool ready for subsequent re-use. If the Server _session_ is
+not used for 5 minutes, then it will get completely freed off.
+
+The *coap_sesson_set_default_mtu*() function is used to set the MTU size
+(the maximum message size) of the data in a packet, excluding any IP or
+TCP/UDP overhead to _mtu_ for the _session_.
+
+The *coap_session_max_pdu_size*() funcition is used to get the maximum MTU
+size of the data for the _session_.
+
+The *coap_session_set_app_data*() funstion is used to define a _data_ pointer
+for the _session_ which can then be retieved at a later date.
+
+The *coap_session_get_app_data*() function is used to retrieve the data
+pointer previously defined by *coap_session_set_app_data*().
+
+The *coap_session_str*() function is used to get a string containing the
+information about the _session_.
+
+RETURN VALUES
+-------------
+*coap_new_client_session*(), *coap_new_client_session_psk*(),
+*coap_new_client_session_pki*() functions returns a newly created client
+session or NULL if there is a creation failure.
+
+*coap_session_reference*() function returns a pointer to the session.
+
+*coap_session_get_app_data*() function return a previously defined pointer.
+
+*coap_session_max_pdu_size*() function returns the MTU size.
+
+*coap_session_str*() function returns a description string of the
+session.
+
+EXAMPLES
+--------
+*CoAP Client Non-Encrypted Setup*
+[source, c]
+----
+#include <coap/coap.h>
+
+#include <netinet/in.h>
+
+static coap_session_t *
+setup_client_session (struct in_addr ip_address) {
+  coap_session_t *session;
+  coap_address_t server;
+  /* See coap_context(3) */
+  coap_context_t *context = coap_new_context(NULL);
+
+  if (!context)
+    return NULL;
+
+  coap_address_init(&server);
+  server.addr.sa.sa_family = AF_INET;
+  server.addr.sin.sin_addr = ip_address;
+  server.addr.sin.sin_port = htons (5683);
+
+  session = coap_new_client_session(context, NULL, &server, COAP_PROTO_UDP);
+  if (!session) {
+    coap_free_context(context);
+    return NULL;
+  }
+  /* The context is in session->context */
+  return session;
+}
+----
+
+*CoAP Client PKI Setup*
+[source, c]
+----
+#include <coap/coap.h>
+
+#include <netinet/in.h>
+
+static int
+verify_cn_callback(const char *cn,
+                   const uint8_t *asn1_public_cert,
+                   size_t asn1_length,
+                   coap_session_t *session,
+                   unsigned depth,
+                   int validated,
+                   void *arg
+) {
+  /* Check that the CN is valid */
+
+  /* ... */
+
+  return 1;
+}
+
+static coap_session_t *
+setup_client_session_pki (struct in_addr ip_address,
+                          const char *public_cert_file,
+                          const char *private_key_file,
+                          const char *ca_file
+) {
+  coap_session_t *session;
+  coap_address_t server;
+  coap_dtls_pki_t dtls_pki;
+  /* See coap_context(3) */
+  coap_context_t *context = coap_new_context(NULL);
+
+  if (!context)
+    return NULL;
+
+  coap_address_init(&server);
+  server.addr.sa.sa_family = AF_INET;
+  server.addr.sin.sin_addr = ip_address;
+  server.addr.sin.sin_port = htons (5684);
+
+  memset (&dtls_pki, 0, sizeof (dtls_pki));
+
+  /* See coap_encryption(3) */
+  dtls_pki.version                 = COAP_DTLS_PKI_SETUP_VERSION;
+  dtls_pki.verify_peer_cert        = 1;
+  dtls_pki.require_peer_cert       = 1;
+  dtls_pki.allow_self_signed       = 1;
+  dtls_pki.allow_expired_certs     = 1;
+  dtls_pki.cert_chain_validation   = 1;
+  dtls_pki.cert_chain_verify_depth = 1;
+  dtls_pki.check_cert_revocation   = 1;
+  dtls_pki.allow_no_crl            = 1;
+  dtls_pki.allow_expired_crl       = 1;
+  dtls_pki.validate_cn_call_back   = verify_cn_callback;
+  dtls_pki.cn_call_back_arg        = NULL;
+  dtls_pki.validate_sni_call_back  = NULL;
+  dtls_pki.sni_call_back_arg       = NULL;
+  dtls_pki.app_override_tls_setup_call_back = NULL;
+  dtls_pki.sni                     = NULL;
+  dtls_pki.pki_key.key_type        = COAP_PKI_KEY_PEM;
+  dtls_pki.pki_key.key.pem.ca_file = ca_file;
+  dtls_pki.pki_key.key.pem.public_cert = public_cert_file;
+  dtls_pki.pki_key.key.pem.private_key = private_key_file;
+
+  session = coap_new_client_session_pki(context, NULL, &server,
+                                        COAP_PROTO_DTLS, &dtls_pki);
+  if (!session) {
+    coap_free_context(context);
+    return NULL;
+  }
+  /* The context is in session->context */
+  return session;
+}
+----
+
+*CoAP Client PSK Setup*
+[source, c]
+----
+#include <coap/coap.h>
+
+#include <netinet/in.h>
+
+static coap_session_t *
+setup_client_session_psk (struct in_addr ip_address,
+                          const char *identity,
+                          const uint8_t *key,
+                          unsigned key_len
+) {
+  coap_session_t *session;
+  coap_address_t server;
+  /* See coap_context(3) */
+  coap_context_t *context = coap_new_context(NULL);
+
+  if (!context)
+    return NULL;
+
+  coap_address_init(&server);
+  server.addr.sa.sa_family = AF_INET;
+  server.addr.sin.sin_addr = ip_address;
+  server.addr.sin.sin_port = htons (5684);
+
+  session = coap_new_client_session_psk(context, NULL, &server,
+                                        COAP_PROTO_DTLS, identity, key, key_len);
+  if (!session) {
+    coap_free_context(context);
+    return NULL;
+  }
+  /* The context is in session->context */
+  return session;
+}
+----
+
+*CoAP Client Setup*
+[source, c]
+----
+#include <coap/coap.h>
+
+#include <netinet/in.h>
+
+static coap_session_t *
+setup_client_session (struct in_addr ip_address) {
+  coap_session_t *session;
+  coap_address_t server;
+  /* See coap_context(3) */
+  coap_context_t *context = coap_new_context(NULL);
+
+  if (!context)
+    return NULL;
+
+  coap_address_init(&server);
+  server.addr.sa.sa_family = AF_INET;
+  server.addr.sin.sin_addr = ip_address;
+  server.addr.sin.sin_port = htons (5683);
+
+  session = coap_new_client_session(context, NULL, &server,
+                                        COAP_PROTO_DTLS);
+  if (!session) {
+    coap_free_context(context);
+    return NULL;
+  }
+  /* The context is in session->context */
+  return session;
+}
+----
+
+SEE ALSO
+--------
+*coap_context*(3), *coap_resource*(3), *coap_encryption*(3) and *coap_tls_library*(3)
+
+FURTHER INFORMATION
+-------------------
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further
+information.
+
+BUGS
+----
+Please report bugs on the mailing list for libcoap:
+libcoap-developers@lists.sourceforge.net
+
+AUTHORS
+-------
+The libcoap project <libcoap-developers@lists.sourceforge.net>

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -399,11 +399,20 @@ coap_socket_bind_tcp(coap_socket_t *sock,
 #else
   if (ioctl(sock->fd, FIONBIO, &on) == COAP_SOCKET_ERROR) {
 #endif
-    coap_log(LOG_WARNING, "coap_socket_bind_tcp: ioctl FIONBIO: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_bind_tcp: ioctl FIONBIO: %s\n",
+                           coap_socket_strerror());
   }
+  if (setsockopt (sock->fd, SOL_SOCKET, SO_KEEPALIVE, OPTVAL_T(&on),
+                  sizeof (on)) == COAP_SOCKET_ERROR)
+    coap_log(LOG_WARNING,
+             "coap_socket_bind_tcp: setsockopt SO_KEEPALIVE: %s\n",
+             coap_socket_strerror());
 
-  if (setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-    coap_log(LOG_WARNING, "coap_socket_bind_tcp: setsockopt SO_REUSEADDR: %s\n", coap_socket_strerror());
+  if (setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, OPTVAL_T(&on),
+                 sizeof(on)) == COAP_SOCKET_ERROR)
+    coap_log(LOG_WARNING,
+             "coap_socket_bind_tcp: setsockopt SO_REUSEADDR: %s\n",
+             coap_socket_strerror());
 
   switch (listen_addr->addr.sa.sa_family) {
   case AF_INET:

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -37,20 +37,32 @@ coap_get_tls_library_version(void) {
   return &version;
 }
 
-int coap_dtls_context_set_pki( coap_context_t *ctx UNUSED,
-  coap_dtls_pki_t* setup_data UNUSED
+int
+coap_dtls_context_set_pki(coap_context_t *ctx UNUSED,
+                          coap_dtls_pki_t* setup_data UNUSED,
+                          int server UNUSED
 ) {
   return 0;
 }
 
-int coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
-  const char *hint UNUSED,
-  const uint8_t *key UNUSED, size_t key_len UNUSED
+int
+coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx UNUSED,
+                                   const char *ca_file UNUSED,
+                                   const char *ca_path UNUSED
 ) {
   return 0;
 }
 
-int coap_dtls_context_check_keys_enabled(coap_context_t *ctx UNUSED)
+int
+coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
+                          const char *hint UNUSED,
+                          int server UNUSED
+) {
+  return 0;
+}
+
+int
+coap_dtls_context_check_keys_enabled(coap_context_t *ctx UNUSED)
 {
   return 0;
 }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -330,6 +330,7 @@ coap_dtls_free_session(coap_session_t *coap_session) {
       dtls_close(ctx, (session_t *)coap_session->tls);
     debug("*** removed session %p\n", coap_session->tls);
     coap_free_type(COAP_DTLS_SESSION, coap_session->tls);
+    coap_session->tls = NULL;
   }
 }
 
@@ -456,20 +457,32 @@ coap_get_tls_library_version(void) {
   return &version;
 }
 
-int coap_dtls_context_set_pki( coap_context_t *ctx UNUSED,
-  coap_dtls_pki_t* setup_data UNUSED
+int
+coap_dtls_context_set_pki(coap_context_t *ctx UNUSED,
+  coap_dtls_pki_t* setup_data UNUSED,
+  int server UNUSED
 ) {
   return 0;
 }
 
-int coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
+int
+coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx UNUSED,
+  const char *ca_file UNUSED,
+  const char *ca_path UNUSED
+) {
+  return 0;
+}
+
+int
+coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
   const char *hint UNUSED,
-  const uint8_t *key UNUSED, size_t key_len UNUSED
+  int server UNUSED
 ) {
   return 1;
 }
 
-int coap_dtls_context_check_keys_enabled(coap_context_t *ctx UNUSED)
+int
+coap_dtls_context_check_keys_enabled(coap_context_t *ctx UNUSED)
 {
   return 1;
 }

--- a/src/net.c
+++ b/src/net.c
@@ -356,7 +356,7 @@ int coap_context_set_psk(coap_context_t *ctx,
       memcpy(ctx->psk_hint, hint, hint_len);
       ctx->psk_hint_len = hint_len;
     } else {
-      coap_log(LOG_ERR, "No memory to store PSK hint");
+      coap_log(LOG_ERR, "No memory to store PSK hint\n");
       return 0;
     }
   }
@@ -372,12 +372,12 @@ int coap_context_set_psk(coap_context_t *ctx,
       memcpy(ctx->psk_key, key, key_len);
       ctx->psk_key_len = key_len;
     } else {
-      coap_log(LOG_ERR, "No memory to store PSK key");
+      coap_log(LOG_ERR, "No memory to store PSK key\n");
       return 0;
     }
   }
   if (coap_dtls_is_supported()) {
-    return coap_dtls_context_set_psk(ctx, hint, key, key_len);
+    return coap_dtls_context_set_psk(ctx, hint, COAP_DTLS_ROLE_SERVER);
   }
   return 0;
 }
@@ -385,8 +385,24 @@ int coap_context_set_psk(coap_context_t *ctx,
 int coap_context_set_pki(coap_context_t *ctx,
   coap_dtls_pki_t* setup_data
 ) {
+  if (!setup_data)
+    return 0;
+  if (setup_data->version != COAP_DTLS_PKI_SETUP_VERSION) {
+    coap_log(LOG_ERR, "coap_context_set_pki: Wrong version of setup_data\n");
+    return 0;
+  }
   if (coap_dtls_is_supported()) {
-    return coap_dtls_context_set_pki(ctx, setup_data);
+    return coap_dtls_context_set_pki(ctx, setup_data, COAP_DTLS_ROLE_SERVER);
+  }
+  return 0;
+}
+
+int coap_context_set_pki_root_cas(coap_context_t *ctx,
+  const char *ca_file,
+  const char *ca_dir
+) {
+  if (coap_dtls_is_supported()) {
+    return coap_dtls_context_set_pki_root_cas(ctx, ca_file, ca_dir);
   }
   return 0;
 }


### PR DESCRIPTION
A late change to the PKI Pull request got missed for the TLS case
in coap_dtls_context_set_pki() for the mapping of private key types to
the OpenSSL version.  Have pulled common DTLS and TLS code into a separate
function
    
Fixed coap_(d)tls_free_session to not shut down a session that is not yet
fully started, as well as calling SSL_shutdown() twice if appropriate.
The ssl parameter is set to NULL after shutdown to prevent re-use
    
Made coap_dtls_context_set_psk() smarter in what whas updated, depending on
whether a client or server
    
Make sure that coap_dtls_psk_client_callback is defined in
coap_dtls_context_set_psk() in case coap_dtls_context_set_pki() was called
first.  This fixes the first time issue after startup where a PSK client
was unable to establish a DTLS session - subsequent times were successful
    
Added in a set of callbacks, invoked from coap_dtls_context_set_pki(), so that
a server can differentiate between an incoming PSK or PKI connection request.
These are only invoked if no call_back was defined in the setup_data
    
Output error messages if PKI or PSK was not set up before a server endpoint was
set up and (D)TLS is being used.

Update internal coap_dtls_context_set_*() functions parameters to remove unused parameters and add in a server parameter

Add in TCP KeepAlive to TCP socket to pick up on failing TCP connections