### PR TITLE
Missing case for #201 to close down con_active

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -2122,6 +2122,9 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
 
       coap_log(LOG_ALERT, "got RST for message %d\n", pdu->tid);
 
+      if (session->con_active)
+        session->con_active--;
+
       /* find transaction in sendqueue to stop retransmission */
       coap_remove_from_queue(&context->sendqueue, session, pdu->tid, &sent);
 


### PR DESCRIPTION
The RST to a CoAP Ping was not decrementing the con_active count, so
all new CON requests were waiting for the Ping to expire.