### PR TITLE
openssl.c: Global dtls_event variable causing confusion when events happen

### DIFF
--- a/include/coap/coap_event.h
+++ b/include/coap/coap_event.h
@@ -10,11 +10,14 @@
 #ifndef _COAP_EVENT_H_
 #define _COAP_EVENT_H_
 
+#include "libcoap.h"
+
 struct coap_context_t;
+struct coap_session_t;
 
 /**
  * @defgroup events Event API
- * API functions for event deliver from lower-layer library functions.
+ * API functions for event delivery from lower-layer library functions.
  * @{
  */
 
@@ -38,8 +41,8 @@ struct coap_context_t;
  * passed as the third argument.
  */
 typedef int (*coap_event_handler_t)(struct coap_context_t *,
-                                    coap_event_t,
-                                    void *);
+                                    coap_event_t event,
+                                    struct coap_session_t *session);
 
 /**
  * Registers the function @p hnd as callback for events from the given
@@ -47,16 +50,34 @@ typedef int (*coap_event_handler_t)(struct coap_context_t *,
  * registered with @p context will be overwritten by this operation.
  *
  * @param context The CoAP context to register the event handler with.
+ * @param hnd     The event handler to be registered.  @c NULL if to be
+ *                de-registered.
+ */
+void coap_register_event_handler(struct coap_context_t *context,
+                            coap_event_handler_t hnd);
+
+/**
+ * Registers the function @p hnd as callback for events from the given
+ * CoAP context @p context. Any event handler that has previously been
+ * registered with @p context will be overwritten by this operation.
+ *
+ * @deprecated Use coap_register_event_handler() instead.
+ *
+ * @param context The CoAP context to register the event handler with.
  * @param hnd     The event handler to be registered.
  */
+COAP_DEPRECATED
 void coap_set_event_handler(struct coap_context_t *context,
                             coap_event_handler_t hnd);
 
 /**
  * Clears the event handler registered with @p context.
  *
+ * @deprecated Use coap_register_event_handler() instead with NULL for hnd.
+ *
  * @param context The CoAP context whose event handler is to be removed.
  */
+COAP_DEPRECATED
 void coap_clear_event_handler(struct coap_context_t *context);
 
 /** @} */

--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -84,7 +84,8 @@ typedef struct coap_session_t {
   unsigned int max_retransmit;          /**< maximum re-transmit count (default 4) */
   coap_fixed_point_t ack_timeout;       /**< timeout waiting for ack (default 2 secs) */
   coap_fixed_point_t ack_random_factor; /**< ack random factor backoff (default 1.5) */
-  unsigned int dtls_timeout_count;      /**<dtls setup retry counter */
+  unsigned int dtls_timeout_count;      /**< dtls setup retry counter */
+  int dtls_event;                       /**< Tracking any (D)TLS events on this sesison */
 } coap_session_t;
 
 /**

--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -570,13 +570,13 @@ int coap_handle_dgram(coap_context_t *ctx, coap_session_t *session, uint8_t *dat
  *
  * @param context The CoAP context whose event handler is to be called.
  * @param event   The event to deliver.
- * @param data    Any data related to @p event.
+ * @param session The session related to @p event.
  * @return The result from the associated event handler or 0 if none was
  * registered.
  */
 int coap_handle_event(coap_context_t *context,
                       coap_event_t event,
-                      void *data);
+                      coap_session_t *session);
 /**
  * This function removes the element with given @p id from the list given list.
  * If @p id was found, @p node is updated to point to the removed element. Note

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -126,6 +126,7 @@ global:
   coap_print_wellknown;
   coap_read;
   coap_register_async;
+  coap_register_event_handler;
   coap_register_handler;
   coap_remove_async;
   coap_remove_from_queue;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -124,6 +124,7 @@ coap_print_link
 coap_print_wellknown
 coap_read
 coap_register_async
+coap_register_event_handler
 coap_register_handler
 coap_remove_async
 coap_remove_from_queue

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -12,7 +12,7 @@ NAME
 ----
 coap_handler, coap_register_handler, coap_register_response_handler, 
 coap_register_nack_handler, coap_register_ping_handler, 
-coap_register_pong_handler
+coap_register_pong_handler, coap_register_event_handler
 - work with CoAP handlers
 
 SYNOPSIS
@@ -33,6 +33,9 @@ coap_ping_handler_t _handler_)*;
 
 *void coap_register_pong_handler(coap_context_t *_context_, 
 coap_pong_handler_t _handler_)*;
+
+*void coap_register_event_handler(coap_context_t *_context_, 
+coap_event_handler_t _handler_)*;
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
 or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
@@ -69,7 +72,8 @@ typedef void (*coap_method_handler_t)(coap_context_t *context,
 The *coap_register_response_handler*() function defines a request's response 
 _handler_ for traffic associated with the _context_.  The application can use 
 this for handling any response packets, including sending a RST packet if this 
-response was unexpected.
+response was unexpected.  If _handler_ is NULL, then the handler is
+de-registered.
 
 The handler function prototype is defined as:
 [source, c]
@@ -83,6 +87,7 @@ typedef void (*coap_response_handler_t)(coap_context_t *context,
 
 The *coap_register_nack_handler*() function defines a request's negative 
 response _handler_ for traffic associated with the _context_.
+If _handler_ is NULL, then the handler is de-registered.
 
 The handler function prototype is defined as:
 [source, c]
@@ -95,27 +100,63 @@ typedef void (*coap_nack_handler_t)(coap_context_t *context,
 ----
 
 The *coap_register_ping_handler*() function defines a _handler_ for tracking 
-CoAP ping traffic associated with the _context_.
+CoAP ping traffic associated with the _context_. If _handler_ is NULL, then
+the handler is de-registered.
 
 The handler function prototype is defined as:
 [source, c]
 ----
 typedef void (*coap_ping_handler_t)(coap_context_t *context,
-                                        coap_session_t *session,
-                                        coap_pdu_t *received,
-                                        const coap_tid_t id);
+                                    coap_session_t *session,
+                                    coap_pdu_t *received,
+                                    const coap_tid_t id);
 ----
 
 The *coap_register_pong_handler*() function defines a _handler_ for tracking 
 CoAP TCP ping response traffic associated with the _context_.
+If _handler_ is NULL, then the handler is de-registered.
 
 The handler function prototype is defined as:
 [source, c]
 ----
 typedef void (*coap_pong_handler_t)(coap_context_t *context,
-                                        coap_session_t *session,
-                                        coap_pdu_t *received,
-                                        const coap_tid_t id);
+                                    coap_session_t *session,
+                                    coap_pdu_t *received,
+                                    const coap_tid_t id);
+----
+
+The *coap_register_event_handler*() function defines a _handler_ for tracking
+(D)TLS events associated with the _context_. If _handler_ is NULL, then
+the handler is de-registered.
+
+The handler function prototype is defined as:
+[source, c]
+----
+typedef void (*coap_event_handler_t)(coap_context_t *context,
+                                     coap_event_t event,
+                                     coap_session_t *session);
+----
+Events can be one of the following
+----
+/**
+ * (D)TLS events for COAP_PROTO_DTLS and COAP_PROTO_TLS
+ */
+COAP_EVENT_DTLS_CLOSED        0x0000
+COAP_EVENT_DTLS_CONNECTED     0x01DE
+COAP_EVENT_DTLS_RENEGOTIATE   0x01DF
+COAP_EVENT_DTLS_ERROR         0x0200
+/**
+ * TCP events for COAP_PROTO_TCP and COAP_PROTO_TLS
+ */
+COAP_EVENT_TCP_CONNECTED      0x1001
+COAP_EVENT_TCP_CLOSED         0x1002
+COAP_EVENT_TCP_FAILED         0x1003
+/**
+ * CSM exchange events for reliable protocols only
+ */
+COAP_EVENT_SESSION_CONNECTED  0x2001
+COAP_EVENT_SESSION_CLOSED     0x2002
+COAP_EVENT_SESSION_FAILED     0x2003
 ----
 
 EXAMPLES

--- a/src/coap_event.c
+++ b/src/coap_event.c
@@ -10,8 +10,19 @@
 #include "coap_event.h"
 #include "net.h"
 
+/*
+ * This replaces coap_set_event_handler() so that handler registration is
+ * consistent in the naming.
+ */
 void
-coap_set_event_handler(struct coap_context_t *context, coap_event_handler_t hnd) {
+coap_register_event_handler(struct coap_context_t *context,
+                            coap_event_handler_t hnd) {
+  context->handle_event = hnd;
+}
+
+void
+coap_set_event_handler(struct coap_context_t *context,
+                       coap_event_handler_t hnd) {
   context->handle_event = hnd;
 }
 

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -135,6 +135,7 @@ coap_make_session(coap_proto_t proto, coap_session_type_t type,
   session->max_retransmit = COAP_DEFAULT_MAX_RETRANSMIT;
   session->ack_timeout = COAP_DEFAULT_ACK_TIMEOUT;
   session->ack_random_factor = COAP_DEFAULT_ACK_RANDOM_FACTOR;
+  session->dtls_event = -1;
 
   /* initialize message id */
   prng((unsigned char *)&session->tx_mid, sizeof(session->tx_mid));

--- a/src/net.c
+++ b/src/net.c
@@ -2212,11 +2212,11 @@ cleanup:
 }
 
 int
-coap_handle_event(coap_context_t *context, coap_event_t event, void *data) {
+coap_handle_event(coap_context_t *context, coap_event_t event, coap_session_t *session) {
   coap_log(LOG_DEBUG, "*** EVENT: 0x%04x\n", event);
 
   if (context->handle_event) {
-    return context->handle_event(context, event, data);
+    return context->handle_event(context, event, session);
   } else {
     return 0;
   }


### PR DESCRIPTION
dtls_event is a static variable, declared outside of all the functions which
tracks (D)TLS errors for generating events etc.

If there are multiple SSL sessions being set up to the same server (as per 
Happy Eyeballs for the DOTS protocol) it is possible to asynchronously get 
dtls_event updated and the wrong SSL session then acts on it. 

Make dtls_event a part of coap_session_t to maintain separation.
Preset dtls_event to -1 in coap_make_session().

Update coap_event_handler() to have the 3rd parameter as
coap_session_t *session instead of void *arg as the parameter is always session.
Updated coap_event_handler_t to have session as the 3rd parameter.

Add in new registration handler coap_register_event_handler() to be consistent
with all the other coap_register_XXX_handler()s.
Consequently, coap_set_event_handler() and coap_clear_enent_handler() are 
deprecated.

Update coap_handler(3) to include new coap_register_event_handler().
(PR #183 event definitions are included presumptive on #183 getting merged)