### PR TITLE
fix typographical error in forward declaration

### DIFF
--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -15,7 +15,7 @@
 #include "pdu.h"
 
 struct coap_endpoint_t;
-struct coap_contex_t;
+struct coap_context_t;
 struct coap_queue_t;
 
 /**


### PR DESCRIPTION
This was the only match for a project-wide grep on 'coap_contex_t'.