### PR TITLE
Fix reported issues #212, #214 and refix #199, add in valgrind to do extra testing

### DIFF
--- a/build-env/Dockerfile.build-env
+++ b/build-env/Dockerfile.build-env
@@ -2,5 +2,5 @@ FROM debian:testing-slim
 
 RUN apt-get update && apt-get install -y autoconf automake gcc clang \
   libtool libtool-bin make pkg-config libcunit1-dev libssl-dev \
-  exuberant-ctags git
+  exuberant-ctags git valgrind
 RUN apt-get clean

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,7 +36,9 @@ esac
 
 err=$?
 if test $err = 0 -a -n "$WITH_TESTS" ; then
-    tests/testdriver
+    EXEC_FILE=tests/testdriver
+    # then run valgrind on the actual executable
+    libtool --mode=execute valgrind --track-origins=yes --leak-check=yes --show-reachable=yes --error-exitcode=123 --quiet $EXEC_FILE
     err=$?
 fi
 

--- a/src/option.c
+++ b/src/option.c
@@ -36,10 +36,11 @@
  * Used to prevent access to *opt when pointing to after end of buffer
  * after doing a ADVANCE_OPT()
  */
-#define ADVANCE_OPT_CHECK(o,e,step) \
-  ADVANCE_OPT(o,e,step);            \
-  if ((e) < 1)                      \
-    return 0;
+#define ADVANCE_OPT_CHECK(o,e,step) do { \
+    ADVANCE_OPT(o,e,step);               \
+    if ((e) < 1)                         \
+      return 0;                          \
+  } while (0)
 
 size_t
 coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -489,6 +489,12 @@ coap_pdu_parse_header(coap_pdu_t *pdu, coap_proto_t proto) {
     debug( "coap_pdu_parse: unsupported protocol\n" );
     return 0;
   }
+  if (pdu->token_length > pdu->alloc_size) {
+    /* Invalid PDU provided - not wise to assert here though */
+    coap_log(LOG_DEBUG, "coap_pdu_parse: PDU header token size broken\n");
+    pdu->token_length = pdu->alloc_size;
+    return 0;
+  }
   return 1;
 }
 

--- a/src/uri.c
+++ b/src/uri.c
@@ -333,7 +333,7 @@ typedef void (*segment_handler_t)(const uint8_t *, size_t, void *);
  */
 COAP_STATIC_INLINE int
 dots(const uint8_t *s, size_t len) {
-  return *s == '.' && (len == 1 || (*(s+1) == '.' && len == 2));
+  return len && *s == '.' && (len == 1 || (len == 2 && *(s+1) == '.'));
 }
 
 /** 

--- a/tests/test_uri.c
+++ b/tests/test_uri.c
@@ -556,6 +556,25 @@ t_parse_uri23(void) {
   coap_delete_string (uri_path);
 }
 
+/*
+ * To test Issue #212 which reads off the end of the input buffer when looking 
+ * for . or .. in the path.
+ * Credit to OSS-Fuzz for finding this, work done by Bhargava Shastry
+ */
+static void
+t_parse_uri24(void) {
+  /* coap://\206cap:// */
+  uint8_t teststr[] = { 0x63, 0x6f, 0x61, 0x70, 0x3a, 0x2f, 0x2f, 0x86, 0x63, 0x6f, 0x61, 0x70, 0x3a, 0x2f, 0x2f };
+  int result;
+  unsigned char buf[40];
+  size_t buflen = sizeof(buf);
+
+  result = coap_split_path(teststr, sizeof(teststr), buf, &buflen);
+  CU_ASSERT(result == 5);
+  CU_ASSERT(buflen == 16);
+}
+
+
 CU_pSuite
 t_init_uri_tests(void) {
   CU_pSuite suite;
@@ -597,6 +616,7 @@ t_init_uri_tests(void) {
   URI_TEST(suite, t_parse_uri21);
   URI_TEST(suite, t_parse_uri22);
   URI_TEST(suite, t_parse_uri23);
+  URI_TEST(suite, t_parse_uri24);
 
   return suite;
 }


### PR DESCRIPTION
build-env/Dockerfile.build-env
scripts/build.sh

Add in valgrind testing of the tests

src/option.c

#199 Better fix of ADVANCE_OPT_CHECK()

src/pdu.c

#214 Validate token length in coap_pdu_parse_header()

src/uri.c

#212 Check not reading off end of buffer in dots()

tests/test_pdu.c
tests/test_uri.c

Tests updated to include tests for #212 & #214