### PR TITLE
option.[ch]: Fix "warning: ISO C++ forbids flexible array member 'data'

### DIFF
--- a/include/coap/async.h
+++ b/include/coap/async.h
@@ -48,7 +48,7 @@ typedef struct coap_async_state_t {
   coap_tid_t id;                   /**< transaction id */
   struct coap_async_state_t *next; /**< internally used for linking */
   size_t tokenlen;                 /**< length of the token */
-  unsigned char token[];           /**< the token to use in a response */
+  uint8_t token[8];                /**< the token to use in a response */
 } coap_async_state_t;
 
 /* Definitions for Async Status Flags These flags can be used to control the

--- a/include/coap/option.h
+++ b/include/coap/option.h
@@ -429,7 +429,7 @@ typedef struct coap_optlist_t {
   struct coap_optlist_t *next;  /**< next entry in the optlist chain */
   uint16_t number;              /**< the option number (no delta coding) */
   size_t length;                /**< the option value length */
-  uint8_t data[];               /**< the option data */
+  uint8_t *data;                /**< the option data */
 } coap_optlist_t;
 
 /**

--- a/src/async.c
+++ b/src/async.c
@@ -47,14 +47,13 @@ coap_register_async(coap_context_t *context, coap_session_t *session,
   }
 
   /* store information for handling the asynchronous task */
-  s = (coap_async_state_t *)coap_malloc(sizeof(coap_async_state_t) + 
-					request->token_length);
+  s = (coap_async_state_t *)coap_malloc(sizeof(coap_async_state_t));
   if (!s) {
     coap_log(LOG_CRIT, "coap_register_async: insufficient memory\n");
     return NULL;
   }
 
-  memset(s, 0, sizeof(coap_async_state_t) + request->token_length);
+  memset(s, 0, sizeof(coap_async_state_t));
 
   /* set COAP_ASYNC_CONFIRM according to request's type */
   s->flags = flags & ~COAP_ASYNC_CONFIRM;
@@ -66,8 +65,9 @@ coap_register_async(coap_context_t *context, coap_session_t *session,
   s->id = id;
 
   if (request->token_length) {
-    s->tokenlen = request->token_length;
-    memcpy(s->token, request->token, request->token_length);
+    /* A token can be up to 8 bytes */
+    s->tokenlen = (request->token_length > 8) ? 8 : request->token_length;
+    memcpy(s->token, request->token, s->tokenlen);
   }
     
   coap_touch_async(s);

--- a/src/option.c
+++ b/src/option.c
@@ -552,6 +552,7 @@ coap_new_optlist(uint16_t number,
   if (node) {
     node->number = number;
     node->length = length;
+    node->data = (uint8_t *)&node[1];
     memcpy(node->data, data, length);
   } else {
     coap_log(LOG_WARNING, "coap_new_optlist: malloc failure\n");


### PR DESCRIPTION
To support C++, variable "uint8_t data[]" in coap_optlist_t has been changed to "unit8_t *data".

coap_new_optlist() has been updated to handle this.

coap_add_optlist_pdu() needs no change.