### PR TITLE
Remove doxygen warnings re text in header files by correcting parameter names

### DIFF
--- a/include/coap/coap_dtls.h
+++ b/include/coap/coap_dtls.h
@@ -21,37 +21,56 @@
  * @{
  */
 
-/** Returns 1 if support for DTLS is enabled, or 0 otherwise. */
+/**
+ * Check whether DTLS is available.
+ * 
+ * @return 1 if support for DTLS is enabled, or 0 otherwise.
+ */
 int coap_dtls_is_supported(void);
 
-/** Returns 1 if support for TLS is enabled, or 0 otherwise. */
-int coap_tls_is_supported( void );
+/**
+ * Check whether TLS is available.
+ *
+ * @return 1 if support for TLS is enabled, or 0 otherwise.
+ */
+int coap_tls_is_supported(void);
 
-#define COAP_TLS_LIBRARY_NOTLS 0
-#define COAP_TLS_LIBRARY_TINYDTLS 1
-#define COAP_TLS_LIBRARY_OPENSSL 2
-#define COAP_TLS_LIBRARY_GNUTLS 3
+#define COAP_TLS_LIBRARY_NOTLS 0 /**< No DTLS library */
+#define COAP_TLS_LIBRARY_TINYDTLS 1 /**< Using TinyDTLS library */
+#define COAP_TLS_LIBRARY_OPENSSL 2 /**< Using OpenSSL library */
+#define COAP_TLS_LIBRARY_GNUTLS 3 /**< Using GnuTLS library */
 
 typedef struct coap_tls_version_t {
-  uint64_t version; /* Library Version */
-  int type; /* One of COAP_TLS_LIBRARY_* */
+  uint64_t version; /**< (D)TLS Library Version */
+  int type; /**< Library type. One of COAP_TLS_LIBRARY_* */
 } coap_tls_version_t;
 
 /**
- * Returns the version and type of library libcoap was compiled against
+ * Determine the type and version of the underlying (D)TLS library.
+ *
+ * @return The version and type of library libcoap was compiled against.
  */
 coap_tls_version_t *coap_get_tls_library_version(void);
 
-/** Sets the log level to the specified value. */
+/**
+ * Sets the (D)TLS logging level to the specified value.
+ * Note: coap_log_level() will influence output if at a lower level 
+ *
+ * @param level The logging level to use - LOG_*
+ */
 void coap_dtls_set_log_level(int level);
 
-/** Returns the current log level. */
+/**
+ * Get the current (D)TLS logging.
+ *
+ * @return The current log level (one of LOG_*).
+ */
 int coap_dtls_get_log_level(void);
 
 struct coap_dtls_pki_t;
 
 /**
- * Security setup handler that is used as call-back in coap_context_set_pki()
+ * Security setup handler that is used as call-back in coap_context_set_pki().
  * Typically, this will be calling additonal functions like
  * SSL_CTX_set_tlsext_servername_callback() etc.
  *
@@ -60,7 +79,8 @@ struct coap_dtls_pki_t;
  *              - see coap_get_tls_library_version()
  * @param setup_data A structure containing setup data originally passed into
  *                  coap_context_set_pki() or coap_new_client_session_pki().
- * @return 1 if successful, else 0
+ *
+ * @return 1 if successful, else 0.
  */
 typedef int (*coap_dtls_security_setup_t)(void *context,
                                         struct coap_dtls_pki_t *setup_data);
@@ -106,30 +126,31 @@ typedef struct coap_dtls_pki_t {
  * returns a pointer to a new DTLS context object or NULL on error.
  *
  * @param coap_context The CoAP context where the DTLS object shall be used.
- * @return A DTLS context object or NULL on error;
+ *
+ * @return A DTLS context object or NULL on error.
  */
 void *
 coap_dtls_new_context(struct coap_context_t *coap_context);
 
 /**
- * Set the dtls context's default server PSK hint and/or key.
+ * Set the DTLS context's default server PSK hint and/or key.
  * This does the PSK specifics for coap_dtls_new_context()
  *
  * @param ctx The CoAP context.
  * @param hint    The default PSK server hint sent to a client. If NULL, PSK
  *                authentication is disabled. Empty string is a valid hint.
  * @param key     The default PSK key. If NULL, PSK authentication will fail.
- * @param key_len The default PSK key's lenght. If 0, PSK authentication will
+ * @param key_len The default PSK key's length. If 0, PSK authentication will
  *                fail.
  *
- * @return 1 if successful, else 0
+ * @return 1 if successful, else 0.
  */
 
 int coap_dtls_context_set_psk(struct coap_context_t *ctx, const char *hint,
                            const uint8_t *key, size_t key_len );
 
 /**
- * Set the dtls context's default server PKI information.
+ * Set the DTLS context's default server PKI information.
  * This does the PKI specifics for coap_dtls_new_context()
  * The Callback is called to set up the appropriate information.
  *
@@ -137,7 +158,7 @@ int coap_dtls_context_set_psk(struct coap_context_t *ctx, const char *hint,
  * @param setup_data     If NULL, PKI authentication will fail. Certificate
  *                       information required.
  *
- * @return 1 if successful, else 0
+ * @return 1 if successful, else 0.
  */
 
 int coap_dtls_context_set_pki(struct coap_context_t *ctx,
@@ -147,7 +168,7 @@ int coap_dtls_context_set_pki(struct coap_context_t *ctx,
  * Check whether one of the coap_dtls_context_set_*() functions have been
  * called.
  *
- * @return 1 if coap_dtls_context_set_*() called, else 0
+ * @return 1 if coap_dtls_context_set_*() called, else 0.
  */
 
 int coap_dtls_context_check_keys_enabled(struct coap_context_t *ctx);
@@ -158,42 +179,45 @@ void coap_dtls_free_context(void *dtls_context);
 /**
  * Create a new client-side session. This should send a HELLO to the server.
  *
- * @param session   The CoAP session
+ * @param session   The CoAP session.
+ *
  * @return Opaque handle to underlying TLS library object containing security
  * parameters for the session.
 */
 void *coap_dtls_new_client_session(coap_session_t *session);
 
 /**
-* Create a new server-side session.
-* Called after coap_dtls_hello() has returned 1, signalling that a validated HELLO was received from a client.
-* This should send a HELLO to the server.
-*
-* @param session   The CoAP session
-* @return Opaque handle to underlying TLS library object containing security parameters for the session.
-*/
+ * Create a new server-side session.
+ * Called after coap_dtls_hello() has returned 1, signalling that a validated HELLO was received from a client.
+ * This should send a HELLO to the server.
+ *
+ * @param session   The CoAP session.
+ *
+ * @return Opaque handle to underlying TLS library object containing security parameters for the session.
+ */
 void *coap_dtls_new_server_session(coap_session_t *session);
 
 /**
  * Terminates the DTLS session (may send an ALERT if necessary) then frees the underlying TLS library object containing security parameters for the session.
  *
- * @param session   The CoAP session
+ * @param session   The CoAP session.
  */
 void coap_dtls_free_session(coap_session_t *session);
 
 /**
  * Notify of a change in the session's MTU, e.g. after a PMTU update.
  *
- * @param session   The CoAP session
+ * @param session   The CoAP session.
  */
 void coap_dtls_session_update_mtu(coap_session_t *session);
 
 /**
  * Send data to a DTLS peer.
  *
- * @param session   The CoAP session
- * @param data      pointer to data
- * @param size      number of bytes to send
+ * @param session   The CoAP session.
+ * @param data      pointer to data.
+ * @param data_len  Number of bytes to send.
+ *
  * @return 0 if this would be blocking, -1 if there is an error or the number of cleartext bytes sent
  */
 int coap_dtls_send(coap_session_t *session,
@@ -201,17 +225,17 @@ int coap_dtls_send(coap_session_t *session,
                    size_t data_len);
 
 /**
-* Check if timeout is handled per session or per context.
-*
-* @param dtls_context The DTLS context
-* @return 1 of timeout and retransmit is per context, 0 if it is per session.
-*/
+ * Check if timeout is handled per session or per context.
+ *
+ * @return 1 of timeout and retransmit is per context, 0 if it is per session.
+ */
 int coap_dtls_is_context_timeout(void);
 
 /**
  * Do all pending retransmits and get next timeout
  * 
- * @param dtls_context The DTLS context
+ * @param dtls_context The DTLS context.
+ *
  * @return 0 If no event is pending or date of the next retransmit.
  */
 coap_tick_t coap_dtls_get_context_timeout(void *dtls_context);
@@ -219,7 +243,8 @@ coap_tick_t coap_dtls_get_context_timeout(void *dtls_context);
 /**
  * Get next timeout for this session.
  *
- * @param session The CoAP session
+ * @param session The CoAP session.
+ *
  * @return 0 If no event is pending or date of the next retransmit.
  */
 coap_tick_t coap_dtls_get_timeout(coap_session_t *session);
@@ -227,31 +252,35 @@ coap_tick_t coap_dtls_get_timeout(coap_session_t *session);
 /**
  * Handle a DTLS timeout expiration.
  *
- * @param session The CoAP session
+ * @param session The CoAP session.
  */
 void coap_dtls_handle_timeout(coap_session_t *session);
 
 /**
-* Handling incoming data from a DTLS peer.
-*
-* @param session   The CoAP session
-* @param data      Encrypted datagram
-* @param data_len  Encrypted datagram size
-* @return result of coap_handle_dgram on the decrypted CoAP PDU or -1 for error.
-*/
+ * Handling incoming data from a DTLS peer.
+ *
+ * @param session   The CoAP session.
+ * @param data      Encrypted datagram.
+ * @param data_len  Encrypted datagram size.
+ *
+ * @return result of coap_handle_dgram on the decrypted CoAP PDU or -1 for error.
+ */
 int coap_dtls_receive(coap_session_t *session,
                       const uint8_t *data,
                       size_t data_len);
 
 /**
-* Handling client HELLO messages from a new candiate peer.
-* Note that session->tls is empty.
-*
-* @param session   The CoAP session
-* @param data      Encrypted datagram
-* @param data_len  Encrypted datagram size
-* @return 0 if a cookie verification message has been sent, 1 if the HELLO contains a valid cookie and a server session should be created, -1 if the message is invalid.
-*/
+ * Handling client HELLO messages from a new candiate peer.
+ * Note that session->tls is empty.
+ *
+ * @param session   The CoAP session.
+ * @param data      Encrypted datagram.
+ * @param data_len  Encrypted datagram size.
+ *
+ * @return 0 if a cookie verification message has been sent, 1 if the HELLO
+          contains a valid cookie and a server session should be created,
+          -1 if the message is invalid.
+ */
 int coap_dtls_hello(coap_session_t *session,
                     const uint8_t *data,
                     size_t data_len);
@@ -260,41 +289,49 @@ int coap_dtls_hello(coap_session_t *session,
  * Get DTLS overhead over cleartext PDUs.
  *
  * @param session   The CoAP session
+ *
  * @return maximum number of bytes added by DTLS layer.
  */
 
 unsigned int coap_dtls_get_overhead(coap_session_t *session);
 
 /**
- * Create a new client-side session.
+ * Create a new TLS client-side session.
  *
- * @param session   The CoAP session
+ * @param session   The CoAP session.
+ * @param connected Updated with  whether the connection is connected yet or not
+ *                  0 is not connected.
+ *
  * @return Opaque handle to underlying TLS library object containing security parameters for the session.
 */
 void *coap_tls_new_client_session(coap_session_t *session, int *connected);
 
 /**
-* Create a new server-side session.
-*
-* @param session   The CoAP session
-* @return Opaque handle to underlying TLS library object containing security parameters for the session.
-*/
+ * Create a TLS new server-side session.
+ *
+ * @param session   The CoAP session.
+ * @param connected Updated with  whether the connection is connected yet or not
+ *                  0 is not connected.
+ *
+ * @return Opaque handle to underlying TLS library object containing security parameters for the session.
+ */
 void *coap_tls_new_server_session(coap_session_t *session, int *connected);
 
 /**
-* Terminates the TLS session (may send an ALERT if necessary) then frees the
-* underlying TLS library object containing security parameters for the session.
-*
-* @param session   The CoAP session
-*/
+ * Terminates the TLS session (may send an ALERT if necessary) then frees the
+ * underlying TLS library object containing security parameters for the session.
+ *
+ * @param session   The CoAP session
+ */
 void coap_tls_free_session( coap_session_t *session );
 
 /**
  * Send data to a TLS peer, with implicit flush.
  *
- * @param session   The CoAP session
- * @param data      pointer to data
- * @param size      number of bytes to send
+ * @param session   The CoAP session.
+ * @param data      Pointer to data.
+ * @param data_len  Number of bytes to send.
+ *
  * @return          0 if this should be retried, -1 if there is an error or
  *                  the number of cleartext bytes sent.
  */
@@ -306,9 +343,10 @@ ssize_t coap_tls_write(coap_session_t *session,
 /**
  * Read some data from a TLS peer.
  *
- * @param session   The CoAP session
- * @param data      pointer to data
- * @param size      maximum number of bytes to read
+ * @param session   The CoAP session.
+ * @param data      Pointer to data.
+ * @param data_len  Maximum number of bytes to read.
+ *
  * @return          0 if this should be retried, -1 if there is an error or
  *                  the number of cleartext bytes read.
  */

--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -120,6 +120,7 @@ void *coap_session_get_app_data(const coap_session_t *session);
 * Notify session that it has failed connecting or has been disconnected.
 *
 * @param session The CoAP session.
+* @param reason The reason why the session was disconnected.
 */
 void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reason);
 
@@ -182,11 +183,10 @@ coap_session_t *coap_new_client_session(
 * @param ctx The CoAP context.
 * @param local_if Address of local interface. It is recommended to use NULL to let the operating system choose a suitable local interface. If an address is specified, the port number should be zero, which means that a free port is automatically selected.
 * @param server The server's address. If the port number is zero, the default port for the protocol will be used.
+* @param proto Protocol.
 * @param identity PSK client identity
-* @param identity_len Length PSK client identity
 * @param key PSK shared key
 * @param key_len PSK shared key length
-* @param proto Protocol.
 *
 * @return A new CoAP session or NULL if failed. Call coap_session_release to free.
 */
@@ -322,10 +322,10 @@ coap_endpoint_t *coap_new_endpoint(struct coap_context_t *context, const coap_ad
 * Set the endpoint's default MTU. This is the maximum message size that can be
 * sent, excluding IP and UDP overhead.
 *
-* @param session The CoAP session.
+* @param endpoint The CoAP endpoint.
 * @param mtu maximum message size
 */
-void coap_endpoint_set_default_mtu(coap_endpoint_t *ep, unsigned mtu);
+void coap_endpoint_set_default_mtu(coap_endpoint_t *endpoint, unsigned mtu);
 
 void coap_free_endpoint(coap_endpoint_t *ep);
 
@@ -333,7 +333,7 @@ void coap_free_endpoint(coap_endpoint_t *ep);
 /**
 * Get endpoint description.
 *
-* @param session  The CoAP endpoint.
+* @param endpoint  The CoAP endpoint.
 * @return description string
 */
 const char *coap_endpoint_str(const coap_endpoint_t *endpoint);
@@ -344,6 +344,7 @@ const char *coap_endpoint_str(const coap_endpoint_t *endpoint);
 *
 * @param endpoint Active endpoint the packet was received on.
 * @param packet Received packet.
+* @param now The current time in ticks.
 * @return The CoAP session.
 */
 coap_session_t *coap_endpoint_get_session(coap_endpoint_t *endpoint,

--- a/include/coap/encode.h
+++ b/include/coap/encode.h
@@ -73,7 +73,8 @@ unsigned int coap_encode_var_safe(uint8_t *buf,
                                   unsigned int value);
 
 /**
- * @deprecated.  Provided for backward compatability.  As @p value has a 
+ * @deprecated.  Use coap_encode_var_safe() instead.
+ * Provided for backward compatability.  As @p value has a 
  * maximum value of 0xffffffff, and buf is usually defined as an array, it
  * is unsafe to continue to use this variant if buf[] is less than buf[4].
  *

--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -280,11 +280,11 @@ int coap_context_set_pki(coap_context_t *context,
                            coap_dtls_pki_t* setup_data);
 
 /**
- * Returns a new message id and updates @p context->message_id accordingly. The
+ * Returns a new message id and updates @p session->tx_mid accordingly. The
  * message id is returned in network byte order to make it easier to read in
  * tracing tools.
  *
- * @param context The current coap_context_t object.
+ * @param session The current coap_session_t object.
  *
  * @return        Incremented message id in network byte order.
  */
@@ -457,18 +457,21 @@ void coap_read(coap_context_t *ctx, coap_tick_t now);
  *
  * @param ctx The CoAP context
  * @param timeout_ms Minimum number of milliseconds to wait for new messages before returning. If zero the call will block until at least one packet is sent or received.
+ *
  * @return number of milliseconds spent or -1 if there was an error
  */
 
 int coap_run_once( coap_context_t *ctx, unsigned int timeout_ms );
 
 /**
- * Parses and interprets a CoAP message with context @p ctx. This function
- * returns @c 0 if the message was handled, or a value less than zero on
+ * Parses and interprets a CoAP datagram with context @p ctx. This function
+ * returns @c 0 if the datagram was handled, or a value less than zero on
  * error.
  *
  * @param ctx    The current CoAP context.
- * @param packet The received packet.
+ * @param session The current CoAP session.
+ * @param data The received packet'd data.
+ * @param data_len The received packet'd data length.
  *
  * @return       @c 0 if message was handled successfully, or less than zero on
  *               error.
@@ -543,6 +546,7 @@ void coap_cancel_all_messages(coap_context_t *context,
 *
 * @param context      The context in use.
 * @param session      Session of the messages to remove.
+* @param reason       The reasion for the session cancellation
 */
 void
 coap_cancel_session_messages(coap_context_t *context,

--- a/include/coap/str.h
+++ b/include/coap/str.h
@@ -49,6 +49,7 @@ void coap_delete_string(coap_string_t *string);
  * allocated, and the provided data copied into the string object.
  * The string must be released using coap_delete_str_const();
  *
+ * @param data The data to put in the new string object.
  * @param size The size to allocate for the binary string data
  *
  * @return       A pointer to the new object or @c NULL on error.
@@ -77,14 +78,14 @@ void coap_delete_str_const(coap_str_const_t *string);
 /**
  * Compares the two strings for equality
  *
- * @param string1 The first string
- * @param string2 The second string
+ * @param string1 The first string.
+ * @param string2 The second string.
  *
  * @return         @c 1 if the strings are equal
  *                 @c 0 otherwise.
  */
-#define coap_string_equal(s1,s2) \
-        ((s1)->length == (s2)->length && ((s1)->length == 0 || \
-         memcmp((s1)->s, (s2)->s, (s1)->length) == 0))
+#define coap_string_equal(string1,string2) \
+        ((string1)->length == (string2)->length && ((string1)->length == 0 || \
+         memcmp((string1)->s, (string2)->s, (string1)->length) == 0))
 
 #endif /* _COAP_STR_H_ */

--- a/include/coap/subscribe.h
+++ b/include/coap/subscribe.h
@@ -1,6 +1,6 @@
 /*
  * subscribe.h -- subscription handling for CoAP
- *                see draft-ietf-core-observe-16
+ *                see RFC7641
  *
  * Copyright (C) 2010-2012,2014-2015 Olaf Bergmann <bergmann@tzi.org>
  *
@@ -17,6 +17,7 @@
 
 /**
  * @defgroup observe Resource observation
+ * API functions for interfacing with the observe handling (RFC7641)
  * @{
  */
 

--- a/src/resource.c
+++ b/src/resource.c
@@ -817,7 +817,7 @@ coap_check_notify(coap_context_t *context) {
  *
  * @param context  The CoAP context to use
  * @param resource The resource to check for (peer, token)
- * @param peer     The observer's address
+ * @param session  The observer's session
  * @param token    The token that has been used for subscription.
  */
 static void


### PR DESCRIPTION
include/coap/coap_dtls.h
include/coap/coap_session.h
include/coap/encode.h
include/coap/net.h
include/coap/str.h
include/coap/subscribe.h
src/resource.c

Several functions have been better commented as well.