### PR TITLE
oss-fuzz: Move test from oss-fuzz repo

### DIFF
--- a/tests/oss-fuzz/pdu_parse_target.c
+++ b/tests/oss-fuzz/pdu_parse_target.c
@@ -1,0 +1,11 @@
+#include <coap.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    coap_pdu_t *pdu = coap_pdu_init(0, 0, 0, size);
+    if (!pdu) return 0;
+    
+    coap_pdu_parse(COAP_PROTO_UDP, data, size, pdu);
+    coap_delete_pdu(pdu);
+    return 0;
+}

--- a/tests/oss-fuzz/pdu_parse_target.c
+++ b/tests/oss-fuzz/pdu_parse_target.c
@@ -3,9 +3,9 @@
 int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     coap_pdu_t *pdu = coap_pdu_init(0, 0, 0, size);
-    if (!pdu) return 0;
-    
-    coap_pdu_parse(COAP_PROTO_UDP, data, size, pdu);
-    coap_delete_pdu(pdu);
+    if (pdu) {
+        coap_pdu_parse(COAP_PROTO_UDP, data, size, pdu);
+        coap_delete_pdu(pdu);
+    }
     return 0;
 }

--- a/tests/oss-fuzz/pdu_parse_target.c
+++ b/tests/oss-fuzz/pdu_parse_target.c
@@ -1,7 +1,7 @@
 #include <coap.h>
 
-int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
-{
+int
+LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     coap_pdu_t *pdu = coap_pdu_init(0, 0, 0, size);
     if (pdu) {
         coap_pdu_parse(COAP_PROTO_UDP, data, size, pdu);


### PR DESCRIPTION
Moves fuzzer test to source tree. Partly addresses #211 