### PR TITLE
coap_io.c,net.c: Fix head of node queue re-transmit timeouts

### DIFF
--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1093,7 +1093,6 @@ coap_write(coap_context_t *ctx,
   nextpdu = coap_peek_next(ctx);
 
   while (nextpdu && now >= ctx->sendqueue_basetime && nextpdu->t <= now - ctx->sendqueue_basetime) {
-    nextpdu->t = 0;
     coap_retransmit(ctx, coap_pop_next(ctx));
     nextpdu = coap_peek_next(ctx);
   }

--- a/src/net.c
+++ b/src/net.c
@@ -2304,7 +2304,6 @@ static void coap_retransmittimer_execute(void *arg) {
       break;
     } else {
       elapsed -= nextinqueue->t;
-      nextinqueue->t = 0;
       coap_retransmit(ctx, coap_pop_next(ctx));
       nextinqueue = coap_peek_next(ctx);
     }


### PR DESCRIPTION
The node queue uses time deltas between each entry in the queue for
retransmissions.  The head entry does not have a time delta.

When the head of the head of the queue is taken off for retransmission
the next in the queue needs to have the time delta updated to be an
absolute value.  However, this does not happen if the current head has had
the time offset force set to 0 and so the retransmit timer fires more frequently
than expected.

There are 2 ways to fix this - not maintain time deltas between queue
entries, or not force set the head entries time to 0.

Doing the latter means that code that relies on the deltas (I can only
find the test suite) continue to work before calling coap_retransmit().

See Issue #197 for further information.