### PR TITLE
Add coap_show_pdu() and coap_split_uri() to existing/new oss fuzz test harness

### DIFF
--- a/tests/oss-fuzz/pdu_parse_target.c
+++ b/tests/oss-fuzz/pdu_parse_target.c
@@ -4,7 +4,9 @@ int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     coap_pdu_t *pdu = coap_pdu_init(0, 0, 0, size);
     if (pdu) {
+        coap_set_log_level(LOG_DEBUG);
         coap_pdu_parse(COAP_PROTO_UDP, data, size, pdu);
+        coap_show_pdu(LOG_DEBUG, pdu);
         coap_delete_pdu(pdu);
     }
     return 0;

--- a/tests/oss-fuzz/split_uri_target.c
+++ b/tests/oss-fuzz/split_uri_target.c
@@ -1,0 +1,8 @@
+#include <coap2/coap.h>
+
+int
+LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    coap_uri_t uri;
+    coap_split_uri(data, size, &uri);
+    return 0;
+}


### PR DESCRIPTION
This PR

- Adds coap_show_pdu() to existing test harness (CC #214)
- Creates a new oss-fuzz test harness for coap_split_uri() (CC #212)