### PR TITLE
Replace str with coap_string_t.  Make tokens coap_binary_t

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -35,7 +35,7 @@
 int flags = 0;
 
 static unsigned char _token_data[8];
-str the_token = { 0, _token_data };
+coap_binary_t the_token = { 0, _token_data };
 
 #define FLAGS_BLOCK 0x01
 
@@ -49,10 +49,10 @@ static uint16_t proxy_port = COAP_DEFAULT_PORT;
 /* reading is done when this flag is set */
 static int ready = 0;
 
-static str output_file = { 0, NULL };   /* output file name */
+static coap_string_t output_file = { 0, NULL };   /* output file name */
 static FILE *file = NULL;               /* output file stream */
 
-static str payload = { 0, NULL };       /* optional payload to send */
+static coap_string_t payload = { 0, NULL };       /* optional payload to send */
 
 static int reliable = 0;
 
@@ -893,7 +893,7 @@ check_segment(const uint8_t *s, size_t length) {
 }
 
 static int
-cmdline_input(char *text, str *buf) {
+cmdline_input(char *text, coap_string_t *buf) {
   int len;
   len = check_segment((unsigned char *)text, strlen(text));
 
@@ -910,7 +910,7 @@ cmdline_input(char *text, str *buf) {
 }
 
 static int
-cmdline_input_from_file(char *filename, str *buf) {
+cmdline_input_from_file(char *filename, coap_string_t *buf) {
   FILE *inputfile = NULL;
   ssize_t len;
   int result = 1;

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -51,12 +51,12 @@
 
 typedef struct rd_t {
   UT_hash_handle hh;      /**< hash handle (for internal use only) */
-  str uri_path;           /**< the actual key for this resource */
+  coap_string_t uri_path; /**< the actual key for this resource */
 
   size_t etag_len;        /**< actual length of @c etag */
   unsigned char etag[8];  /**< ETag for current description */
 
-  str data;               /**< points to the resource description  */
+  coap_string_t data;     /**< points to the resource description  */
 } rd_t;
 
 rd_t *resources = NULL;
@@ -93,8 +93,8 @@ hnd_get_resource(coap_context_t  *ctx UNUSED_PARAM,
                  struct coap_resource_t *resource,
                  coap_session_t *session UNUSED_PARAM,
                  coap_pdu_t *request UNUSED_PARAM,
-                 str *token UNUSED_PARAM,
-                 str *query UNUSED_PARAM,
+                 coap_binary_t *token UNUSED_PARAM,
+                 coap_string_t *query UNUSED_PARAM,
                  coap_pdu_t *response) {
   rd_t *rd = NULL;
   unsigned char buf[3];
@@ -121,8 +121,8 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
                  struct coap_resource_t *resource UNUSED_PARAM,
                  coap_session_t *session UNUSED_PARAM,
                  coap_pdu_t *request UNUSED_PARAM,
-                 str *token UNUSED_PARAM,
-                 str *query UNUSED_PARAM,
+                 coap_binary_t *token UNUSED_PARAM,
+                 coap_string_t *query UNUSED_PARAM,
                  coap_pdu_t *response) {
 #if 1
   response->code = COAP_RESPONSE_CODE(501);
@@ -136,7 +136,7 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
   rd_t *rd = NULL;
   unsigned char code;     /* result code */
   unsigned char *data;
-  str tmp;
+  coap_string_t tmp;
 
   HASH_FIND(hh, resources, resource->uri_path.s, resource->uri_path.length, rd);
   if (rd) {
@@ -200,8 +200,8 @@ hnd_delete_resource(coap_context_t  *ctx,
                     struct coap_resource_t *resource,
                     coap_session_t *session UNUSED_PARAM,
                     coap_pdu_t *request UNUSED_PARAM,
-                    str *token UNUSED_PARAM,
-                    str *query UNUSED_PARAM,
+                    coap_binary_t *token UNUSED_PARAM,
+                    coap_string_t *query UNUSED_PARAM,
                     coap_pdu_t *response) {
   rd_t *rd = NULL;
 
@@ -222,8 +222,8 @@ hnd_get_rd(coap_context_t  *ctx UNUSED_PARAM,
            struct coap_resource_t *resource UNUSED_PARAM,
            coap_session_t *session UNUSED_PARAM,
            coap_pdu_t *request UNUSED_PARAM,
-           str *token UNUSED_PARAM,
-           str *query UNUSED_PARAM,
+           coap_binary_t *token UNUSED_PARAM,
+           coap_string_t *query UNUSED_PARAM,
            coap_pdu_t *response) {
   unsigned char buf[3];
 
@@ -245,10 +245,10 @@ parse_param(const uint8_t *search,
             size_t search_len,
             unsigned char *data,
             size_t data_len,
-            str *result) {
+            coap_string_t *result) {
 
   if (result)
-    memset(result, 0, sizeof(str));
+    memset(result, 0, sizeof(coap_string_t));
 
   if (!search_len)
     return 0;
@@ -387,14 +387,14 @@ hnd_post_rd(coap_context_t  *ctx,
             struct coap_resource_t *resource UNUSED_PARAM,
             coap_session_t *session,
             coap_pdu_t *request,
-            str *token UNUSED_PARAM,
-            str *query UNUSED_PARAM,
+            coap_binary_t *token UNUSED_PARAM,
+            coap_string_t *query UNUSED_PARAM,
             coap_pdu_t *response) {
   coap_resource_t *r;
 #define LOCSIZE 68
   unsigned char *loc;
   size_t loc_size;
-  str h = {0, NULL}, ins = {0, NULL}, rt = {0, NULL}, lt = {0, NULL}; /* store query parameters */
+  coap_string_t h = {0, NULL}, ins = {0, NULL}, rt = {0, NULL}, lt = {0, NULL}; /* store query parameters */
   unsigned char *buf;
   coap_str_const_t attr_val;
   coap_str_const_t resource_val;

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -83,8 +83,8 @@ hnd_get_index(coap_context_t *ctx UNUSED_PARAM,
               struct coap_resource_t *resource UNUSED_PARAM,
               coap_session_t *session UNUSED_PARAM,
               coap_pdu_t *request UNUSED_PARAM,
-              str *token UNUSED_PARAM,
-              str *query UNUSED_PARAM,
+              coap_binary_t *token UNUSED_PARAM,
+              coap_string_t *query UNUSED_PARAM,
               coap_pdu_t *response) {
   unsigned char buf[3];
 
@@ -108,8 +108,8 @@ hnd_get_time(coap_context_t  *ctx UNUSED_PARAM,
              struct coap_resource_t *resource,
              coap_session_t *session,
              coap_pdu_t *request,
-             str *token,
-             str *query,
+             coap_binary_t *token,
+             coap_string_t *query,
              coap_pdu_t *response) {
   unsigned char buf[40];
   size_t len;
@@ -174,8 +174,8 @@ hnd_put_time(coap_context_t *ctx UNUSED_PARAM,
              struct coap_resource_t *resource,
              coap_session_t *session UNUSED_PARAM,
              coap_pdu_t *request,
-             str *token UNUSED_PARAM,
-             str *query UNUSED_PARAM,
+             coap_binary_t *token UNUSED_PARAM,
+             coap_string_t *query UNUSED_PARAM,
              coap_pdu_t *response) {
   coap_tick_t t;
   size_t size;
@@ -190,7 +190,7 @@ hnd_put_time(coap_context_t *ctx UNUSED_PARAM,
   response->code =
     my_clock_base ? COAP_RESPONSE_CODE(204) : COAP_RESPONSE_CODE(201);
 
-  coap_resource_set_dirty(resource, NULL);
+  coap_resource_notify_observers(resource, NULL);
 
   /* coap_get_data() sets size to 0 on error */
   (void)coap_get_data(request, &size, &data);
@@ -224,8 +224,8 @@ hnd_delete_time(coap_context_t *ctx UNUSED_PARAM,
                 struct coap_resource_t *resource UNUSED_PARAM,
                 coap_session_t *session UNUSED_PARAM,
                 coap_pdu_t *request UNUSED_PARAM,
-                str *token UNUSED_PARAM,
-                str *query UNUSED_PARAM,
+                coap_binary_t *token UNUSED_PARAM,
+                coap_string_t *query UNUSED_PARAM,
                 coap_pdu_t *response UNUSED_PARAM) {
   my_clock_base = 0;    /* mark clock as "deleted" */
 
@@ -239,8 +239,8 @@ hnd_get_async(coap_context_t *ctx,
               struct coap_resource_t *resource UNUSED_PARAM,
               coap_session_t *session,
               coap_pdu_t *request,
-              str *token UNUSED_PARAM,
-              str *query UNUSED_PARAM,
+              coap_binary_t *token UNUSED_PARAM,
+              coap_string_t *query UNUSED_PARAM,
               coap_pdu_t *response) {
   unsigned long delay = 5;
   size_t size;
@@ -325,7 +325,7 @@ hnd_delete(coap_context_t *ctx,
            coap_resource_t *resource,
            coap_session_t *session UNUSED_PARAM,
            coap_pdu_t *request UNUSED_PARAM,
-           coap_string_t *token UNUSED_PARAM,
+           coap_binary_t *token UNUSED_PARAM,
            coap_string_t *query UNUSED_PARAM,
            coap_pdu_t *response UNUSED_PARAM
 ) {
@@ -369,7 +369,7 @@ hnd_get(coap_context_t *ctx UNUSED_PARAM,
         coap_resource_t *resource,
         coap_session_t *session,
         coap_pdu_t *request UNUSED_PARAM,
-        coap_string_t *token,
+        coap_binary_t *token,
         coap_string_t *query UNUSED_PARAM,
         coap_pdu_t *response
 ) {
@@ -418,7 +418,7 @@ hnd_put(coap_context_t *ctx UNUSED_PARAM,
         coap_resource_t *resource UNUSED_PARAM,
         coap_session_t *session UNUSED_PARAM,
         coap_pdu_t *request,
-        coap_string_t *token UNUSED_PARAM,
+        coap_binary_t *token UNUSED_PARAM,
         coap_string_t *query UNUSED_PARAM,
         coap_pdu_t *response
 ) {
@@ -483,7 +483,7 @@ hnd_unknown_put(coap_context_t *ctx,
                 coap_resource_t *resource,
                 coap_session_t *session,
                 coap_pdu_t *request,
-                coap_string_t *token,
+                coap_binary_t *token,
                 coap_string_t *query,
                 coap_pdu_t *response
 ) {

--- a/examples/contiki/server.c
+++ b/examples/contiki/server.c
@@ -94,7 +94,7 @@ init_coap_server(coap_context_t **ctx) {
 void 
 hnd_get_time(coap_context_t  *ctx, struct coap_resource_t *resource,
 	     const coap_endpoint_t *local_interface,
-	     coap_address_t *peer, coap_pdu_t *request, str *token, 
+	     coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token, 
 	     coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -127,7 +127,7 @@ coap_delete_payload(coap_payload_t *payload) {
 
 void 
 hnd_get_index(coap_context_t  *ctx, struct coap_resource_t *resource, 
-	      coap_address_t *peer, coap_pdu_t *request, str *token,
+	      coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
 	      coap_pdu_t *response) {
   unsigned char buf[3];
 
@@ -147,7 +147,7 @@ hnd_get_index(coap_context_t  *ctx, struct coap_resource_t *resource,
 
 void 
 hnd_get_resource(coap_context_t  *ctx, struct coap_resource_t *resource, 
-		 coap_address_t *peer, coap_pdu_t *request, str *token,
+		 coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
 		 coap_pdu_t *response) {
   coap_key_t etag;
   unsigned char buf[2];
@@ -225,7 +225,7 @@ hnd_get_resource(coap_context_t  *ctx, struct coap_resource_t *resource,
 /* DELETE handler for dynamic resources created by POST /test */
 void 
 hnd_delete_resource(coap_context_t  *ctx, struct coap_resource_t *resource, 
-		coap_address_t *peer, coap_pdu_t *request, str *token,
+		coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
 		coap_pdu_t *response) {
   coap_payload_t *payload;
 
@@ -241,7 +241,7 @@ hnd_delete_resource(coap_context_t  *ctx, struct coap_resource_t *resource,
 
 void 
 hnd_post_test(coap_context_t  *ctx, struct coap_resource_t *resource, 
-	      coap_address_t *peer, coap_pdu_t *request, str *token,
+	      coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
 	      coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
@@ -307,7 +307,7 @@ hnd_post_test(coap_context_t  *ctx, struct coap_resource_t *resource,
 
 void 
 hnd_put_test(coap_context_t  *ctx, struct coap_resource_t *resource, 
-	      coap_address_t *peer, coap_pdu_t *request, str *token,
+	      coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
 	      coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
@@ -358,7 +358,7 @@ hnd_put_test(coap_context_t  *ctx, struct coap_resource_t *resource,
 
 void 
 hnd_delete_test(coap_context_t  *ctx, struct coap_resource_t *resource, 
-		coap_address_t *peer, coap_pdu_t *request, str *token,
+		coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
 		coap_pdu_t *response) {
   /* the ETSI validation tool does not like empty resources... */
 #if 0
@@ -374,7 +374,7 @@ hnd_delete_test(coap_context_t  *ctx, struct coap_resource_t *resource,
 
 void 
 hnd_get_query(coap_context_t  *ctx, struct coap_resource_t *resource, 
-	      coap_address_t *peer, coap_pdu_t *request, str *token,
+	      coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
 	      coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_filter_t f;
@@ -414,7 +414,7 @@ hnd_get_query(coap_context_t  *ctx, struct coap_resource_t *resource,
 /* handler for TD_COAP_CORE_16 */
 void 
 hnd_get_separate(coap_context_t  *ctx, struct coap_resource_t *resource, 
-		 coap_address_t *peer, coap_pdu_t *request, str *token,
+		 coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
 		 coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;

--- a/include/coap/resource.h
+++ b/include/coap/resource.h
@@ -37,7 +37,7 @@ typedef void (*coap_method_handler_t)
    struct coap_resource_t *,
    coap_session_t *,
    coap_pdu_t *,
-   coap_string_t * /* token */,
+   coap_binary_t * /* token */,
    coap_string_t * /* query string */,
    coap_pdu_t * /* response */);
 
@@ -373,7 +373,7 @@ coap_resource_t *coap_get_resource_from_uri_path(coap_context_t *context,
  */
 coap_subscription_t *coap_add_observer(coap_resource_t *resource,
                                        coap_session_t *session,
-                                       const coap_string_t *token,
+                                       const coap_binary_t *token,
                                        coap_string_t *query);
 
 /**
@@ -387,7 +387,7 @@ coap_subscription_t *coap_add_observer(coap_resource_t *resource,
  */
 coap_subscription_t *coap_find_observer(coap_resource_t *resource,
                                         coap_session_t *session,
-                                        const coap_string_t *token);
+                                        const coap_binary_t *token);
 
 /**
  * Marks an observer as alive.
@@ -399,7 +399,7 @@ coap_subscription_t *coap_find_observer(coap_resource_t *resource,
  */
 void coap_touch_observer(coap_context_t *context,
                          coap_session_t *session,
-                         const coap_string_t *token);
+                         const coap_binary_t *token);
 
 /**
  * Removes any subscription for @p observer from @p resource and releases the
@@ -414,7 +414,7 @@ void coap_touch_observer(coap_context_t *context,
  */
 int coap_delete_observer(coap_resource_t *resource,
                          coap_session_t *session,
-                         const coap_string_t *token);
+                         const coap_binary_t *token);
 
 /**
  * Removes any subscription for @p session and releases the allocated storage.
@@ -451,7 +451,10 @@ coap_print_status_t coap_print_wellknown(coap_context_t *,
                                          size_t *, size_t,
                                          coap_opt_t *);
 
-void coap_handle_failed_notify(coap_context_t *, coap_session_t *, const str *);
+void
+coap_handle_failed_notify(coap_context_t *,
+                          coap_session_t *,
+                          const coap_binary_t *);
 
 /**
  * Set whether a @p resource is observable.  If the resource is observable
@@ -477,7 +480,9 @@ coap_resource_set_get_observable(coap_resource_t *resource, int mode) {
  *
  * @return         @c 1 if the Observe has been triggered, @c 0 otherwise.
  */
-int coap_resource_notify_observers(coap_resource_t *resource, const str *query);
+int
+coap_resource_notify_observers(coap_resource_t *resource,
+                               const coap_string_t *query);
 
 /**
  * Get the UriPath from a @p resource.
@@ -496,6 +501,8 @@ coap_resource_get_uri_path(coap_resource_t *resource) {
 /**
  * @deprecated use coap_resource_notify_observers() instead.
  */
-int coap_resource_set_dirty(coap_resource_t *r, const str *query);
+COAP_DEPRECATED int
+coap_resource_set_dirty(coap_resource_t *r,
+                        const coap_string_t *query);
 
 #endif /* _COAP_RESOURCE_H_ */

--- a/include/coap/str.h
+++ b/include/coap/str.h
@@ -12,26 +12,50 @@
 
 #include <string.h>
 
+
+/**
+ * @defgroup string String handling support
+ * API functions for handling strings
+ * @{
+ */
+
+/**
+ * Coap string data definition
+ */
 typedef struct coap_string_t {
-  size_t length;    /* length of string */
-  uint8_t *s; /* string data */
+  size_t length;    /**< length of string */
+  uint8_t *s;       /**< string data */
 } coap_string_t;
 
+/**
+ * Coap string data definition with const data
+ */
 typedef struct coap_str_const_t {
-  size_t length;    /* length of string */
-  const uint8_t *s; /* string data */
+  size_t length;    /**< length of string */
+  const uint8_t *s; /**< string data */
 } coap_str_const_t;
 
-/* For backwards compatability */
+/**
+ * @deprecated Use coap_string_t instead.
+ */
+COAP_DEPRECATED
 typedef coap_string_t str;
 
 #define COAP_SET_STR(st,l,v) { (st)->length = (l), (st)->s = (v); }
 
 /**
+ * Coap binary data definition
+ */
+typedef struct coap_binary_t {
+  size_t length;    /**< length of binary data */
+  uint8_t *s;       /**< binary data */
+} coap_binary_t;
+
+/**
  * Returns a new string object with at least size+1 bytes storage allocated.
- * The string must be released using coap_delete_string();
+ * The string must be released using coap_delete_string().
  *
- * @param size The size to allocate for the binary string data
+ * @param size The size to allocate for the binary string data.
  *
  * @return       A pointer to the new object or @c NULL on error.
  */
@@ -40,17 +64,17 @@ coap_string_t *coap_new_string(size_t size);
 /**
  * Deletes the given string and releases any memory allocated.
  *
- * @param string The string to free off
+ * @param string The string to free off.
  */
 void coap_delete_string(coap_string_t *string);
 
 /**
  * Returns a new const string object with at least size+1 bytes storage
  * allocated, and the provided data copied into the string object.
- * The string must be released using coap_delete_str_const();
+ * The string must be released using coap_delete_str_const().
  *
  * @param data The data to put in the new string object.
- * @param size The size to allocate for the binary string data
+ * @param size The size to allocate for the binary string data.
  *
  * @return       A pointer to the new object or @c NULL on error.
  */
@@ -59,7 +83,7 @@ coap_str_const_t *coap_new_str_const(const uint8_t *data, size_t size);
 /**
  * Deletes the given const string and releases any memory allocated.
  *
- * @param string The string to free off
+ * @param string The string to free off.
  */
 void coap_delete_str_const(coap_str_const_t *string);
 
@@ -73,7 +97,7 @@ void coap_delete_str_const(coap_str_const_t *string);
  * @param string The const byte array to convert to a coap_str_const_t *
  */
 #define coap_make_str_const(string) \
-  (&(coap_str_const_t){.length = sizeof(string)-1,.s = (const uint8_t *)(string)})
+  (&(coap_str_const_t){sizeof(string)-1,(const uint8_t *)(string)})
 
 /**
  * Compares the two strings for equality
@@ -87,5 +111,7 @@ void coap_delete_str_const(coap_str_const_t *string);
 #define coap_string_equal(string1,string2) \
         ((string1)->length == (string2)->length && ((string1)->length == 0 || \
          memcmp((string1)->s, (string2)->s, (string1)->length) == 0))
+
+/** @} */
 
 #endif /* _COAP_STR_H_ */

--- a/include/coap/subscribe.h
+++ b/include/coap/subscribe.h
@@ -63,7 +63,7 @@ typedef struct coap_subscription_t {
                             *   dirty flag is set too) */
   size_t token_length;     /**< actual length of token */
   unsigned char token[8];  /**< token used for subscription */
-  str *query;              /**< query string used for subscription, if any */
+  coap_string_t *query;    /**< query string used for subscription, if any */
 } coap_subscription_t;
 
 void coap_subscription_init(coap_subscription_t *);

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -23,7 +23,7 @@ int _mode_);*
 *int coap_resource_notify_observers(coap_resource_t *_resource_, 
 const const_string_t *_query_);*
 
-*const str *coap_resource_get_uri_path(coap_resource_t *_resource_);*
+*const coap_string_t *coap_resource_get_uri_path(coap_resource_t *_resource_);*
 
 *coap_subscription_t *coap_find_observer(coap_resource_t *_resource_, 
 coap_session_t *_session_, const const_string_t *_token_);*

--- a/src/net.c
+++ b/src/net.c
@@ -956,7 +956,7 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
   /* Check if subscriptions exist that should be canceled after
      COAP_MAX_NOTIFY_FAILURES */
   if (node->pdu->code >= 64) {
-    str token = { 0, NULL };
+    coap_binary_t token = { 0, NULL };
 
     token.length = node->pdu->token_length;
     token.s = node->pdu->token;
@@ -1706,7 +1706,7 @@ error:
 static int
 coap_cancel(coap_context_t *context, const coap_queue_t *sent) {
 #ifndef WITHOUT_OBSERVE
-  coap_string_t token = { 0, NULL };
+  coap_binary_t token = { 0, NULL };
   int num_cancelled = 0;    /* the number of observers cancelled */
 
   /* remove observer for this resource, if any
@@ -1921,7 +1921,7 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
     /* Implementation detail: coap_add_token() immediately returns 0
        if response == NULL */
     if (coap_add_token(response, pdu->token_length, pdu->token)) {
-      coap_string_t token = { pdu->token_length, pdu->token };
+      coap_binary_t token = { pdu->token_length, pdu->token };
       coap_opt_iterator_t opt_iter;
       coap_opt_t *observe = NULL;
       int observe_action = COAP_OBSERVE_CANCEL;
@@ -2115,7 +2115,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
        * notification. Then, we must flag the observer to be alive
        * by setting obs->fail_cnt = 0. */
       if (sent && COAP_RESPONSE_CLASS(sent->pdu->code) == 2) {
-	const coap_string_t token =
+	const coap_binary_t token =
 	{ sent->pdu->token_length, sent->pdu->token };
 	coap_touch_observer(context, sent->session, &token);
       }

--- a/src/resource.c
+++ b/src/resource.c
@@ -584,7 +584,7 @@ coap_register_handler(coap_resource_t *resource,
 #ifndef WITHOUT_OBSERVE
 coap_subscription_t *
 coap_find_observer(coap_resource_t *resource, coap_session_t *session,
-		     const coap_string_t *token) {
+		     const coap_binary_t *token) {
   coap_subscription_t *s;
 
   assert(resource);
@@ -621,7 +621,7 @@ coap_find_observer_query(coap_resource_t *resource, coap_session_t *session,
 coap_subscription_t *
 coap_add_observer(coap_resource_t *resource, 
                   coap_session_t *session,
-		  const coap_string_t *token,
+		  const coap_binary_t *token,
                   coap_string_t *query) {
   coap_subscription_t *s;
   
@@ -638,7 +638,7 @@ coap_add_observer(coap_resource_t *resource,
     s = coap_find_observer_query(resource, session, query);
     if (s) {
       /* Delete old entry with old token */
-      coap_string_t tmp_token = { s->token_length, s->token };
+      coap_binary_t tmp_token = { s->token_length, s->token };
       coap_delete_observer(resource, session, &tmp_token);
       s = NULL;
     }
@@ -680,7 +680,7 @@ coap_add_observer(coap_resource_t *resource,
 
 void
 coap_touch_observer(coap_context_t *context, coap_session_t *session,
-		    const coap_string_t *token) {
+		    const coap_binary_t *token) {
   coap_subscription_t *s;
 
   RESOURCES_ITER(context->resources, r) {
@@ -693,7 +693,7 @@ coap_touch_observer(coap_context_t *context, coap_session_t *session,
 
 int
 coap_delete_observer(coap_resource_t *resource, coap_session_t *session,
-		     const coap_string_t *token) {
+		     const coap_binary_t *token) {
   coap_subscription_t *s;
 
   s = coap_find_observer(resource, session, token);
@@ -729,7 +729,7 @@ static void
 coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
   coap_method_handler_t h;
   coap_subscription_t *obs;
-  coap_string_t token;
+  coap_binary_t token;
   coap_pdu_t *response;
 
   if (r->observable && (r->dirty || r->partiallydirty)) {
@@ -802,12 +802,12 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
 }
 
 int
-coap_resource_set_dirty(coap_resource_t *r, const str *query) {
+coap_resource_set_dirty(coap_resource_t *r, const coap_string_t *query) {
   return coap_resource_notify_observers(r, query);
 }
 
 int
-coap_resource_notify_observers(coap_resource_t *r, const str *query) {
+coap_resource_notify_observers(coap_resource_t *r, const coap_string_t *query) {
   if (!r->observable)
     return 0;
   if (query) {
@@ -858,7 +858,7 @@ static void
 coap_remove_failed_observers(coap_context_t *context,
 			     coap_resource_t *resource,
 			     coap_session_t *session,
-			     const str *token) {
+			     const coap_binary_t *token) {
   coap_subscription_t *obs, *otmp;
 
   LL_FOREACH_SAFE(resource->subscribers, obs, otmp) {
@@ -900,7 +900,7 @@ coap_remove_failed_observers(coap_context_t *context,
 void
 coap_handle_failed_notify(coap_context_t *context, 
 			  coap_session_t *session, 
-			  const str *token) {
+			  const coap_binary_t *token) {
 
   RESOURCES_ITER(context->resources, r) {
 	coap_remove_failed_observers(context, r, session, token);

--- a/src/str.c
+++ b/src/str.c
@@ -27,6 +27,7 @@ coap_string_t *coap_new_string(size_t size) {
 
   memset(s, 0, sizeof(coap_string_t));
   s->s = ((unsigned char *)s) + sizeof(coap_string_t);
+  s->s[size] = '\000';
   return s;
 }
 

--- a/src/uri.c
+++ b/src/uri.c
@@ -377,7 +377,7 @@ coap_split_path_impl(const uint8_t *s, size_t length,
 }
 
 struct cnt_str {
-  str buf;
+  coap_string_t buf;
   int n;
 };
 

--- a/tests/test_options.c
+++ b/tests/test_options.c
@@ -184,7 +184,7 @@ static void
 t_parse_option13(void) {
   /* delta == 280, length == 500 */
   unsigned char _data[505];
-  str teststr = {  sizeof(_data), _data };
+  coap_string_t teststr = {  sizeof(_data), _data };
   teststr.s[0] = 0xee;
   teststr.s[1] = 0x00;
   teststr.s[2] = 0x0b;


### PR DESCRIPTION
New struct coap_binary_t - same as coap_string_t, used for tokens

Deprecate struct str with the intent of removing it downstream as it
polutes namespace.

Make byte after end of allocated coap_string_t data a NUL for string terminators - an extra byte is allocated for this.

coap_string_t still contains uint_8_t* - it makes sense to do this as a seperate PR depending on the outcome of the discussion in thread https://sourceforge.net/p/libcoap/mailman/message/36335932/

Files:
examples/client.c
examples/coap-rd.c
examples/coap-server.c
examples/contiki/server.c
examples/etsi_iot_01.c
include/coap/resource.h
include/coap/str.h
include/coap/subscribe.h
man/coap_observe.txt.in
src/net.c
src/resource.c
src/str.c
src/uri.c
tests/test_options.c