### PR TITLE
Rename coap_session_t sendqueue variable to delayqueue

### DIFF
--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -69,7 +69,7 @@ typedef struct coap_session_t {
   void *tls;			  /**< security parameters */
   uint16_t tx_mid;                /**< the last message id that was used in this session */
   uint8_t con_active;             /**< Active CON request sent */
-  struct coap_queue_t *sendqueue; /**< list of messages waiting to be sent */
+  struct coap_queue_t *delayqueue; /**< list of delayed messages waiting to be sent */
   size_t partial_write;           /**< if > 0 indicates number of bytes already written from the pdu at the head of sendqueue */
   uint8_t read_header[8];         /**< storage space for header of incoming message header */
   size_t partial_read;            /**< if > 0 indicates number of bytes already read for an incoming message */

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1077,10 +1077,13 @@ coap_write(coap_context_t *ctx,
         sockets[(*num_sockets)++] = &ep->sock;
     }
     LL_FOREACH_SAFE(ep->sessions, s, tmp) {
-      if (s->type == COAP_SESSION_TYPE_SERVER && s->ref == 0 && s->sendqueue == NULL && (s->last_rx_tx + session_timeout <= now || s->state == COAP_SESSION_STATE_NONE)) {
+      if (s->type == COAP_SESSION_TYPE_SERVER && s->ref == 0 &&
+          s->delayqueue == NULL &&
+          (s->last_rx_tx + session_timeout <= now ||
+           s->state == COAP_SESSION_STATE_NONE)) {
         coap_session_free(s);
       } else {
-        if (s->type == COAP_SESSION_TYPE_SERVER && s->ref == 0 && s->sendqueue == NULL) {
+        if (s->type == COAP_SESSION_TYPE_SERVER && s->ref == 0 && s->delayqueue == NULL) {
           coap_tick_t s_timeout = (s->last_rx_tx + session_timeout) - now;
           if (timeout == 0 || s_timeout < timeout)
             timeout = s_timeout;


### PR DESCRIPTION
This better describes what is going on here (as they are created by
coap_session_delay_pdu()) and are only released off this queue when
either the session becomes established, or the outstanding CON requests
falls below COAP_DEFAULT_NSTART (a value of 1).

This is to remove confusion with the use of coap_context_t sendqueue
which is used for retransmitting data after no response detected for a
CON request.

include/coap/coap_session.h
src/coap_io.c
src/coap_session.c
src/net.c

As discussed in #230 comment.