### PR TITLE
options: Fix subtle memory leak in coap_add_optlist_pdu()

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -147,7 +147,7 @@ coap_new_request(coap_context_t *ctx,
   }
 
   if (options)
-    coap_add_optlist_pdu(pdu, *options);
+    coap_add_optlist_pdu(pdu, options);
 
   if (length) {
     if ((flags & FLAGS_BLOCK) == 0)

--- a/include/coap/option.h
+++ b/include/coap/option.h
@@ -62,22 +62,6 @@ size_t coap_opt_parse(const coap_opt_t *opt,
 size_t coap_opt_size(const coap_opt_t *opt);
 
 /**
- * Calculates the beginning of the PDU's option section.
- *
- * @param pdu The PDU containing the options.
- * @return    A pointer to the first option if available, or @c NULL otherwise.
- */
-coap_opt_t *options_start(coap_pdu_t *pdu);
-
-/**
- * Interprets @p opt as pointer to a CoAP option and advances to
- * the next byte past this option.
- * @hideinitializer
- */
-#define options_next(opt) \
-  ((coap_opt_t *)((uint8_t *)(opt) + coap_opt_size(opt)))
-
-/**
  * @defgroup opt_filter Option Filters
  * @{
  */
@@ -415,7 +399,7 @@ const uint8_t *coap_opt_value(const coap_opt_t *opt);
  * coap_insert_optlist(&optlist_chain, coap_new_optlist(COAP_OPTION_OBSERVE,
  *                    COAP_OBSERVE_ESTABLISH, NULL));
  *
- * coap_add_optlist_pdu(pdu, *optlist_chain);
+ * coap_add_optlist_pdu(pdu, &optlist_chain);
  * ... other code ...
  * coap_delete_optlist(optlist_chain);
  * @endcode
@@ -449,7 +433,7 @@ coap_optlist_t *coap_new_optlist(uint16_t number,
  *
  * @return     @c 1 if succesful or @c 0 if failure;
  */
-int coap_add_optlist_pdu(coap_pdu_t *pdu, coap_optlist_t* optlist_chain);
+int coap_add_optlist_pdu(coap_pdu_t *pdu, coap_optlist_t** optlist_chain);
 
 /**
  * Adds @p optlist to the given @p optlist_chain. The optlist_chain variable

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -300,7 +300,7 @@ coap_optlist_t **options, unsigned char *data, size_t length, int observe) {
   /* ... Other code / options etc. ... */
 
   /* Add in all the options (after internal sorting) to the pdu */
-  if (!coap_add_optlist_pdu(pdu, *options))
+  if (!coap_add_optlist_pdu(pdu, options))
     goto error;
 
   if (data && length) {

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -27,12 +27,12 @@ const uint8_t *_data_);*
 *coap_optlist_t *coap_new_optlist(uint16_t _number_, size_t _length_,
 const uint8_t *_data_);*
 
-*int coap_insert_optlist(coap_optlist_t *_optlist_chain_,
+*int coap_insert_optlist(coap_optlist_t **_optlist_chain_,
 coap_optlist_t *_optlist_);*
 
 *void coap_delete_optlist(coap_optlist_t *_optlist_chain_);*
 
-*int coap_add_optlist_pdu(coap_pdu_t *_pdu_, coap_optlist_t *_optlist_chain_);*
+*int coap_add_optlist_pdu(coap_pdu_t *_pdu_, coap_optlist_t **_optlist_chain_);*
 
 *size_t coap_add_option(coap_pdu_t *_pdu_, uint16_t _number_, size_t _length_,
 const uint8_t *_data_);*
@@ -281,7 +281,7 @@ unsigned char *data, size_t length, int observe) {
   /* ... Other code / options etc. ... */
 
   /* Add in all the options (after internal sorting) to the pdu */
-  if (!coap_add_optlist_pdu(pdu, optlist_chain))
+  if (!coap_add_optlist_pdu(pdu, &optlist_chain))
     goto error;
 
   if (data && length) {

--- a/src/option.c
+++ b/src/option.c
@@ -24,15 +24,6 @@
 #include "mem.h"
 #include "utlist.h"
 
-coap_opt_t *
-options_start(coap_pdu_t *pdu) {
-  if (pdu && pdu->token_length < pdu->used_size) {
-    coap_opt_t *opt = pdu->token + pdu->token_length;
-    return (*opt == COAP_PAYLOAD_START) ? NULL : opt;
-  } else 
-    return NULL;
-}
-
 size_t
 coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
 
@@ -573,14 +564,14 @@ order_opts(void *a, void *b) {
 }
 
 int
-coap_add_optlist_pdu(coap_pdu_t *pdu, coap_optlist_t* options) {
+coap_add_optlist_pdu(coap_pdu_t *pdu, coap_optlist_t** options) {
   coap_optlist_t *opt;
 
-  if (options) {
+  if (options && *options) {
     /* sort options for delta encoding */
-    LL_SORT((options), order_opts);
+    LL_SORT((*options), order_opts);
 
-    LL_FOREACH((options), opt) {
+    LL_FOREACH((*options), opt) {
       coap_add_option(pdu, opt->number, opt->length, opt->data);
     }
     return 1;

--- a/tests/test_pdu.c
+++ b/tests/test_pdu.c
@@ -616,6 +616,112 @@ t_encode_pdu11(void) {
   pdu->max_size = old_max;
 }
 
+static void
+t_encode_pdu12(void) {
+  coap_optlist_t *optlist = NULL;
+  int n;
+  uint8_t opt_num[] = { 50, 51, 52, 53, 54, 55, 56, 57, 58, 59 };
+  uint8_t opt_val[] = { 50, 51, 52, 53, 54, 55, 56, 57, 58, 59 };
+  uint8_t opt_srt[] = { 50, 51, 52, 53, 54, 55, 56, 57, 58, 59 };
+  coap_opt_iterator_t oi;
+  coap_opt_t *option;
+
+  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+
+  CU_ASSERT(pdu->data == NULL);
+
+  for (n = 0; n < (int)sizeof(opt_num); n++) {
+    coap_insert_optlist(&optlist, coap_new_optlist(opt_num[n],
+                     sizeof(opt_val[n]), &opt_val[n]));
+  }
+  coap_add_optlist_pdu(pdu, &optlist);
+
+  /* Check options in pdu are in right order */
+  coap_option_iterator_init(pdu, &oi, COAP_OPT_ALL);
+  for (n = 0; n < (int)sizeof(opt_num); n++) {
+    option = coap_option_next(&oi);
+    CU_ASSERT(oi.bad == 0);
+    CU_ASSERT(option != NULL);
+    CU_ASSERT(coap_opt_length(option) == 1);
+    CU_ASSERT(*coap_opt_value(option) == opt_srt[n]);
+  }
+  option = coap_option_next(&oi);
+  CU_ASSERT(oi.bad == 1);
+  CU_ASSERT(option == NULL);
+  coap_delete_optlist(optlist);
+}
+
+static void
+t_encode_pdu13(void) {
+  coap_optlist_t *optlist = NULL;
+  int n;
+  uint8_t opt_num[] = { 59, 58, 57, 56, 55, 54, 53, 52, 51, 50 };
+  uint8_t opt_val[] = { 59, 58, 57, 56, 55, 54, 53, 52, 51, 50 };
+  uint8_t opt_srt[] = { 50, 51, 52, 53, 54, 55, 56, 57, 58, 59 };
+  coap_opt_iterator_t oi;
+  coap_opt_t *option;
+
+  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+
+  CU_ASSERT(pdu->data == NULL);
+
+  for (n = 0; n < (int)sizeof(opt_num); n++) {
+    coap_insert_optlist(&optlist, coap_new_optlist(opt_num[n],
+                     sizeof(opt_val[n]), &opt_val[n]));
+  }
+  coap_add_optlist_pdu(pdu, &optlist);
+
+  /* Check options in pdu are in right order */
+  coap_option_iterator_init(pdu, &oi, COAP_OPT_ALL);
+  for (n = 0; n < (int)sizeof(opt_num); n++) {
+    option = coap_option_next(&oi);
+    CU_ASSERT(oi.bad == 0);
+    CU_ASSERT(option != NULL);
+    CU_ASSERT(coap_opt_length(option) == 1);
+    CU_ASSERT(*coap_opt_value(option) == opt_srt[n]);
+  }
+  option = coap_option_next(&oi);
+  CU_ASSERT(oi.bad == 1);
+  CU_ASSERT(option == NULL);
+  coap_delete_optlist(optlist);
+}
+
+
+static void
+t_encode_pdu14(void) {
+  coap_optlist_t *optlist = NULL;
+  int n;
+  uint8_t opt_num[] = { 53, 52, 51, 50, 51, 52, 52, 51, 50, 50 };
+  uint8_t opt_val[] = { 59, 56, 53, 50, 54, 57, 58, 55, 51, 52 };
+  uint8_t opt_srt[] = { 50, 51, 52, 53, 54, 55, 56, 57, 58, 59 };
+  coap_opt_iterator_t oi;
+  coap_opt_t *option;
+
+  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+
+  CU_ASSERT(pdu->data == NULL);
+
+  for (n = 0; n < (int)sizeof(opt_num); n++) {
+    coap_insert_optlist(&optlist, coap_new_optlist(opt_num[n],
+                     sizeof(opt_val[n]), &opt_val[n]));
+  }
+  coap_add_optlist_pdu(pdu, &optlist);
+
+  /* Check options in pdu are in right order */
+  coap_option_iterator_init(pdu, &oi, COAP_OPT_ALL);
+  for (n = 0; n < (int)sizeof(opt_num); n++) {
+    option = coap_option_next(&oi);
+    CU_ASSERT(oi.bad == 0);
+    CU_ASSERT(option != NULL);
+    CU_ASSERT(coap_opt_length(option) == 1);
+    CU_ASSERT(*coap_opt_value(option) == opt_srt[n]);
+  }
+  option = coap_option_next(&oi);
+  CU_ASSERT(oi.bad == 1);
+  CU_ASSERT(option == NULL);
+  coap_delete_optlist(optlist);
+}
+
 static int
 t_pdu_tests_create(void) {
   pdu = coap_pdu_init(0, 0, 0, COAP_DEFAULT_MTU);
@@ -680,6 +786,9 @@ t_init_pdu_tests(void) {
     PDU_ENCODER_TEST(suite[1], t_encode_pdu9);
     PDU_ENCODER_TEST(suite[1], t_encode_pdu10);
     PDU_ENCODER_TEST(suite[1], t_encode_pdu11);
+    PDU_ENCODER_TEST(suite[1], t_encode_pdu12);
+    PDU_ENCODER_TEST(suite[1], t_encode_pdu13);
+    PDU_ENCODER_TEST(suite[1], t_encode_pdu14);
 
   } else 			/* signal error */
     fprintf(stderr, "W: cannot add pdu parser test suite (%s)\n",


### PR DESCRIPTION
coap_add_optlist_pdu() sorted the options for insertion, but did not update
the coap_optlist_t head (whch may then no longer point to the first entry in the
sorted chain) and so when coap_delete_optlist() was called, the first few
entries of the sorted chain may not get deleted.
Fixed by making it
 `coap_add_optlist_pdu(coap_pdu_t *pdu, coap_optlist_t** optlist_chain)`
instead of
 `coap_add_optlist_pdu(coap_pdu_t *pdu, coap_optlist_t* optlist_chain)`

Addtionally named options_start() coap_options_start() and options_next()
coap_options_next() - Issue #184.

examples/client.c:
Fix coap_add_optlist_pdu() call

include/coap/options.h:
Rename to coap_options_start() and coap_options_next()
Fix coap_add_optlist_pdu() call

libcoap-2.{map|sym}:
Add in coap_options_start()

man/coap_observe.txt.in:
man/coap_pdu_setup.txt.in:

Update docmentation

src/option.c:
Rename to coap_options_start()
Update coap_add_optlist_pdu()

tests/test_pdu.c:
New tests for checkout out coap_insert_optlist() and coap_add_optlist_pdu()
functions