### PR TITLE
coap-server: Support for being able to create dynamic resources on the fly

### DIFF
--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -16,7 +16,7 @@ SYNOPSIS
 --------
 *coap-server* [*-A* addr] [*-g* group] [*-p* port] [*-l* loss]
               [*-k* key] [*-h* hint] [*-c* certfile] [*-C* cafile]
-              [*-R* root_cafile] [*-v* num]
+              [*-R* root_cafile] [*-v* num] [-d max]
 
 DESCRIPTION
 -----------
@@ -77,6 +77,11 @@ OPTIONS
 
 *-v* num::
    The verbosity level to use (default: 3, maximum is 9).
+
+*-d* max::
+   Enable support for creation of dynamic resources when doing a PUT up to a
+   limit of max.  If max is reached, a 4.06 code is returned until one of the
+   dynamic resources has been deleted.
 
 EXAMPLES
 --------

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -301,7 +301,7 @@ coap_string_t *query, coap_pdu_t *response) {
   int len;
   coap_string_t *uri_path;
 
-  /* get the uri_path - wwhill will get used by coap_resource_init() */
+  /* get the uri_path - which will get used by coap_resource_init() */
   uri_path = coap_get_uri_path(request);
   if (!uri_path) {
     response->code = COAP_RESPONSE_CODE(404);


### PR DESCRIPTION
Add in -d option, which then causes coap_resource_unknown_init() to get
called to support creation of dynamic resources for unknown resources.