### PR TITLE
debug.c: Make coap_show_pdu() use fprintf() or coap_log() for output

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -211,8 +211,7 @@ clear_obs(coap_context_t *ctx, coap_session_t *session) {
     }
   }
 
-  if (LOG_INFO <= coap_get_log_level())
-    coap_show_pdu(pdu);
+  coap_show_pdu(LOG_INFO, pdu);
 
   tid = coap_send(session, pdu);
 
@@ -297,11 +296,9 @@ message_handler(struct coap_context_t *ctx,
   coap_tid_t tid;
 
 #ifndef NDEBUG
-  if (LOG_INFO <= coap_get_log_level()) {
-    coap_log(LOG_DEBUG, "** process incoming %d.%02d response:\n",
-          (received->code >> 5), received->code & 0x1F);
-    coap_show_pdu(received);
-  }
+  coap_log(LOG_DEBUG, "** process incoming %d.%02d response:\n",
+           (received->code >> 5), received->code & 0x1F);
+  coap_show_pdu(LOG_INFO, received);
 #endif
 
   /* check if this is a response to our original request */
@@ -456,7 +453,7 @@ message_handler(struct coap_context_t *ctx,
                          payload.s,
                          block.num,
                          block.szx);
-          coap_show_pdu(pdu);
+          coap_show_pdu(LOG_WARNING, pdu);
 
 	  tid = coap_send(session, pdu);
 
@@ -1278,10 +1275,8 @@ main(int argc, char **argv) {
   }
 
 #ifndef NDEBUG
-  if (LOG_INFO <= coap_get_log_level()) {
-    coap_log(LOG_DEBUG, "sending CoAP request:\n");
-    coap_show_pdu(pdu);
-  }
+  coap_log(LOG_DEBUG, "sending CoAP request:\n");
+  coap_show_pdu(LOG_INFO, pdu);
 #endif
 
   coap_send(session, pdu);

--- a/examples/contiki/coap-observer.c
+++ b/examples/contiki/coap-observer.c
@@ -103,7 +103,7 @@ message_handler(struct coap_context_t  *ctx,
 
   debug("** process incoming %d.%02d response:\n",
 	(received->hdr->code >> 5), received->hdr->code & 0x1F);
-  coap_show_pdu(received);
+  coap_show_pdu(LOG_WARNING, received);
 
   coap_ticks(&last_seen);
 }

--- a/include/coap/debug.h
+++ b/include/coap/debug.h
@@ -74,7 +74,22 @@ void coap_log_impl(coap_log_t level, const char *format, ...);
 #define debug(...) coap_log(LOG_DEBUG, __VA_ARGS__)
 
 #include "pdu.h"
-void coap_show_pdu(const coap_pdu_t *);
+
+/**
+ * Defines the output mode for the coap_show_pdu() function.
+ *
+ * @param use_printf  1 if the output is to use fprintf() (the default)
+ *                    0 if the output is to use coap_log()
+ */
+void coap_set_show_pdu_output(int use_fprintf);
+
+/**
+ * Display the contents of the specified @p pdu.
+ *
+ * @param level The required minimum logging level
+ * @param pdu The PDU to decode
+ */
+void coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu);
 
 struct coap_address_t;
 size_t coap_print_addr(const struct coap_address_t *, unsigned char *, size_t);

--- a/include/coap/pdu.h
+++ b/include/coap/pdu.h
@@ -52,6 +52,15 @@ struct coap_session_t;
 #endif
 #endif /* COAP_DEFAULT_MAX_PDU_RX_SIZE */
 
+#ifndef COAP_DEBUG_BUF_SIZE
+#if defined(WITH_CONTIKI) || defined(WITH_LWIP)
+#define COAP_DEBUG_BUF_SIZE 128
+#else /* defined(WITH_CONTIKI) || defined(WITH_LWIP) */
+/* 1024 derived from RFC7252 4.6.  Message Size max payload */
+#define COAP_DEBUG_BUF_SIZE (8 + 1024 * 2)
+#endif /* defined(WITH_CONTIKI) || defined(WITH_LWIP) */
+#endif /* COAP_DEBUG_BUF_SIZE */
+
 #define COAP_DEFAULT_VERSION      1 /* version of CoAP supported */
 #define COAP_DEFAULT_SCHEME  "coap" /* the default scheme for CoAP URIs */
 

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -167,6 +167,7 @@ global:
   coap_set_event_handler;
   coap_set_log_handler;
   coap_set_log_level;
+  coap_set_show_pdu_output;
   coap_show_pdu;
   coap_socket_strerror;
   coap_split_path;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -165,6 +165,7 @@ coap_set_app_data
 coap_set_event_handler
 coap_set_log_handler
 coap_set_log_level
+coap_set_show_pdu_output
 coap_show_pdu
 coap_socket_strerror
 coap_split_path

--- a/src/net.c
+++ b/src/net.c
@@ -617,9 +617,7 @@ coap_session_send_pdu(coap_session_t *session, coap_pdu_t *pdu) {
     default:
       break;
   }
-  if (LOG_DEBUG <= coap_get_log_level()) {
-    coap_show_pdu(pdu);
-  }
+  coap_show_pdu(LOG_DEBUG, pdu);
   return bytes_written;
 }
 
@@ -2075,7 +2073,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
 	    (int)msg_len, addr, localaddr);
 
 	    */
-    coap_show_pdu(pdu);
+    coap_show_pdu(LOG_DEBUG, pdu);
   }
 #endif
 

--- a/tests/test_pdu.c
+++ b/tests/test_pdu.c
@@ -300,8 +300,9 @@ t_parse_pdu16(void) {
   result = coap_pdu_parse(COAP_PROTO_UDP, teststr, sizeof(teststr), testpdu);
   CU_ASSERT(result == 0);
 
+  coap_set_show_pdu_output(0);
   coap_set_log_handler(log_handler);
-  coap_show_pdu(testpdu);	/* display PDU */
+  coap_show_pdu(LOG_ERR, testpdu);	/* display PDU */
   coap_set_log_handler(NULL);
 
   coap_delete_pdu(testpdu);

--- a/tests/test_wellknown.c
+++ b/tests/test_wellknown.c
@@ -241,7 +241,7 @@ t_wellknown6(void) {
 
     CU_ASSERT_PTR_NOT_NULL(response);
 
-    /* coap_show_pdu(response); */
+    /* coap_show_pdu(LOG_INFO, response); */
 
     CU_ASSERT(coap_get_block(response, COAP_OPTION_BLOCK2, &block) != 0);
 


### PR DESCRIPTION
Output COAP_OPTION_SIZE2 option as well

For binary data, output ascii readable equivalent immediately under the
hex output for ease of debugging.

This then allows the coap_set_log_handler() log handler to be used.

Currently in the code, there are several code fragments of the form
```` 
if (LOG_DEBUG <= coap_get_log_level()) {
 coap_show_pdu(pdu);
}
````

Should coap_show_pdu() become `coap_show_pdu(coap_log_t level, coap_pdu_t *pdu)` to simplify the code ?