### PR TITLE
coap_{notls|openssl|tinydtls}.c: Support older gcc compilers

### DIFF
--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -165,13 +165,13 @@ ssize_t coap_tls_read(coap_session_t *session UNUSED,
 
 #else /* !HAVE_LIBTINYDTLS && !HAVE_OPENSSL */
 
-/* Make compilers happy that do not like empty modules. As this
- * function is never used, we ignore -Wunused-function temporarily.
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
  */
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 static inline void dummy(void) {
 }
-#pragma GCC diagnostic pop
 
 #endif /* !HAVE_LIBTINYDTLS && !HAVE_OPENSSL */

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1174,13 +1174,13 @@ ssize_t coap_tls_read(coap_session_t *session,
 
 #else /* !HAVE_OPENSSL */
 
-/* Make compilers happy that do not like empty modules. As this
- * function is never used, we ignore -Wunused-function temporarily.
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
  */
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 static inline void dummy(void) {
 }
-#pragma GCC diagnostic pop
 
 #endif /* HAVE_OPENSSL */

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -503,13 +503,13 @@ ssize_t coap_tls_read(coap_session_t *session UNUSED,
 
 #else /* !HAVE_LIBTINYDTLS */
 
-/* Make compilers happy that do not like empty modules. As this
- * function is never used, we ignore -Wunused-function temporarily.
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
  */
-#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 static inline void dummy(void) {
 }
-#pragma GCC diagnostic pop
 
 #endif /* HAVE_LIBTINYDTLS */


### PR DESCRIPTION
#pragma GCC diagnostic push
#pragma GCC diagnostic pop

is not supported by gcc version less than 4.6

[I also think the push/pop is not needed as it is at the end of the
file and only one file is complied at one time]

gcc in general does not complain about (when the only entry in the file)

static inline void dummy(void) {
}

Also current code before fix is unlikely to work on Windows so the
additional compiler wrapper tests should fix this.