### PR TITLE
Limit outstanding CON requests to 1 per session for congestion control

### DIFF
--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -68,6 +68,7 @@ typedef struct coap_session_t {
   struct coap_context_t *context;	  /**< session's context */
   void *tls;			  /**< security parameters */
   uint16_t tx_mid;                /**< the last message id that was used in this session */
+  uint8_t con_active;             /**< Active CON request sent */
   struct coap_queue_t *sendqueue; /**< list of messages waiting to be sent */
   size_t partial_write;           /**< if > 0 indicates number of bytes already written from the pdu at the head of sendqueue */
   uint8_t read_header[8];         /**< storage space for header of incoming message header */

--- a/src/resource.c
+++ b/src/resource.c
@@ -712,6 +712,8 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
       if (r->dirty == 0 && obs->dirty == 0)
         /* running this resource due to partiallydirty, but this observation's notification was already enqueued */
         continue;
+      if (obs->session->con_active >= COAP_DEFAULT_NSTART)
+        continue;
 
       coap_tid_t tid = COAP_INVALID_TID;
       obs->dirty = 0;


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7641#section-4.5

In order not to cause congestion, servers MUST strictly limit the number of
simultaneous outstanding notifications/responses that they transmit to a given
client to NSTART (1 by default; see Section 4.7 of RFC 7252 [RFC7252]).
An outstanding notification/response is either a confirmable message for which
an acknowledgement has not yet been received and whose last retransmission
attempt has not yet timed out or a non-confirmable message for which the
waiting time that results from the following rate-limiting rules has not yet
elapsed.

Delay sending of PDUs if active CON request waiting for ACK.

Do not start of another Observer unsolicited response if active CON waiting
waiting for ACK.

Display outgoing PDU if log level DEBUG or higher to help troubleshooting.

This does not fix the ratelimiting of non-confirmable messages, which
should be handled by the application.

Fixes #198 