### PR TITLE
Delete trailing spaces from files, replace TAB with 8*SPACE

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -13,7 +13,7 @@ General Building
 make
 sudo make install
 
-./autogen.sh will fail if there is a required package for buildling libcoap 
+./autogen.sh will fail if there is a required package for buildling libcoap
 that is missing. Install the missing package and try ./autogen.sh again.
 
 It is possible that you may need to provide some options to ./configure

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ PACKAGE CONTENTS
 This directory contains a protocol parser and basic networking
 functions for platform with support for malloc() and BSD-style
 sockets. The examples directory contains a client and a server to
-demonstrate the use of this library. 
+demonstrate the use of this library.
 
 LICENSE INFORMATION
 ===================

--- a/TODO
+++ b/TODO
@@ -2,7 +2,7 @@ This is a simple file for all kinds of stuff related on devlopment for
 libcoap. Please append (and remove) any issue you think its worthy.
 
 Classification of issues:
- Critical -> Break the library in some kind or a missing feature, maybe not 
+ Critical -> Break the library in some kind or a missing feature, maybe not
              directly but later
  Serious  -> No regression on the user side, more likly on the libcoap
              development
@@ -16,7 +16,7 @@ Classification of issues:
 -> Use coap.h as the only header to include from the public view.
 -> DTLS functionality
  -> Adding DTLS functions based on openssl
-  -> Bill Benett has starting some improvements here, please contact him 
+  -> Bill Benett has starting some improvements here, please contact him
      first before starting something
 -> Proxy functionality
  -> A coap-server should be able to act as proxy server
@@ -31,8 +31,8 @@ Classification of issues:
 -> Clean up the various inclusion for #ifdef __cplusplus #extern "C" {}
 -> Adding additional config options (like --with-pdu-size)
 -> Split of the platform related code into [foo]_platform.c files
--> In general, improving the online doxygen documentation like creating some 
-   additional information for doxygen (startpage, development information, 
+-> In general, improving the online doxygen documentation like creating some
+   additional information for doxygen (startpage, development information,
    ...)
 -> In special, improving ...
   Adding prams and return explanation in:

--- a/coap_config.h.contiki
+++ b/coap_config.h.contiki
@@ -23,14 +23,14 @@
 #define COAP_MAX_RESOURCES 3
 #endif /* COAP_MAX_RESOURCES */
 
-/** Number of attributes that can be handled (should be at least 
- * @c 2 * COAP_MAX_RESOURCES. to carry the content type and the 
+/** Number of attributes that can be handled (should be at least
+ * @c 2 * COAP_MAX_RESOURCES. to carry the content type and the
  * resource type. */
 #ifndef COAP_MAX_ATTRIBUTES
 #define COAP_MAX_ATTRIBUTES 4
 #endif /* COAP_MAX_ATTRIBUTES */
 
-/** 
+/**
  * Number of PDUs that can be stored simultaneously. This number
  * includes both, the PDUs stored for retransmission as well as the
  * PDUs received. Beware that choosing a too small value can lead to
@@ -89,8 +89,8 @@
 
 #if (defined(PLATFORM) && PLATFORM == PLATFORM_MC1322X) || defined(CONTIKI_TARGET_ECONOTAG)
 /* Redbee econotags get a special treatment here: endianness is set
- * explicitly, and 
- */ 
+ * explicitly, and
+ */
 
 #define BYTE_ORDER UIP_LITTLE_ENDIAN
 

--- a/configure.ac
+++ b/configure.ac
@@ -365,7 +365,7 @@ if test "x$build_dtls" = "xyes"; then
         # Some more sanity checking.
         if test "x$have_gnutls" != "xyes"; then
             AC_MSG_ERROR([==> You want to build libcoap with DTLS support by the GnuTLS library but pkg-config file 'gnutls.pc' could not be found!
-                      Install the package(s) containing the development files for GnuTLS, 
+                      Install the package(s) containing the development files for GnuTLS,
                       or use '--with-openssl' or disable the DTLS support using '--disable-dtls'.])
         fi
         AC_MSG_NOTICE([The use of GnuTLS was explicit requested due configure option '--with-gnutls'!])

--- a/examples/README.etsi_iot
+++ b/examples/README.etsi_iot
@@ -2,7 +2,7 @@ This README documents the test cases supported for the 1st ETSI CoAP
 plugtest on March 24/25 in Paris, France.
 <http://www.etsi.org/plugtests/coap/coap.htm>
 
-Legend: 
+Legend:
   [+] full support
   [o] partial support
   [-] no support

--- a/examples/client.c
+++ b/examples/client.c
@@ -71,7 +71,7 @@ method_t method = 1;                    /* the method we are using in our reques
 
 coap_block_t block = { .num = 0, .m = 0, .szx = 6 };
 
-unsigned int wait_seconds = 90;		/* default timeout in seconds */
+unsigned int wait_seconds = 90;                /* default timeout in seconds */
 unsigned int wait_ms = 0;
 int wait_ms_reset = 0;
 int obs_started = 0;
@@ -228,7 +228,7 @@ clear_obs(coap_context_t *ctx, coap_session_t *session) {
 
   if (coap_get_log_level() < LOG_DEBUG)
     coap_show_pdu(LOG_INFO, pdu);
-  
+
 
   tid = coap_send(session, pdu);
 
@@ -400,8 +400,8 @@ message_handler(struct coap_context_t *ctx,
           if (tid == COAP_INVALID_TID) {
             coap_log(LOG_DEBUG, "message_handler: error sending new request\n");
           } else {
-	    wait_ms = wait_seconds * 1000;
-	    wait_ms_reset = 1;
+            wait_ms = wait_seconds * 1000;
+            wait_ms_reset = 1;
           }
 
           return;
@@ -480,13 +480,13 @@ message_handler(struct coap_context_t *ctx,
           if (coap_get_log_level() < LOG_DEBUG)
             coap_show_pdu(LOG_INFO, pdu);
 
-	  tid = coap_send(session, pdu);
+          tid = coap_send(session, pdu);
 
           if (tid == COAP_INVALID_TID) {
             coap_log(LOG_DEBUG, "message_handler: error sending new request\n");
           } else {
-	    wait_ms = wait_seconds * 1000;
-	    wait_ms_reset = 1;
+            wait_ms = wait_seconds * 1000;
+            wait_ms_reset = 1;
           }
 
           return;
@@ -773,7 +773,7 @@ cmdline_blocksize(char *arg) {
  * Block1 or Block2 depending on method. */
 static void
 set_blocksize(void) {
-  static unsigned char buf[4];	/* hack: temporarily take encoded bytes */
+  static unsigned char buf[4];        /* hack: temporarily take encoded bytes */
   uint16_t opt;
   unsigned int opt_length;
 
@@ -1120,23 +1120,23 @@ get_session(
     for ( rp = result; rp != NULL; rp = rp->ai_next ) {
       coap_address_t bind_addr;
       if ( rp->ai_addrlen <= sizeof( bind_addr.addr ) ) {
-	coap_address_init( &bind_addr );
-	bind_addr.size = rp->ai_addrlen;
-	memcpy( &bind_addr.addr, rp->ai_addr, rp->ai_addrlen );
+        coap_address_init( &bind_addr );
+        bind_addr.size = rp->ai_addrlen;
+        memcpy( &bind_addr.addr, rp->ai_addr, rp->ai_addrlen );
         if (cert_file && (proto == COAP_PROTO_DTLS || proto == COAP_PROTO_TLS)) {
           coap_dtls_pki_t *dtls_pki = setup_pki();
           session = coap_new_client_session_pki(ctx, &bind_addr, dst, proto, dtls_pki);
         }
         else if ((identity || key) &&
                  (proto == COAP_PROTO_DTLS || proto == COAP_PROTO_TLS) ) {
-	  session = coap_new_client_session_psk( ctx, &bind_addr, dst, proto,
+          session = coap_new_client_session_psk( ctx, &bind_addr, dst, proto,
                            identity, key, key_len );
         }
-	else {
-	  session = coap_new_client_session( ctx, &bind_addr, dst, proto );
+        else {
+          session = coap_new_client_session( ctx, &bind_addr, dst, proto );
         }
-	if ( session )
-	  break;
+        if ( session )
+          break;
       }
     }
     freeaddrinfo( result );
@@ -1197,11 +1197,11 @@ main(int argc, char **argv) {
       break;
     case 'e':
       if (!cmdline_input(optarg, &payload))
-	payload.length = 0;
+        payload.length = 0;
       break;
     case 'f':
       if (!cmdline_input_from_file(optarg, &payload))
-	payload.length = 0;
+        payload.length = 0;
       break;
     case 'k':
       key_length = cmdline_read_key(optarg, key, MAX_KEY);
@@ -1224,11 +1224,11 @@ main(int argc, char **argv) {
       output_file.s = (unsigned char *)coap_malloc(output_file.length + 1);
 
       if (!output_file.s) {
-	fprintf(stderr, "cannot set output file: insufficient memory\n");
-	exit(-1);
+        fprintf(stderr, "cannot set output file: insufficient memory\n");
+        exit(-1);
       } else {
-	/* copy filename including trailing zero */
-	memcpy(output_file.s, optarg, output_file.length + 1);
+        /* copy filename including trailing zero */
+        memcpy(output_file.s, optarg, output_file.length + 1);
       }
       break;
     case 'A':
@@ -1242,8 +1242,8 @@ main(int argc, char **argv) {
       break;
     case 'P':
       if (!cmdline_proxy(optarg)) {
-	fprintf(stderr, "error specifying proxy address\n");
-	exit(-1);
+        fprintf(stderr, "error specifying proxy address\n");
+        exit(-1);
       }
       break;
     case 'T':
@@ -1252,7 +1252,7 @@ main(int argc, char **argv) {
     case 'u':
       user_length = cmdline_read_user(optarg, user, MAX_USER);
       if (user_length >= 0)
-	user[user_length] = 0;
+        user[user_length] = 0;
       break;
     case 'U':
       create_uri_opts = 0;
@@ -1262,8 +1262,8 @@ main(int argc, char **argv) {
       break;
     case 'l':
       if (!coap_debug_set_packet_loss(optarg)) {
-	usage(argv[0], LIBCOAP_PACKAGE_VERSION);
-	exit(1);
+        usage(argv[0], LIBCOAP_PACKAGE_VERSION);
+        exit(1);
       }
       break;
     case 'r':
@@ -1295,7 +1295,7 @@ main(int argc, char **argv) {
     coap_log( LOG_CRIT, "Invalid user name or key specified\n" );
     goto finish;
   }
-  
+
   if (proxy.length) {
     server.length = proxy.length;
     server.s = proxy.s;
@@ -1401,24 +1401,24 @@ main(int argc, char **argv) {
 
     if ( result >= 0 ) {
       if ( wait_ms > 0 && !wait_ms_reset ) {
-	if ( (unsigned)result >= wait_ms ) {
-	  info( "timeout\n" );
-	  break;
-	} else {
-	  wait_ms -= result;
-	}
+        if ( (unsigned)result >= wait_ms ) {
+          info( "timeout\n" );
+          break;
+        } else {
+          wait_ms -= result;
+        }
       }
       if ( obs_ms > 0 && !obs_ms_reset ) {
-	if ( (unsigned)result >= obs_ms ) {
-	  coap_log(LOG_DEBUG, "clear observation relationship\n" );
-	  clear_obs( ctx, session ); /* FIXME: handle error case COAP_TID_INVALID */
+        if ( (unsigned)result >= obs_ms ) {
+          coap_log(LOG_DEBUG, "clear observation relationship\n" );
+          clear_obs( ctx, session ); /* FIXME: handle error case COAP_TID_INVALID */
 
-	  /* make sure that the obs timer does not fire again */
-	  obs_ms = 0;
-	  obs_seconds = 0;
-	} else {
-	  obs_ms -= result;
-	}
+          /* make sure that the obs timer does not fire again */
+          obs_ms = 0;
+          obs_seconds = 0;
+        } else {
+          obs_ms -= result;
+        }
       }
       wait_ms_reset = 0;
       obs_ms_reset = 0;

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -334,7 +334,7 @@ hnd_delete(coap_context_t *ctx,
       }
       dynamic_count--;
       break;
-    } 
+    }
   }
 
   /* Dynamic resource no longer required - delete it */
@@ -376,7 +376,7 @@ hnd_get(coap_context_t *ctx UNUSED_PARAM,
   for (i = 0; i < dynamic_count; i++) {
     if (coap_string_equal(uri_path, dynamic_entry[i].uri_path)) {
       break;
-    } 
+    }
   }
   if (i == dynamic_count) {
     response->code = COAP_RESPONSE_CODE(404);
@@ -429,7 +429,7 @@ hnd_put(coap_context_t *ctx UNUSED_PARAM,
   for (i = 0; i < dynamic_count; i++) {
     if (coap_string_equal(uri_path, dynamic_entry[i].uri_path)) {
       break;
-    } 
+    }
   }
   if (i == dynamic_count) {
     if (dynamic_count >= support_dynamic) {
@@ -438,7 +438,7 @@ hnd_put(coap_context_t *ctx UNUSED_PARAM,
       return;
     }
     dynamic_count++;
-    dynamic_entry = realloc (dynamic_entry, dynamic_count * sizeof(dynamic_entry[0])); 
+    dynamic_entry = realloc (dynamic_entry, dynamic_count * sizeof(dynamic_entry[0]));
     if (dynamic_entry) {
       dynamic_entry[i].uri_path = uri_path;
       dynamic_entry[i].value = NULL;
@@ -807,27 +807,27 @@ get_context(const char *node, const char *port) {
 
       ep_udp = coap_new_endpoint(ctx, &addr, COAP_PROTO_UDP);
       if (ep_udp) {
-	if (coap_dtls_is_supported() && (key_defined || cert_file)) {
-	  ep_dtls = coap_new_endpoint(ctx, &addrs, COAP_PROTO_DTLS);
-	  if (!ep_dtls)
-	    coap_log(LOG_CRIT, "cannot create DTLS endpoint\n");
-	}
+        if (coap_dtls_is_supported() && (key_defined || cert_file)) {
+          ep_dtls = coap_new_endpoint(ctx, &addrs, COAP_PROTO_DTLS);
+          if (!ep_dtls)
+            coap_log(LOG_CRIT, "cannot create DTLS endpoint\n");
+        }
       } else {
         coap_log(LOG_CRIT, "cannot create UDP endpoint\n");
         continue;
       }
       ep_tcp = coap_new_endpoint(ctx, &addr, COAP_PROTO_TCP);
       if (ep_tcp) {
-	if (coap_tls_is_supported() && (key_defined || cert_file)) {
-	  ep_tls = coap_new_endpoint(ctx, &addrs, COAP_PROTO_TLS);
-	  if (!ep_tls)
-	    coap_log(LOG_CRIT, "cannot create TLS endpoint\n");
-	}
+        if (coap_tls_is_supported() && (key_defined || cert_file)) {
+          ep_tls = coap_new_endpoint(ctx, &addrs, COAP_PROTO_TLS);
+          if (!ep_tls)
+            coap_log(LOG_CRIT, "cannot create TLS endpoint\n");
+        }
       } else {
         coap_log(LOG_CRIT, "cannot create TCP endpoint\n");
       }
       if (ep_udp)
-	goto finish;
+        goto finish;
     }
   }
 
@@ -961,8 +961,8 @@ main(int argc, char **argv) {
       break;
     case 'l':
       if (!coap_debug_set_packet_loss(optarg)) {
-	usage(argv[0], LIBCOAP_PACKAGE_VERSION);
-	exit(1);
+        usage(argv[0], LIBCOAP_PACKAGE_VERSION);
+        exit(1);
       }
       break;
     case 'N':

--- a/examples/contiki/Makefile.contiki
+++ b/examples/contiki/Makefile.contiki
@@ -28,6 +28,6 @@ LDFLAGS += -Wl,--gc-sections,--undefined=_reset_vector__,--undefined=InterruptVe
 
 CFLAGS += #-DSHORT_ERROR_RESPONSE -DNDEBUG
 
-APPS += libcoap 
+APPS += libcoap
 
 include $(CONTIKI)/Makefile.include

--- a/examples/contiki/coap-observer.c
+++ b/examples/contiki/coap-observer.c
@@ -55,7 +55,7 @@ AUTOSTART_PROCESSES(&coap_server_process);
 void
 init_coap() {
   coap_address_t listen_addr;
-  
+
   coap_address_init(&listen_addr);
   listen_addr.port = UIP_HTONS(COAP_DEFAULT_PORT);
 
@@ -73,15 +73,15 @@ init_coap() {
 
 #ifdef WITH_CONTIKI
   printf("tentative address: [%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x]:%d\r\n",
-	 listen_addr.addr.u8[0], listen_addr.addr.u8[1], 
-	 listen_addr.addr.u8[2], listen_addr.addr.u8[3], 
-	 listen_addr.addr.u8[4], listen_addr.addr.u8[5], 
-	 listen_addr.addr.u8[6], listen_addr.addr.u8[7], 
-	 listen_addr.addr.u8[8], listen_addr.addr.u8[9], 
-	 listen_addr.addr.u8[10], listen_addr.addr.u8[11], 
-	 listen_addr.addr.u8[12], listen_addr.addr.u8[13], 
-	 listen_addr.addr.u8[14], listen_addr.addr.u8[15] ,
-	 uip_ntohs(listen_addr.port));
+         listen_addr.addr.u8[0], listen_addr.addr.u8[1],
+         listen_addr.addr.u8[2], listen_addr.addr.u8[3],
+         listen_addr.addr.u8[4], listen_addr.addr.u8[5],
+         listen_addr.addr.u8[6], listen_addr.addr.u8[7],
+         listen_addr.addr.u8[8], listen_addr.addr.u8[9],
+         listen_addr.addr.u8[10], listen_addr.addr.u8[11],
+         listen_addr.addr.u8[12], listen_addr.addr.u8[13],
+         listen_addr.addr.u8[14], listen_addr.addr.u8[15] ,
+         uip_ntohs(listen_addr.port));
 #endif
 
   coap_context = coap_new_context(&listen_addr);
@@ -93,16 +93,16 @@ init_coap() {
 }
 
 void
-message_handler(struct coap_context_t  *ctx, 
-		const coap_address_t *remote, 
-		coap_pdu_t *sent,
-		coap_pdu_t *received,
-		const coap_tid_t id) {
+message_handler(struct coap_context_t  *ctx,
+                const coap_address_t *remote,
+                coap_pdu_t *sent,
+                coap_pdu_t *received,
+                const coap_tid_t id) {
   /* send ACK if received message is confirmable (i.e. a separate response) */
   coap_send_ack(ctx, remote, received);
 
   debug("** process incoming %d.%02d response:\n",
-	(received->hdr->code >> 5), received->hdr->code & 0x1F);
+        (received->hdr->code >> 5), received->hdr->code & 0x1F);
   coap_show_pdu(LOG_WARNING, received);
 
   coap_ticks(&last_seen);
@@ -131,16 +131,16 @@ PROCESS_THREAD(coap_server_process, ev, data)
   uip_ip6addr(&dst.addr, 0xaaaa, 0, 0, 0, 0x206, 0x98ff, 0xfe00, 0x232);
   /* uip_ip6addr(&dst.addr, 0xfe80, 0, 0, 0, 0x206, 0x98ff, 0xfe00, 0x232); */
 
-  request = coap_pdu_init(COAP_MESSAGE_CON, COAP_REQUEST_GET, 
-			  coap_new_message_id(coap_context), 
-			  COAP_DEFAULT_MTU);
-  
+  request = coap_pdu_init(COAP_MESSAGE_CON, COAP_REQUEST_GET,
+                          coap_new_message_id(coap_context),
+                          COAP_DEFAULT_MTU);
+
   coap_split_uri((unsigned char *)resource, strlen(resource), &uri);
 
   if (uri.port != COAP_DEFAULT_PORT) {
     unsigned char portbuf[2];
     coap_add_option(request, COAP_OPTION_URI_PORT,
-		    coap_encode_var_safe(portbuf, sizeof(portbuf),
+                    coap_encode_var_safe(portbuf, sizeof(portbuf),
                                          uri.port),
                     portbuf);
   }
@@ -157,10 +157,10 @@ PROCESS_THREAD(coap_server_process, ev, data)
     res = coap_split_path(uri.path.s, uri.path.length, buf, &buflen);
 
     while (res--) {
-      coap_add_option(request, COAP_OPTION_URI_PATH, 
-		      coap_opt_length(buf), coap_opt_value(buf));
+      coap_add_option(request, COAP_OPTION_URI_PATH,
+                      coap_opt_length(buf), coap_opt_value(buf));
 
-      buf += coap_opt_size(buf);      
+      buf += coap_opt_size(buf);
     }
   }
 
@@ -177,7 +177,7 @@ PROCESS_THREAD(coap_server_process, ev, data)
   while(1) {
     PROCESS_YIELD();
     if(ev == tcpip_event) {
-      coap_read(coap_context);	/* read received data */
+      coap_read(coap_context);        /* read received data */
       coap_dispatch(coap_context); /* and dispatch PDUs from receivequeue */
     }
   }

--- a/examples/contiki/radvd.conf.sample
+++ b/examples/contiki/radvd.conf.sample
@@ -6,9 +6,9 @@ interface tap0
 
    prefix aaaa::/64
    {
-  	AdvOnLink on; 
-        AdvAutonomous on; 
-        AdvRouterAddr on; 
+  	AdvOnLink on;
+        AdvAutonomous on;
+        AdvRouterAddr on;
 
    };
-};   
+};  

--- a/examples/contiki/server.c
+++ b/examples/contiki/server.c
@@ -58,7 +58,7 @@ init_coap_server(coap_context_t **ctx) {
   assert(ctx);
 
   coap_set_log_level(LOG_DEBUG);
-  
+
   coap_address_init(&listen_addr);
   listen_addr.port = UIP_HTONS(COAP_DEFAULT_PORT);
 
@@ -66,7 +66,7 @@ init_coap_server(coap_context_t **ctx) {
 #ifndef CONTIKI_TARGET_MINIMAL_NET
   uip_ds6_prefix_add(&listen_addr.addr, 64, 0, 0, 0, 0);
 #endif /* not CONTIKI_TARGET_MINIMAL_NET */
-  
+
   uip_ds6_addr_add(&listen_addr.addr, 0, ADDR_MANUAL);
 
   /* set default route to gateway aaaa::1 */
@@ -90,12 +90,12 @@ init_coap_server(coap_context_t **ctx) {
 # define min(a,b) ((a) < (b) ? (a) : (b))
 #endif
 
-void 
+void
 hnd_get_time(coap_context_t  *ctx, struct coap_resource_t *resource,
-	     coap_session_t *session,
-	     coap_pdu_t *request, coap_binary_t *token, 
+             coap_session_t *session,
+             coap_pdu_t *request, coap_binary_t *token,
              coap_string_t *query,
-	     coap_pdu_t *response) {
+             coap_pdu_t *response) {
   unsigned char buf[40];
   size_t len;
   coap_tick_t now;
@@ -105,31 +105,31 @@ hnd_get_time(coap_context_t  *ctx, struct coap_resource_t *resource,
    * when query ?ticks is given. */
 
   /* if my_clock_base was deleted, we pretend to have no such resource */
-  response->code = 
+  response->code =
     my_clock_base ? COAP_RESPONSE_CODE(205) : COAP_RESPONSE_CODE(404);
 
   if (coap_find_observer(resource, session, token)) {
-    coap_add_option(response, COAP_OPTION_OBSERVE, 
-		    coap_encode_var_safe(buf, sizeof(buf),
+    coap_add_option(response, COAP_OPTION_OBSERVE,
+                    coap_encode_var_safe(buf, sizeof(buf),
                                          resource->observe),
                     buf);
   }
 
   if (my_clock_base)
     coap_add_option(response, COAP_OPTION_CONTENT_FORMAT,
-		    coap_encode_var_safe(buf, sizeof(buf),
+                    coap_encode_var_safe(buf, sizeof(buf),
                     COAP_MEDIATYPE_TEXT_PLAIN),
                     buf);
 
   coap_add_option(response, COAP_OPTION_MAXAGE,
-	  coap_encode_var_safe(buf, sizeof(buf), 0x01), buf);
+          coap_encode_var_safe(buf, sizeof(buf), 0x01), buf);
 
   if (my_clock_base) {
 
     /* calculate current time */
     coap_ticks(&t);
     now = my_clock_base + (t / COAP_TICKS_PER_SECOND);
-    
+
 
     if (query != NULL
         && coap_string_equal(query, coap_make_str_const("ticks"))) {

--- a/examples/etsi_coaptest.sh
+++ b/examples/etsi_coaptest.sh
@@ -86,7 +86,7 @@ testnumber=$((OPTARG-1))
 g) # name of test group
 # is there a group with that name?
 for i in "${testgroups[@]}"
-  do 
+  do
   # group doesn't have to be case sensitive
   tmpgroup=$(echo $OPTARG | tr '[:lower:]' '[:upper:]')
   if [  $i == $tmpgroup ] ; then

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2012--2013 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <string.h>
@@ -37,28 +37,28 @@ static int quit = 0;
 
 #define COAP_OPT_BLOCK_SZX_MAX 6 /**< allowed maximum for block szx value */
 
-#define REQUIRE_ETAG 0x01 	/* flag for coap_payload_t: require ETag option  */
+#define REQUIRE_ETAG 0x01         /* flag for coap_payload_t: require ETag option  */
 typedef struct {
   UT_hash_handle hh;
-  coap_key_t resource_key;	/* foreign key that points into resource space */
-  unsigned int flags;		/* some flags to control behavior */
-  size_t max_data;		/* maximum size allocated for @p data */
-  uint16_t media_type;		/* media type for this object */
-  size_t length;		/* length of data */
-  unsigned char data[];		/* the actual contents */
+  coap_key_t resource_key;        /* foreign key that points into resource space */
+  unsigned int flags;             /* some flags to control behavior */
+  size_t max_data;                /* maximum size allocated for @p data */
+  uint16_t media_type;            /* media type for this object */
+  size_t length;                  /* length of data */
+  unsigned char data[];           /* the actual contents */
 } coap_payload_t;
 
 coap_payload_t *test_resources = NULL;
 
-/** 
+/**
  * This structure is used to store URIs for dynamically allocated
  * resources, usually by POST or PUT.
  */
 typedef struct {
   UT_hash_handle hh;
-  coap_key_t resource_key;	/* foreign key that points into resource space */
-  size_t length;		/* length of data */
-  unsigned char data[];		/* the actual contents */
+  coap_key_t resource_key;        /* foreign key that points into resource space */
+  size_t length;                  /* length of data */
+  unsigned char data[];           /* the actual contents */
 } coap_dynamic_uri_t;
 
 coap_dynamic_uri_t *test_dynamic_uris = NULL;
@@ -74,7 +74,7 @@ handle_sigint(int signum) {
 }
 
 #define INDEX "libcoap server for ETSI CoAP Plugtest, March 2012, Paris\n" \
-   	      "Copyright (C) 2012 Olaf Bergmann <bergmann@tzi.org>\n\n"
+                 "Copyright (C) 2012 Olaf Bergmann <bergmann@tzi.org>\n\n"
 
 coap_payload_t *
 coap_new_payload(size_t size) {
@@ -97,9 +97,9 @@ coap_find_payload(const coap_key_t key) {
 
 static inline void
 coap_add_payload(const coap_key_t key, coap_payload_t *payload,
-		 coap_dynamic_uri_t *uri) {
+                 coap_dynamic_uri_t *uri) {
   assert(payload);
-  
+
   memcpy(payload->resource_key, key, sizeof(coap_key_t));
   HASH_ADD(hh, test_resources, resource_key, sizeof(coap_key_t), payload);
 
@@ -113,8 +113,8 @@ static inline void
 coap_delete_payload(coap_payload_t *payload) {
   if (payload) {
     coap_dynamic_uri_t *uri;
-    HASH_FIND(hh, test_dynamic_uris, 
-	      payload->resource_key, sizeof(coap_key_t), uri);
+    HASH_FIND(hh, test_dynamic_uris,
+              payload->resource_key, sizeof(coap_key_t), uri);
     if (uri) {
       HASH_DELETE(hh, test_dynamic_uris, uri);
       coap_free(uri);
@@ -125,30 +125,30 @@ coap_delete_payload(coap_payload_t *payload) {
   coap_free(payload);
 }
 
-void 
-hnd_get_index(coap_context_t  *ctx, struct coap_resource_t *resource, 
-	      coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
-	      coap_pdu_t *response) {
+void
+hnd_get_index(coap_context_t  *ctx, struct coap_resource_t *resource,
+              coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
+              coap_pdu_t *response) {
   unsigned char buf[3];
 
   response->code = COAP_RESPONSE_CODE(205);
 
   coap_add_option(response, COAP_OPTION_CONTENT_TYPE,
-	          coap_encode_var_safe(buf, sizeof(buf),
+                  coap_encode_var_safe(buf, sizeof(buf),
                                        COAP_MEDIATYPE_TEXT_PLAIN),
                   buf);
 
   coap_add_option(response, COAP_OPTION_MAXAGE,
-	  coap_encode_var_safe(buf, sizeof(buf), 0x2ffff), buf);
-    
+          coap_encode_var_safe(buf, sizeof(buf), 0x2ffff), buf);
+
   coap_add_data(response, strlen(INDEX), (unsigned char *)INDEX);
 }
 
 
-void 
-hnd_get_resource(coap_context_t  *ctx, struct coap_resource_t *resource, 
-		 coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
-		 coap_pdu_t *response) {
+void
+hnd_get_resource(coap_context_t  *ctx, struct coap_resource_t *resource,
+                 coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
+                 coap_pdu_t *response) {
   coap_key_t etag;
   unsigned char buf[2];
   coap_payload_t *test_payload;
@@ -157,14 +157,14 @@ hnd_get_resource(coap_context_t  *ctx, struct coap_resource_t *resource,
   test_payload = coap_find_payload(resource->key);
   if (!test_payload) {
     response->code = COAP_RESPONSE_CODE(500);
-    
+
     return;
   }
 
   response->code = COAP_RESPONSE_CODE(205);
 
   coap_add_option(response, COAP_OPTION_CONTENT_TYPE,
-	          coap_encode_var_safe(buf, sizeof(buf),
+                  coap_encode_var_safe(buf, sizeof(buf),
                                        test_payload->media_type),
                   buf);
 
@@ -174,59 +174,59 @@ hnd_get_resource(coap_context_t  *ctx, struct coap_resource_t *resource,
     coap_hash(test_payload->data, test_payload->length, etag);
     coap_add_option(response, COAP_OPTION_ETAG, sizeof(etag), etag);
   }
-      
+
   if (request) {
     int res;
 
     if (coap_get_block(request, COAP_OPTION_BLOCK2, &block)) {
       res = coap_write_block_opt(&block, COAP_OPTION_BLOCK2, response,
-				 test_payload->length);
+                                 test_payload->length);
 
       switch (res) {
-      case -2:			/* illegal block */
-	response->code = COAP_RESPONSE_CODE(400);
-	goto error;
-      case -1:			/* should really not happen */
-	assert(0);
-	/* fall through if assert is a no-op */
-      case -3:			/* cannot handle request */
-	response->code = COAP_RESPONSE_CODE(500);
-	goto error;
-      default:			/* everything is good */
-	;
+      case -2:                        /* illegal block */
+        response->code = COAP_RESPONSE_CODE(400);
+        goto error;
+      case -1:                        /* should really not happen */
+        assert(0);
+        /* fall through if assert is a no-op */
+      case -3:                        /* cannot handle request */
+        response->code = COAP_RESPONSE_CODE(500);
+        goto error;
+      default:                        /* everything is good */
+        ;
       }
-      
+
       coap_add_block(response, test_payload->length, test_payload->data,
-		     block.num, block.szx);
+                     block.num, block.szx);
     } else {
       if (!coap_add_data(response, test_payload->length, test_payload->data)) {
-	/* set initial block size, will be lowered by
-	 * coap_write_block_opt) automatically */
-	block.szx = 6;
-	coap_write_block_opt(&block, COAP_OPTION_BLOCK2, response,
-			     test_payload->length);
-	
-	coap_add_block(response, test_payload->length, test_payload->data,
-		       block.num, block.szx);	
+        /* set initial block size, will be lowered by
+         * coap_write_block_opt) automatically */
+        block.szx = 6;
+        coap_write_block_opt(&block, COAP_OPTION_BLOCK2, response,
+                             test_payload->length);
+
+        coap_add_block(response, test_payload->length, test_payload->data,
+                       block.num, block.szx);
       }
-    }    
-  } else {		      /* this is a notification, block is 0 */
+    }
+  } else {                      /* this is a notification, block is 0 */
     /* FIXME: need to store block size with subscription */
   }
-  
+
   return;
 
  error:
-  coap_add_data(response, 
-		strlen(coap_response_phrase(response->code)),
-		(unsigned char *)coap_response_phrase(response->code));
+  coap_add_data(response,
+                strlen(coap_response_phrase(response->code)),
+                (unsigned char *)coap_response_phrase(response->code));
 }
 
 /* DELETE handler for dynamic resources created by POST /test */
-void 
-hnd_delete_resource(coap_context_t  *ctx, struct coap_resource_t *resource, 
-		coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
-		coap_pdu_t *response) {
+void
+hnd_delete_resource(coap_context_t  *ctx, struct coap_resource_t *resource,
+                coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
+                coap_pdu_t *response) {
   coap_payload_t *payload;
 
   payload = coap_find_payload(resource->key);
@@ -239,10 +239,10 @@ hnd_delete_resource(coap_context_t  *ctx, struct coap_resource_t *resource,
   response->code = COAP_RESPONSE_CODE(202);
 }
 
-void 
-hnd_post_test(coap_context_t  *ctx, struct coap_resource_t *resource, 
-	      coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
-	      coap_pdu_t *response) {
+void
+hnd_post_test(coap_context_t  *ctx, struct coap_resource_t *resource,
+              coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
+              coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
   coap_payload_t *test_payload;
@@ -264,7 +264,7 @@ hnd_post_test(coap_context_t  *ctx, struct coap_resource_t *resource,
   uri = (coap_dynamic_uri_t *)coap_malloc(sizeof(coap_dynamic_uri_t) + l);
   if (!(test_payload && uri)) {
     coap_log(LOG_CRIT, "cannot allocate new resource under /test");
-    response->code = COAP_RESPONSE_CODE(500);    
+    response->code = COAP_RESPONSE_CODE(500);
     coap_free(test_payload);
     coap_free(uri);
   } else {
@@ -283,8 +283,8 @@ hnd_post_test(coap_context_t  *ctx, struct coap_resource_t *resource,
     /* set media_type if available */
     option = coap_check_option(request, COAP_OPTION_CONTENT_TYPE, &opt_iter);
     if (option) {
-      test_payload->media_type = 
-	coap_decode_var_bytes(COAP_OPT_VALUE(option), COAP_OPT_LENGTH(option));
+      test_payload->media_type =
+        coap_decode_var_bytes(COAP_OPT_VALUE(option), COAP_OPT_LENGTH(option));
     }
 
     coap_add_resource(ctx, r);
@@ -295,9 +295,9 @@ hnd_post_test(coap_context_t  *ctx, struct coap_resource_t *resource,
 
     while (res--) {
       coap_add_option(response, COAP_OPTION_LOCATION_PATH,
-		      coap_opt_length(buf), coap_opt_value(buf));
-      
-      buf += coap_opt_size(buf);      
+                      coap_opt_length(buf), coap_opt_value(buf));
+
+      buf += coap_opt_size(buf);
     }
 
     response->code = COAP_RESPONSE_CODE(201);
@@ -305,10 +305,10 @@ hnd_post_test(coap_context_t  *ctx, struct coap_resource_t *resource,
 
 }
 
-void 
-hnd_put_test(coap_context_t  *ctx, struct coap_resource_t *resource, 
-	      coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
-	      coap_pdu_t *response) {
+void
+hnd_put_test(coap_context_t  *ctx, struct coap_resource_t *resource,
+              coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
+              coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
   coap_payload_t *payload;
@@ -327,26 +327,26 @@ hnd_put_test(coap_context_t  *ctx, struct coap_resource_t *resource,
        is gone */
   }
 
-  if (!payload) {		/* create new payload */
+  if (!payload) {                /* create new payload */
     payload = coap_new_payload(len);
     if (!payload)
       goto error;
 
     coap_add_payload(resource->key, payload, NULL);
-  } 
+  }
   payload->length = len;
   memcpy(payload->data, data, len);
 
   option = coap_check_option(request, COAP_OPTION_CONTENT_TYPE, &opt_iter);
   if (option) {
     /* set media type given in request */
-    payload->media_type = 
+    payload->media_type =
       coap_decode_var_bytes(COAP_OPT_VALUE(option), COAP_OPT_LENGTH(option));
   } else {
     /* set default value */
     payload->media_type = COAP_MEDIATYPE_TEXT_PLAIN;
   }
-  /* FIXME: need to change attribute ct of resource. 
+  /* FIXME: need to change attribute ct of resource.
      To do so, we need dynamic management of the attribute value
   */
 
@@ -356,10 +356,10 @@ hnd_put_test(coap_context_t  *ctx, struct coap_resource_t *resource,
   response->code = COAP_RESPONSE_CODE(500);
 }
 
-void 
-hnd_delete_test(coap_context_t  *ctx, struct coap_resource_t *resource, 
-		coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
-		coap_pdu_t *response) {
+void
+hnd_delete_test(coap_context_t  *ctx, struct coap_resource_t *resource,
+                coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
+                coap_pdu_t *response) {
   /* the ETSI validation tool does not like empty resources... */
 #if 0
   coap_payload_t *payload;
@@ -372,10 +372,10 @@ hnd_delete_test(coap_context_t  *ctx, struct coap_resource_t *resource,
   response->code = COAP_RESPONSE_CODE(202);
 }
 
-void 
-hnd_get_query(coap_context_t  *ctx, struct coap_resource_t *resource, 
-	      coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
-	      coap_pdu_t *response) {
+void
+hnd_get_query(coap_context_t  *ctx, struct coap_resource_t *resource,
+              coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
+              coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_filter_t f;
   coap_opt_t *q;
@@ -385,15 +385,15 @@ hnd_get_query(coap_context_t  *ctx, struct coap_resource_t *resource,
   response->code = COAP_RESPONSE_CODE(205);
 
   coap_add_option(response, COAP_OPTION_CONTENT_TYPE,
-	          coap_encode_var_safe(buf, sizeof(buf),
+                  coap_encode_var_safe(buf, sizeof(buf),
                                        COAP_MEDIATYPE_TEXT_PLAIN),
                   buf);
 
   coap_option_filter_clear(f);
   coap_option_setb(f, COAP_OPTION_URI_QUERY);
-  
+
   coap_option_iterator_init(request, &opt_iter, f);
-  
+
   len = 0;
   while ((len < sizeof(buf)) && (q = coap_option_next(&opt_iter))) {
     L = min(sizeof(buf) - len, 11);
@@ -403,19 +403,19 @@ hnd_get_query(coap_context_t  *ctx, struct coap_resource_t *resource,
     L = min(sizeof(buf) - len, COAP_OPT_LENGTH(q));
     memcpy(buf + len, COAP_OPT_VALUE(q), L);
     len += L;
-    
+
     if (len < sizeof(buf))
       buf[len++] = '\n';
   }
-  
+
   coap_add_data(response, len, buf);
 }
 
 /* handler for TD_COAP_CORE_16 */
-void 
-hnd_get_separate(coap_context_t  *ctx, struct coap_resource_t *resource, 
-		 coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
-		 coap_pdu_t *response) {
+void
+hnd_get_separate(coap_context_t  *ctx, struct coap_resource_t *resource,
+                 coap_address_t *peer, coap_pdu_t *request, coap_binary_t *token,
+                 coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
   coap_opt_filter_t f;
@@ -433,70 +433,70 @@ hnd_get_separate(coap_context_t  *ctx, struct coap_resource_t *resource,
   /* search for option delay in query list */
   coap_option_filter_clear(f);
   coap_option_setb(f, COAP_OPTION_URI_QUERY);
-  
+
   coap_option_iterator_init(request, &opt_iter, f);
-  
+
   while ((option = coap_option_next(&opt_iter))) {
     if (strncmp("delay=", (char *)COAP_OPT_VALUE(option), 6) == 0) {
       int i;
       unsigned long d = 0;
-      
+
       for (i = 6; i < COAP_OPT_LENGTH(option); ++i)
-	d = d * 10 + COAP_OPT_VALUE(option)[i] - '0';
+        d = d * 10 + COAP_OPT_VALUE(option)[i] - '0';
 
       /* don't allow delay to be less than COAP_RESOURCE_CHECK_TIME*/
-      delay = d < COAP_RESOURCE_CHECK_TIME_SEC 
-	? COAP_RESOURCE_CHECK_TIME_SEC
-	: d;
+      delay = d < COAP_RESOURCE_CHECK_TIME_SEC
+        ? COAP_RESOURCE_CHECK_TIME_SEC
+        : d;
       debug("set delay to %lu\n", delay);
       break;
     }
   }
 
   async = coap_register_async(ctx, peer, request, COAP_ASYNC_SEPARATE,
-			      (void *)(COAP_TICKS_PER_SECOND * delay));
+                              (void *)(COAP_TICKS_PER_SECOND * delay));
 }
 
-void 
+void
 check_async(coap_context_t  *ctx, coap_tick_t now) {
   coap_pdu_t *response;
   coap_async_state_t *tmp;
   unsigned char buf[2];
   size_t size = 8;
 
-  if (!async || now < async->created + (unsigned long)async->appdata) 
+  if (!async || now < async->created + (unsigned long)async->appdata)
     return;
 
   size += async->tokenlen;
 
-  response = coap_pdu_init(async->flags & COAP_ASYNC_CONFIRM 
-			   ? COAP_MESSAGE_CON
-			   : COAP_MESSAGE_NON, 
-			   COAP_RESPONSE_CODE(205), 0, size);
+  response = coap_pdu_init(async->flags & COAP_ASYNC_CONFIRM
+                           ? COAP_MESSAGE_CON
+                           : COAP_MESSAGE_NON,
+                           COAP_RESPONSE_CODE(205), 0, size);
   if (!response) {
     debug("check_async: insufficient memory, we'll try later\n");
-    async->appdata = 
+    async->appdata =
       (void *)((unsigned long)async->appdata + 15 * COAP_TICKS_PER_SECOND);
     return;
   }
-  
+
   response->tid = coap_new_message_id(ctx);
 
   if (async->tokenlen)
     coap_add_token(response, async->tokenlen, async->token);
 
   coap_add_option(response, COAP_OPTION_CONTENT_TYPE,
-		  coap_encode_var_safe(buf, sizeof(buf),
+                  coap_encode_var_safe(buf, sizeof(buf),
                                        COAP_MEDIATYPE_TEXT_PLAIN),
                   buf);
 
   coap_add_data(response, 4, (unsigned char *)"done");
 
   if (coap_send(ctx, &async->peer, response) == COAP_INVALID_TID) {
-    debug("check_async: cannot send response for message %d\n", 
-	  response->tid);
+    debug("check_async: cannot send response for message %d\n",
+          response->tid);
   }
-  
+
   coap_remove_async(ctx, async->id, &tmp);
   coap_free_async(async);
   async = NULL;
@@ -565,7 +565,7 @@ init_resources(coap_context_t *ctx) {
     coap_add_payload(r->key, test_payload, NULL);
   }
 
-  /* TD_COAP_BLOCK_01 
+  /* TD_COAP_BLOCK_01
    * TD_COAP_BLOCK_02 */
   test_payload = make_large("etsi_iot_01_largedata.txt");
   if (!test_payload)
@@ -604,10 +604,10 @@ init_resources(coap_context_t *ctx) {
   /* For TD_COAP_CORE_13 */
   r = coap_resource_init((unsigned char *)"query", 5, 0);
   coap_register_handler(r, COAP_REQUEST_GET, hnd_get_query);
-  
+
   coap_add_attr(r, (unsigned char *)"ct", 2, (unsigned char *)"0", 1, 0);
   coap_add_resource(ctx, r);
-  
+
   /* For TD_COAP_CORE_16 */
   r = coap_resource_init((unsigned char *)"separate", 8, 0);
   coap_register_handler(r, COAP_REQUEST_GET, hnd_get_separate);
@@ -626,17 +626,17 @@ usage( const char *program, const char *version) {
     program = ++p;
 
   fprintf( stderr, "%s v%s -- ETSI CoAP plugtest server\n"
-	   "(c) 2012 Olaf Bergmann <bergmann@tzi.org>\n\n"
-	   "usage: %s [-A address] [-p port]\n\n"
-	   "\t-A address\tinterface address to bind to\n"
-	   "\t-p port\t\tlisten on specified port\n"
-	   "\t-v num\t\tverbosity level (default: 3)\n",
-	   program, version, program );
+           "(c) 2012 Olaf Bergmann <bergmann@tzi.org>\n\n"
+           "usage: %s [-A address] [-p port]\n\n"
+           "\t-A address\tinterface address to bind to\n"
+           "\t-p port\t\tlisten on specified port\n"
+           "\t-v num\t\tverbosity level (default: 3)\n",
+           program, version, program );
 }
 
 coap_context_t *
 get_context(const char *node, const char *port) {
-  coap_context_t *ctx = NULL;  
+  coap_context_t *ctx = NULL;
   int s;
   struct addrinfo hints;
   struct addrinfo *result, *rp;
@@ -645,12 +645,12 @@ get_context(const char *node, const char *port) {
   hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
   hints.ai_socktype = SOCK_DGRAM; /* Coap uses UDP */
   hints.ai_flags = AI_PASSIVE | AI_NUMERICHOST;
-  
+
   s = getaddrinfo(node, port, &hints, &result);
   if ( s != 0 ) {
     fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(s));
     return NULL;
-  } 
+  }
 
   /* iterate through results until success */
   for (rp = result; rp != NULL; rp = rp->ai_next) {
@@ -663,12 +663,12 @@ get_context(const char *node, const char *port) {
 
       ctx = coap_new_context(&addr);
       if (ctx) {
-	/* TODO: output address:port for successful binding */
-	goto finish;
+        /* TODO: output address:port for successful binding */
+        goto finish;
       }
     }
   }
-  
+
   fprintf(stderr, "no context available for interface '%s'\n", node);
 
  finish:
@@ -744,15 +744,15 @@ main(int argc, char **argv) {
     }
     result = select( FD_SETSIZE, &readfds, 0, 0, timeout );
 
-    if ( result < 0 ) {		/* error */
+    if ( result < 0 ) {                /* error */
       if (errno != EINTR)
-	perror("select");
-    } else if ( result > 0 ) {	/* read from socket */
+        perror("select");
+    } else if ( result > 0 ) {        /* read from socket */
       if ( FD_ISSET( ctx->sockfd, &readfds ) ) {
-	coap_read( ctx );	/* read received data */
-	coap_dispatch( ctx );	/* and dispatch PDUs from receivequeue */
+        coap_read( ctx );        /* read received data */
+        coap_dispatch( ctx );        /* and dispatch PDUs from receivequeue */
       }
-    } else {			/* timeout */
+    } else {                        /* timeout */
       /* coap_check_resource_list( ctx ); */
     }
 

--- a/examples/etsi_testcases.sh
+++ b/examples/etsi_testcases.sh
@@ -69,7 +69,7 @@ function start_coap_test {
 #
 # pre: resource /test exists and can handle GET with arbitrary payload
 #
-# client sends GET request with Type=0(CON) and Code=1(GET) 
+# client sends GET request with Type=0(CON) and Code=1(GET)
 #
 # check if sent request contains Type value indicating 0 and Code
 # value indicating 1
@@ -474,7 +474,7 @@ function TD_COAP_LINK_01 {
   testaddress=coap://$SERVERTUP/.well-known/core
   echo "retrieve server's list of resource"
   start_tcpdump $1
-  if [ $verbose ]; then 
+  if [ $verbose ]; then
     echo "client command: $COAP_CLIENT $clientopts $testaddress"
   fi
   clientoutput=$($COAP_CLIENT $clientopts "$testaddress")
@@ -753,12 +753,12 @@ function TD_COAP_OBS_04 {
 # check: Server does not send further response
 #
 function TD_COAP_OBS_05 {
-  clientopts="$callopts -s 0 -p $CLIENTPORT" 
+  clientopts="$callopts -s 0 -p $CLIENTPORT"
 #"-v 5 -B $longtimeout -p $CLIENTPORT -s 0"
   testaddress=coap://$SERVERTUP/obs
   echo "server detection of deregistration (explicit RST)"
   start_coap_test $1 stop
-  clientopts="$callopts -p $CLIENTPORT -s 0 -N" 
+  clientopts="$callopts -p $CLIENTPORT -s 0 -N"
 #"-v 5 -B $clienttimeout -p $CLIENTPORT -s 0 -N"
   testaddress=coap://[::1]/obs
   start_coap_test $1

--- a/examples/lwip/server.c
+++ b/examples/lwip/server.c
@@ -5,9 +5,9 @@
  *
  *
  * Copyright (c) 2001-2003 Swedish Institute of Computer Science.
- * All rights reserved. 
- * 
- * Redistribution and use in source and binary forms, with or without modification, 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
@@ -16,17 +16,17 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  * 3. The name of the author may not be used to endorse or promote products
- *    derived from this software without specific prior written permission. 
+ *    derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED 
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
- * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
  * OF SUCH DAMAGE.
  *
  * Author: Adam Dunkels <adam@sics.se>
@@ -49,43 +49,43 @@ static ip4_addr_t ipaddr, netmask, gw;
 int
 main(int argc, char **argv)
 {
-	struct netif netif;
+        struct netif netif;
 
-	/* startup defaults (may be overridden by one or more opts). this is
-	 * hard-coded v4 even in presence of v6, which does auto-discovery and
-	 * should thus wind up with an address of fe80::12:34ff:fe56:78ab%tap0
-	 * */
-	IP4_ADDR(&gw, 192,168,113,1);
-	IP4_ADDR(&ipaddr, 192,168,113,2);
-	IP4_ADDR(&netmask, 255,255,255,0);
+        /* startup defaults (may be overridden by one or more opts). this is
+         * hard-coded v4 even in presence of v6, which does auto-discovery and
+         * should thus wind up with an address of fe80::12:34ff:fe56:78ab%tap0
+         * */
+        IP4_ADDR(&gw, 192,168,113,1);
+        IP4_ADDR(&ipaddr, 192,168,113,2);
+        IP4_ADDR(&netmask, 255,255,255,0);
 
-	lwip_init();
+        lwip_init();
 
-	printf("TCP/IP initialized.\n");
+        printf("TCP/IP initialized.\n");
 
-	netif_add(&netif, &ipaddr, &netmask, &gw, NULL, tapif_init, ethernet_input);
-	netif.flags |= NETIF_FLAG_ETHARP;
-	netif_set_default(&netif);
-	netif_set_up(&netif);
+        netif_add(&netif, &ipaddr, &netmask, &gw, NULL, tapif_init, ethernet_input);
+        netif.flags |= NETIF_FLAG_ETHARP;
+        netif_set_default(&netif);
+        netif_set_up(&netif);
 #if LWIP_IPV6
-	netif_create_ip6_linklocal_address(&netif, 1);
-#endif 
+        netif_create_ip6_linklocal_address(&netif, 1);
+#endif
 
-	/* start applications here */
+        /* start applications here */
 
-	server_coap_init();
+        server_coap_init();
 
-	printf("Applications started.\n");
+        printf("Applications started.\n");
 
 
-	while (1) {
-		/* poll netif, pass packet to lwIP */
-		tapif_select(&netif);
+        while (1) {
+                /* poll netif, pass packet to lwIP */
+                tapif_select(&netif);
 
-		sys_check_timeouts();
+                sys_check_timeouts();
 
-		server_coap_poll();
-	}
+                server_coap_poll();
+        }
 
-	return 0;
+        return 0;
 }

--- a/examples/tiny.c
+++ b/examples/tiny.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2010,2011 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <string.h>
@@ -56,15 +56,15 @@ usage( const char *program ) {
     program = ++p;
 
   fprintf( stderr, "%s -- tiny fake sensor\n"
-	   "(c) 2010 Olaf Bergmann <bergmann@tzi.org>\n\n"
-	   "usage: %s [group address]\n"
-	   "\n\nSends some fake sensor values to specified multicast group\n",
-	   program, program );
+           "(c) 2010 Olaf Bergmann <bergmann@tzi.org>\n\n"
+           "usage: %s [group address]\n"
+           "\n\nSends some fake sensor values to specified multicast group\n",
+           program, program );
 }
 
 coap_context_t *
 get_context(const char *node, const char *port) {
-  coap_context_t *ctx = NULL;  
+  coap_context_t *ctx = NULL;
   int s;
   struct addrinfo hints;
   struct addrinfo *result, *rp;
@@ -73,12 +73,12 @@ get_context(const char *node, const char *port) {
   hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
   hints.ai_socktype = SOCK_DGRAM; /* Coap uses UDP */
   hints.ai_flags = AI_PASSIVE | AI_NUMERICHOST | AI_NUMERICSERV | AI_ALL;
-  
+
   s = getaddrinfo(node, port, &hints, &result);
   if ( s != 0 ) {
     fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(s));
     return NULL;
-  } 
+  }
 
   /* iterate through results until success */
   for (rp = result; rp != NULL; rp = rp->ai_next) {
@@ -88,7 +88,7 @@ get_context(const char *node, const char *port) {
       goto finish;
     }
   }
-  
+
   fprintf(stderr, "no context available for interface '%s'\n", node);
 
  finish:
@@ -124,7 +124,7 @@ main(int argc, char **argv) {
     /* set socket options for multicast */
 
     if ( setsockopt( ctx->sockfd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS,
-		     (char *)&hops, sizeof(hops) ) < 0 )
+                     (char *)&hops, sizeof(hops) ) < 0 )
       perror("setsockopt: IPV6_MULTICAST_HOPS");
 
   }

--- a/include/coap/async.h
+++ b/include/coap/async.h
@@ -44,7 +44,7 @@ typedef struct coap_async_state_t {
    */
   void *appdata;
   uint16_t message_id;       /**< id of last message seen */
-  coap_session_t *session;	   /**< transaction session */
+  coap_session_t *session;         /**< transaction session */
   coap_tid_t id;                   /**< transaction id */
   struct coap_async_state_t *next; /**< internally used for linking */
   size_t tokenlen;                 /**< length of the token */

--- a/include/coap/coap_dtls.h
+++ b/include/coap/coap_dtls.h
@@ -23,7 +23,7 @@
 
 /**
  * Check whether DTLS is available.
- * 
+ *
  * @return @c 1 if support for DTLS is enabled, or @c 0 otherwise.
  */
 int coap_dtls_is_supported(void);
@@ -209,14 +209,14 @@ typedef struct coap_dtls_pki_t {
                                     * COAP_DTLS_PKI_SETUP_VERSION and just
                                     * decrement the reserved[] count.
                                     */
- 
+
   /** CN check call-back function.
    * If not NULL, is called when the TLS connection has passed the configured
    * TLS options above for the application to verify if the CN is valid.
    */
   coap_dtls_cn_callback_t validate_cn_call_back;
   void *cn_call_back_arg;  /**< Passed in to the CN call-back function */
- 
+
   /** SNI check call-back function.
    * If not @p NULL, called if the SNI is not previously seen and prior to
    * sending a certificate set back to the client so that the appropriate
@@ -231,7 +231,7 @@ typedef struct coap_dtls_pki_t {
    * setup.
    */
   coap_dtls_security_setup_t additional_tls_setup_call_back;
- 
+
   char* client_sni;    /**<  If not NULL, SNI to use in client TLS setup.
                              Owned by the client app and must remain valid
                              during the call to coap_new_client_session_pki() */
@@ -265,11 +265,11 @@ coap_dtls_new_context(struct coap_context_t *coap_context);
 
 /**
  * Set the DTLS context's default PSK information.
- * This does the PSK specifics following coap_dtls_new_context(). 
+ * This does the PSK specifics following coap_dtls_new_context().
  * If @p COAP_DTLS_ROLE_SERVER, then identity hint will also get set.
- * If @p COAP_DTLS_ROLE_SERVER, then the information will get put into the 
+ * If @p COAP_DTLS_ROLE_SERVER, then the information will get put into the
  * TLS library's context (from which sessions are derived).
- * If @p COAP_DTLS_ROLE_CLIENT, then the information will get put into the 
+ * If @p COAP_DTLS_ROLE_CLIENT, then the information will get put into the
  * TLS library's session.
  *
  * Internal function.
@@ -292,9 +292,9 @@ coap_dtls_context_set_psk(struct coap_context_t *coap_context,
 /**
  * Set the DTLS context's default server PKI information.
  * This does the PKI specifics following coap_dtls_new_context().
- * If @p COAP_DTLS_ROLE_SERVER, then the information will get put into the 
+ * If @p COAP_DTLS_ROLE_SERVER, then the information will get put into the
  * TLS library's context (from which sessions are derived).
- * If @p COAP_DTLS_ROLE_CLIENT, then the information will get put into the 
+ * If @p COAP_DTLS_ROLE_CLIENT, then the information will get put into the
  * TLS library's session.
  *
  * Internal function.
@@ -431,7 +431,7 @@ int coap_dtls_is_context_timeout(void);
  * Do all pending retransmits and get next timeout
  *
  * Internal function.
- * 
+ *
  * @param dtls_context The DTLS context.
  *
  * @return @c 0 if no event is pending or date of the next retransmit.
@@ -557,7 +557,7 @@ ssize_t coap_tls_write(coap_session_t *coap_session,
                        const uint8_t *data,
                        size_t data_len
                        );
-  
+
 /**
  * Read some data from a TLS peer.
  *

--- a/include/coap/coap_io.h
+++ b/include/coap/coap_io.h
@@ -187,15 +187,15 @@ struct pbuf *coap_packet_extract_pbuf(struct coap_packet_t *packet);
 struct coap_packet_t {
   struct pbuf *pbuf;
   const struct coap_endpoint_t *local_interface;
-  coap_address_t src;	      /**< the packet's source address */
-  coap_address_t dst;	      /**< the packet's destination address */
+  coap_address_t src;              /**< the packet's source address */
+  coap_address_t dst;              /**< the packet's destination address */
   int ifindex;                /**< the interface index */
 //  uint16_t srcport;
 };
 #else
 struct coap_packet_t {
-  coap_address_t src;	      /**< the packet's source address */
-  coap_address_t dst;	      /**< the packet's destination address */
+  coap_address_t src;              /**< the packet's source address */
+  coap_address_t dst;              /**< the packet's destination address */
   int ifindex;                /**< the interface index */
   size_t length;              /**< length of payload */
   unsigned char payload[COAP_RXBUFFER_SIZE]; /**< payload */

--- a/include/coap/coap_session.h
+++ b/include/coap/coap_session.h
@@ -20,7 +20,7 @@ struct coap_queue_t;
 
 /**
 * Abstraction of a fixed point number that can be used where necessary instead
-* of a float.  1,000 fractional bits equals one integer 
+* of a float.  1,000 fractional bits equals one integer
 */
 typedef struct coap_fixed_point_t {
   uint16_t integer_part;    /**< Integer part of fixed point variable */
@@ -45,35 +45,35 @@ typedef uint8_t coap_session_state_t;
 /**
  * coap_session_state_t values
  */
-#define COAP_SESSION_STATE_NONE		0
-#define COAP_SESSION_STATE_CONNECTING	1
-#define COAP_SESSION_STATE_HANDSHAKE	2
-#define COAP_SESSION_STATE_CSM		3
-#define COAP_SESSION_STATE_ESTABLISHED	4
+#define COAP_SESSION_STATE_NONE                0
+#define COAP_SESSION_STATE_CONNECTING        1
+#define COAP_SESSION_STATE_HANDSHAKE        2
+#define COAP_SESSION_STATE_CSM                3
+#define COAP_SESSION_STATE_ESTABLISHED        4
 
 typedef struct coap_session_t {
   struct coap_session_t *next;
-  coap_proto_t proto;		  /**< protocol used */
-  coap_session_type_t type;	  /**< client or server side socket */
-  coap_session_state_t state;	  /**< current state of relationaship with peer */
-  unsigned ref;			  /**< reference count from queues */
-  unsigned tls_overhead;	  /**< overhead of TLS layer */
-  unsigned mtu;			  /**< path or CSM mtu */
-  coap_address_t local_if;        /**< optional local interface address */
-  coap_address_t remote_addr;     /**< remote address and port */
-  coap_address_t local_addr;	  /**< local address and port */
-  int ifindex;                    /**< interface index */
-  coap_socket_t sock;		  /**< socket object for the session, if any */
-  struct coap_endpoint_t *endpoint;	  /**< session's endpoint */
-  struct coap_context_t *context;	  /**< session's context */
-  void *tls;			  /**< security parameters */
-  uint16_t tx_mid;                /**< the last message id that was used in this session */
-  uint8_t con_active;             /**< Active CON request sent */
-  struct coap_queue_t *delayqueue; /**< list of delayed messages waiting to be sent */
-  size_t partial_write;           /**< if > 0 indicates number of bytes already written from the pdu at the head of sendqueue */
-  uint8_t read_header[8];         /**< storage space for header of incoming message header */
-  size_t partial_read;            /**< if > 0 indicates number of bytes already read for an incoming message */
-  coap_pdu_t *partial_pdu;        /**< incomplete incoming pdu */
+  coap_proto_t proto;               /**< protocol used */
+  coap_session_type_t type;         /**< client or server side socket */
+  coap_session_state_t state;       /**< current state of relationaship with peer */
+  unsigned ref;                     /**< reference count from queues */
+  unsigned tls_overhead;            /**< overhead of TLS layer */
+  unsigned mtu;                     /**< path or CSM mtu */
+  coap_address_t local_if;          /**< optional local interface address */
+  coap_address_t remote_addr;       /**< remote address and port */
+  coap_address_t local_addr;        /**< local address and port */
+  int ifindex;                      /**< interface index */
+  coap_socket_t sock;               /**< socket object for the session, if any */
+  struct coap_endpoint_t *endpoint; /**< session's endpoint */
+  struct coap_context_t *context;   /**< session's context */
+  void *tls;                        /**< security parameters */
+  uint16_t tx_mid;                  /**< the last message id that was used in this session */
+  uint8_t con_active;               /**< Active CON request sent */
+  struct coap_queue_t *delayqueue;  /**< list of delayed messages waiting to be sent */
+  size_t partial_write;             /**< if > 0 indicates number of bytes already written from the pdu at the head of sendqueue */
+  uint8_t read_header[8];           /**< storage space for header of incoming message header */
+  size_t partial_read;              /**< if > 0 indicates number of bytes already read for an incoming message */
+  coap_pdu_t *partial_pdu;          /**< incomplete incoming pdu */
   coap_tick_t last_rx_tx;
   coap_tick_t last_tx_rst;
   coap_tick_t last_ping;
@@ -83,9 +83,9 @@ typedef struct coap_session_t {
   size_t psk_identity_len;
   uint8_t *psk_key;
   size_t psk_key_len;
-  void *app;                    /**< application-specific data */
-  unsigned int max_retransmit;          /**< maximum re-transmit count (default 4) */
-  coap_fixed_point_t ack_timeout;       /**< timeout waiting for ack (default 2 secs) */
+  void *app;                        /**< application-specific data */
+  unsigned int max_retransmit;      /**< maximum re-transmit count (default 4) */
+  coap_fixed_point_t ack_timeout;   /**< timeout waiting for ack (default 2 secs) */
   coap_fixed_point_t ack_random_factor; /**< ack random factor backoff (default 1.5) */
   unsigned int dtls_timeout_count;      /**< dtls setup retry counter */
   int dtls_event;                       /**< Tracking any (D)TLS events on this sesison */
@@ -299,20 +299,20 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
 typedef struct coap_endpoint_t {
   struct coap_endpoint_t *next;
   struct coap_context_t *context; /**< endpoint's context */
-  coap_proto_t proto;		  /**< protocol used on this interface */
-  uint16_t default_mtu; 	  /**< default mtu for this interface */
-  coap_socket_t sock;		  /**< socket object for the interface, if any */
-  coap_address_t bind_addr;	  /**< local interface address */
-  coap_session_t *sessions;	  /**< list of active sessions */
-  coap_session_t hello;		  /**< special session of DTLS hello messages */
+  coap_proto_t proto;             /**< protocol used on this interface */
+  uint16_t default_mtu;           /**< default mtu for this interface */
+  coap_socket_t sock;             /**< socket object for the interface, if any */
+  coap_address_t bind_addr;       /**< local interface address */
+  coap_session_t *sessions;       /**< list of active sessions */
+  coap_session_t hello;           /**< special session of DTLS hello messages */
 } coap_endpoint_t;
 
 /**
 * Create a new endpoint for communicating with peers.
 *
-* @param context	The coap context that will own the new endpoint
-* @param listen_addr	Address the endpoint will listen for incoming requests on or originate outgoing requests from. Use NULL to specify that no incoming request will be accepted and use a random endpoint.
-* @param proto		Protocol used on this endpoint
+* @param context        The coap context that will own the new endpoint
+* @param listen_addr    Address the endpoint will listen for incoming requests on or originate outgoing requests from. Use NULL to specify that no incoming request will be accepted and use a random endpoint.
+* @param proto          Protocol used on this endpoint
 */
 
 coap_endpoint_t *coap_new_endpoint(struct coap_context_t *context, const coap_address_t *listen_addr, coap_proto_t proto);
@@ -350,16 +350,16 @@ const char *coap_endpoint_str(const coap_endpoint_t *endpoint);
 coap_session_t *coap_endpoint_get_session(coap_endpoint_t *endpoint,
   const struct coap_packet_t *packet, coap_tick_t now);
 
-/**   
+/**
  * Create a new DTLS session for the @p endpoint.
- *    
+ *
  * @ingroup dtls_internal
- *  
+ *
  * @param endpoint  Endpoint to add DTLS session to
  * @param packet    Received packet information to base session on.
  * @param now       The current time in ticks.
  *
- * @return Created CoAP session or @c NULL if error. 
+ * @return Created CoAP session or @c NULL if error.
  */
 coap_session_t *coap_endpoint_new_dtls_session(coap_endpoint_t *endpoint,
   const struct coap_packet_t *packet, coap_tick_t now);

--- a/include/coap/encode.h
+++ b/include/coap/encode.h
@@ -74,7 +74,7 @@ unsigned int coap_encode_var_safe(uint8_t *buf,
 
 /**
  * @deprecated Use coap_encode_var_safe() instead.
- * Provided for backward compatability.  As @p value has a 
+ * Provided for backward compatability.  As @p value has a
  * maximum value of 0xffffffff, and buf is usually defined as an array, it
  * is unsafe to continue to use this variant if buf[] is less than buf[4].
  *

--- a/include/coap/net.h
+++ b/include/coap/net.h
@@ -125,9 +125,9 @@ typedef void (*coap_nack_handler_t)(struct coap_context_t *context,
  * @param id CoAP transaction ID.
  */
 typedef void (*coap_ping_handler_t)(struct coap_context_t *context,
-                                        coap_session_t *session,
-                                        coap_pdu_t *received,
-                                        const coap_tid_t id);
+                                    coap_session_t *session,
+                                    coap_pdu_t *received,
+                                    const coap_tid_t id);
 
 /**
  * Recieved Pong handler that is used as call-back in coap_context_t.
@@ -138,9 +138,9 @@ typedef void (*coap_ping_handler_t)(struct coap_context_t *context,
  * @param id CoAP transaction ID.
  */
 typedef void (*coap_pong_handler_t)(struct coap_context_t *context,
-				  	coap_session_t *session,
-					coap_pdu_t *received,
-					const coap_tid_t id);
+                                    coap_session_t *session,
+                                    coap_pdu_t *received,
+                                    const coap_tid_t id);
 
 /**
  * The CoAP stack's global state is stored in a coap_context_t object.
@@ -164,7 +164,7 @@ typedef struct coap_context_t {
   coap_tick_t sendqueue_basetime;
   coap_queue_t *sendqueue;
   coap_endpoint_t *endpoint;      /**< the endpoints used for listening  */
-  coap_session_t *sessions;	  /**< client sessions */
+  coap_session_t *sessions;       /**< client sessions */
 
 #ifdef WITH_CONTIKI
   struct uip_udp_conn *conn;      /**< uIP connection object */
@@ -210,10 +210,10 @@ typedef struct coap_context_t {
   uint8_t *psk_key;
   size_t psk_key_len;
 
-  unsigned int session_timeout;	   /**< Number of seconds of inactivity after which an unused session will be closed. 0 means use default. */
+  unsigned int session_timeout;    /**< Number of seconds of inactivity after which an unused session will be closed. 0 means use default. */
   unsigned int max_idle_sessions;  /**< Maximum number of simultaneous unused sessions per endpoint. 0 means no maximum. */
-  unsigned int ping_timeout;	   /**< Minimum inactivity time before sending a ping message. 0 means disabled. */
-  unsigned int csm_timeout;	   /**< Timeout for waiting for a CSM from the remote side. 0 means disabled. */
+  unsigned int ping_timeout;           /**< Minimum inactivity time before sending a ping message. 0 means disabled. */
+  unsigned int csm_timeout;           /**< Timeout for waiting for a CSM from the remote side. 0 means disabled. */
 
   void *app;                       /**< application-specific data */
 } coap_context_t;
@@ -358,7 +358,7 @@ coap_context_set_pki_root_cas(coap_context_t *context,
  * considered as disconnected.
  *
  * @param context        The coap_context_t object.
- * @param seconds		 Number of seconds for the inactivity timer, or zero
+ * @param seconds                 Number of seconds for the inactivity timer, or zero
  *                       to disable CoAP-level keepalive messages.
  *
  * @return 1 if successful, else 0

--- a/include/coap/option.h
+++ b/include/coap/option.h
@@ -90,7 +90,7 @@ size_t coap_opt_size(const coap_opt_t *opt);
 #endif /* (COAP_OPT_FILTER_SHORT + COAP_OPT_FILTER_LONG > 16) */
 
 /** The number of elements in coap_opt_filter_t. */
-#define COAP_OPT_FILTER_SIZE					\
+#define COAP_OPT_FILTER_SIZE                                        \
   (((COAP_OPT_FILTER_SHORT + 1) >> 1) + COAP_OPT_FILTER_LONG) +1
 
 /**

--- a/include/coap/pdu.h
+++ b/include/coap/pdu.h
@@ -287,7 +287,7 @@ COAP_DEPRECATED typedef struct {
 typedef struct coap_pdu_t {
   uint8_t type;             /**< message type */
   uint8_t code;             /**< request method (value 1--10) or response code (value 40-255) */
-  uint8_t max_hdr_size;	    /**< space reserved for protocol-specific header */
+  uint8_t max_hdr_size;     /**< space reserved for protocol-specific header */
   uint8_t hdr_size;         /**< actaul size used for protocol-specific header */
   uint8_t token_length;     /**< length of Token */
   uint16_t tid;             /**< transaction id, if any, in regular host byte order */
@@ -296,16 +296,16 @@ typedef struct coap_pdu_t {
   size_t used_size;         /**< used bytes of storage for token, options and payload */
   size_t max_size;          /**< maximum size for token, options and payload, or zero for variable size pdu */
   uint8_t *token;           /**< first byte of token, if any, or options */
-  uint8_t *data;	    /**< first byte of payload, if any */
+  uint8_t *data;            /**< first byte of payload, if any */
 #ifdef WITH_LWIP
   struct pbuf *pbuf;        /**< lwIP PBUF. The package data will always reside
-			    *    inside the pbuf's payload, but this pointer
-			    *    has to be kept because no exact offset can be
-			    *    given. This field must not be accessed from
-			    *    outside, because the pbuf's reference count
-			    *    is checked to be 1 when the pbuf is assigned
-			    *    to the pdu, and the pbuf stays exclusive to
-			    *    this pdu. */
+                             *   inside the pbuf's payload, but this pointer
+                             *   has to be kept because no exact offset can be
+                             *   given. This field must not be accessed from
+                             *   outside, because the pbuf's reference count
+                             *   is checked to be 1 when the pbuf is assigned
+                             *   to the pdu, and the pbuf stays exclusive to
+                             *   this pdu. */
 #endif
 } coap_pdu_t;
 
@@ -340,11 +340,11 @@ typedef uint8_t coap_proto_t;
 /**
 * coap_proto_t values
 */
-#define COAP_PROTO_NONE	  0
-#define COAP_PROTO_UDP	  1
-#define COAP_PROTO_DTLS	  2
-#define COAP_PROTO_TCP	  3
-#define COAP_PROTO_TLS	  4
+#define COAP_PROTO_NONE         0
+#define COAP_PROTO_UDP          1
+#define COAP_PROTO_DTLS         2
+#define COAP_PROTO_TCP          3
+#define COAP_PROTO_TLS          4
 
 /**
  * Creates a new CoAP PDU with at least enough storage space for the given
@@ -447,7 +447,7 @@ int coap_pdu_parse_opt(coap_pdu_t *pdu);
 
 /**
 * Parses @p data into the CoAP PDU structure given in @p result.
-* The target pdu must be large enough to 
+* The target pdu must be large enough to
 * This function returns @c 0 on error or a number greater than zero on success.
 *
 * @param proto   Session's protocol

--- a/include/coap/prng.h
+++ b/include/coap/prng.h
@@ -72,18 +72,18 @@ errno_t __cdecl rand_s( _Out_ unsigned int* _RandomValue );
  */
 COAP_STATIC_INLINE int
 coap_prng_impl( unsigned char *buf, size_t len ) {
-	while ( len != 0 ) {
-		uint32_t r = 0;
-		size_t i;
-		if ( rand_s( &r ) != 0 )
-			return 0;
-		for ( i = 0; i < len && i < 4; i++ ) {
-			*buf++ = (uint8_t)r;
-			r >>= 8;
-		}
-		len -= i;
-	}
-	return 1;
+        while ( len != 0 ) {
+                uint32_t r = 0;
+                size_t i;
+                if ( rand_s( &r ) != 0 )
+                        return 0;
+                for ( i = 0; i < len && i < 4; i++ ) {
+                        *buf++ = (uint8_t)r;
+                        r >>= 8;
+                }
+                len -= i;
+        }
+        return 1;
 }
 
 #else
@@ -96,9 +96,9 @@ coap_prng_impl( unsigned char *buf, size_t len ) {
  */
 COAP_STATIC_INLINE int
 coap_prng_impl( unsigned char *buf, size_t len ) {
-	while ( len-- )
-		*buf++ = rand() & 0xFF;
-	return 1;
+        while ( len-- )
+                *buf++ = rand() & 0xFF;
+        return 1;
 }
 #endif
 

--- a/include/coap/resource.h
+++ b/include/coap/resource.h
@@ -138,7 +138,7 @@ typedef struct coap_resource_t {
  *
  *                  If flags is set to 0 then the
  *                  COAP_RESOURCE_FLAGS_NOTIFY_NON is considered.
- * 
+ *
  * @return         A pointer to the new object or @c NULL on error.
  */
 coap_resource_t *coap_resource_init(coap_str_const_t *uri_path,
@@ -180,9 +180,9 @@ coap_resource_set_mode(coap_resource_t *resource, int mode) {
  * Sets the user_data. The user_data is exclusively used by the library-user
  * and can be used as context in the handler functions.
  *
- * @param r	Resource to attach the data to
- * @param data	Data to attach to the user_data field. This pointer is only used for
- *		storage, the data remains under user control
+ * @param r       Resource to attach the data to
+ * @param data    Data to attach to the user_data field. This pointer is only used for
+ *                storage, the data remains under user control
  */
 COAP_STATIC_INLINE void
 coap_resource_set_userdata(coap_resource_t *r, void *data) {
@@ -193,9 +193,9 @@ coap_resource_set_userdata(coap_resource_t *r, void *data) {
  * Gets the user_data. The user_data is exclusively used by the library-user
  * and can be used as context in the handler functions.
  *
- * @param r	Resource to retrieve the user_darta from
+ * @param r        Resource to retrieve the user_darta from
  *
- * @return	The user_data pointer
+ * @return        The user_data pointer
  */
 COAP_STATIC_INLINE void *
 coap_resource_get_userdata(coap_resource_t *r) {
@@ -480,7 +480,7 @@ coap_resource_set_get_observable(coap_resource_t *resource, int mode) {
  * optionally matching @p query if not NULL
  *
  * @param resource The CoAP resource to use.
- * @param query    The Query to match against or NULL  
+ * @param query    The Query to match against or NULL
  *
  * @return         @c 1 if the Observe has been triggered, @c 0 otherwise.
  */

--- a/include/coap/subscribe.h
+++ b/include/coap/subscribe.h
@@ -55,7 +55,7 @@
 /** Subscriber information */
 typedef struct coap_subscription_t {
   struct coap_subscription_t *next; /**< next element in linked list */
-  coap_session_t *session;	    /**< subscriber session */
+  coap_session_t *session;          /**< subscriber session */
 
   unsigned int non_cnt:4;  /**< up to 15 non-confirmable notifies allowed */
   unsigned int fail_cnt:2; /**< up to 3 confirmable notifies can fail */

--- a/include/coap/uri.h
+++ b/include/coap/uri.h
@@ -36,7 +36,7 @@ enum coap_uri_scheme_t {
 typedef struct {
   coap_str_const_t host;  /**< host part of the URI */
   uint16_t port;          /**< The port in host byte order */
-  coap_str_const_t path;  /**< Beginning of the first path segment. 
+  coap_str_const_t path;  /**< Beginning of the first path segment.
                            Use coap_split_path() to create Uri-Path options */
   coap_str_const_t query; /**<  The query part if present */
 
@@ -81,7 +81,7 @@ coap_uri_t *coap_clone_uri(const coap_uri_t *uri);
  * components that are not specified will be set to { 0, 0 }, except for the
  * port which is set to @c COAP_DEFAULT_PORT. This function returns @p 0 if
  * parsing succeeded, a value less than zero otherwise.
- * 
+ *
  * @param str_var The string to split up.
  * @param len     The actual length of @p str_var
  * @param uri     The coap_uri_t object to store the result.
@@ -94,13 +94,13 @@ int coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri);
  * Splits the given URI path into segments. Each segment is preceded
  * by an option pseudo-header with delta-value 0 and the actual length
  * of the respective segment after percent-decoding.
- * 
- * @param s      The path string to split. 
+ *
+ * @param s      The path string to split.
  * @param length The actual length of @p s.
- * @param buf    Result buffer for parsed segments. 
+ * @param buf    Result buffer for parsed segments.
  * @param buflen Maximum length of @p buf. Will be set to the actual number
  *               of bytes written into buf on success.
- * 
+ *
  * @return       The number of segments created or @c -1 on error.
  */
 int coap_split_path(const uint8_t *s,
@@ -108,17 +108,17 @@ int coap_split_path(const uint8_t *s,
                     unsigned char *buf,
                     size_t *buflen);
 
-/** 
+/**
  * Splits the given URI query into segments. Each segment is preceded
  * by an option pseudo-header with delta-value 0 and the actual length
  * of the respective query term.
- * 
- * @param s      The query string to split. 
+ *
+ * @param s      The query string to split.
  * @param length The actual length of @p s.
- * @param buf    Result buffer for parsed segments. 
+ * @param buf    Result buffer for parsed segments.
  * @param buflen Maximum length of @p buf. Will be set to the actual number
  *               of bytes written into buf on success.
- * 
+ *
  * @return       The number of segments created or @c -1 on error.
  *
  * @bug This function does not reserve additional space for delta > 12.

--- a/man/coap_attribute.txt.in
+++ b/man/coap_attribute.txt.in
@@ -17,10 +17,10 @@ SYNOPSIS
 --------
 *#include <coap/coap.h>*
 
-*coap_attr_t *coap_add_attr(coap_resource_t *_resource_, coap_str_const_t 
+*coap_attr_t *coap_add_attr(coap_resource_t *_resource_, coap_str_const_t
 *_name_, coap_str_const_t *_value_, int _flags_);*
 
-*coap_attr_t *coap_find_attr(coap_resource_t *_resource_, coap_str_const_t 
+*coap_attr_t *coap_find_attr(coap_resource_t *_resource_, coap_str_const_t
 *_name_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
@@ -29,25 +29,25 @@ type.
 
 DESCRIPTION
 -----------
-CoAP Resources on a CoAP Server need to be created, updated etc. The URI in 
-the request packet defines the resource to work with, with possibly the Query 
+CoAP Resources on a CoAP Server need to be created, updated etc. The URI in
+the request packet defines the resource to work with, with possibly the Query
 referring to a sub-resource.
-When resources are configured on the CoAP server, the URI to match against 
-is specified. 
-Callback Handlers are then added to the resource to handle the different 
+When resources are configured on the CoAP server, the URI to match against
+is specified.
+Callback Handlers are then added to the resource to handle the different
 request methods.
-Adding Attributes allows textual information to be added to the resource 
-which can then be reported back to any client doing a "GET .well-known/core" 
-request. 
+Adding Attributes allows textual information to be added to the resource
+which can then be reported back to any client doing a "GET .well-known/core"
+request.
 
 Attributes are automatically freed when a Resource is deleted.
 
 The *coap_add_attr*() function
-registers a new attribute called _name_ for the _resource_. 
+registers a new attribute called _name_ for the _resource_.
 The value of the attribute is _value_.
 
-_flags_ can be one or more of the following, which, if set, defines what is 
-to be internally freed off when the attribute is deleted with 
+_flags_ can be one or more of the following, which, if set, defines what is
+to be internally freed off when the attribute is deleted with
 *coap_delete_resource*().
 
 [horizontal]
@@ -57,16 +57,16 @@ Free off _name_ when attribute is deleted with *coap_delete_resource*().
 *COAP_ATTR_FLAGS_RELEASE_VALUE*::
 Free off _value_ when attribute is deleted with *coap_delete_resource*().
 
-The *coap_find_attr*() function returns the attribute with the _name_, 
+The *coap_find_attr*() function returns the attribute with the _name_,
 if found, associated with _resource_.
 
 RETURN VALUES
 -------------
-*coap_add_attr*() function return a pointer to 
-the attribute that was created or NULL if there is a malloc failure. 
+*coap_add_attr*() function return a pointer to
+the attribute that was created or NULL if there is a malloc failure.
 
-*coap_find_attr*() function returns a pointer to the first matching 
-attribute or NULL if the _name_ was not found. 
+*coap_find_attr*() function returns a pointer to the first matching
+attribute or NULL if the _name_ was not found.
 
 EXAMPLE
 -------
@@ -120,7 +120,7 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See RFC7252 `The Constrained Application Protocol (CoAP)' for further 
+See RFC7252 `The Constrained Application Protocol (CoAP)' for further
 information.
 
 BUGS

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -19,19 +19,19 @@ SYNOPSIS
 --------
 *#include <coap/coap.h>*
 
-*void coap_register_handler(coap_resource_t *_resource_, unsigned char 
+*void coap_register_handler(coap_resource_t *_resource_, unsigned char
 _method_, coap_method_handler_t _handler_);*
 
-*void coap_register_response_handler(coap_context_t *_context_, 
+*void coap_register_response_handler(coap_context_t *_context_,
 coap_response_handler_t _handler_)*;
 
-*void coap_register_nack_handler(coap_context_t *_context_, 
+*void coap_register_nack_handler(coap_context_t *_context_,
 coap_nack_handler_t _handler_)*;
 
-*void coap_register_ping_handler(coap_context_t *_context_, 
+*void coap_register_ping_handler(coap_context_t *_context_,
 coap_ping_handler_t _handler_)*;
 
-*void coap_register_pong_handler(coap_context_t *_context_, 
+*void coap_register_pong_handler(coap_context_t *_context_,
 coap_pong_handler_t _handler_)*;
 
 *void coap_register_event_handler(coap_context_t *_context_, 
@@ -44,8 +44,8 @@ type.
 DESCRIPTION
 -----------
 
-The *coap_register_handler*() function registers a callback handler _handler_ 
-that is called when there is a URI match against the _resource_ and there is 
+The *coap_register_handler*() function registers a callback handler _handler_
+that is called when there is a URI match against the _resource_ and there is
 a _method_ (e.g. PUT, POST etc.) match. _method_ can be one of the following.
 ----
 COAP_REQUEST_GET
@@ -85,7 +85,7 @@ typedef void (*coap_response_handler_t)(coap_context_t *context,
                                         const coap_tid_t id);
 ----
 
-The *coap_register_nack_handler*() function defines a request's negative 
+The *coap_register_nack_handler*() function defines a request's negative
 response _handler_ for traffic associated with the _context_.
 If _handler_ is NULL, then the handler is de-registered.
 
@@ -112,7 +112,7 @@ typedef void (*coap_ping_handler_t)(coap_context_t *context,
                                     const coap_tid_t id);
 ----
 
-The *coap_register_pong_handler*() function defines a _handler_ for tracking 
+The *coap_register_pong_handler*() function defines a _handler_ for tracking
 CoAP TCP ping response traffic associated with the _context_.
 If _handler_ is NULL, then the handler is de-registered.
 
@@ -228,7 +228,7 @@ coap_string_t *query, coap_pdu_t *response) {
 #include <coap/coap.h>
 
 static void
-response_handler(coap_context_t *ctx, coap_session_t *session, 
+response_handler(coap_context_t *ctx, coap_session_t *session,
 coap_pdu_t *sent, coap_pdu_t *received, const coap_tid_t id) {
 
   coap_pdu_t *pdu = NULL;
@@ -269,7 +269,7 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further 
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further
 information.
 
 BUGS

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -117,16 +117,16 @@ The *coap_package_version*() function returns the version of this library.
 The *coap_set_show_pdu_output*() function defines whether the output from
 *coap_show_pdu*() is to be either sent to stdout/stderr, or output using
 *coap_log*().  _use_fprintf_ is set to 1 for stdout/stderr (the default), and
-_use_fprintf_ is set to 0 for *coap_log*(). 
+_use_fprintf_ is set to 0 for *coap_log*().
 
 The *coap_show_pdu*() function is used to decode the _pdu_, outputing as
 appropriate for logging _level_.  Where the output goes is dependent on
 *coap_set_show_pdu_output*().
 
-The *coap_endpoint_str*() function returns a description string of the 
+The *coap_endpoint_str*() function returns a description string of the
 _endpoint_.
 
-The *coap_session_str*() function is used to get a string containing the 
+The *coap_session_str*() function is used to get a string containing the
 information about the _session_.
 
 RETURN VALUES
@@ -140,10 +140,10 @@ The *coap_get_log_level*() function returns the current logging level.
 The *coap_dtls_get_log_level*() function returns the current logging level
 for the DTLS library specifics.
 
-The *coap_endpoint_str*() function returns a description string of the 
+The *coap_endpoint_str*() function returns a description string of the
 _endpoint_.
 
-The *coap_session_str*() function returns a description string of the 
+The *coap_session_str*() function returns a description string of the
 _session_.
 
 SEE ALSO
@@ -152,7 +152,7 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further 
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further
 information.
 
 BUGS

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -18,15 +18,15 @@ SYNOPSIS
 --------
 *#include <coap/coap.h>*
 
-*void coap_resource_set_get_observable(coap_resource_t *_resource_, 
+*void coap_resource_set_get_observable(coap_resource_t *_resource_,
 int _mode_);*
 
-*int coap_resource_notify_observers(coap_resource_t *_resource_, 
+*int coap_resource_notify_observers(coap_resource_t *_resource_,
 const const_string_t *_query_);*
 
 *const coap_string_t *coap_resource_get_uri_path(coap_resource_t *_resource_);*
 
-*coap_subscription_t *coap_find_observer(coap_resource_t *_resource_, 
+*coap_subscription_t *coap_find_observer(coap_resource_t *_resource_,
 coap_session_t *_session_, const const_string_t *_token_);*
 
 *int coap_delete_observer(coap_resource_t *_resource_, coap_session_t *_session_,
@@ -40,15 +40,15 @@ type.
 
 DESCRIPTION
 -----------
-RFC 7641 extends the CoAP protocol to be able to monitor the state of a 
+RFC 7641 extends the CoAP protocol to be able to monitor the state of a
 resource over time.
 
-This enables clients to "observe" resources with a defined query, i.e., to 
-retrieve a representation of a resource and keep this representation updated 
+This enables clients to "observe" resources with a defined query, i.e., to
+retrieve a representation of a resource and keep this representation updated
 by the server over a period of time.
 
-The server has to flag a resource as "observable", and then the client has 
-to request in a GET request that it wants to observe this resource by the use 
+The server has to flag a resource as "observable", and then the client has
+to request in a GET request that it wants to observe this resource by the use
 of the COAP_OPTION_OBSERVE Option with a value of COAP_OBSERVE_ESTABLISH.
 Optionally, the client can specify query options for the resource.
 
@@ -79,9 +79,9 @@ in the handler defined by *coap_register_response_handler*(3).  It is the
 responsibility of the client application to match the supplied token and 
 update the appropriate internal information.
 
-The *coap_resource_set_get_observable*() function enables or disables the 
-observable status of the _resource_ by the setting of _mode_.  If _mode_ is 
-1, then the _resource_ is observable.  If _mode_ is 0, then the 
+The *coap_resource_set_get_observable*() function enables or disables the
+observable status of the _resource_ by the setting of _mode_.  If _mode_ is
+1, then the _resource_ is observable.  If _mode_ is 0, then the
 _resource_ is no longer observable.
 
 *NOTE:* It is not possible for the Unknown Resource, created by 
@@ -108,8 +108,8 @@ _resource_, possibly only matching a specific _query_ if _query_ is not NULL.
 The *coap_resource_get_uri_path*() function is used to obtain the UriPath of
 the _resource_ definion.
 
-The *coap_find_observer*() function is used to check whether the current GET 
-request as determined from _resource_, _session_ and _token_ is currently 
+The *coap_find_observer*() function is used to check whether the current GET
+request as determined from _resource_, _session_ and _token_ is currently
 being observed or not.
 
 The *coap_delete_observer*() function deletes the specific observer associated
@@ -120,13 +120,13 @@ associated with the _session_ that is a part of the _context_.
 
 RETURN VALUES
 -------------
-The *coap_resource_get_uri_path*() function returns the uri_path or NULL if 
+The *coap_resource_get_uri_path*() function returns the uri_path or NULL if
 there was a failure.
 
-The *coap_find_observer*() function returns the subscription or NULL if there 
-was a failure. 
+The *coap_find_observer*() function returns the subscription or NULL if there
+was a failure.
 
-The *coap_resource_set_get_observable*() function return 0 on failure, 1 on 
+The *coap_resource_set_get_observable*() function return 0 on failure, 1 on
 success.
 
 The *coap_delete_observer*() function return 0 on failure, 1 on success.
@@ -346,7 +346,7 @@ coap_optlist_t **options, unsigned char *data, size_t length, int observe) {
 
   if (request_code == COAP_REQUEST_GET && observe) {
     /* Indicate that we want to observe this resource */
-    if (!coap_insert_optlist(options, 
+    if (!coap_insert_optlist(options,
                              coap_new_optlist(COAP_OPTION_OBSERVE,
                                          COAP_OBSERVE_ESTABLISH, NULL)))
       goto error;

--- a/man/coap_recovery.txt.in
+++ b/man/coap_recovery.txt.in
@@ -10,9 +10,9 @@ coap_recovery(3)
 
 NAME
 ----
-coap_recovery, coap_session_set_max_retransmit, coap_session_set_ack_timeout, 
-coap_session_set_ack_random_factor, coap_session_get_max_transmit, 
-coap_session_get_ack_timeout, coap_session_get_ack_random_factor, 
+coap_recovery, coap_session_set_max_retransmit, coap_session_set_ack_timeout,
+coap_session_set_ack_random_factor, coap_session_get_max_transmit,
+coap_session_get_ack_timeout, coap_session_get_ack_random_factor,
 coap_debug_set_packet_loss
 - Work with CoAP packet transmissions
 
@@ -20,20 +20,20 @@ SYNOPSIS
 --------
 *#include <coap/coap.h>*
 
-*void coap_session_set_max_retransmit(coap_session_t *_session_, 
+*void coap_session_set_max_retransmit(coap_session_t *_session_,
 unsigned int _value_)*;
 
-*void coap_session_set_ack_timeout(coap_session_t *_session_, 
+*void coap_session_set_ack_timeout(coap_session_t *_session_,
 coap_fixed_point_t _value_)*;
 
-*void coap_session_set_ack_random_factor(coap_session_t *_session_, 
+*void coap_session_set_ack_random_factor(coap_session_t *_session_,
 coap_fixed_point_t _value_)*;
 
 *unsigned int coap_session_get_max_transmit(coap_session_t *_session_)*;
 
 *coap_fixed_point_t coap_session_get_ack_timeout(coap_session_t *_session_)*;
 
-*coap_fixed_point_t coap_session_get_ack_random_factor(coap_session_t 
+*coap_fixed_point_t coap_session_get_ack_random_factor(coap_session_t
 *_session_)*;
 
 *int coap_debug_set_packet_loss(const char *_loss_level_)*;
@@ -44,17 +44,17 @@ type.
 
 DESCRIPTION
 -----------
-For CoAP Confirmable messages, it is possible to define the retry counts, 
-repeat rate etc. for error recovery.  Further information can be found in 
+For CoAP Confirmable messages, it is possible to define the retry counts,
+repeat rate etc. for error recovery.  Further information can be found in
 "RFC7272: 4.2. Messages Transmitted Reliably".
 
-It is not recommended that the suggested default setting are changed, but 
-there may be some special requirements that need different values and the 
+It is not recommended that the suggested default setting are changed, but
+there may be some special requirements that need different values and the
 consequences of changing these values is fully understood.
 
 Changing the default values for multicast packets is not supported.
 
-Some of the parameters or return values are in fixed point format as defined 
+Some of the parameters or return values are in fixed point format as defined
 by the coap_fixed_point_t structure as below
 ----
 typedef struct coap_fixed_point_t {
@@ -82,45 +82,45 @@ encrypted session setup retry timeouts. For DTLS, the initial requesting
 packet will get sent max_retransmit times before reporting failure.
 For TLS the initial TCP connection will timeout before reporting failure.
 
-It is also possible to set up packet losses, for both confirmable, and 
-non-confirmable messages.  This can be used for stress testing packet 
+It is also possible to set up packet losses, for both confirmable, and
+non-confirmable messages.  This can be used for stress testing packet
 transmission recovery as well as application handling of lossy networks.
 
-The *coap_session_set_max_retransmit*() function updates the _session_ maximum 
+The *coap_session_set_max_retransmit*() function updates the _session_ maximum
 retransmit count with the new _value_.  The default value is 4.
 
-The *coap_session_set_ack_timeout*() function updates the _session_ initial 
+The *coap_session_set_ack_timeout*() function updates the _session_ initial
 ack or response timeout with the new _value_.  The default value is 2.0.
 
-The *coap_session_set_ack_random_factor*() function updates the _session_ ack 
-random wait factor, used to randomize re-transmissions, with the new _value_. 
+The *coap_session_set_ack_random_factor*() function updates the _session_ ack
+random wait factor, used to randomize re-transmissions, with the new _value_.
 The default value is 1.5.
 
-The *coap_session_get_max_retransmit*() function returns the current _session_ 
+The *coap_session_get_max_retransmit*() function returns the current _session_
 maximum retransmit count.
 
-The *coap_session_get_ack_timeout*() function returns the current _session_ 
+The *coap_session_get_ack_timeout*() function returns the current _session_
 initial ack or response timeout.
 
-The *coap_session_get_ack_random_factor*() function returns the current 
+The *coap_session_get_ack_random_factor*() function returns the current
 _session_ ack random wait factor.
 
-The *coap_debug_set_packet_loss*() function is uses to set the packet loss 
-levels as defined in _loss_level_.  _loss_level_ can be set as a percentage 
+The *coap_debug_set_packet_loss*() function is uses to set the packet loss
+levels as defined in _loss_level_.  _loss_level_ can be set as a percentage
 from "0%" to "100%".
-Alternatively, it is possible to specify which packets of a packet sequence 
-are dropped.  A definition of "1,5-9,11-20,101" means that packets 1, 5 
-through 9, 11 through 20 and 101 will get dropped. A maximum of 10 different 
-packet sets is supported.  The packet count is reset to 0 when 
-coap_debug_set_packet_loss() is called. 
+Alternatively, it is possible to specify which packets of a packet sequence
+are dropped.  A definition of "1,5-9,11-20,101" means that packets 1, 5
+through 9, 11 through 20 and 101 will get dropped. A maximum of 10 different
+packet sets is supported.  The packet count is reset to 0 when
+coap_debug_set_packet_loss() is called.
 To remove any packet losses, set the _loss_level_ to "0%".
 
 RETURN VALUES
 -------------
-*coap_session_get_max_retransmit*(), *coap_session_get_ack_timeout*() and 
+*coap_session_get_max_retransmit*(), *coap_session_get_ack_timeout*() and
 *coap_session_get_ack_random_factor*() return their respective current values.
 
-*coap_debug_set_packet_loss*() returns 0 if _loss_level_ does not parse 
+*coap_debug_set_packet_loss*() returns 0 if _loss_level_ does not parse
 correctly, otherwise 1 if successful.
 
 TESTING
@@ -128,31 +128,31 @@ TESTING
 
 The libcoap recovery/re-transmit logic will only work for confirmable requests.
 
-To see what is happening (other than by sniffing the network traffic), the 
-logging level needs to be set to LOG_DEBUG in the client by using 
+To see what is happening (other than by sniffing the network traffic), the
+logging level needs to be set to LOG_DEBUG in the client by using
 coap_set_log_level(LOG_DEBUG) and coap_dtls_set_log_level(LOG_DEBUG).
 
-The client needs to be sending confirmable requests during the test.  
+The client needs to be sending confirmable requests during the test. 
 
-The server can either be stopped, or if packet loss levels are set to 100% by 
-using coap_debug_set_packet_loss("100%") when receiving the client requests. 
+The server can either be stopped, or if packet loss levels are set to 100% by
+using coap_debug_set_packet_loss("100%") when receiving the client requests.
 
-*NOTE:* If the server end of the connection is returning ICMP unreachable packets 
-after being turned off, you will get a debug message of the form 
+*NOTE:* If the server end of the connection is returning ICMP unreachable packets
+after being turned off, you will get a debug message of the form
 "coap_network_read: unreachable", so libcoap will stop doing the retries.  If
 this is the case, then you need to make use of (on the server)
-coap_debug_set_packet_loss("100%") or put in some packet filtering to drop the 
+coap_debug_set_packet_loss("100%") or put in some packet filtering to drop the
 packets.
 
-The client should then restart transmitting the requests based on the 
-ack_timeout, ack_random_factor and max_retransmit values.  The client's 
-nack_handler will get called with COAP_NACK_TOO_MANY_RETRIES when the 
+The client should then restart transmitting the requests based on the
+ack_timeout, ack_random_factor and max_retransmit values.  The client's
+nack_handler will get called with COAP_NACK_TOO_MANY_RETRIES when the
 confirmable request cannot be successfully transmitted.
 
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further 
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further
 information.
 
 BUGS

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -18,16 +18,16 @@ SYNOPSIS
 --------
 *#include <coap/coap.h>*
 
-*coap_resource_t *coap_resource_init(coap_str_const_t *_uri_path_, 
+*coap_resource_t *coap_resource_init(coap_str_const_t *_uri_path_,
 int _flags_);*
 
-*coap_resource_t *coap_resource_unknown_init(coap_method_handler_t 
+*coap_resource_t *coap_resource_unknown_init(coap_method_handler_t
 _put_handler_);*
 
-*void coap_add_resource(coap_context_t *_context_, 
+*void coap_add_resource(coap_context_t *_context_,
 coap_resource_t *_resource_);*
 
-*int coap_delete_resource(coap_context_t _context_, 
+*int coap_delete_resource(coap_context_t _context_,
 coap_resource_t _resource_);*
 
 *void coap_delete_all_resources(coap_context_t *_context_);*
@@ -40,31 +40,31 @@ type.
 
 DESCRIPTION
 -----------
-CoAP Resources on a CoAP Server need to be created and updated etc. The URI in 
-the request packet defines the resource to work with, with possibly the Query 
+CoAP Resources on a CoAP Server need to be created and updated etc. The URI in
+the request packet defines the resource to work with, with possibly the Query
 referring to a sub-resource.
 
-When resources are configured on the CoAP server, the URI to match against 
-in the request packet is specified. 
+When resources are configured on the CoAP server, the URI to match against
+in the request packet is specified.
 
-Callback Handlers are then added to the resource to handle the different 
+Callback Handlers are then added to the resource to handle the different
 request methods.
 
-Adding Attributes allows textual information to be added to the resource 
-which can then be reported back to any client doing a "GET .well-known/core" 
-request. 
+Adding Attributes allows textual information to be added to the resource
+which can then be reported back to any client doing a "GET .well-known/core"
+request.
 
 If an incoming packet request matches a resource's URI and Method, then
-the appropriate callback resource handler is invoked to process the packet 
-which then should update a suitable response packet for sending back to the 
+the appropriate callback resource handler is invoked to process the packet
+which then should update a suitable response packet for sending back to the
 requester.
 
 There is support for handling incoming packets where the URI is unknown.
 This could, for example, happen when a PUT request is trying to create a new
-resource. It is the responsibility of the unknown resource callback handler 
-to either create a new resource for the URI or just manage things separately. 
+resource. It is the responsibility of the unknown resource callback handler
+to either create a new resource for the URI or just manage things separately.
 
-CoAP Observe (RFC 7641) is not supported for unknown resources, so a new 
+CoAP Observe (RFC 7641) is not supported for unknown resources, so a new
 resource with GET handler must be created by the unknown resource callback
 handle matching the URI which then can be Observable.
 
@@ -87,40 +87,40 @@ Set the notification message type to confirmable for any trigggered
 *COAP_RESOURCE_FLAGS_RELEASE_URI*::
 Free off the coap_str_const_t for _uri_path_ when the _resource_ is deleted.
 
-*NOTE:* _uri_path_, if not 7 bit readable ASCII, binary bytes must be hex 
+*NOTE:* _uri_path_, if not 7 bit readable ASCII, binary bytes must be hex
 encoded according to the rules defined in RFC3968 Section 2.1.
 
 The *coap_resource_unknown_init*() returns a newly created _resource_ of
-type _coap_resource_t_ *. _put_handler_ is automatically added to the 
+type _coap_resource_t_ *. _put_handler_ is automatically added to the
 _resource_ to handle PUT requests to resources that are unknown.
 
-The *coap_add_resource*() function registers the given _resource_ with the 
-_context_. The _resource_ must have been created by *coap_resource_init*(), 
-or *coap_resource_unknown_init*(). The storage allocated for the _resource_ 
+The *coap_add_resource*() function registers the given _resource_ with the
+_context_. The _resource_ must have been created by *coap_resource_init*(),
+or *coap_resource_unknown_init*(). The storage allocated for the _resource_
 will be released by *coap_delete_resource*().
 
-As the _uri_path_ of the resource has to be unique across all of the resources 
-associated with a _context_, *coap_add_resource*() (or 
+As the _uri_path_ of the resource has to be unique across all of the resources
+associated with a _context_, *coap_add_resource*() (or
 *coap_add_resource_release*()) will delete any previous
 _resource_ with the same _uri_path_ before adding in the new _resource_.
 
-The *coap_delete_resource*() function deletes a _resource_ identified by 
-_resource_ from _context_. The storage allocated for that _resource_ is freed, 
+The *coap_delete_resource*() function deletes a _resource_ identified by
+_resource_ from _context_. The storage allocated for that _resource_ is freed,
 along with any attrigutes associated with the _resource_.
 
-The *coap_delete_all_resources*() function deletes all resources from 
+The *coap_delete_all_resources*() function deletes all resources from
 _context_ and frees their storage.
 
-The *coap_resource_set_mode*() changes the notification message type of 
-_resource_ to the given _mode_ which must be one of 
+The *coap_resource_set_mode*() changes the notification message type of
+_resource_ to the given _mode_ which must be one of
 COAP_RESOURCE_FLAGS_NOTIFY_NON or COAP_RESOURCE_FLAGS_NOTIFY_CON.
 
 RETURN VALUES
 -------------
-The *coap_resource_init*() and *coap_resource_unknown_init*() functions 
-return a newly created resource or NULL if there is a malloc failure. 
+The *coap_resource_init*() and *coap_resource_unknown_init*() functions
+return a newly created resource or NULL if there is a malloc failure.
 
-The *coap_delete_resource*() function return 0 on failure (_resource_ not 
+The *coap_delete_resource*() function return 0 on failure (_resource_ not
 found), 1 on success.
 
 EXAMPLES
@@ -359,7 +359,7 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further 
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further
 information.
 
 BUGS

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -10,7 +10,7 @@ coap_tls_library(3)
 
 NAME
 ----
-coap_tls_library, coap_dtls_is_supported, coap_tls_is_supported, 
+coap_tls_library, coap_dtls_is_supported, coap_tls_is_supported,
 coap_get_tls_library_version
 - Work with CoAP contexts
 
@@ -30,33 +30,33 @@ type.
 
 DESCRIPTION
 -----------
-When the libcoap library was built, it will have been compiled using a 
-specific TLS implementation type (e.g. OpenSSL, GnuTLS, TinyDTLS or noTLS).  
-When the libcoap library is linked into an application, it is possible that 
-the application needs to dynamically determine whether DTLS or TLS is 
-supported, what type of TLS implementation libcoap was compiled with, as well 
+When the libcoap library was built, it will have been compiled using a
+specific TLS implementation type (e.g. OpenSSL, GnuTLS, TinyDTLS or noTLS). 
+When the libcoap library is linked into an application, it is possible that
+the application needs to dynamically determine whether DTLS or TLS is
+supported, what type of TLS implementation libcoap was compiled with, as well
 as detect what is the version of the currently loaded TLS library is.
 
-*NOTE:* If OpenSSL is being used, then the minimum OpenSSL library version is 
+*NOTE:* If OpenSSL is being used, then the minimum OpenSSL library version is
 1.1.0.
 
 Network traffic can be encrypted or un-encrypted with libcoap - how to set 
 this up is described in *coap_context*(3).
 
-Due to the nature of TLS, there can be Callbacks that are invoked as the TLS 
+Due to the nature of TLS, there can be Callbacks that are invoked as the TLS
 session negotiates encryption algorithms, encryption keys etc.
-Where possible, by default, the CoAP layer handles all this automatically.  
-However, there is the flexibility of the Callbacks for imposing additional 
-security checks etc. when PKI is being used.  These callbacks need to need to 
+Where possible, by default, the CoAP layer handles all this automatically. 
+However, there is the flexibility of the Callbacks for imposing additional
+security checks etc. when PKI is being used.  These callbacks need to need to
 match the TLS implementation type.
 
-The *coap_dtls_is_supported*() function returns 1 if support for DTLS is 
+The *coap_dtls_is_supported*() function returns 1 if support for DTLS is
 enabled, otherwise 0;
 
-The *coap_tls_is_supported*() function returns 1 if support for TLS is 
+The *coap_tls_is_supported*() function returns 1 if support for TLS is
 enabled, otherwise 0;
 
-The *coap_get_tls_library_version*() function returns the TLS implementation 
+The *coap_get_tls_library_version*() function returns the TLS implementation
 type and library version in a coap_tls_version_t* structure.
 
 [source, c]
@@ -77,7 +77,7 @@ RETURN VALUES
 *coap_dtls_is_supported*() and *coap_tls_is_supported*() functions
 return 0 on failure, 1 on success.
 
-*coap_get_tls_library_version*() function returns the TLS implementation type 
+*coap_get_tls_library_version*() function returns the TLS implementation type
 and library version in a coap_tls_version_t* structure.
 
 SEE ALSO
@@ -86,7 +86,7 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further 
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further
 information.
 
 BUGS

--- a/src/address.c
+++ b/src/address.c
@@ -27,24 +27,24 @@
 
 #include "address.h"
 
-int 
+int
 coap_address_equals(const coap_address_t *a, const coap_address_t *b) {
   assert(a); assert(b);
 
   if (a->size != b->size || a->addr.sa.sa_family != b->addr.sa.sa_family)
     return 0;
-  
+
   /* need to compare only relevant parts of sockaddr_in6 */
  switch (a->addr.sa.sa_family) {
  case AF_INET:
-   return 
-     a->addr.sin.sin_port == b->addr.sin.sin_port && 
-     memcmp(&a->addr.sin.sin_addr, &b->addr.sin.sin_addr, 
-	    sizeof(struct in_addr)) == 0;
+   return
+     a->addr.sin.sin_port == b->addr.sin.sin_port &&
+     memcmp(&a->addr.sin.sin_addr, &b->addr.sin.sin_addr,
+            sizeof(struct in_addr)) == 0;
  case AF_INET6:
-   return a->addr.sin6.sin6_port == b->addr.sin6.sin6_port && 
-     memcmp(&a->addr.sin6.sin6_addr, &b->addr.sin6.sin6_addr, 
-	    sizeof(struct in6_addr)) == 0;
+   return a->addr.sin6.sin6_port == b->addr.sin6.sin6_port &&
+     memcmp(&a->addr.sin6.sin6_addr, &b->addr.sin6.sin6_addr,
+            sizeof(struct in6_addr)) == 0;
  default: /* fall through and signal error */
    ;
  }

--- a/src/async.c
+++ b/src/async.c
@@ -3,10 +3,10 @@
  * Copyright (C) 2010,2011 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
-/** 
+/**
  * @file async.c
  * @brief state management for asynchronous messages
  */
@@ -33,7 +33,7 @@
 
 coap_async_state_t *
 coap_register_async(coap_context_t *context, coap_session_t *session,
-		    coap_pdu_t *request, unsigned char flags, void *data) {
+                    coap_pdu_t *request, unsigned char flags, void *data) {
   coap_async_state_t *s;
   coap_tid_t id = request->tid;
 
@@ -69,7 +69,7 @@ coap_register_async(coap_context_t *context, coap_session_t *session,
     s->tokenlen = (request->token_length > 8) ? 8 : request->token_length;
     memcpy(s->token, request->token, s->tokenlen);
   }
-    
+
   coap_touch_async(s);
 
   LL_PREPEND(context->async_state, s);
@@ -96,7 +96,7 @@ coap_remove_async(coap_context_t *context, coap_session_t *session,
   return tmp != NULL;
 }
 
-void 
+void
 coap_free_async(coap_async_state_t *s) {
   if (s) {
     if (s->session) {
@@ -110,5 +110,5 @@ coap_free_async(coap_async_state_t *s) {
 }
 
 #else
-void does_not_exist(void);	/* make some compilers happy */
+void does_not_exist(void);        /* make some compilers happy */
 #endif /* WITHOUT_ASYNC */

--- a/src/block.c
+++ b/src/block.c
@@ -208,7 +208,7 @@ coap_add_data_blocked_response(coap_resource_t *resource,
                     COAP_OPTION_MAXAGE,
                     coap_encode_var_safe(buf, sizeof(buf), maxage), buf);
   }
-     
+
   if (block2_requested) {
     int res;
 
@@ -228,7 +228,7 @@ coap_add_data_blocked_response(coap_resource_t *resource,
     default:                        /* everything is good */
         ;
     }
-     
+
     coap_add_option(response,
                     COAP_OPTION_SIZE2,
                     coap_encode_var_safe(buf, sizeof(buf), length),
@@ -256,7 +256,7 @@ coap_add_data_blocked_response(coap_resource_t *resource,
                     buf);
 
     coap_add_block(response, length, data,
-                   block2.num, block2.szx);        
+                   block2.num, block2.szx);
   }
   return;
 

--- a/src/coap_hashkey.c
+++ b/src/coap_hashkey.c
@@ -14,7 +14,7 @@ coap_hash_impl(const unsigned char *s, unsigned int len, coap_key_t h) {
 
   while (len--) {
     j = sizeof(coap_key_t)-1;
- 
+
     while (j) {
       h[j] = ((h[j] << 7) | (h[j-1] >> 1)) + h[j];
       --j;

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -585,7 +585,7 @@ void coap_socket_close(coap_socket_t *sock) {
 ssize_t
 coap_socket_write(coap_socket_t *sock, const uint8_t *data, size_t data_len) {
   ssize_t r;
-  
+
   sock->flags &= ~(COAP_SOCKET_WANT_WRITE | COAP_SOCKET_CAN_WRITE);
 #ifdef _WIN32
   r = send(sock->fd, (const char *)data, (int)data_len, 0);
@@ -617,7 +617,7 @@ coap_socket_read(coap_socket_t *sock, uint8_t *data, size_t data_len) {
 #ifdef _WIN32
   int error;
 #endif
-  
+
 #ifdef _WIN32
   r = recv(sock->fd, (char *)data, (int)data_len, 0);
 #else
@@ -659,8 +659,8 @@ coap_socket_read(coap_socket_t *sock, uint8_t *data, size_t data_len) {
    FIXME: check with configure
 */
 struct in6_pktinfo {
-  struct in6_addr ipi6_addr;	/* src/dst IPv6 address */
-  unsigned int ipi6_ifindex;	/* send/recv interface index */
+  struct in6_addr ipi6_addr;        /* src/dst IPv6 address */
+  unsigned int ipi6_ifindex;        /* send/recv interface index */
 };
 
 struct in_pktinfo {
@@ -749,33 +749,33 @@ coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint
       struct cmsghdr *cmsg;
 
       if (IN6_IS_ADDR_V4MAPPED(&session->local_addr.addr.sin6.sin6_addr)) {
-	struct in_pktinfo *pktinfo;
-	mhdr.msg_control = buf;
-	mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in_pktinfo));
+        struct in_pktinfo *pktinfo;
+        mhdr.msg_control = buf;
+        mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in_pktinfo));
 
-	cmsg = CMSG_FIRSTHDR(&mhdr);
-	cmsg->cmsg_level = SOL_IP;
-	cmsg->cmsg_type = IP_PKTINFO;
-	cmsg->cmsg_len = CMSG_LEN(sizeof(struct in_pktinfo));
+        cmsg = CMSG_FIRSTHDR(&mhdr);
+        cmsg->cmsg_level = SOL_IP;
+        cmsg->cmsg_type = IP_PKTINFO;
+        cmsg->cmsg_len = CMSG_LEN(sizeof(struct in_pktinfo));
 
-	pktinfo = (struct in_pktinfo *)CMSG_DATA(cmsg);
+        pktinfo = (struct in_pktinfo *)CMSG_DATA(cmsg);
 
-	pktinfo->ipi_ifindex = session->ifindex;
-	memcpy(&pktinfo->ipi_spec_dst, session->local_addr.addr.sin6.sin6_addr.s6_addr + 12, sizeof(pktinfo->ipi_spec_dst));
+        pktinfo->ipi_ifindex = session->ifindex;
+        memcpy(&pktinfo->ipi_spec_dst, session->local_addr.addr.sin6.sin6_addr.s6_addr + 12, sizeof(pktinfo->ipi_spec_dst));
       } else {
-	struct in6_pktinfo *pktinfo;
-	mhdr.msg_control = buf;
-	mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in6_pktinfo));
+        struct in6_pktinfo *pktinfo;
+        mhdr.msg_control = buf;
+        mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in6_pktinfo));
 
-	cmsg = CMSG_FIRSTHDR(&mhdr);
-	cmsg->cmsg_level = IPPROTO_IPV6;
-	cmsg->cmsg_type = IPV6_PKTINFO;
-	cmsg->cmsg_len = CMSG_LEN(sizeof(struct in6_pktinfo));
+        cmsg = CMSG_FIRSTHDR(&mhdr);
+        cmsg->cmsg_level = IPPROTO_IPV6;
+        cmsg->cmsg_type = IPV6_PKTINFO;
+        cmsg->cmsg_len = CMSG_LEN(sizeof(struct in6_pktinfo));
 
-	pktinfo = (struct in6_pktinfo *)CMSG_DATA(cmsg);
+        pktinfo = (struct in6_pktinfo *)CMSG_DATA(cmsg);
 
-	pktinfo->ipi6_ifindex = session->ifindex;
-	memcpy(&pktinfo->ipi6_addr, &session->local_addr.addr.sin6.sin6_addr, sizeof(pktinfo->ipi6_addr));
+        pktinfo->ipi6_ifindex = session->ifindex;
+        memcpy(&pktinfo->ipi6_addr, &session->local_addr.addr.sin6.sin6_addr, sizeof(pktinfo->ipi6_addr));
       }
       break;
     }
@@ -912,8 +912,8 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
       GUID wsaid = WSAID_WSARECVMSG;
       DWORD cbBytesReturned = 0;
       if (WSAIoctl(sock->fd, SIO_GET_EXTENSION_FUNCTION_POINTER, &wsaid, sizeof(wsaid), &lpWSARecvMsg, sizeof(lpWSARecvMsg), &cbBytesReturned, NULL, NULL) != 0) {
-	coap_log(LOG_WARNING, "coap_network_read: no WSARecvMsg\n");
-	return -1;
+        coap_log(LOG_WARNING, "coap_network_read: no WSARecvMsg\n");
+        return -1;
       }
     }
     r = lpWSARecvMsg(sock->fd, &mhdr, &dwNumberOfBytesRecvd, NULL /* LPWSAOVERLAPPED */, NULL /* LPWSAOVERLAPPED_COMPLETION_ROUTINE */);
@@ -929,8 +929,8 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
 #else
       if (errno == ECONNREFUSED) {
 #endif
-	/* server-side ICMP destination unreachable, ignore it. The destination address is in msg_name. */
-	return 0;
+        /* server-side ICMP destination unreachable, ignore it. The destination address is in msg_name. */
+        return 0;
       }
       coap_log(LOG_WARNING, "coap_network_read: %s\n", coap_socket_strerror());
       goto error;
@@ -944,43 +944,43 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
        * is found where the data was received. */
       for (cmsg = CMSG_FIRSTHDR(&mhdr); cmsg; cmsg = CMSG_NXTHDR(&mhdr, cmsg)) {
 
-	/* get the local interface for IPv6 */
-	if (cmsg->cmsg_level == IPPROTO_IPV6 && cmsg->cmsg_type == IPV6_PKTINFO) {
-	  union {
-	    uint8_t *c;
-	    struct in6_pktinfo *p;
-	  } u;
-	  u.c = CMSG_DATA(cmsg);
-	  packet->ifindex = (int)(u.p->ipi6_ifindex);
-	  memcpy(&packet->dst.addr.sin6.sin6_addr, &u.p->ipi6_addr, sizeof(struct in6_addr));
-	  break;
-	}
+        /* get the local interface for IPv6 */
+        if (cmsg->cmsg_level == IPPROTO_IPV6 && cmsg->cmsg_type == IPV6_PKTINFO) {
+          union {
+            uint8_t *c;
+            struct in6_pktinfo *p;
+          } u;
+          u.c = CMSG_DATA(cmsg);
+          packet->ifindex = (int)(u.p->ipi6_ifindex);
+          memcpy(&packet->dst.addr.sin6.sin6_addr, &u.p->ipi6_addr, sizeof(struct in6_addr));
+          break;
+        }
 
-	/* local interface for IPv4 */
+        /* local interface for IPv4 */
 #if defined(IP_PKTINFO)
-	if (cmsg->cmsg_level == SOL_IP && cmsg->cmsg_type == IP_PKTINFO) {
-	  union {
-	    uint8_t *c;
-	    struct in_pktinfo *p;
-	  } u;
-	  u.c = CMSG_DATA(cmsg);
-	  packet->ifindex = u.p->ipi_ifindex;
-	  if (packet->dst.addr.sa.sa_family == AF_INET6) {
-	    memset(packet->dst.addr.sin6.sin6_addr.s6_addr, 0, 10);
-	    packet->dst.addr.sin6.sin6_addr.s6_addr[10] = 0xff;
-	    packet->dst.addr.sin6.sin6_addr.s6_addr[11] = 0xff;
-	    memcpy(packet->dst.addr.sin6.sin6_addr.s6_addr + 12, &u.p->ipi_addr, sizeof(struct in_addr));
-	  } else {
-	    memcpy(&packet->dst.addr.sin.sin_addr, &u.p->ipi_addr, sizeof(struct in_addr));
-	  }
-	  break;
-	}
+        if (cmsg->cmsg_level == SOL_IP && cmsg->cmsg_type == IP_PKTINFO) {
+          union {
+            uint8_t *c;
+            struct in_pktinfo *p;
+          } u;
+          u.c = CMSG_DATA(cmsg);
+          packet->ifindex = u.p->ipi_ifindex;
+          if (packet->dst.addr.sa.sa_family == AF_INET6) {
+            memset(packet->dst.addr.sin6.sin6_addr.s6_addr, 0, 10);
+            packet->dst.addr.sin6.sin6_addr.s6_addr[10] = 0xff;
+            packet->dst.addr.sin6.sin6_addr.s6_addr[11] = 0xff;
+            memcpy(packet->dst.addr.sin6.sin6_addr.s6_addr + 12, &u.p->ipi_addr, sizeof(struct in_addr));
+          } else {
+            memcpy(&packet->dst.addr.sin.sin_addr, &u.p->ipi_addr, sizeof(struct in_addr));
+          }
+          break;
+        }
 #elif defined(IP_RECVDSTADDR)
-	if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_RECVDSTADDR) {
-	  packet->ifindex = 0;
-	  memcpy(&packet->dst.addr.sin.sin_addr, CMSG_DATA(cmsg), sizeof(struct in_addr));
-	  break;
-	}
+        if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_RECVDSTADDR) {
+          packet->ifindex = 0;
+          memcpy(&packet->dst.addr.sin.sin_addr, CMSG_DATA(cmsg), sizeof(struct in_addr));
+          break;
+        }
 #endif /* IP_PKTINFO */
       }
     }
@@ -999,9 +999,9 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
       len = uip_datalen();
 
       if (len > COAP_RXBUFFER_SIZE) {
-	/* FIXME: we might want to send back a response */
-	warn("discarded oversized packet\n");
-	return -1;
+        /* FIXME: we might want to send back a response */
+        warn("discarded oversized packet\n");
+        return -1;
       }
 
       ((char *)uip_appdata)[len] = 0;
@@ -1010,11 +1010,11 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN 40
 #endif
-	unsigned char addr_str[INET6_ADDRSTRLEN + 8];
+        unsigned char addr_str[INET6_ADDRSTRLEN + 8];
 
-	if (coap_print_addr(&packet->src, addr_str, INET6_ADDRSTRLEN + 8)) {
-	  debug("received %zd bytes from %s\n", len, addr_str);
-	}
+        if (coap_print_addr(&packet->src, addr_str, INET6_ADDRSTRLEN + 8)) {
+          debug("received %zd bytes from %s\n", len, addr_str);
+        }
       }
 #endif /* NDEBUG */
 
@@ -1096,21 +1096,21 @@ coap_write(coap_context_t *ctx,
     ) {
       coap_tick_t s_timeout;
       if (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND <= now) {
-	if ((s->last_ping > 0 && s->last_pong < s->last_ping)
-	  || coap_session_send_ping(s) == COAP_INVALID_TID)
-	{
-	  /* Make sure the session object is not deleted in the callback */
-	  coap_session_reference(s);
-	  coap_session_disconnected(s, COAP_NACK_NOT_DELIVERABLE);
-	  coap_session_release(s);
-	  continue;
-	}
+        if ((s->last_ping > 0 && s->last_pong < s->last_ping)
+          || coap_session_send_ping(s) == COAP_INVALID_TID)
+        {
+          /* Make sure the session object is not deleted in the callback */
+          coap_session_reference(s);
+          coap_session_disconnected(s, COAP_NACK_NOT_DELIVERABLE);
+          coap_session_release(s);
+          continue;
+        }
         s->last_rx_tx = now;
-	s->last_ping = now;
+        s->last_ping = now;
       }
       s_timeout = (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND) - now;
       if (timeout == 0 || s_timeout < timeout)
-	timeout = s_timeout;
+        timeout = s_timeout;
     }
 
     if (
@@ -1121,17 +1121,17 @@ coap_write(coap_context_t *ctx,
     ) {
       coap_tick_t s_timeout;
       if (s->csm_tx == 0) {
-	s->csm_tx = now;
+        s->csm_tx = now;
       } else if (s->csm_tx + ctx->csm_timeout * COAP_TICKS_PER_SECOND <= now) {
-	/* Make sure the session object is not deleted in the callback */
-	coap_session_reference(s);
-	coap_session_disconnected(s, COAP_NACK_NOT_DELIVERABLE);
-	coap_session_release(s);
-	continue;
+        /* Make sure the session object is not deleted in the callback */
+        coap_session_reference(s);
+        coap_session_disconnected(s, COAP_NACK_NOT_DELIVERABLE);
+        coap_session_release(s);
+        continue;
       }
       s_timeout = (s->csm_tx + ctx->csm_timeout * COAP_TICKS_PER_SECOND) - now;
       if (timeout == 0 || s_timeout < timeout)
-	timeout = s_timeout;
+        timeout = s_timeout;
     }
 
     if (s->sock.flags & (COAP_SOCKET_WANT_READ | COAP_SOCKET_WANT_WRITE | COAP_SOCKET_WANT_CONNECT)) {

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -4,7 +4,7 @@
  *               2014 chrysn <chrysn@fsfe.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include "coap_config.h"
@@ -21,28 +21,28 @@ int lwprot_count = 0;
 #if 0
 void coap_packet_copy_source(coap_packet_t *packet, coap_address_t *target)
 {
-	target->port = packet->srcport;
-	memcpy(&target->addr, ip_current_src_addr(), sizeof(ip_addr_t));
+        target->port = packet->srcport;
+        memcpy(&target->addr, ip_current_src_addr(), sizeof(ip_addr_t));
 }
 #endif
 void coap_packet_get_memmapped(coap_packet_t *packet, unsigned char **address, size_t *length)
 {
-	LWIP_ASSERT("Can only deal with contiguous PBUFs to read the initial details", packet->pbuf->tot_len == packet->pbuf->len);
-	*address = packet->pbuf->payload;
-	*length = packet->pbuf->tot_len;
+        LWIP_ASSERT("Can only deal with contiguous PBUFs to read the initial details", packet->pbuf->tot_len == packet->pbuf->len);
+        *address = packet->pbuf->payload;
+        *length = packet->pbuf->tot_len;
 }
 void coap_free_packet(coap_packet_t *packet)
 {
-	if (packet->pbuf)
-		pbuf_free(packet->pbuf);
-	coap_free_type(COAP_PACKET, packet);
+        if (packet->pbuf)
+                pbuf_free(packet->pbuf);
+        coap_free_type(COAP_PACKET, packet);
 }
 
 struct pbuf *coap_packet_extract_pbuf(coap_packet_t *packet)
 {
-	struct pbuf *ret = packet->pbuf;
-	packet->pbuf = NULL;
-	return ret;
+        struct pbuf *ret = packet->pbuf;
+        packet->pbuf = NULL;
+        return ret;
 }
 
 
@@ -103,39 +103,39 @@ error:
 
 coap_endpoint_t *
 coap_new_endpoint(coap_context_t *context, const coap_address_t *addr, coap_proto_t proto) {
-	coap_endpoint_t *result;
-	err_t err;
+        coap_endpoint_t *result;
+        err_t err;
 
-	LWIP_ASSERT("Proto not supported for LWIP endpoints", proto == COAP_PROTO_UDP);
+        LWIP_ASSERT("Proto not supported for LWIP endpoints", proto == COAP_PROTO_UDP);
 
-	result = coap_malloc_type(COAP_ENDPOINT, sizeof(coap_endpoint_t));
-	if (!result) return NULL;
+        result = coap_malloc_type(COAP_ENDPOINT, sizeof(coap_endpoint_t));
+        if (!result) return NULL;
 
-	result->sock.pcb = udp_new_ip_type(IPADDR_TYPE_ANY);
-	if (result->sock.pcb == NULL) goto error;
+        result->sock.pcb = udp_new_ip_type(IPADDR_TYPE_ANY);
+        if (result->sock.pcb == NULL) goto error;
 
-	udp_recv(result->sock.pcb, coap_recv, (void*)result);
-	err = udp_bind(result->sock.pcb, &addr->addr, addr->port);
-	if (err) {
-		udp_remove(result->sock.pcb);
-		goto error;
-	}
+        udp_recv(result->sock.pcb, coap_recv, (void*)result);
+        err = udp_bind(result->sock.pcb, &addr->addr, addr->port);
+        if (err) {
+                udp_remove(result->sock.pcb);
+                goto error;
+        }
 
-	result->default_mtu = COAP_DEFAULT_MTU;
-	result->context = context;
-	result->proto = proto;
+        result->default_mtu = COAP_DEFAULT_MTU;
+        result->context = context;
+        result->proto = proto;
 
-	return result;
+        return result;
 
 error:
-	coap_free_type(COAP_ENDPOINT, result);
-	return NULL;
+        coap_free_type(COAP_ENDPOINT, result);
+        return NULL;
 }
 
 void coap_free_endpoint(coap_endpoint_t *ep)
 {
-	udp_remove(ep->sock.pcb);
-	coap_free_type(COAP_ENDPOINT, ep);
+        udp_remove(ep->sock.pcb);
+        coap_free_type(COAP_ENDPOINT, ep);
 }
 
 ssize_t

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -15,7 +15,7 @@
 /*
  * OpenSSL 1.1.0 has support for making decisions during receipt of
  * the Client Hello - the call back function is set up using
- * SSL_CTX_set_tlsext_servername_callback() which is called later in the 
+ * SSL_CTX_set_tlsext_servername_callback() which is called later in the
  * Client Hello processing - but called every Client Hello.
  * Certificates and Preshared Keys have to be set up in the SSL CTX before
  * SSL_Accept() is called, making the code messy to decide whether this is a
@@ -24,7 +24,7 @@
  * with different crtificates.
  *
  * OpenSSL 1.1.1 introduces a new function SSL_CTX_set_client_hello_cb().
- * The call back is invoked early on in the Client Hello processing giving 
+ * The call back is invoked early on in the Client Hello processing giving
  * the ability to easily use different Preshared Keys, Certificates etc.
  * Certificates do not have to be set up in the SSL CTX before SSL_Accept is
  * called.
@@ -71,7 +71,7 @@
 /* This structure encapsulates the OpenSSL context object. */
 typedef struct coap_dtls_context_t {
   SSL_CTX *ctx;
-  SSL *ssl;	/* OpenSSL object for listening to connection requests */
+  SSL *ssl;        /* OpenSSL object for listening to connection requests */
   HMAC_CTX *cookie_hmac;
   BIO_METHOD *meth;
   BIO_ADDR *bio_addr;
@@ -197,15 +197,15 @@ static int coap_dgram_read(BIO *a, char *out, int outl) {
   if (out != NULL) {
     if (data != NULL && data->pdu_len > 0) {
       if (outl < (int)data->pdu_len) {
-	memcpy(out, data->pdu, outl);
-	ret = outl;
+        memcpy(out, data->pdu, outl);
+        ret = outl;
       } else {
-	memcpy(out, data->pdu, data->pdu_len);
-	ret = (int)data->pdu_len;
+        memcpy(out, data->pdu, data->pdu_len);
+        ret = (int)data->pdu_len;
       }
       if (!data->peekmode) {
-	data->pdu_len = 0;
-	data->pdu = NULL;
+        data->pdu_len = 0;
+        data->pdu = NULL;
       }
     } else {
       ret = -1;
@@ -386,20 +386,20 @@ static void coap_dtls_info_callback(const SSL *ssl, int where, int ret) {
   } else if (where & SSL_CB_EXIT) {
     if (ret == 0) {
       if (dtls_log_level >= LOG_WARNING) {
-	unsigned long e;
-	coap_log(LOG_WARNING, "*   %s: %s:failed in %s\n", coap_session_str(session), pstr, SSL_state_string_long(ssl));
-	while ((e = ERR_get_error()))
-	  coap_log(LOG_WARNING, "*   %s:   %s at %s:%s\n", coap_session_str(session), ERR_reason_error_string(e), ERR_lib_error_string(e), ERR_func_error_string(e));
+        unsigned long e;
+        coap_log(LOG_WARNING, "*   %s: %s:failed in %s\n", coap_session_str(session), pstr, SSL_state_string_long(ssl));
+        while ((e = ERR_get_error()))
+          coap_log(LOG_WARNING, "*   %s:   %s at %s:%s\n", coap_session_str(session), ERR_reason_error_string(e), ERR_lib_error_string(e), ERR_func_error_string(e));
       }
     } else if (ret < 0) {
       if (dtls_log_level >= LOG_WARNING) {
-	int err = SSL_get_error(ssl, ret);
-	if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE && err != SSL_ERROR_WANT_CONNECT && err != SSL_ERROR_WANT_ACCEPT && err != SSL_ERROR_WANT_X509_LOOKUP) {
-	  long e;
-	  coap_log(LOG_WARNING, "*   %s: %s:error in %s\n", coap_session_str(session), pstr, SSL_state_string_long(ssl));
-	  while ((e = ERR_get_error()))
-	    coap_log(LOG_WARNING, "*   %s: %s at %s:%s\n", coap_session_str(session), ERR_reason_error_string(e), ERR_lib_error_string(e), ERR_func_error_string(e));
-	}
+        int err = SSL_get_error(ssl, ret);
+        if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE && err != SSL_ERROR_WANT_CONNECT && err != SSL_ERROR_WANT_ACCEPT && err != SSL_ERROR_WANT_X509_LOOKUP) {
+          long e;
+          coap_log(LOG_WARNING, "*   %s: %s:error in %s\n", coap_session_str(session), pstr, SSL_state_string_long(ssl));
+          while ((e = ERR_get_error()))
+            coap_log(LOG_WARNING, "*   %s: %s at %s:%s\n", coap_session_str(session), ERR_reason_error_string(e), ERR_lib_error_string(e), ERR_func_error_string(e));
+        }
       }
     }
   }
@@ -497,7 +497,7 @@ void *coap_dtls_new_context(struct coap_context_t *coap_context) {
     SSL_CTX_set_cipher_list(context->dtls.ctx, "TLSv1.2:TLSv1.0");
     if (!RAND_bytes(cookie_secret, (int)sizeof(cookie_secret))) {
       if (dtls_log_level >= LOG_WARNING)
-	coap_log(LOG_WARNING, "Insufficient entropy for random cookie generation");
+        coap_log(LOG_WARNING, "Insufficient entropy for random cookie generation");
       prng(cookie_secret, sizeof(cookie_secret));
     }
     context->dtls.cookie_hmac = HMAC_CTX_new();
@@ -1196,7 +1196,7 @@ tls_server_name_call_back(SSL *ssl,
   if (setup_data->validate_sni_call_back) {
     /* SNI checking requested */
     coap_session_t *session = (coap_session_t*)SSL_get_app_data(ssl);
-    coap_openssl_context_t *context = 
+    coap_openssl_context_t *context =
                   ((coap_openssl_context_t *)session->context->dtls_context);
     const char *sni = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
     size_t i;
@@ -1376,7 +1376,7 @@ is_x509:
      * SNI checking requested
      */
     coap_dtls_pki_t sni_setup_data;
-    coap_openssl_context_t *context = 
+    coap_openssl_context_t *context =
                   ((coap_openssl_context_t *)session->context->dtls_context);
     const char *sni = "";
     char *sni_tmp = NULL;
@@ -1811,9 +1811,9 @@ int coap_dtls_send(coap_session_t *session,
     } else {
       coap_log(LOG_WARNING, "coap_dtls_send: cannot send PDU\n");
       if (err == SSL_ERROR_ZERO_RETURN)
-	session->dtls_event = COAP_EVENT_DTLS_CLOSED;
+        session->dtls_event = COAP_EVENT_DTLS_CLOSED;
       else if (err == SSL_ERROR_SSL)
-	session->dtls_event = COAP_EVENT_DTLS_ERROR;
+        session->dtls_event = COAP_EVENT_DTLS_ERROR;
       r = -1;
     }
   }
@@ -1853,7 +1853,7 @@ void coap_dtls_handle_timeout(coap_session_t *session) {
 
   assert(ssl != NULL);
   if (((session->state == COAP_SESSION_STATE_HANDSHAKE) &&
-       (++session->dtls_timeout_count > session->max_retransmit)) || 
+       (++session->dtls_timeout_count > session->max_retransmit)) ||
       (DTLSv1_handle_timeout(ssl) < 0)) {
     /* Too many retries */
     coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
@@ -1908,23 +1908,23 @@ int coap_dtls_receive(coap_session_t *session,
     int err = SSL_get_error(ssl, r);
     if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
       if (in_init && SSL_is_init_finished(ssl)) {
-	coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
-	coap_session_connected(session);
+        coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+        coap_session_connected(session);
       }
       r = 0;
     } else {
-      if (err == SSL_ERROR_ZERO_RETURN)	/* Got a close notify alert from the remote side */
-	session->dtls_event = COAP_EVENT_DTLS_CLOSED;
+      if (err == SSL_ERROR_ZERO_RETURN)        /* Got a close notify alert from the remote side */
+        session->dtls_event = COAP_EVENT_DTLS_CLOSED;
       else if (err == SSL_ERROR_SSL)
-	session->dtls_event = COAP_EVENT_DTLS_ERROR;
+        session->dtls_event = COAP_EVENT_DTLS_ERROR;
       r = -1;
     }
     if (session->dtls_event >= 0) {
       coap_handle_event(session->context, session->dtls_event, session);
       if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
           session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
-	coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
-	r = -1;
+        coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
+        r = -1;
       }
     }
   }
@@ -1939,7 +1939,7 @@ unsigned int coap_dtls_get_overhead(coap_session_t *session) {
     s_ciph = SSL_get_current_cipher(session->tls);
   if ( s_ciph ) {
     unsigned int ivlen, maclen, blocksize = 1, pad = 0;
-    
+
     const EVP_CIPHER *e_ciph;
     const EVP_MD *e_md;
     char cipher[128];
@@ -1956,9 +1956,9 @@ unsigned int coap_dtls_get_overhead(coap_session_t *session) {
       ivlen = EVP_CCM_TLS_EXPLICIT_IV_LEN;
       SSL_CIPHER_description(s_ciph, cipher, sizeof(cipher));
       if (strstr(cipher, "CCM8"))
-	maclen = 8;
+        maclen = 8;
       else
-	maclen = 16;
+        maclen = 16;
       break;
 
     case EVP_CIPH_CBC_MODE:
@@ -2116,16 +2116,16 @@ ssize_t coap_tls_write(coap_session_t *session,
         coap_session_send_csm(session);
       }
       if (err == SSL_ERROR_WANT_READ)
-	session->sock.flags |= COAP_SOCKET_WANT_READ;
+        session->sock.flags |= COAP_SOCKET_WANT_READ;
       if (err == SSL_ERROR_WANT_WRITE)
-	session->sock.flags |= COAP_SOCKET_WANT_WRITE;
+        session->sock.flags |= COAP_SOCKET_WANT_WRITE;
       r = 0;
     } else {
       coap_log(LOG_WARNING, "*** %s: coap_tls_write: cannot send PDU\n", coap_session_str(session));
       if (err == SSL_ERROR_ZERO_RETURN)
-	session->dtls_event = COAP_EVENT_DTLS_CLOSED;
+        session->dtls_event = COAP_EVENT_DTLS_CLOSED;
       else if (err == SSL_ERROR_SSL)
-	session->dtls_event = COAP_EVENT_DTLS_ERROR;
+        session->dtls_event = COAP_EVENT_DTLS_ERROR;
       r = -1;
     }
   } else if (in_init && SSL_is_init_finished(ssl)) {
@@ -2162,19 +2162,19 @@ ssize_t coap_tls_read(coap_session_t *session,
     int err = SSL_get_error(ssl, r);
     if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
       if (in_init && SSL_is_init_finished(ssl)) {
-	coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
-	coap_session_send_csm(session);
+        coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+        coap_session_send_csm(session);
       }
       if (err == SSL_ERROR_WANT_READ)
-	session->sock.flags |= COAP_SOCKET_WANT_READ;
+        session->sock.flags |= COAP_SOCKET_WANT_READ;
       if (err == SSL_ERROR_WANT_WRITE)
-	session->sock.flags |= COAP_SOCKET_WANT_WRITE;
+        session->sock.flags |= COAP_SOCKET_WANT_WRITE;
       r = 0;
     } else {
-      if (err == SSL_ERROR_ZERO_RETURN)	/* Got a close notify alert from the remote side */
-	session->dtls_event = COAP_EVENT_DTLS_CLOSED;
+      if (err == SSL_ERROR_ZERO_RETURN)        /* Got a close notify alert from the remote side */
+        session->dtls_event = COAP_EVENT_DTLS_CLOSED;
       else if (err == SSL_ERROR_SSL)
-	session->dtls_event = COAP_EVENT_DTLS_ERROR;
+        session->dtls_event = COAP_EVENT_DTLS_ERROR;
       r = -1;
     }
   } else if (in_init && SSL_is_init_finished(ssl)) {

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -348,20 +348,20 @@ void coap_session_connected(coap_session_t *session) {
     bytes_written = coap_session_send_pdu(session, q->pdu);
     if (q->pdu->type == COAP_MESSAGE_CON && COAP_PROTO_NOT_RELIABLE(session->proto)) {
       if (coap_wait_ack(session->context, session, q) >= 0)
-	q = NULL;
+        q = NULL;
     }
     if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
       if (q)
-	coap_delete_node(q);
+        coap_delete_node(q);
       if (bytes_written < 0)
-	break;
+        break;
     } else {
       if (bytes_written <= 0 || (size_t)bytes_written < q->pdu->used_size + q->pdu->hdr_size) {
-	q->next = session->delayqueue;
-	session->delayqueue = q;
-	if (bytes_written > 0)
-	  session->partial_write = (size_t)bytes_written;
-	break;
+        q->next = session->delayqueue;
+        session->delayqueue = q;
+        if (bytes_written > 0)
+          session->partial_write = (size_t)bytes_written;
+        break;
       } else {
         coap_delete_node(q);
       }
@@ -406,13 +406,13 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
       && reason != COAP_NACK_RST)
     {
       if (coap_wait_ack(session->context, session, q) >= 0)
-	q = NULL;
+        q = NULL;
     }
     if (q && q->pdu->type == COAP_MESSAGE_CON
       && session->context->nack_handler)
     {
       session->context->nack_handler(session->context, session, q->pdu,
-	                             reason, q->id);
+                                     reason, q->id);
     }
     if (q)
       coap_delete_node(q);
@@ -421,13 +421,13 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
     if (session->sock.flags != COAP_SOCKET_EMPTY) {
       coap_socket_close(&session->sock);
       coap_handle_event(session->context,
-	state == COAP_SESSION_STATE_CONNECTING ?
-	COAP_EVENT_TCP_FAILED : COAP_EVENT_TCP_CLOSED, session);
+        state == COAP_SESSION_STATE_CONNECTING ?
+        COAP_EVENT_TCP_FAILED : COAP_EVENT_TCP_CLOSED, session);
     }
     if (state != COAP_SESSION_STATE_NONE) {
       coap_handle_event(session->context,
-	state == COAP_SESSION_STATE_ESTABLISHED ?
-	COAP_EVENT_SESSION_CLOSED : COAP_EVENT_SESSION_FAILED, session);
+        state == COAP_SESSION_STATE_ESTABLISHED ?
+        COAP_EVENT_SESSION_CLOSED : COAP_EVENT_SESSION_FAILED, session);
     }
   }
 }
@@ -452,7 +452,7 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
     if (session->ref == 0 && session->delayqueue == NULL && session->type == COAP_SESSION_TYPE_SERVER) {
       ++num_idle;
       if (oldest==NULL || session->last_rx_tx < oldest->last_rx_tx)
-	oldest = session;
+        oldest = session;
     }
   }
 
@@ -471,7 +471,7 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
     if (session) {
       session->last_rx_tx = now;
       if (endpoint->proto == COAP_PROTO_UDP)
-	session->state = COAP_SESSION_STATE_ESTABLISHED;
+        session->state = COAP_SESSION_STATE_ESTABLISHED;
       LL_PREPEND(endpoint->sessions, session);
       debug("*** %s: new incoming session\n", coap_session_str(session));
     }
@@ -570,7 +570,7 @@ coap_session_connect(coap_session_t *session) {
       int connected = 0;
       session->tls = coap_tls_new_client_session(session, &connected);
       if (session->tls) {
-	session->state = COAP_SESSION_STATE_HANDSHAKE;
+        session->state = COAP_SESSION_STATE_HANDSHAKE;
         if (connected)
           coap_session_send_csm(session);
       } else {
@@ -579,8 +579,8 @@ coap_session_connect(coap_session_t *session) {
          * first before trying to release the object.
          */
         coap_session_reference(session);
-	coap_session_release(session);
-	return NULL;
+        coap_session_release(session);
+        return NULL;
       }
     } else {
       coap_session_send_csm(session);
@@ -814,10 +814,10 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
 
     if (coap_print_addr(&ep->bind_addr, addr_str, INET6_ADDRSTRLEN + 8)) {
       debug("created %s endpoint %s\n",
-	  ep->proto == COAP_PROTO_TLS ? "TLS"
-	: ep->proto == COAP_PROTO_TCP ? "TCP"
-	: ep->proto == COAP_PROTO_DTLS ? "DTLS " : "UDP",
-	addr_str);
+          ep->proto == COAP_PROTO_TLS ? "TLS"
+        : ep->proto == COAP_PROTO_TCP ? "TCP"
+        : ep->proto == COAP_PROTO_DTLS ? "DTLS " : "UDP",
+        addr_str);
     }
   }
 #endif /* NDEBUG */
@@ -883,7 +883,7 @@ coap_session_get_by_peer(coap_context_t *ctx,
       return &ep->hello;
     LL_FOREACH(ep->sessions, s) {
       if (s->ifindex == ifindex && coap_address_equals(&s->remote_addr, remote_addr))
-	return s;
+        return s;
     }
   }
   return NULL;

--- a/src/coap_time.c
+++ b/src/coap_time.c
@@ -29,7 +29,7 @@ static coap_tick_t coap_clock_offset = 0;
 #if _POSIX_TIMERS && !defined(__APPLE__)
   /* _POSIX_TIMERS is > 0 when clock_gettime() is available */
 
-  /* Use real-time clock for correct timestamps in coap_log(). */  
+  /* Use real-time clock for correct timestamps in coap_log(). */
 #define COAP_CLOCK CLOCK_REALTIME
 #endif
 

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -300,8 +300,8 @@ void *coap_dtls_new_client_session(coap_session_t *session) {
     if (dtls_connect((struct dtls_context_t *)session->context->dtls_context,
       dtls_session) >= 0) {
       peer =
-	dtls_get_peer((struct dtls_context_t *)session->context->dtls_context,
-	  dtls_session);
+        dtls_get_peer((struct dtls_context_t *)session->context->dtls_context,
+          dtls_session);
     }
   }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2010--2012,2014--2015 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include "coap_config.h"
@@ -50,7 +50,7 @@
 #include "net/ip/uip-debug.h"
 #endif
 
-static coap_log_t maxlog = LOG_WARNING;	/* default maximum log level */
+static coap_log_t maxlog = LOG_WARNING;        /* default maximum log level */
 
 static int use_fprintf_for_show_pdu = 1; /* non zero to output with fprintf */
 
@@ -67,7 +67,7 @@ coap_set_show_pdu_output(int use_fprintf) {
   use_fprintf_for_show_pdu = use_fprintf;
 }
 
-coap_log_t 
+coap_log_t
 coap_get_log_level(void) {
   return maxlog;
 }
@@ -79,7 +79,7 @@ coap_set_log_level(coap_log_t level) {
 
 /* this array has the same order as the type log_t */
 static const char *loglevels[] = {
-  "EMRG", "ALRT", "CRIT", "ERR", "WARN", "NOTE", "INFO", "DEBG" 
+  "EMRG", "ALRT", "CRIT", "ERR", "WARN", "NOTE", "INFO", "DEBG"
 };
 
 #ifdef HAVE_TIME_H
@@ -97,9 +97,9 @@ print_timestamp(char *s, size_t len, coap_tick_t t) {
 COAP_STATIC_INLINE size_t
 print_timestamp(char *s, size_t len, coap_tick_t t) {
 #ifdef HAVE_SNPRINTF
-  return snprintf(s, len, "%u.%03u", 
-		  (unsigned int)coap_ticks_to_rt(t),
-		  (unsigned int)(t % COAP_TICKS_PER_SECOND));
+  return snprintf(s, len, "%u.%03u",
+                  (unsigned int)coap_ticks_to_rt(t),
+                  (unsigned int)(t % COAP_TICKS_PER_SECOND));
 #else /* HAVE_SNPRINTF */
   /* @todo do manual conversion of timestamp */
   return 0;
@@ -109,12 +109,12 @@ print_timestamp(char *s, size_t len, coap_tick_t t) {
 #endif /* HAVE_TIME_H */
 
 #ifndef HAVE_STRNLEN
-/** 
- * A length-safe strlen() fake. 
- * 
+/**
+ * A length-safe strlen() fake.
+ *
  * @param s      The string to count characters != 0.
  * @param maxlen The maximum length of @p s.
- * 
+ *
  * @return The length of @p s.
  */
 static inline size_t
@@ -128,7 +128,7 @@ strnlen(const char *s, size_t maxlen) {
 
 static size_t
 print_readable( const uint8_t *data, size_t len,
-		unsigned char *result, size_t buflen, int encode_always ) {
+                unsigned char *result, size_t buflen, int encode_always ) {
   const uint8_t hex[] = "0123456789ABCDEF";
   size_t cnt = 0;
   assert(data || len == 0);
@@ -143,17 +143,17 @@ print_readable( const uint8_t *data, size_t len,
       *result++ = *data;
       ++cnt;
       } else {
-	break;
+        break;
       }
     } else {
       if (cnt+4 < buflen) { /* keep one byte for terminating zero */
-	*result++ = '\\';
-	*result++ = 'x';
-	*result++ = hex[(*data & 0xf0) >> 4];
-	*result++ = hex[*data & 0x0f];
-	cnt += 4;
+        *result++ = '\\';
+        *result++ = 'x';
+        *result++ = hex[(*data & 0xf0) >> 4];
+        *result++ = hex[*data & 0x0f];
+        cnt += 4;
       } else
-	break;
+        break;
     }
 
     ++data; --len;
@@ -175,7 +175,7 @@ coap_print_addr(const struct coap_address_t *addr, unsigned char *buf, size_t le
   unsigned char *p = buf;
 
   switch (addr->addr.sa.sa_family) {
-  case AF_INET: 
+  case AF_INET:
     addrptr = &addr->addr.sin.sin_addr;
     port = ntohs(addr->addr.sin.sin_port);
     break;
@@ -205,7 +205,7 @@ coap_print_addr(const struct coap_address_t *addr, unsigned char *buf, size_t le
   if (addr->addr.sa.sa_family == AF_INET6) {
     if (p < buf + len) {
       *p++ = ']';
-    } else 
+    } else
       return 0;
   }
 
@@ -351,32 +351,32 @@ msg_option_string(uint8_t code, uint16_t option_type) {
   if (code == COAP_SIGNALING_CSM) {
     for (i = 0; i < sizeof(options_csm)/sizeof(struct option_desc_t); i++) {
       if (option_type == options_csm[i].type) {
-	return options_csm[i].name;
+        return options_csm[i].name;
       }
     }
   } else if (code == COAP_SIGNALING_PING || code == COAP_SIGNALING_PONG) {
     for (i = 0; i < sizeof(options_pingpong)/sizeof(struct option_desc_t); i++) {
       if (option_type == options_pingpong[i].type) {
-	return options_pingpong[i].name;
+        return options_pingpong[i].name;
       }
     }
   } else if (code == COAP_SIGNALING_RELEASE) {
     for (i = 0; i < sizeof(options_release)/sizeof(struct option_desc_t); i++) {
       if (option_type == options_release[i].type) {
-	return options_release[i].name;
+        return options_release[i].name;
       }
     }
   } else if (code == COAP_SIGNALING_ABORT) {
     for (i = 0; i < sizeof(options_abort)/sizeof(struct option_desc_t); i++) {
       if (option_type == options_abort[i].type) {
-	return options_abort[i].name;
+        return options_abort[i].name;
       }
     }
   } else {
     /* search option_type in list of known options */
     for (i = 0; i < sizeof(options)/sizeof(struct option_desc_t); i++) {
       if (option_type == options[i].type) {
-	return options[i].name;
+        return options[i].name;
       }
     }
   }
@@ -387,7 +387,7 @@ msg_option_string(uint8_t code, uint16_t option_type) {
 
 static unsigned int
 print_content_format(unsigned int format_type,
-		     unsigned char *result, unsigned int buflen) {
+                     unsigned char *result, unsigned int buflen) {
   struct desc_t {
     unsigned int type;
     const char *name;
@@ -441,10 +441,10 @@ print_content_format(unsigned int format_type,
 COAP_STATIC_INLINE int
 is_binary(int content_format) {
   return !(content_format == -1 ||
-	   content_format == COAP_MEDIATYPE_TEXT_PLAIN ||
-	   content_format == COAP_MEDIATYPE_APPLICATION_LINK_FORMAT ||
-	   content_format == COAP_MEDIATYPE_APPLICATION_XML ||
-	   content_format == COAP_MEDIATYPE_APPLICATION_JSON);
+           content_format == COAP_MEDIATYPE_TEXT_PLAIN ||
+           content_format == COAP_MEDIATYPE_APPLICATION_LINK_FORMAT ||
+           content_format == COAP_MEDIATYPE_APPLICATION_XML ||
+           content_format == COAP_MEDIATYPE_APPLICATION_JSON);
 }
 
 #define COAP_DO_SHOW_OUTPUT_LINE           \
@@ -469,14 +469,14 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
   unsigned char *data;
   char outbuf[COAP_DEBUG_BUF_SIZE];
   int outbuflen = 0;
- 
+
   /* Save time if not needed */
   if (level > coap_get_log_level())
     return;
 
   snprintf(outbuf, sizeof(outbuf), "v:%d t:%s c:%s i:%04x {",
-	  COAP_DEFAULT_VERSION, msg_type_string(pdu->type),
-	  msg_code_string(pdu->code), pdu->tid);
+          COAP_DEFAULT_VERSION, msg_type_string(pdu->type),
+          msg_code_string(pdu->code), pdu->tid);
 
   for (i = 0; i < pdu->token_length; i++) {
     outbuflen = strlen(outbuf);
@@ -502,8 +502,8 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
     if (pdu->code == COAP_SIGNALING_CSM) switch(opt_iter.type) {
     case COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE:
       buf_len = snprintf((char *)buf, sizeof(buf), "%u",
-			 coap_decode_var_bytes(coap_opt_value(option),
-					       coap_opt_length(option)));
+                         coap_decode_var_bytes(coap_opt_value(option),
+                                               coap_opt_length(option)));
       break;
     default:
       buf_len = 0;
@@ -514,13 +514,13 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
     } else if (pdu->code == COAP_SIGNALING_RELEASE) switch(opt_iter.type) {
     case COAP_SIGNALING_OPTION_ALTERNATIVE_ADDRESS:
       buf_len = print_readable(coap_opt_value(option),
-			       coap_opt_length(option),
-			       buf, sizeof(buf), 0);
+                               coap_opt_length(option),
+                               buf, sizeof(buf), 0);
       break;
     case COAP_SIGNALING_OPTION_HOLD_OFF:
       buf_len = snprintf((char *)buf, sizeof(buf), "%u",
-			 coap_decode_var_bytes(coap_opt_value(option),
-					       coap_opt_length(option)));
+                         coap_decode_var_bytes(coap_opt_value(option),
+                                               coap_opt_length(option)));
       break;
     default:
       buf_len = 0;
@@ -528,8 +528,8 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
     } else if (pdu->code == COAP_SIGNALING_ABORT) switch(opt_iter.type) {
     case COAP_SIGNALING_OPTION_BAD_CSM_OPTION:
       buf_len = snprintf((char *)buf, sizeof(buf), "%u",
-			 coap_decode_var_bytes(coap_opt_value(option),
-					       coap_opt_length(option)));
+                         coap_decode_var_bytes(coap_opt_value(option),
+                                               coap_opt_length(option)));
       break;
     default:
       buf_len = 0;
@@ -537,7 +537,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
     } else switch (opt_iter.type) {
     case COAP_OPTION_CONTENT_FORMAT:
       content_format = (int)coap_decode_var_bytes(coap_opt_value(option),
-						  coap_opt_length(option));
+                                                  coap_opt_length(option));
 
       buf_len = print_content_format(content_format, buf, sizeof(buf));
       break;
@@ -547,9 +547,9 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
       /* split block option into number/more/size where more is the
        * letter M if set, the _ otherwise */
       buf_len = snprintf((char *)buf, sizeof(buf), "%u/%c/%u",
-			 coap_opt_block_num(option), /* block number */
-			 COAP_OPT_BLOCK_MORE(option) ? 'M' : '_', /* M bit */
-			 (1 << (COAP_OPT_BLOCK_SZX(option) + 4))); /* block size */
+                         coap_opt_block_num(option), /* block number */
+                         COAP_OPT_BLOCK_MORE(option) ? 'M' : '_', /* M bit */
+                         (1 << (COAP_OPT_BLOCK_SZX(option) + 4))); /* block size */
 
       break;
 
@@ -560,37 +560,37 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
     case COAP_OPTION_SIZE2:
       /* show values as unsigned decimal value */
       buf_len = snprintf((char *)buf, sizeof(buf), "%u",
-			 coap_decode_var_bytes(coap_opt_value(option),
-					       coap_opt_length(option)));
+                         coap_decode_var_bytes(coap_opt_value(option),
+                                               coap_opt_length(option)));
       break;
 
     default:
       /* generic output function for all other option types */
       if (opt_iter.type == COAP_OPTION_URI_PATH ||
-	  opt_iter.type == COAP_OPTION_PROXY_URI ||
-	  opt_iter.type == COAP_OPTION_URI_HOST ||
-	  opt_iter.type == COAP_OPTION_LOCATION_PATH ||
-	  opt_iter.type == COAP_OPTION_LOCATION_QUERY ||
-	  opt_iter.type == COAP_OPTION_URI_QUERY) {
-	encode = 0;
+          opt_iter.type == COAP_OPTION_PROXY_URI ||
+          opt_iter.type == COAP_OPTION_URI_HOST ||
+          opt_iter.type == COAP_OPTION_LOCATION_PATH ||
+          opt_iter.type == COAP_OPTION_LOCATION_QUERY ||
+          opt_iter.type == COAP_OPTION_URI_QUERY) {
+        encode = 0;
       } else {
-	encode = 1;
+        encode = 1;
       }
 
       buf_len = print_readable(coap_opt_value(option),
-			       coap_opt_length(option),
-			       buf, sizeof(buf), encode);
+                               coap_opt_length(option),
+                               buf, sizeof(buf), encode);
     }
 
     outbuflen = strlen(outbuf);
     snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
               " %s:%.*s", msg_option_string(pdu->code, opt_iter.type),
-	      (int)buf_len, buf);
+              (int)buf_len, buf);
   }
 
   outbuflen = strlen(outbuf);
   snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  " ]");
-  
+
   if (coap_get_data(pdu, &data_len, &data)) {
 
     outbuflen = strlen(outbuf);
@@ -603,14 +603,14 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
       outbuflen = strlen(outbuf);
       snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
                "binary data length %ld\n", data_len);
-      COAP_DO_SHOW_OUTPUT_LINE; 
+      COAP_DO_SHOW_OUTPUT_LINE;
       /*
        * Output hex dump of binary data as a continuous entry
        */
       outbuf[0] = '\000';
       snprintf(outbuf, sizeof(outbuf),  "<<");
       while (data_len--) {
-	outbuflen = strlen(outbuf);
+        outbuflen = strlen(outbuf);
         snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
                  "%02x", *data++);
       }
@@ -620,7 +620,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
       data = keep_data;
       outbuflen = strlen(outbuf);
       snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  "\n");
-      COAP_DO_SHOW_OUTPUT_LINE; 
+      COAP_DO_SHOW_OUTPUT_LINE;
       /*
        * Output ascii readable (if possible), immediately under the
        * hex value of the character output above to help binary debugging
@@ -628,7 +628,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
       outbuf[0] = '\000';
       snprintf(outbuf, sizeof(outbuf),  "<<");
       while (data_len--) {
-	outbuflen = strlen(outbuf);
+        outbuflen = strlen(outbuf);
         snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
                  "%c ", isprint (*data) ? *data : '.');
         data++;
@@ -637,7 +637,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
       snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  ">>");
     } else {
       if (print_readable(data, data_len, buf, sizeof(buf), 0)) {
-	outbuflen = strlen(outbuf);
+        outbuflen = strlen(outbuf);
         snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  "'%s'", buf);
       }
     }
@@ -645,7 +645,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
 
   outbuflen = strlen(outbuf);
   snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  "\n");
-  COAP_DO_SHOW_OUTPUT_LINE; 
+  COAP_DO_SHOW_OUTPUT_LINE;
 }
 
 static coap_log_handler_t log_handler = NULL;
@@ -654,7 +654,7 @@ void coap_set_log_handler(coap_log_handler_t handler) {
   log_handler = handler;
 }
 
-void 
+void
 coap_log_impl(coap_log_t level, const char *format, ...) {
 
   if (maxlog < level)
@@ -676,7 +676,7 @@ coap_log_impl(coap_log_t level, const char *format, ...) {
     coap_tick_t now;
     va_list ap;
     FILE *log_fd;
-  
+
     log_fd = level <= LOG_CRIT ? COAP_ERR_FD : COAP_DEBUG_FD;
 
     coap_ticks(&now);
@@ -718,20 +718,20 @@ int coap_debug_set_packet_loss(const char *loss_level) {
     while (i < 10) {
       packet_loss_intervals[i].start = n;
       if (*end == '-') {
-	p = end + 1;
-	n = (int)strtol(p, &end, 10);
-	if (end == p || n <= 0)
-	  return 0;
+        p = end + 1;
+        n = (int)strtol(p, &end, 10);
+        if (end == p || n <= 0)
+          return 0;
       }
       packet_loss_intervals[i++].end = n;
       if (*end == 0)
-	break;
+        break;
       if (*end != ',')
-	return 0;
+        return 0;
       p = end + 1;
       n = (int)strtol(p, &end, 10);
       if (end == p || n <= 0)
-	return 0;
+        return 0;
     }
     if (i == 10)
       return 0;
@@ -747,8 +747,8 @@ int coap_debug_send_packet(void) {
     int i;
     for (i = 0; i < num_packet_loss_intervals; i++) {
       if (send_packet_count >= packet_loss_intervals[i].start
-	&& send_packet_count <= packet_loss_intervals[i].end)
-	return 0;
+        && send_packet_count <= packet_loss_intervals[i].end)
+        return 0;
     }
   }
   if ( packet_loss_level > 0 ) {

--- a/src/encode.c
+++ b/src/encode.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2010,2011 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #ifndef NDEBUG

--- a/src/mem.c
+++ b/src/mem.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2014--2015 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 
@@ -124,7 +124,7 @@ void *
 coap_malloc_type(coap_memory_tag_t type, size_t size) {
   struct memb *container =  get_container(type);
   void *ptr;
-  
+
   assert(container);
 
   if (size > container->size) {

--- a/src/net.c
+++ b/src/net.c
@@ -65,21 +65,21 @@
 #define FRAC_BITS 6
 
        /**
-	* The maximum number of bits for fixed point integers that are used
-	* for retransmission time calculation. Currently this must be @c 8.
-	*/
+        * The maximum number of bits for fixed point integers that are used
+        * for retransmission time calculation. Currently this must be @c 8.
+        */
 #define MAX_BITS 8
 
 #if FRAC_BITS > 8
 #error FRAC_BITS must be less or equal 8
 #endif
 
-	/** creates a Qx.frac from fval in coap_fixed_point_t */
+        /** creates a Qx.frac from fval in coap_fixed_point_t */
 #define Q(frac,fval) ((uint16_t)(((1 << (frac)) * fval.integer_part) + \
                       ((1 << (frac)) * fval.fractional_part + 500)/1000))
 
 /** creates a Qx.FRAC_BITS from session's 'ack_random_factor' */
-#define ACK_RANDOM_FACTOR					\
+#define ACK_RANDOM_FACTOR                                        \
   Q(FRAC_BITS, session->ack_random_factor)
 
 /** creates a Qx.FRAC_BITS from session's 'ack_timeout' */
@@ -165,15 +165,15 @@ coap_adjust_basetime(coap_context_t *ctx, coap_tick_t now) {
       coap_queue_t *q = ctx->sendqueue;
       coap_tick_t t = 0;
       while (q && (t + q->t < (coap_tick_t)delta)) {
-	t += q->t;
-	q->t = 0;
-	result++;
-	q = q->next;
+        t += q->t;
+        q->t = 0;
+        result++;
+        q = q->next;
       }
 
       /* finally adjust the first element that has not expired */
       if (q) {
-	q->t = (coap_tick_t)delta - t;
+        q->t = (coap_tick_t)delta - t;
       }
     }
   }
@@ -201,20 +201,20 @@ coap_insert_node(coap_queue_t **queue, coap_queue_t *node) {
   if (node->t < q->t) {
     node->next = q;
     *queue = node;
-    q->t -= node->t;		/* make q->t relative to node->t */
+    q->t -= node->t;                /* make q->t relative to node->t */
     return 1;
   }
 
   /* search for right place to insert */
   do {
-    node->t -= q->t;		/* make node-> relative to q->t */
+    node->t -= q->t;                /* make node-> relative to q->t */
     p = q;
     q = q->next;
   } while (q && q->t <= node->t);
 
   /* insert new item */
   if (q) {
-    q->t -= node->t;		/* make q->t relative to node->t */
+    q->t -= node->t;                /* make q->t relative to node->t */
   }
   node->next = q;
   p->next = node;
@@ -582,19 +582,19 @@ coap_option_check_critical(coap_context_t *ctx,
       case COAP_OPTION_PROXY_SCHEME:
       case COAP_OPTION_BLOCK2:
       case COAP_OPTION_BLOCK1:
-	break;
+        break;
       default:
-	if (coap_option_filter_get(ctx->known_options, opt_iter.type) <= 0) {
-	  debug("unknown critical option %d\n", opt_iter.type);
-	  ok = 0;
+        if (coap_option_filter_get(ctx->known_options, opt_iter.type) <= 0) {
+          debug("unknown critical option %d\n", opt_iter.type);
+          ok = 0;
 
-	  /* When opt_iter.type is beyond our known option range,
-	   * coap_option_filter_set() will return -1 and we are safe to leave
-	   * this loop. */
-	  if (coap_option_filter_set(unknown, opt_iter.type) == -1) {
-	    break;
-	  }
-	}
+          /* When opt_iter.type is beyond our known option range,
+           * coap_option_filter_set() will return -1 and we are safe to leave
+           * this loop. */
+          if (coap_option_filter_set(unknown, opt_iter.type) == -1) {
+            break;
+          }
+        }
       }
     }
   }
@@ -623,19 +623,19 @@ coap_session_send_pdu(coap_session_t *session, coap_pdu_t *pdu) {
   switch(session->proto) {
     case COAP_PROTO_UDP:
       bytes_written = coap_session_send(session, pdu->token - pdu->hdr_size,
-					pdu->used_size + pdu->hdr_size);
+                                        pdu->used_size + pdu->hdr_size);
       break;
     case COAP_PROTO_DTLS:
       bytes_written = coap_dtls_send(session, pdu->token - pdu->hdr_size,
-				     pdu->used_size + pdu->hdr_size);
+                                     pdu->used_size + pdu->hdr_size);
       break;
     case COAP_PROTO_TCP:
       bytes_written = coap_session_write(session, pdu->token - pdu->hdr_size,
-	                                 pdu->used_size + pdu->hdr_size);
+                                         pdu->used_size + pdu->hdr_size);
       break;
     case COAP_PROTO_TLS:
       bytes_written = coap_tls_write(session, pdu->token - pdu->hdr_size,
-	                             pdu->used_size + pdu->hdr_size);
+                                     pdu->used_size + pdu->hdr_size);
       break;
     default:
       break;
@@ -679,19 +679,19 @@ coap_send_pdu(coap_session_t *session, coap_pdu_t *pdu, coap_queue_t *node) {
     if (session->proto == COAP_PROTO_DTLS && !session->tls) {
       session->tls = coap_dtls_new_client_session(session);
       if (session->tls) {
-	session->state = COAP_SESSION_STATE_HANDSHAKE;
-	return coap_session_delay_pdu(session, pdu, node);
+        session->state = COAP_SESSION_STATE_HANDSHAKE;
+        return coap_session_delay_pdu(session, pdu, node);
       }
       coap_handle_event(session->context, COAP_EVENT_DTLS_ERROR, session);
       return -1;
     } else if(COAP_PROTO_RELIABLE(session->proto)) {
       if (!coap_socket_connect_tcp1(
-	&session->sock, &session->local_if, &session->remote_addr,
-	session->proto == COAP_PROTO_TLS ? COAPS_DEFAULT_PORT : COAP_DEFAULT_PORT,
-	&session->local_addr, &session->remote_addr
+        &session->sock, &session->local_if, &session->remote_addr,
+        session->proto == COAP_PROTO_TLS ? COAPS_DEFAULT_PORT : COAP_DEFAULT_PORT,
+        &session->local_addr, &session->remote_addr
       )) {
-	coap_handle_event(session->context, COAP_EVENT_TCP_FAILED, session);
-	return -1;
+        coap_handle_event(session->context, COAP_EVENT_TCP_FAILED, session);
+        return -1;
       }
       session->last_ping = 0;
       session->last_pong = 0;
@@ -699,25 +699,25 @@ coap_send_pdu(coap_session_t *session, coap_pdu_t *pdu, coap_queue_t *node) {
       coap_ticks( &session->last_rx_tx );
       if ((session->sock.flags & COAP_SOCKET_WANT_CONNECT) != 0) {
         session->state = COAP_SESSION_STATE_CONNECTING;
-	return coap_session_delay_pdu(session, pdu, node);
+        return coap_session_delay_pdu(session, pdu, node);
       }
       coap_handle_event(session->context, COAP_EVENT_TCP_CONNECTED, session);
       if (session->proto == COAP_PROTO_TLS) {
         int connected = 0;
-	session->state = COAP_SESSION_STATE_HANDSHAKE;
-	session->tls = coap_tls_new_client_session(session, &connected);
-	if (session->tls) {
+        session->state = COAP_SESSION_STATE_HANDSHAKE;
+        session->tls = coap_tls_new_client_session(session, &connected);
+        if (session->tls) {
           if (connected) {
             coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
             coap_session_send_csm(session);
           }
-	  return coap_session_delay_pdu(session, pdu, node);
-	}
-	coap_handle_event(session->context, COAP_EVENT_DTLS_ERROR, session);
-	coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
-	return -1;
+          return coap_session_delay_pdu(session, pdu, node);
+        }
+        coap_handle_event(session->context, COAP_EVENT_DTLS_ERROR, session);
+        coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
+        return -1;
       } else {
-	coap_session_send_csm(session);
+        coap_session_send_csm(session);
       }
     } else {
       return -1;
@@ -845,13 +845,13 @@ coap_wait_ack(coap_context_t *context, coap_session_t *session,
 #endif
 
 #ifdef WITH_CONTIKI
-  {			    /* (re-)initialize retransmission timer */
+  {                            /* (re-)initialize retransmission timer */
     coap_queue_t *nextpdu;
 
     nextpdu = coap_peek_next(context);
-    assert(nextpdu);		/* we have just inserted a node */
+    assert(nextpdu);                /* we have just inserted a node */
 
-				/* must set timer within the context of the retransmit process */
+                                /* must set timer within the context of the retransmit process */
     PROCESS_CONTEXT_BEGIN(&coap_retransmit_process);
     etimer_set(&context->retransmit_timer, nextpdu->t);
     PROCESS_CONTEXT_END(&coap_retransmit_process);
@@ -954,7 +954,7 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
 
     if (bytes_written == COAP_PDU_DELAYED) {
       /* PDU was not retransmitted immediately because a new handshake is
-	 in progress. node was moved to the send queue of the session. */
+         in progress. node was moved to the send queue of the session. */
       return node->id;
     }
 
@@ -1042,8 +1042,8 @@ coap_connect_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t n
           coap_session_send_csm(session);
         }
       } else {
-	coap_handle_event(session->context, COAP_EVENT_DTLS_ERROR, session);
-	coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
+        coap_handle_event(session->context, COAP_EVENT_DTLS_ERROR, session);
+        coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
       }
     }
   } else {
@@ -1064,19 +1064,19 @@ coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now
     assert(session->partial_write < q->pdu->used_size + q->pdu->hdr_size);
     switch (session->proto) {
       case COAP_PROTO_TCP:
-	bytes_written = coap_session_write(
-	  session,
-	  q->pdu->token - q->pdu->hdr_size - session->partial_write,
-	  q->pdu->used_size + q->pdu->hdr_size - session->partial_write
-	);
-	break;
+        bytes_written = coap_session_write(
+          session,
+          q->pdu->token - q->pdu->hdr_size - session->partial_write,
+          q->pdu->used_size + q->pdu->hdr_size - session->partial_write
+        );
+        break;
       case COAP_PROTO_TLS:
-	bytes_written = coap_tls_write(
-	  session,
-	  q->pdu->token - q->pdu->hdr_size - session->partial_write,
-	  q->pdu->used_size + q->pdu->hdr_size - session->partial_write
-	);
-	break;
+        bytes_written = coap_tls_write(
+          session,
+          q->pdu->token - q->pdu->hdr_size - session->partial_write,
+          q->pdu->used_size + q->pdu->hdr_size - session->partial_write
+        );
+        break;
       default:
         bytes_written = -1;
         break;
@@ -1085,7 +1085,7 @@ coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now
       session->last_rx_tx = now;
     if (bytes_written <= 0 || (size_t)bytes_written < q->pdu->used_size + q->pdu->hdr_size - session->partial_write) {
       if (bytes_written > 0)
-	session->partial_write += (size_t)bytes_written;
+        session->partial_write += (size_t)bytes_written;
       break;
     }
     session->delayqueue = q->next;
@@ -1127,9 +1127,9 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
 
     if (bytes_read < 0) {
       if (bytes_read == -2)
-	coap_session_disconnected(session, COAP_NACK_RST);
+        coap_session_disconnected(session, COAP_NACK_RST);
       else
-	warn("*  %s: read error\n", coap_session_str(session));
+        warn("*  %s: read error\n", coap_session_str(session));
     } else if (bytes_read > 0) {
       debug("*  %s: received %zd bytes\n", coap_session_str(session), bytes_read);
       session->last_rx_tx = now;
@@ -1146,9 +1146,9 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
 
     do {
       if (session->proto == COAP_PROTO_TCP)
-	bytes_read = coap_socket_read(&session->sock, buf, buf_len);
+        bytes_read = coap_socket_read(&session->sock, buf, buf_len);
       else if (session->proto == COAP_PROTO_TLS)
-	bytes_read = coap_tls_read(session, buf, buf_len);
+        bytes_read = coap_tls_read(session, buf, buf_len);
       if (bytes_read > 0) {
         debug("*  %s: received %zd bytes\n", coap_session_str(session), bytes_read);
         session->last_rx_tx = now;
@@ -1156,71 +1156,71 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
       p = buf;
       retry = bytes_read == (ssize_t)buf_len;
       while (bytes_read > 0) {
-	if (session->partial_pdu) {
-	  size_t len = session->partial_pdu->used_size
-		     + session->partial_pdu->hdr_size
-		     - session->partial_read;
-	  size_t n = min(len, (size_t)bytes_read);
-	  memcpy(session->partial_pdu->token - session->partial_pdu->hdr_size
-	         + session->partial_read, p, n);
-	  p += n;
-	  bytes_read -= n;
-	  if (n == len) {
-	    if (coap_pdu_parse_header(session->partial_pdu, session->proto)
-	      && coap_pdu_parse_opt(session->partial_pdu)) {
-	      coap_dispatch(ctx, session, session->partial_pdu);
-	    }
-	    coap_delete_pdu(session->partial_pdu);
-	    session->partial_pdu = NULL;
-	    session->partial_read = 0;
-	  } else {
-	    session->partial_read += n;
-	  }
-	} else if (session->partial_read > 0) {
-	  size_t hdr_size = coap_pdu_parse_header_size(session->proto,
-	    session->read_header);
-	  size_t len = hdr_size - session->partial_read;
-	  size_t n = min(len, (size_t)bytes_read);
-	  memcpy(session->read_header + session->partial_read, p, n);
-	  p += n;
-	  bytes_read -= n;
-	  if (n == len) {
-	    size_t size = coap_pdu_parse_size(session->proto, session->read_header,
-	      hdr_size);
-	    session->partial_pdu = coap_pdu_init(0, 0, 0, size);
-	    if (session->partial_pdu == NULL) {
-	      bytes_read = -1;
-	      break;
-	    }
+        if (session->partial_pdu) {
+          size_t len = session->partial_pdu->used_size
+                     + session->partial_pdu->hdr_size
+                     - session->partial_read;
+          size_t n = min(len, (size_t)bytes_read);
+          memcpy(session->partial_pdu->token - session->partial_pdu->hdr_size
+                 + session->partial_read, p, n);
+          p += n;
+          bytes_read -= n;
+          if (n == len) {
+            if (coap_pdu_parse_header(session->partial_pdu, session->proto)
+              && coap_pdu_parse_opt(session->partial_pdu)) {
+              coap_dispatch(ctx, session, session->partial_pdu);
+            }
+            coap_delete_pdu(session->partial_pdu);
+            session->partial_pdu = NULL;
+            session->partial_read = 0;
+          } else {
+            session->partial_read += n;
+          }
+        } else if (session->partial_read > 0) {
+          size_t hdr_size = coap_pdu_parse_header_size(session->proto,
+            session->read_header);
+          size_t len = hdr_size - session->partial_read;
+          size_t n = min(len, (size_t)bytes_read);
+          memcpy(session->read_header + session->partial_read, p, n);
+          p += n;
+          bytes_read -= n;
+          if (n == len) {
+            size_t size = coap_pdu_parse_size(session->proto, session->read_header,
+              hdr_size);
+            session->partial_pdu = coap_pdu_init(0, 0, 0, size);
+            if (session->partial_pdu == NULL) {
+              bytes_read = -1;
+              break;
+            }
             if (session->partial_pdu->alloc_size < size && !coap_pdu_resize(session->partial_pdu, size)) {
               bytes_read = -1;
               break;
             }
-	    session->partial_pdu->hdr_size = (uint8_t)hdr_size;
-	    session->partial_pdu->used_size = size;
-	    memcpy(session->partial_pdu->token - hdr_size, session->read_header, hdr_size);
-	    session->partial_read = hdr_size;
-	    if (size == 0) {
-	      if (coap_pdu_parse_header(session->partial_pdu, session->proto)) {
-		coap_dispatch(ctx, session, session->partial_pdu);
-	      }
-	      coap_delete_pdu(session->partial_pdu);
-	      session->partial_pdu = NULL;
-	      session->partial_read = 0;
-	    }
-	  } else {
+            session->partial_pdu->hdr_size = (uint8_t)hdr_size;
+            session->partial_pdu->used_size = size;
+            memcpy(session->partial_pdu->token - hdr_size, session->read_header, hdr_size);
+            session->partial_read = hdr_size;
+            if (size == 0) {
+              if (coap_pdu_parse_header(session->partial_pdu, session->proto)) {
+                coap_dispatch(ctx, session, session->partial_pdu);
+              }
+              coap_delete_pdu(session->partial_pdu);
+              session->partial_pdu = NULL;
+              session->partial_read = 0;
+            }
+          } else {
             session->partial_read += bytes_read;
-	  }
-	} else {
-	  session->read_header[0] = *p++;
-	  bytes_read -= 1;
-	  if (!coap_pdu_parse_header_size(session->proto,
-	    session->read_header)) {
-	    bytes_read = -1;
-	    break;
-	  }
-	  session->partial_read = 1;
-	}
+          }
+        } else {
+          session->read_header[0] = *p++;
+          bytes_read -= 1;
+          if (!coap_pdu_parse_header_size(session->proto,
+            session->read_header)) {
+            bytes_read = -1;
+            break;
+          }
+          session->partial_read = 1;
+        }
       }
     } while (bytes_read == 0 && retry);
     if (bytes_read < 0)
@@ -1236,7 +1236,7 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
 static int
 coap_read_endpoint(coap_context_t *ctx, coap_endpoint_t *endpoint, coap_tick_t now) {
   ssize_t bytes_read = -1;
-  int result = -1;		/* the value to be returned */
+  int result = -1;                /* the value to be returned */
 #ifdef WITH_CONTIKI
   coap_packet_t *packet = coap_malloc_packet();
 #else /* WITH_CONTIKI */
@@ -1265,7 +1265,7 @@ coap_read_endpoint(coap_context_t *ctx, coap_endpoint_t *endpoint, coap_tick_t n
       debug("*  %s: received %zd bytes\n", coap_session_str(session), bytes_read);
       result = coap_handle_dgram_for_proto(ctx, session, packet);
       if (endpoint->proto == COAP_PROTO_DTLS && session->type == COAP_SESSION_TYPE_HELLO && result == 1)
-	coap_endpoint_new_dtls_session(endpoint, packet, now);
+        coap_endpoint_new_dtls_session(endpoint, packet, now);
     }
   }
 
@@ -1308,16 +1308,16 @@ coap_read(coap_context_t *ctx, coap_tick_t now) {
       coap_accept_endpoint(ctx, ep, now);
     LL_FOREACH_SAFE(ep->sessions, s, tmp_s) {
       if ((s->sock.flags & COAP_SOCKET_CAN_READ) != 0) {
-	/* Make sure the session object is not deleted in one of the callbacks  */
-	coap_session_reference(s);
-	coap_read_session(ctx, s, now);
-	coap_session_release(s);
+        /* Make sure the session object is not deleted in one of the callbacks  */
+        coap_session_reference(s);
+        coap_read_session(ctx, s, now);
+        coap_session_release(s);
       }
       if ((s->sock.flags & COAP_SOCKET_CAN_WRITE) != 0) {
-	/* Make sure the session object is not deleted in one of the callbacks  */
-	coap_session_reference(s);
-	coap_write_session(ctx, s, now);
-	coap_session_release(s);
+        /* Make sure the session object is not deleted in one of the callbacks  */
+        coap_session_reference(s);
+        coap_write_session(ctx, s, now);
+        coap_session_release(s);
       }
     }
   }
@@ -1384,7 +1384,7 @@ coap_remove_from_queue(coap_queue_t **queue, coap_session_t *session, coap_tid_t
   if (session == (*queue)->session && id == (*queue)->id) { /* found transaction */
     *node = *queue;
     *queue = (*queue)->next;
-    if (*queue) {	  /* adjust relative time of new queue head */
+    if (*queue) {          /* adjust relative time of new queue head */
       (*queue)->t += (*node)->t;
     }
     (*node)->next = NULL;
@@ -1399,9 +1399,9 @@ coap_remove_from_queue(coap_queue_t **queue, coap_session_t *session, coap_tid_t
     q = q->next;
   } while (q && (session != q->session || id != q->id));
 
-  if (q) {			/* found transaction */
+  if (q) {                        /* found transaction */
     p->next = q->next;
-    if (p->next) {		/* must update relative time of p->next */
+    if (p->next) {                /* must update relative time of p->next */
       p->next->t += q->t;
     }
     q->next = NULL;
@@ -1482,7 +1482,7 @@ coap_cancel_all_messages(coap_context_t *context, coap_session_t *session,
   while (q) {
     if (q->session == session &&
       token_match(token, token_length,
-	q->pdu->token, q->pdu->token_length)) {
+        q->pdu->token, q->pdu->token_length)) {
       p->next = q->next;
       debug("** %s tid=%d: removed\n", coap_session_str(session), q->id);
       coap_delete_node(q);
@@ -1510,7 +1510,7 @@ coap_new_error_response(coap_pdu_t *request, unsigned char code,
   size_t size = request->token_length;
   unsigned char type;
   coap_opt_t *option;
-  uint16_t opt_type = 0;	/* used for calculating delta-storage */
+  uint16_t opt_type = 0;        /* used for calculating delta-storage */
 
 #if COAP_ERROR_PHRASE_LENGTH > 0
   const char *phrase = coap_response_phrase(code);
@@ -1582,8 +1582,8 @@ coap_new_error_response(coap_pdu_t *request, unsigned char code,
     coap_option_iterator_init(request, &opt_iter, opts);
     while ((option = coap_option_next(&opt_iter))) {
       coap_add_option(response, opt_iter.type,
-	coap_opt_length(option),
-	coap_opt_value(option));
+        coap_opt_length(option),
+        coap_opt_value(option));
     }
 
 #if COAP_ERROR_PHRASE_LENGTH > 0
@@ -1626,7 +1626,7 @@ coap_wellknown_response(coap_context_t *context, coap_session_t *session,
   size_t len, wkc_len;
   uint8_t buf[2];
   int result = 0;
-  int need_block2 = 0;	   /* set to 1 if Block2 option is required */
+  int need_block2 = 0;           /* set to 1 if Block2 option is required */
   coap_block_t block;
   coap_opt_t *query_filter;
   size_t offset = 0;
@@ -1701,10 +1701,10 @@ coap_wellknown_response(coap_context_t *context, coap_session_t *session,
     block.szx = COAP_MAX_BLOCK_SZX;
     while (payloadlen < SZX_TO_BYTES(block.szx) + 6) {
       if (block.szx == 0) {
-	debug("coap_wellknown_response: message to small even for szx == 0\n");
-	goto error;
+        debug("coap_wellknown_response: message to small even for szx == 0\n");
+        goto error;
       } else {
-	block.szx--;
+        block.szx--;
       }
     }
 
@@ -1771,9 +1771,9 @@ coap_cancel(coap_context_t *context, const coap_queue_t *sent) {
   }
 
   return num_cancelled;
-#else /* WITOUT_OBSERVE */  
+#else /* WITOUT_OBSERVE */
   return 0;
-#endif /* WITOUT_OBSERVE */  
+#endif /* WITOUT_OBSERVE */
 }
 
 /**
@@ -1831,9 +1831,9 @@ no_response(coap_pdu_t *request, coap_pdu_t *response) {
        * bit is not set, the sender explicitly indicates interest in
        * this response. */
       if (((1 << (COAP_RESPONSE_CLASS(response->code) - 1)) & val) > 0) {
-	return RESPONSE_DROP;
+        return RESPONSE_DROP;
       } else {
-	return RESPONSE_SEND;
+        return RESPONSE_SEND;
       }
     }
   }
@@ -1889,12 +1889,12 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
     if (coap_string_equal(uri_path, &coap_default_uri_wellknown)) {
       /* request for .well-known/core */
       if (pdu->code == COAP_REQUEST_GET) { /* GET */
-	info("create default response for %s\n", COAP_DEFAULT_URI_WELLKNOWN);
-	response = coap_wellknown_response(context, session, pdu);
+        info("create default response for %s\n", COAP_DEFAULT_URI_WELLKNOWN);
+        response = coap_wellknown_response(context, session, pdu);
       } else {
-	debug("method not allowed for .well-known/core\n");
-	response = coap_new_error_response(pdu, COAP_RESPONSE_CODE(405),
-	  opt_filter);
+        debug("method not allowed for .well-known/core\n");
+        response = coap_new_error_response(pdu, COAP_RESPONSE_CODE(405),
+          opt_filter);
       }
     } else if ((context->unknown_resource != NULL) &&
                ((size_t)pdu->code - 1 <
@@ -1917,19 +1917,19 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
        */
       coap_log(LOG_DEBUG, "request for unknown resource '%*.*s',"
                           " return 2.02\n",
-	                  (int)uri_path->length,
-	                  (int)uri_path->length,
-	                  uri_path->s);
+                          (int)uri_path->length,
+                          (int)uri_path->length,
+                          uri_path->s);
       response =
-	coap_new_error_response(pdu, COAP_RESPONSE_CODE(202),
-	  opt_filter);
+        coap_new_error_response(pdu, COAP_RESPONSE_CODE(202),
+          opt_filter);
     } else { /* request for any another resource, return 4.04 */
 
       coap_log(LOG_DEBUG, "request for unknown resource '%*.*s', return 4.04\n",
-	(int)uri_path->length, (int)uri_path->length, uri_path->s);
+        (int)uri_path->length, (int)uri_path->length, uri_path->s);
       response =
-	coap_new_error_response(pdu, COAP_RESPONSE_CODE(404),
-	  opt_filter);
+        coap_new_error_response(pdu, COAP_RESPONSE_CODE(404),
+          opt_filter);
     }
 
     if (!resource) {
@@ -1978,66 +1978,66 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
 
       /* check for Observe option */
       if (resource->observable) {
-	observe = coap_check_option(pdu, COAP_OPTION_OBSERVE, &opt_iter);
-	if (observe) {
-	  observe_action =
-	    coap_decode_var_bytes(coap_opt_value(observe),
-	      coap_opt_length(observe));
+        observe = coap_check_option(pdu, COAP_OPTION_OBSERVE, &opt_iter);
+        if (observe) {
+          observe_action =
+            coap_decode_var_bytes(coap_opt_value(observe),
+              coap_opt_length(observe));
 
-	  if ((observe_action & COAP_OBSERVE_CANCEL) == 0) {
-	    coap_subscription_t *subscription;
+          if ((observe_action & COAP_OBSERVE_CANCEL) == 0) {
+            coap_subscription_t *subscription;
             coap_block_t block2;
             int has_block2 = 0;
 
             if (coap_get_block(pdu, COAP_OPTION_BLOCK2, &block2)) {
               has_block2 = 1;
             }
-	    subscription = coap_add_observer(resource, session, &token, query, has_block2, block2);
-	    owns_query = 0;
-	    if (subscription) {
-	      coap_touch_observer(context, session, &token);
-	    }
-	  } else {
-	    coap_delete_observer(resource, session, &token);
-	  }
-	}
+            subscription = coap_add_observer(resource, session, &token, query, has_block2, block2);
+            owns_query = 0;
+            if (subscription) {
+              coap_touch_observer(context, session, &token);
+            }
+          } else {
+            coap_delete_observer(resource, session, &token);
+          }
+        }
       }
 
       h(context, resource, session, pdu, &token, query, response);
 
       if (query && owns_query)
-	coap_delete_string(query);
+        coap_delete_string(query);
 
       respond = no_response(pdu, response);
       if (respond != RESPONSE_DROP) {
-	if (observe && (COAP_RESPONSE_CLASS(response->code) > 2)) {
-	  coap_delete_observer(resource, session, &token);
-	}
+        if (observe && (COAP_RESPONSE_CLASS(response->code) > 2)) {
+          coap_delete_observer(resource, session, &token);
+        }
 
-	/* If original request contained a token, and the registered
-	 * application handler made no changes to the response, then
-	 * this is an empty ACK with a token, which is a malformed
-	 * PDU */
-	if ((response->type == COAP_MESSAGE_ACK)
-	  && (response->code == 0)) {
-	  /* Remove token from otherwise-empty acknowledgment PDU */
-	  response->token_length = 0;
-	  response->used_size = 0;
-	}
+        /* If original request contained a token, and the registered
+         * application handler made no changes to the response, then
+         * this is an empty ACK with a token, which is a malformed
+         * PDU */
+        if ((response->type == COAP_MESSAGE_ACK)
+          && (response->code == 0)) {
+          /* Remove token from otherwise-empty acknowledgment PDU */
+          response->token_length = 0;
+          response->used_size = 0;
+        }
 
-	if ((respond == RESPONSE_SEND)
-	  || /* RESPOND_DEFAULT */
-	  (response->type != COAP_MESSAGE_NON ||
-	  (response->code >= 64
-	    && !coap_mcast_interface(&node->local_if)))) {
+        if ((respond == RESPONSE_SEND)
+          || /* RESPOND_DEFAULT */
+          (response->type != COAP_MESSAGE_NON ||
+          (response->code >= 64
+            && !coap_mcast_interface(&node->local_if)))) {
 
-	  if (coap_send(session, response) == COAP_INVALID_TID)
-	    debug("cannot send response for message %d\n", pdu->tid);
-	} else {
-	  coap_delete_pdu(response);
-	}
+          if (coap_send(session, response) == COAP_INVALID_TID)
+            debug("cannot send response for message %d\n", pdu->tid);
+        } else {
+          coap_delete_pdu(response);
+        }
       } else {
-	coap_delete_pdu(response);
+        coap_delete_pdu(response);
       }
       response = NULL;
     } else {
@@ -2051,11 +2051,11 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
       debug("have wellknown response %p\n", (void *)response);
     } else
       response = coap_new_error_response(pdu, COAP_RESPONSE_CODE(405),
-	opt_filter);
+        opt_filter);
 
     if (response && (no_response(pdu, response) != RESPONSE_DROP)) {
       if (coap_send(session, response) == COAP_INVALID_TID)
-	debug("cannot send response for transaction %d\n", pdu->tid);
+        debug("cannot send response for transaction %d\n", pdu->tid);
     } else {
       coap_delete_pdu(response);
     }
@@ -2096,8 +2096,8 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
   if (pdu->code == COAP_SIGNALING_CSM) {
     while ((option = coap_option_next(&opt_iter))) {
       if (opt_iter.type == COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE) {
-	coap_session_set_mtu(session, coap_decode_var_bytes(coap_opt_value(option),
-	  coap_opt_length(option)));
+        coap_session_set_mtu(session, coap_decode_var_bytes(coap_opt_value(option),
+          coap_opt_length(option)));
       } else if (opt_iter.type == COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER) {
         /* ... */
       }
@@ -2139,11 +2139,11 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
     /** @FIXME get debug to work again **
     unsigned char addr[INET6_ADDRSTRLEN+8], localaddr[INET6_ADDRSTRLEN+8];
     if (coap_print_addr(remote, addr, INET6_ADDRSTRLEN+8) &&
-	coap_print_addr(&packet->dst, localaddr, INET6_ADDRSTRLEN+8) )
+        coap_print_addr(&packet->dst, localaddr, INET6_ADDRSTRLEN+8) )
       debug("** received %d bytes from %s on interface %s:\n",
-	    (int)msg_len, addr, localaddr);
+            (int)msg_len, addr, localaddr);
 
-	    */
+            */
     coap_show_pdu(LOG_DEBUG, pdu);
   }
 #endif
@@ -2168,9 +2168,9 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
        * notification. Then, we must flag the observer to be alive
        * by setting obs->fail_cnt = 0. */
       if (sent && COAP_RESPONSE_CLASS(sent->pdu->code) == 2) {
-	const coap_binary_t token =
-	{ sent->pdu->token_length, sent->pdu->token };
-	coap_touch_observer(context, sent->session, &token);
+        const coap_binary_t token =
+        { sent->pdu->token_length, sent->pdu->token };
+        coap_touch_observer(context, sent->session, &token);
       }
       break;
 
@@ -2192,34 +2192,34 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
       coap_remove_from_queue(&context->sendqueue, session, pdu->tid, &sent);
 
       if (sent) {
-	coap_cancel(context, sent);
+        coap_cancel(context, sent);
 
         if(sent->pdu->type==COAP_MESSAGE_CON && context->nack_handler)
           context->nack_handler(context, sent->session, sent->pdu, COAP_NACK_RST, sent->id);
       }
       goto cleanup;
 
-    case COAP_MESSAGE_NON:	/* check for unknown critical options */
+    case COAP_MESSAGE_NON:        /* check for unknown critical options */
       if (coap_option_check_critical(context, pdu, opt_filter) == 0)
-	goto cleanup;
+        goto cleanup;
       break;
 
-    case COAP_MESSAGE_CON:	/* check for unknown critical options */
+    case COAP_MESSAGE_CON:        /* check for unknown critical options */
       if (coap_option_check_critical(context, pdu, opt_filter) == 0) {
 
-	/* FIXME: send response only if we have received a request. Otherwise,
-	 * send RST. */
-	response =
-	  coap_new_error_response(pdu, COAP_RESPONSE_CODE(402), opt_filter);
+        /* FIXME: send response only if we have received a request. Otherwise,
+         * send RST. */
+        response =
+          coap_new_error_response(pdu, COAP_RESPONSE_CODE(402), opt_filter);
 
-	if (!response) {
-	  warn("coap_dispatch: cannot create error response\n");
-	} else {
-	  if (coap_send(session, response) == COAP_INVALID_TID)
-	    warn("coap_dispatch: error sending response\n");
-	}
+        if (!response) {
+          warn("coap_dispatch: cannot create error response\n");
+        } else {
+          if (coap_send(session, response) == COAP_INVALID_TID)
+            warn("coap_dispatch: error sending response\n");
+        }
 
-	goto cleanup;
+        goto cleanup;
       }
     default: break;
   }
@@ -2342,22 +2342,22 @@ PROCESS_THREAD(coap_retransmit_process, ev, data) {
     if (ev == PROCESS_EVENT_TIMER) {
       if (etimer_expired(&the_coap_context.retransmit_timer)) {
 
-	nextpdu = coap_peek_next(&the_coap_context);
+        nextpdu = coap_peek_next(&the_coap_context);
 
-	coap_ticks(&now);
-	while (nextpdu && nextpdu->t <= now) {
-	  coap_retransmit(&the_coap_context, coap_pop_next(&the_coap_context));
-	  nextpdu = coap_peek_next(&the_coap_context);
-	}
+        coap_ticks(&now);
+        while (nextpdu && nextpdu->t <= now) {
+          coap_retransmit(&the_coap_context, coap_pop_next(&the_coap_context));
+          nextpdu = coap_peek_next(&the_coap_context);
+        }
 
-	/* need to set timer to some value even if no nextpdu is available */
-	etimer_set(&the_coap_context.retransmit_timer,
-	  nextpdu ? nextpdu->t - now : 0xFFFF);
+        /* need to set timer to some value even if no nextpdu is available */
+        etimer_set(&the_coap_context.retransmit_timer,
+          nextpdu ? nextpdu->t - now : 0xFFFF);
       }
 #ifndef WITHOUT_OBSERVE
       if (etimer_expired(&the_coap_context.notify_timer)) {
-	coap_check_notify(&the_coap_context);
-	etimer_reset(&the_coap_context.notify_timer);
+        coap_check_notify(&the_coap_context);
+        etimer_reset(&the_coap_context.notify_timer);
       }
 #endif /* WITHOUT_OBSERVE */
     }

--- a/src/option.c
+++ b/src/option.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2010-2013 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 
@@ -19,17 +19,17 @@
 
 #include "libcoap.h"
 #include "option.h"
-#include "encode.h"		/* for coap_fls() */
+#include "encode.h"                /* for coap_fls() */
 #include "debug.h"
 #include "mem.h"
 #include "utlist.h"
 
-#define ADVANCE_OPT(o,e,step) if ((e) < step) {			\
-    debug("cannot advance opt past end\n");			\
-    return 0;							\
-  } else {							\
-    (e) -= step;						\
-    (o) = ((o)) + step;			\
+#define ADVANCE_OPT(o,e,step) if ((e) < step) {                        \
+    debug("cannot advance opt past end\n");                        \
+    return 0;                                                        \
+  } else {                                                        \
+    (e) -= step;                                                \
+    (o) = ((o)) + step;                        \
   }
 
 /*
@@ -76,7 +76,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
     ADVANCE_OPT_CHECK(opt,length,1);
     result->delta += *opt & 0xff;
     break;
-    
+
   default:
     ;
   }
@@ -96,7 +96,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
     ADVANCE_OPT_CHECK(opt,length,1);
     result->length += *opt & 0xff;
     break;
-    
+
   default:
     ;
   }
@@ -119,11 +119,11 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
 
 coap_opt_iterator_t *
 coap_option_iterator_init(const coap_pdu_t *pdu, coap_opt_iterator_t *oi,
-			  const coap_opt_filter_t filter) {
-  assert(pdu); 
+                          const coap_opt_filter_t filter) {
+  assert(pdu);
   assert(pdu->token);
   assert(oi);
-  
+
   memset(oi, 0, sizeof(coap_opt_iterator_t));
 
   oi->next_option = pdu->token + pdu->token_length;
@@ -145,7 +145,7 @@ COAP_STATIC_INLINE int
 opt_finished(coap_opt_iterator_t *oi) {
   assert(oi);
 
-  if (oi->bad || oi->length == 0 || 
+  if (oi->bad || oi->length == 0 ||
       !oi->next_option || *oi->next_option == COAP_PAYLOAD_START) {
     oi->bad = 1;
   }
@@ -158,7 +158,7 @@ coap_option_next(coap_opt_iterator_t *oi) {
   coap_option_t option;
   coap_opt_t *current_opt = NULL;
   size_t optsize;
-  int b;		   /* to store result of coap_option_getb() */
+  int b;                   /* to store result of coap_option_getb() */
 
   assert(oi);
 
@@ -170,18 +170,18 @@ coap_option_next(coap_opt_iterator_t *oi) {
      * opt_finished() filters out any bad conditions, we can assume that
      * oi->option is valid. */
     current_opt = oi->next_option;
-    
+
     /* Advance internal pointer to next option, skipping any option that
      * is not included in oi->filter. */
     optsize = coap_opt_parse(oi->next_option, oi->length, &option);
     if (optsize) {
       assert(optsize <= oi->length);
-      
+
       oi->next_option += optsize;
       oi->length -= optsize;
-      
+
       oi->type += option.delta;
-    } else {			/* current option is malformed */
+    } else {                        /* current option is malformed */
       oi->bad = 1;
       return NULL;
     }
@@ -189,12 +189,12 @@ coap_option_next(coap_opt_iterator_t *oi) {
     /* Exit the while loop when:
      *   - no filtering is done at all
      *   - the filter matches for the current option
-     *   - the filter is too small for the current option number 
+     *   - the filter is too small for the current option number
      */
     if (!oi->filtered ||
-	(b = coap_option_getb(oi->filter, oi->type)) > 0)
+        (b = coap_option_getb(oi->filter, oi->type)) > 0)
       break;
-    else if (b < 0) {		/* filter too small, cannot proceed */
+    else if (b < 0) {                /* filter too small, cannot proceed */
       oi->bad = 1;
       return NULL;
     }
@@ -204,10 +204,10 @@ coap_option_next(coap_opt_iterator_t *oi) {
 }
 
 coap_opt_t *
-coap_check_option(coap_pdu_t *pdu, uint16_t type, 
-		  coap_opt_iterator_t *oi) {
+coap_check_option(coap_pdu_t *pdu, uint16_t type,
+                  coap_opt_iterator_t *oi) {
   coap_opt_filter_t f;
-  
+
   coap_option_filter_clear(f);
   coap_option_setb(f, type);
 
@@ -229,7 +229,7 @@ coap_opt_delta(const coap_opt_t *opt) {
     /* This case usually should not happen, hence we do not have a
      * proper way to indicate an error. */
     return 0;
-  case 14: 
+  case 14:
     /* Handle two-byte value: First, the MSB + 269 is stored as delta value.
      * After that, the option pointer is advanced to the LSB which is handled
      * just like case delta == 13. */
@@ -326,13 +326,13 @@ coap_opt_size(const coap_opt_t *opt) {
 }
 
 size_t
-coap_opt_setheader(coap_opt_t *opt, size_t maxlen, 
-		   uint16_t delta, size_t length) {
+coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
+                   uint16_t delta, size_t length) {
   size_t skip = 0;
 
   assert(opt);
 
-  if (maxlen == 0)		/* need at least one byte */
+  if (maxlen == 0)                /* need at least one byte */
     return 0;
 
   if (delta < 13) {
@@ -355,7 +355,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[++skip] = ((delta - 269) >> 8) & 0xff;
     opt[++skip] = (delta - 269) & 0xff;
   }
-    
+
   if (length < 13) {
     opt[0] |= length & 0x0f;
   } else if (length < 269) {
@@ -363,7 +363,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
       debug("insufficient space to encode option length %zu\n", length);
       return 0;
     }
-    
+
     opt[0] |= 0x0d;
     opt[++skip] = (coap_opt_t)(length - 13);
   } else {
@@ -383,37 +383,37 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
 size_t
 coap_opt_encode_size(uint16_t delta, size_t length) {
   size_t n = 1;
-  
+
   if (delta >= 13) {
     if (delta < 269)
       n += 1;
     else
       n += 2;
   }
-  
+
   if (length >= 13) {
     if (length < 269)
       n += 1;
     else
       n += 2;
   }
-  
+
   return n + length;
 }
 
 size_t
 coap_opt_encode(coap_opt_t *opt, size_t maxlen, uint16_t delta,
-		const uint8_t *val, size_t length) {
+                const uint8_t *val, size_t length) {
   size_t l = 1;
 
   l = coap_opt_setheader(opt, maxlen, delta, length);
   assert(l <= maxlen);
-  
+
   if (!l) {
     debug("coap_opt_encode: cannot set option header\n");
     return 0;
   }
-  
+
   maxlen -= l;
   opt += l;
 
@@ -422,7 +422,7 @@ coap_opt_encode(coap_opt_t *opt, size_t maxlen, uint16_t delta,
     return 0;
   }
 
-  if (val)			/* better be safe here */
+  if (val)                        /* better be safe here */
     memcpy(opt, val, length);
 
   return l + length;
@@ -468,8 +468,8 @@ enum filter_op_t { FILTER_SET, FILTER_CLEAR, FILTER_GET };
  */
 static int
 coap_option_filter_op(coap_opt_filter_t filter,
-		      uint16_t type,
-		      enum filter_op_t op) {
+                      uint16_t type,
+                      enum filter_op_t op) {
   size_t lindex = 0;
   opt_filter *of = (opt_filter *)filter;
   uint16_t nr, mask = 0;
@@ -480,25 +480,25 @@ coap_option_filter_op(coap_opt_filter_t filter,
     for (nr = 1; lindex < COAP_OPT_FILTER_LONG; nr <<= 1, lindex++) {
 
       if (((of->mask & nr) > 0) && (of->long_opts[lindex] == type)) {
-	if (op == FILTER_CLEAR) {
-	  of->mask &= ~nr;
-	}
+        if (op == FILTER_CLEAR) {
+          of->mask &= ~nr;
+        }
 
-	return 1;
+        return 1;
       }
     }
   } else {
     mask = SHORT_MASK;
 
     for (nr = 1 << COAP_OPT_FILTER_LONG; lindex < COAP_OPT_FILTER_SHORT;
-	 nr <<= 1, lindex++) {
+         nr <<= 1, lindex++) {
 
       if (((of->mask & nr) > 0) && (of->short_opts[lindex] == (type & 0xff))) {
-	if (op == FILTER_CLEAR) {
-	  of->mask &= ~nr;
-	}
+        if (op == FILTER_CLEAR) {
+          of->mask &= ~nr;
+        }
 
-	return 1;
+        return 1;
       }
     }
   }
@@ -548,10 +548,10 @@ coap_new_optlist(uint16_t number,
                           size_t length,
                           const uint8_t *data
 ) {
-  coap_optlist_t *node;          
-     
+  coap_optlist_t *node;
+
   node = coap_malloc_type(COAP_OPTLIST, sizeof(coap_optlist_t) + length);
-     
+
   if (node) {
     node->number = number;
     node->length = length;
@@ -560,7 +560,7 @@ coap_new_optlist(uint16_t number,
   } else {
     coap_log(LOG_WARNING, "coap_new_optlist: malloc failure\n");
   }
-  
+
   return node;
 }
 

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2010--2016 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include "coap_config.h"
@@ -193,7 +193,7 @@ coap_pdu_check_resize(coap_pdu_t *pdu, size_t size) {
     if (pdu->max_size && new_size > pdu->max_size) {
       new_size = pdu->max_size;
       if (new_size < size)
-	return 0;
+        return 0;
     }
     if (!coap_pdu_resize(pdu, new_size))
       return 0;
@@ -229,7 +229,7 @@ size_t
 coap_add_option(coap_pdu_t *pdu, uint16_t type, size_t len, const uint8_t *data) {
   size_t optsize;
   coap_opt_t *opt;
-  
+
   assert(pdu);
   pdu->data = NULL;
 
@@ -245,8 +245,8 @@ coap_add_option(coap_pdu_t *pdu, uint16_t type, size_t len, const uint8_t *data)
   opt = pdu->token + pdu->used_size;
 
   /* encode option and check length */
-  optsize = coap_opt_encode(opt, pdu->alloc_size - pdu->used_size, 
-			    type - pdu->max_delta, data, len);
+  optsize = coap_opt_encode(opt, pdu->alloc_size - pdu->used_size,
+                            type - pdu->max_delta, data, len);
 
   if (!optsize) {
     warn("coap_add_option: cannot add option\n");
@@ -282,7 +282,7 @@ coap_add_option_later(coap_pdu_t *pdu, uint16_t type, size_t len) {
 
   /* encode option and check length */
   optsize = coap_opt_encode(opt, pdu->alloc_size - pdu->used_size,
-			    type - pdu->max_delta, NULL, len);
+                            type - pdu->max_delta, NULL, len);
 
   if (!optsize) {
     warn("coap_add_option: cannot add option\n");
@@ -349,7 +349,7 @@ typedef struct {
   const char *phrase;
 } error_desc_t;
 
-/* if you change anything here, make sure, that the longest string does not 
+/* if you change anything here, make sure, that the longest string does not
  * exceed COAP_ERROR_PHRASE_LENGTH. */
 error_desc_t coap_error[] = {
   { COAP_RESPONSE_CODE(201), "Created" },
@@ -375,7 +375,7 @@ error_desc_t coap_error[] = {
   { COAP_RESPONSE_CODE(503), "Service Unavailable" },
   { COAP_RESPONSE_CODE(504), "Gateway Timeout" },
   { COAP_RESPONSE_CODE(505), "Proxying Not Supported" },
-  { 0, NULL }			/* end marker */
+  { 0, NULL }                        /* end marker */
 };
 
 const char *
@@ -390,7 +390,7 @@ coap_response_phrase(unsigned char code) {
 #endif
 
 /**
- * Advances *optp to next option if still in PDU. This function 
+ * Advances *optp to next option if still in PDU. This function
  * returns the number of bytes opt has been advanced or @c 0
  * on error.
  */
@@ -399,7 +399,7 @@ next_option_safe(coap_opt_t **optp, size_t *length) {
   coap_option_t option;
   size_t optsize;
 
-  assert(optp); assert(*optp); 
+  assert(optp); assert(*optp);
   assert(length);
 
   optsize = coap_opt_parse(*optp, *length, &option);
@@ -452,19 +452,19 @@ coap_pdu_parse_size(coap_proto_t proto,
       size = len;
     } else if (length >= 2) {
       if (len==13) {
-	size = (size_t)data[1] + COAP_MESSAGE_SIZE_OFFSET_TCP8;
+        size = (size_t)data[1] + COAP_MESSAGE_SIZE_OFFSET_TCP8;
       } else if (length >= 3) {
-	if (len==14) {
-	  size = ((size_t)data[1] << 8) + data[2] + COAP_MESSAGE_SIZE_OFFSET_TCP16;
-	} else if (length >= 5) {
-	  size = ((size_t)data[1] << 24) + ((size_t)data[2] << 16)
+        if (len==14) {
+          size = ((size_t)data[1] << 8) + data[2] + COAP_MESSAGE_SIZE_OFFSET_TCP16;
+        } else if (length >= 5) {
+          size = ((size_t)data[1] << 24) + ((size_t)data[2] << 16)
                + ((size_t)data[3] << 8) + data[4] + COAP_MESSAGE_SIZE_OFFSET_TCP32;
-	}
+        }
       }
     }
     size += data[0] & 0x0f;
   }
-  
+
   return size;
 }
 
@@ -527,8 +527,8 @@ coap_pdu_parse_opt(coap_pdu_t *pdu) {
 
     while (length > 0 && *opt != COAP_PAYLOAD_START) {
       if ( !next_option_safe( &opt, (size_t *)&length ) ) {
-	debug( "coap_pdu_parse: missing payload start code\n" );
-	return 0;
+        debug( "coap_pdu_parse: missing payload start code\n" );
+        return 0;
       }
     }
 
@@ -542,7 +542,7 @@ coap_pdu_parse_opt(coap_pdu_t *pdu) {
       }
     }
     if (length > 0)
-		pdu->data = (uint8_t*)opt;
+                pdu->data = (uint8_t*)opt;
     else
       pdu->data = NULL;
   }
@@ -601,8 +601,8 @@ coap_pdu_encode_header(coap_pdu_t *pdu, coap_proto_t proto) {
     if (len <= COAP_MAX_MESSAGE_SIZE_TCP0) {
       assert(pdu->max_hdr_size >= 2);
       if (pdu->max_hdr_size < 2) {
-	warn("coap_pdu_encode_header: not enough space for TCP0 header");
-	return 0;
+        warn("coap_pdu_encode_header: not enough space for TCP0 header");
+        return 0;
       }
       pdu->token[-2] = (uint8_t)len << 4
                      | pdu->token_length;
@@ -611,8 +611,8 @@ coap_pdu_encode_header(coap_pdu_t *pdu, coap_proto_t proto) {
     } else if (len <= COAP_MAX_MESSAGE_SIZE_TCP8) {
       assert(pdu->max_hdr_size >= 3);
       if (pdu->max_hdr_size < 3) {
-	warn("coap_pdu_encode_header: not enough space for TCP8 header");
-	return 0;
+        warn("coap_pdu_encode_header: not enough space for TCP8 header");
+        return 0;
       }
       pdu->token[-3] = 13 << 4 | pdu->token_length;
       pdu->token[-2] = (uint8_t)(len - COAP_MESSAGE_SIZE_OFFSET_TCP8);
@@ -621,8 +621,8 @@ coap_pdu_encode_header(coap_pdu_t *pdu, coap_proto_t proto) {
     } else if (len <= COAP_MAX_MESSAGE_SIZE_TCP16) {
       assert(pdu->max_hdr_size >= 4);
       if (pdu->max_hdr_size < 4) {
-	warn("coap_pdu_encode_header: not enough space for TCP16 header");
-	return 0;
+        warn("coap_pdu_encode_header: not enough space for TCP16 header");
+        return 0;
       }
       pdu->token[-4] = 14 << 4 | pdu->token_length;
       pdu->token[-3] = (uint8_t)((len - COAP_MESSAGE_SIZE_OFFSET_TCP16) >> 8);
@@ -632,8 +632,8 @@ coap_pdu_encode_header(coap_pdu_t *pdu, coap_proto_t proto) {
     } else {
       assert(pdu->max_hdr_size >= 6);
       if (pdu->max_hdr_size < 6) {
-	warn("coap_pdu_encode_header: not enough space for TCP32 header");
-	return 0;
+        warn("coap_pdu_encode_header: not enough space for TCP32 header");
+        return 0;
       }
       pdu->token[-6] = 15 << 4 | pdu->token_length;
       pdu->token[-5] = (uint8_t)((len - COAP_MESSAGE_SIZE_OFFSET_TCP32) >> 24);

--- a/src/resource.c
+++ b/src/resource.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2010--2015 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <stdio.h>
@@ -72,21 +72,21 @@ coap_free_subscription(coap_subscription_t *subscription) {
  * Adds Char to Buf if Offset is zero. Otherwise, Char is not written
  * and Offset is decremented.
  */
-#define PRINT_WITH_OFFSET(Buf,Offset,Char)		\
-  if ((Offset) == 0) {					\
-    (*(Buf)++) = (Char);				\
-  } else {						\
-    (Offset)--;						\
-  }							\
+#define PRINT_WITH_OFFSET(Buf,Offset,Char)                \
+  if ((Offset) == 0) {                                        \
+    (*(Buf)++) = (Char);                                \
+  } else {                                                \
+    (Offset)--;                                                \
+  }                                                        \
 
 /**
  * Adds Char to Buf if Offset is zero and Buf is less than Bufend.
  */
-#define PRINT_COND_WITH_OFFSET(Buf,Bufend,Offset,Char,Result) {		\
-    if ((Buf) < (Bufend)) {						\
-      PRINT_WITH_OFFSET(Buf,Offset,Char);				\
-    }									\
-    (Result)++;								\
+#define PRINT_COND_WITH_OFFSET(Buf,Bufend,Offset,Char,Result) {                \
+    if ((Buf) < (Bufend)) {                                                \
+      PRINT_WITH_OFFSET(Buf,Offset,Char);                                \
+    }                                                                        \
+    (Result)++;                                                                \
   }
 
 /**
@@ -94,19 +94,19 @@ coap_free_subscription(coap_subscription_t *subscription) {
  * characters are skipped. Output may be truncated to Bufend - Buf
  * characters.
  */
-#define COPY_COND_WITH_OFFSET(Buf,Bufend,Offset,Str,Length,Result) {	\
-    size_t i;								\
-    for (i = 0; i < (Length); i++) {					\
+#define COPY_COND_WITH_OFFSET(Buf,Bufend,Offset,Str,Length,Result) {        \
+    size_t i;                                                                \
+    for (i = 0; i < (Length); i++) {                                        \
       PRINT_COND_WITH_OFFSET((Buf), (Bufend), (Offset), (Str)[i], (Result)); \
-    }									\
+    }                                                                        \
   }
- 
+
 static int
 match(const coap_str_const_t *text, const coap_str_const_t *pattern, int match_prefix,
   int match_substring
 ) {
   assert(text); assert(pattern);
-  
+
   if (text->length < pattern->length)
     return 0;
 
@@ -126,7 +126,7 @@ match(const coap_str_const_t *text, const coap_str_const_t *pattern, int match_p
         token_length = remaining_length;
         remaining_length = 0;
       }
-      
+
       if ((match_prefix || pattern->length == token_length) &&
             memcmp(token, pattern->s, pattern->length) == 0)
         return 1;
@@ -138,22 +138,22 @@ match(const coap_str_const_t *text, const coap_str_const_t *pattern, int match_p
     memcmp(text->s, pattern->s, pattern->length) == 0;
 }
 
-/** 
+/**
  * Prints the names of all known resources to @p buf. This function
  * sets @p buflen to the number of bytes actually written and returns
  * @c 1 on succes. On error, the value in @p buflen is undefined and
  * the return value will be @c 0.
- * 
+ *
  * @param context The context with the resource map.
  * @param buf     The buffer to write the result.
  * @param buflen  Must be initialized to the maximum length of @p buf and will be
  *                set to the length of the well-known response on return.
  * @param offset  The offset in bytes where the output shall start and is
  *                shifted accordingly with the characters that have been
- *                processed. This parameter is used to support the block 
- *                option. 
+ *                processed. This parameter is used to support the block
+ *                option.
  * @param query_filter A filter query according to <a href="http://tools.ietf.org/html/draft-ietf-core-link-format-11#section-4.1">Link Format</a>
- * 
+ *
  * @return COAP_PRINT_STATUS_ERROR on error. Otherwise, the lower 28 bits are
  *         set to the number of bytes that have actually been written to
  *         @p buf. COAP_PRINT_STATUS_TRUNC is set when the output has been
@@ -162,12 +162,12 @@ match(const coap_str_const_t *text, const coap_str_const_t *pattern, int match_p
 #if defined(__GNUC__) && defined(WITHOUT_QUERY_FILTER)
 coap_print_status_t
 coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen,
-		size_t offset,
-		coap_opt_t *query_filter __attribute__ ((unused))) {
+                size_t offset,
+                coap_opt_t *query_filter __attribute__ ((unused))) {
 #else /* not a GCC */
 coap_print_status_t
 coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen,
-		size_t offset, coap_opt_t *query_filter) {
+                size_t offset, coap_opt_t *query_filter) {
 #endif /* GCC */
   size_t output_length = 0;
   unsigned char *p = buf;
@@ -194,17 +194,17 @@ coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen
   if (query_filter) {
     resource_param.s = coap_opt_value(query_filter);
     while (resource_param.length < coap_opt_length(query_filter)
-	   && resource_param.s[resource_param.length] != '=')
+           && resource_param.s[resource_param.length] != '=')
       resource_param.length++;
-    
+
     if (resource_param.length < coap_opt_length(query_filter)) {
       const coap_str_const_t *rt_attributes;
-      if (resource_param.length == 4 && 
-	  memcmp(resource_param.s, "href", 4) == 0)
-	flags |= MATCH_URI;
+      if (resource_param.length == 4 &&
+          memcmp(resource_param.s, "href", 4) == 0)
+        flags |= MATCH_URI;
 
       for (rt_attributes = _rt_attributes; rt_attributes->s; rt_attributes++) {
-        if (resource_param.length == rt_attributes->length && 
+        if (resource_param.length == rt_attributes->length &&
             memcmp(resource_param.s, rt_attributes->s, rt_attributes->length) == 0) {
           flags |= MATCH_SUBSTRING;
           break;
@@ -212,23 +212,23 @@ coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen
       }
 
       /* rest is query-pattern */
-      query_pattern.s = 
-	coap_opt_value(query_filter) + resource_param.length + 1;
+      query_pattern.s =
+        coap_opt_value(query_filter) + resource_param.length + 1;
 
       assert((resource_param.length + 1) <= coap_opt_length(query_filter));
-      query_pattern.length = 
-	coap_opt_length(query_filter) - (resource_param.length + 1);
+      query_pattern.length =
+        coap_opt_length(query_filter) - (resource_param.length + 1);
 
      if ((query_pattern.s[0] == '/') && ((flags & MATCH_URI) == MATCH_URI)) {
        query_pattern.s++;
        query_pattern.length--;
       }
 
-      if (query_pattern.length && 
-	  query_pattern.s[query_pattern.length-1] == '*') {
-	query_pattern.length--;
-	flags |= MATCH_PREFIX;
-      }      
+      if (query_pattern.length &&
+          query_pattern.s[query_pattern.length-1] == '*') {
+        query_pattern.length--;
+        flags |= MATCH_PREFIX;
+      }
     }
   }
 #endif /* WITHOUT_QUERY_FILTER */
@@ -237,30 +237,30 @@ coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen
 
 #ifndef WITHOUT_QUERY_FILTER
     if (resource_param.length) { /* there is a query filter */
-      
-      if (flags & MATCH_URI) {	/* match resource URI */
-	if (!match(r->uri_path, &query_pattern, (flags & MATCH_PREFIX) != 0,
+
+      if (flags & MATCH_URI) {        /* match resource URI */
+        if (!match(r->uri_path, &query_pattern, (flags & MATCH_PREFIX) != 0,
             (flags & MATCH_SUBSTRING) != 0))
-	  continue;
-      } else {			/* match attribute */
-	coap_attr_t *attr;
+          continue;
+      } else {                        /* match attribute */
+        coap_attr_t *attr;
         coap_str_const_t unquoted_val;
-	attr = coap_find_attr(r, &resource_param);
+        attr = coap_find_attr(r, &resource_param);
         if (!attr || !attr->value) continue;
         unquoted_val = *attr->value;
         if (attr->value->s[0] == '"') {          /* if attribute has a quoted value, remove double quotes */
           unquoted_val.length -= 2;
           unquoted_val.s += 1;
         }
-	if (!(match(&unquoted_val, &query_pattern, 
+        if (!(match(&unquoted_val, &query_pattern,
                     (flags & MATCH_PREFIX) != 0,
                     (flags & MATCH_SUBSTRING) != 0)))
-	  continue;
+          continue;
       }
     }
 #endif /* WITHOUT_QUERY_FILTER */
 
-    if (!subsequent_resource) {	/* this is the first resource  */
+    if (!subsequent_resource) {        /* this is the first resource  */
       subsequent_resource = 1;
     } else {
       PRINT_COND_WITH_OFFSET(p, bufend, offset, ',', written);
@@ -315,7 +315,7 @@ coap_resource_init(coap_str_const_t *uri_path, int flags) {
       /* Do not expecte this, but ... */
       uri_path = coap_new_str_const(null_path->s, null_path->length);
     }
-      
+
     if (uri_path)
       r->uri_path = uri_path;
 
@@ -323,7 +323,7 @@ coap_resource_init(coap_str_const_t *uri_path, int flags) {
   } else {
     coap_log(LOG_DEBUG, "coap_resource_init: no memory left\n");
   }
-  
+
   return r;
 }
 
@@ -344,20 +344,20 @@ coap_resource_unknown_init(coap_method_handler_t put_handler) {
   } else {
     coap_log(LOG_DEBUG, "coap_resource_unknown_init: no memory left\n");
   }
-  
+
   return r;
 }
 
 coap_attr_t *
-coap_add_attr(coap_resource_t *resource, 
-	      coap_str_const_t *name,
-	      coap_str_const_t *val,
+coap_add_attr(coap_resource_t *resource,
+              coap_str_const_t *name,
+              coap_str_const_t *val,
               int flags) {
   coap_attr_t *attr;
 
   if (!resource || !name)
     return NULL;
- 
+
   attr = (coap_attr_t *)coap_malloc_type(COAP_RESOURCEATTR, sizeof(coap_attr_t));
 
   if (attr) {
@@ -381,13 +381,13 @@ coap_add_attr(coap_resource_t *resource,
   } else {
     coap_log(LOG_DEBUG, "coap_add_attr: no memory left\n");
   }
-  
+
   return attr;
 }
 
 coap_attr_t *
-coap_find_attr(coap_resource_t *resource, 
-	       coap_str_const_t *name) {
+coap_find_attr(coap_resource_t *resource,
+               coap_str_const_t *name) {
   coap_attr_t *attr;
 
   if (!resource || !name)
@@ -395,7 +395,7 @@ coap_find_attr(coap_resource_t *resource,
 
   LL_FOREACH(resource->link_attr, attr) {
     if (attr->name->length == name->length &&
-	memcmp(attr->name->s, name->s, name->length) == 0)
+        memcmp(attr->name->s, name->s, name->length) == 0)
       return attr;
   }
 
@@ -521,22 +521,22 @@ coap_get_resource_from_uri_path(coap_context_t *context, coap_str_const_t *uri_p
 }
 
 coap_print_status_t
-coap_print_link(const coap_resource_t *resource, 
-		unsigned char *buf, size_t *len, size_t *offset) {
+coap_print_link(const coap_resource_t *resource,
+                unsigned char *buf, size_t *len, size_t *offset) {
   unsigned char *p = buf;
   const uint8_t *bufend = buf + *len;
   coap_attr_t *attr;
   coap_print_status_t result = 0;
   size_t output_length = 0;
   const size_t old_offset = *offset;
-  
+
   *len = 0;
   PRINT_COND_WITH_OFFSET(p, bufend, *offset, '<', *len);
   PRINT_COND_WITH_OFFSET(p, bufend, *offset, '/', *len);
 
-  COPY_COND_WITH_OFFSET(p, bufend, *offset, 
-			resource->uri_path->s, resource->uri_path->length, *len);
-  
+  COPY_COND_WITH_OFFSET(p, bufend, *offset,
+                        resource->uri_path->s, resource->uri_path->length, *len);
+
   PRINT_COND_WITH_OFFSET(p, bufend, *offset, '>', *len);
 
   LL_FOREACH(resource->link_attr, attr) {
@@ -544,13 +544,13 @@ coap_print_link(const coap_resource_t *resource,
     PRINT_COND_WITH_OFFSET(p, bufend, *offset, ';', *len);
 
     COPY_COND_WITH_OFFSET(p, bufend, *offset,
-			  attr->name->s, attr->name->length, *len);
+                          attr->name->s, attr->name->length, *len);
 
     if (attr->value && attr->value->s) {
       PRINT_COND_WITH_OFFSET(p, bufend, *offset, '=', *len);
 
       COPY_COND_WITH_OFFSET(p, bufend, *offset,
-			    attr->value->s, attr->value->length, *len);
+                            attr->value->s, attr->value->length, *len);
     }
 
   }
@@ -585,7 +585,7 @@ coap_register_handler(coap_resource_t *resource,
 #ifndef WITHOUT_OBSERVE
 coap_subscription_t *
 coap_find_observer(coap_resource_t *resource, coap_session_t *session,
-		     const coap_binary_t *token) {
+                     const coap_binary_t *token) {
   coap_subscription_t *s;
 
   assert(resource);
@@ -593,17 +593,17 @@ coap_find_observer(coap_resource_t *resource, coap_session_t *session,
 
   LL_FOREACH(resource->subscribers, s) {
     if (s->session == session
-	&& (!token || (token->length == s->token_length 
-		       && memcmp(token->s, s->token, token->length) == 0)))
+        && (!token || (token->length == s->token_length
+                       && memcmp(token->s, s->token, token->length) == 0)))
       return s;
   }
-  
+
   return NULL;
 }
 
 static coap_subscription_t *
 coap_find_observer_query(coap_resource_t *resource, coap_session_t *session,
-		     const coap_string_t *query) {
+                     const coap_string_t *query) {
   coap_subscription_t *s;
 
   assert(resource);
@@ -615,19 +615,19 @@ coap_find_observer_query(coap_resource_t *resource, coap_session_t *session,
              || (query && s->query && coap_string_equal(query, s->query))))
       return s;
   }
-  
+
   return NULL;
 }
 
 coap_subscription_t *
-coap_add_observer(coap_resource_t *resource, 
+coap_add_observer(coap_resource_t *resource,
                   coap_session_t *session,
-		  const coap_binary_t *token,
+                  const coap_binary_t *token,
                   coap_string_t *query,
                   int has_block2,
                   coap_block_t block2) {
   coap_subscription_t *s;
-  
+
   assert( session );
 
   /* Check if there is already a subscription for this peer. */
@@ -667,7 +667,7 @@ coap_add_observer(coap_resource_t *resource,
 
   coap_subscription_init(s);
   s->session = coap_session_reference( session );
-  
+
   if (token && token->length) {
     s->token_length = token->length;
     memcpy(s->token, token->s, min(s->token_length, 8));
@@ -688,7 +688,7 @@ coap_add_observer(coap_resource_t *resource,
 
 void
 coap_touch_observer(coap_context_t *context, coap_session_t *session,
-		    const coap_binary_t *token) {
+                    const coap_binary_t *token) {
   coap_subscription_t *s;
 
   RESOURCES_ITER(context->resources, r) {
@@ -701,7 +701,7 @@ coap_touch_observer(coap_context_t *context, coap_session_t *session,
 
 int
 coap_delete_observer(coap_resource_t *resource, coap_session_t *session,
-		     const coap_binary_t *token) {
+                     const coap_binary_t *token) {
   coap_subscription_t *s;
 
   s = coap_find_observer(resource, session, token);
@@ -733,11 +733,11 @@ coap_delete_observers(coap_context_t *context, coap_session_t *session) {
     coap_subscription_t *s, *tmp;
     LL_FOREACH_SAFE(resource->subscribers, s, tmp) {
       if (s->session == session) {
-	LL_DELETE(resource->subscribers, s);
-	coap_session_release(session);
+        LL_DELETE(resource->subscribers, s);
+        coap_session_release(session);
         if (s->query)
           coap_delete_string(s->query);
-	COAP_FREE_TYPE(subscription, s);
+        COAP_FREE_TYPE(subscription, s);
       }
     }
   }
@@ -755,8 +755,8 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
 
     /* retrieve GET handler, prepare response */
     h = r->handler[COAP_REQUEST_GET - 1];
-    assert(h);		/* we do not allow subscriptions if no
-			 * GET handler is defined */
+    assert(h);                /* we do not allow subscriptions if no
+                         * GET handler is defined */
 
     LL_FOREACH(r->subscribers, obs) {
       if (r->dirty == 0 && obs->dirty == 0)
@@ -777,16 +777,16 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
       if (!response) {
         obs->dirty = 1;
         r->partiallydirty = 1;
-	debug("coap_check_notify: pdu init failed, resource stays partially dirty\n");
-	continue;
+        debug("coap_check_notify: pdu init failed, resource stays partially dirty\n");
+        continue;
       }
 
       if (!coap_add_token(response, obs->token_length, obs->token)) {
         obs->dirty = 1;
         r->partiallydirty = 1;
-	debug("coap_check_notify: cannot add token, resource stays partially dirty\n");
-	coap_delete_pdu(response);
-	continue;
+        debug("coap_check_notify: cannot add token, resource stays partially dirty\n");
+        coap_delete_pdu(response);
+        continue;
       }
 
       token.length = obs->token_length;
@@ -794,27 +794,27 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
 
       response->tid = coap_new_message_id(obs->session);
       if ((r->flags & COAP_RESOURCE_FLAGS_NOTIFY_CON) == 0
-	  && obs->non_cnt < COAP_OBS_MAX_NON) {
-	response->type = COAP_MESSAGE_NON;
+          && obs->non_cnt < COAP_OBS_MAX_NON) {
+        response->type = COAP_MESSAGE_NON;
       } else {
-	response->type = COAP_MESSAGE_CON;
+        response->type = COAP_MESSAGE_CON;
       }
       /* fill with observer-specific data */
       h(context, r, obs->session, NULL, &token, obs->query, response);
 
-      /* TODO: do not send response and remove observer when 
+      /* TODO: do not send response and remove observer when
        *  COAP_RESPONSE_CLASS(response->hdr->code) > 2
        */
       if (response->type == COAP_MESSAGE_CON) {
-	obs->non_cnt = 0;
+        obs->non_cnt = 0;
       } else {
-	obs->non_cnt++;
+        obs->non_cnt++;
       }
 
       tid = coap_send( obs->session, response );
 
       if (COAP_INVALID_TID == tid) {
-	debug("coap_check_notify: sending failed, resource stays partially dirty\n");
+        debug("coap_check_notify: sending failed, resource stays partially dirty\n");
         obs->dirty = 1;
         r->partiallydirty = 1;
       }
@@ -840,11 +840,11 @@ coap_resource_notify_observers(coap_resource_t *r, const coap_string_t *query) {
       if (obs->query
        && obs->query->length==query->length
        && memcmp(obs->query->s, query->s, query->length)==0 ) {
-	found = 1;
-	if (!r->dirty && !obs->dirty) {
-	  obs->dirty = 1;
-	  r->partiallydirty = 1;
-	}
+        found = 1;
+        if (!r->dirty && !obs->dirty) {
+          obs->dirty = 1;
+          r->partiallydirty = 1;
+        }
       }
     }
     if (!found)
@@ -881,54 +881,54 @@ coap_check_notify(coap_context_t *context) {
  */
 static void
 coap_remove_failed_observers(coap_context_t *context,
-			     coap_resource_t *resource,
-			     coap_session_t *session,
-			     const coap_binary_t *token) {
+                             coap_resource_t *resource,
+                             coap_session_t *session,
+                             const coap_binary_t *token) {
   coap_subscription_t *obs, *otmp;
 
   LL_FOREACH_SAFE(resource->subscribers, obs, otmp) {
     if ( obs->session == session &&
-	token->length == obs->token_length &&
-	memcmp(token->s, obs->token, token->length) == 0) {
-      
+        token->length == obs->token_length &&
+        memcmp(token->s, obs->token, token->length) == 0) {
+
       /* count failed notifies and remove when
        * COAP_MAX_FAILED_NOTIFY is reached */
       if (obs->fail_cnt < COAP_OBS_MAX_FAIL)
-	obs->fail_cnt++;
+        obs->fail_cnt++;
       else {
-	LL_DELETE(resource->subscribers, obs);
-	obs->fail_cnt = 0;
-	
+        LL_DELETE(resource->subscribers, obs);
+        obs->fail_cnt = 0;
+
 #ifndef NDEBUG
-	if (LOG_DEBUG <= coap_get_log_level()) {
+        if (LOG_DEBUG <= coap_get_log_level()) {
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN 40
 #endif
-	  unsigned char addr[INET6_ADDRSTRLEN+8];
+          unsigned char addr[INET6_ADDRSTRLEN+8];
 
-	  if (coap_print_addr(&obs->session->remote_addr, addr, INET6_ADDRSTRLEN+8))
-	    debug("** removed observer %s\n", addr);
-	}
+          if (coap_print_addr(&obs->session->remote_addr, addr, INET6_ADDRSTRLEN+8))
+            debug("** removed observer %s\n", addr);
+        }
 #endif
-	coap_cancel_all_messages(context, obs->session, 
-				 obs->token, obs->token_length);
-	coap_session_release( obs->session );
+        coap_cancel_all_messages(context, obs->session,
+                                 obs->token, obs->token_length);
+        coap_session_release( obs->session );
         if (obs->query)
           coap_delete_string(obs->query);
-	COAP_FREE_TYPE(subscription, obs);
+        COAP_FREE_TYPE(subscription, obs);
       }
-      break;			/* break loop if observer was found */
+      break;                        /* break loop if observer was found */
     }
   }
 }
 
 void
-coap_handle_failed_notify(coap_context_t *context, 
-			  coap_session_t *session, 
-			  const coap_binary_t *token) {
+coap_handle_failed_notify(coap_context_t *context,
+                          coap_session_t *session,
+                          const coap_binary_t *token) {
 
   RESOURCES_ITER(context->resources, r) {
-	coap_remove_failed_observers(context, r, session, token);
+        coap_remove_failed_observers(context, r, session, token);
   }
 }
 #endif /* WITHOUT_NOTIFY */

--- a/src/str.c
+++ b/src/str.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2010,2011 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include "coap_config.h"

--- a/src/subscribe.c
+++ b/src/subscribe.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2010--2013,2015 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include "coap_config.h"

--- a/src/uri.c
+++ b/src/uri.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2010--2012,2015-2016 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include "coap_config.h"
@@ -27,22 +27,22 @@
 #include "option.h"
 #include "uri.h"
 
-/** 
+/**
  * A length-safe version of strchr(). This function returns a pointer
  * to the first occurrence of @p c  in @p s, or @c NULL if not found.
- * 
+ *
  * @param s   The string to search for @p c.
  * @param len The length of @p s.
  * @param c   The character to search.
- * 
- * @return A pointer to the first occurence of @p c, or @c NULL 
+ *
+ * @return A pointer to the first occurence of @p c, or @c NULL
  * if not found.
  */
 COAP_STATIC_INLINE const uint8_t *
 strnchr(const uint8_t *s, size_t len, unsigned char c) {
   while (len && *s++ != c)
     --len;
-  
+
   return len ? s : NULL;
 }
 
@@ -71,7 +71,7 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
   while (len && *q && ISEQUAL_CI(*p, *q)) {
     ++p; ++q; --len;
   }
-  
+
   /* If q does not point to the string end marker '\0', the schema
    * identifier is wrong. */
   if (*q) {
@@ -109,9 +109,9 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
 
   /* p points to beginning of Uri-Host */
   q = p;
-  if (len && *p == '[') {	/* IPv6 address reference */
+  if (len && *p == '[') {        /* IPv6 address reference */
     ++p;
-    
+
     while (len && *q != ']') {
       ++q; --len;
     }
@@ -119,11 +119,11 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
     if (!len || *q != ']' || p == q) {
       res = -3;
       goto error;
-    } 
+    }
 
     COAP_SET_STR(&uri->host, q - p, p);
     ++q; --len;
-  } else {			/* IPv4 address or FQDN */
+  } else {                        /* IPv4 address or FQDN */
     while (len && *q != ':' && *q != '/' && *q != '?') {
       ++q;
       --len;
@@ -141,33 +141,33 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
   if (len && *q == ':') {
     p = ++q;
     --len;
-    
+
     while (len && isdigit(*q)) {
       ++q;
       --len;
     }
 
-    if (p < q) {		/* explicit port number given */
+    if (p < q) {                /* explicit port number given */
       int uri_port = 0;
-    
+
       while (p < q)
-	      uri_port = uri_port * 10 + (*p++ - '0');
+              uri_port = uri_port * 10 + (*p++ - '0');
 
       /* check if port number is in allowed range */
       if (uri_port > 65535) {
-	      res = -4;
-	      goto error;
+              res = -4;
+              goto error;
       }
 
       uri->port = (uint16_t)uri_port;
-    } 
+    }
   }
-  
- path:		 /* at this point, p must point to an absolute path */
+
+ path:                 /* at this point, p must point to an absolute path */
 
   if (!len)
     goto end;
-  
+
   if (*q == '/') {
     p = ++q;
     --len;
@@ -176,7 +176,7 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
       ++q;
       --len;
     }
-  
+
     if (p < q) {
       COAP_SET_STR(&uri->path, q - p, p);
       p = q;
@@ -193,28 +193,28 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
 
   end:
   return len ? -1 : 0;
-  
+
   error:
   return res;
 }
 
-/** 
+/**
  * Calculates decimal value from hexadecimal ASCII character given in
  * @p c. The caller must ensure that @p c actually represents a valid
- * heaxdecimal character, e.g. with isxdigit(3). 
+ * heaxdecimal character, e.g. with isxdigit(3).
  *
  * @hideinitializer
  */
 #define hexchar_to_dec(c) ((c) & 0x40 ? ((c) & 0x0F) + 9 : ((c) & 0x0F))
 
-/** 
+/**
  * Decodes percent-encoded characters while copying the string @p seg
  * of size @p length to @p buf. The caller of this function must
  * ensure that the percent-encodings are correct (i.e. the character
  * '%' is always followed by two hex digits. and that @p buf provides
  * sufficient space to hold the result. This function is supposed to
  * be called by make_decoded_option() only.
- * 
+ *
  * @param seg     The segment to decode and copy.
  * @param length  Length of @p seg.
  * @param buf     The result buffer.
@@ -226,12 +226,12 @@ decode_segment(const uint8_t *seg, size_t length, unsigned char *buf) {
 
     if (*seg == '%') {
       *buf = (hexchar_to_dec(seg[1]) << 4) + hexchar_to_dec(seg[2]);
-      
+
       seg += 2; length -= 2;
     } else {
       *buf = *seg;
     }
-    
+
     ++buf; ++seg;
   }
 }
@@ -248,21 +248,21 @@ check_segment(const uint8_t *s, size_t length, size_t *segment_size) {
   while (length) {
     if (*s == '%') {
       if (length < 2 || !(isxdigit(s[1]) && isxdigit(s[2])))
-	      return -1;
-      
+              return -1;
+
       s += 2;
       length -= 2;
     }
 
     ++s; ++n; --length;
   }
-  
+
   *segment_size = n;
 
   return 0;
 }
-	 
-/** 
+
+/**
  * Writes a coap option from given string @p s to @p buf. @p s should
  * point to a (percent-encoded) path or query segment of a coap_uri_t
  * object.  The created option will have type @c 0, and the length
@@ -270,21 +270,21 @@ check_segment(const uint8_t *s, size_t length, size_t *segment_size) {
  * On success, this function returns @c 0 and sets @p optionsize to the option's
  * size. On error the function returns a value less than zero. This function
  * must be called from coap_split_path_impl() only.
- * 
+ *
  * @param s           The string to decode.
  * @param length      The size of the percent-encoded string @p s.
  * @param buf         The buffer to store the new coap option.
  * @param buflen      The maximum size of @p buf.
  * @param optionsize  The option's size.
- * 
+ *
  * @return @c 0 on success and @c -1 on error.
  *
  * @bug This function does not split segments that are bigger than 270
  * bytes.
  */
 static int
-make_decoded_option(const uint8_t *s, size_t length, 
-		    unsigned char *buf, size_t buflen, size_t* optionsize) {
+make_decoded_option(const uint8_t *s, size_t length,
+                    unsigned char *buf, size_t buflen, size_t* optionsize) {
   int res;
   size_t segmentlen;
   size_t written;
@@ -303,10 +303,10 @@ make_decoded_option(const uint8_t *s, size_t length,
 
   assert(written <= buflen);
 
-  if (!written)			/* encoding error */
+  if (!written)                        /* encoding error */
     return -1;
 
-  buf += written;		/* advance past option type/length */
+  buf += written;                /* advance past option type/length */
   buflen -= written;
 
   if (buflen < segmentlen) {
@@ -336,29 +336,29 @@ dots(const uint8_t *s, size_t len) {
   return len && *s == '.' && (len == 1 || (len == 2 && *(s+1) == '.'));
 }
 
-/** 
+/**
  * Splits the given string into segments. You should call one of the
  * macros coap_split_path() or coap_split_query() instead.
- * 
+ *
  * @param s      The URI string to be tokenized.
  * @param length The length of @p s.
  * @param h      A handler that is called with every token.
  * @param data   Opaque data that is passed to @p h when called.
- * 
+ *
  * @return The number of characters that have been parsed from @p s.
  */
 static size_t
 coap_split_path_impl(const uint8_t *s, size_t length,
-		     segment_handler_t h, void *data) {
+                     segment_handler_t h, void *data) {
 
   const uint8_t *p, *q;
 
   p = q = s;
   while (length > 0 && !strnchr((const uint8_t *)"?#", 2, *q)) {
-    if (*q == '/') {		/* start new segment */
+    if (*q == '/') {                /* start new segment */
 
       if (!dots(p, q - p)) {
-	h(p, q - p, data);
+        h(p, q - p, data);
       }
 
       p = q + 1;
@@ -397,8 +397,8 @@ write_option(const uint8_t *s, size_t len, void *data) {
 }
 
 int
-coap_split_path(const uint8_t *s, size_t length, 
-		unsigned char *buf, size_t *buflen) {
+coap_split_path(const uint8_t *s, size_t length,
+                unsigned char *buf, size_t *buflen) {
   struct cnt_str tmp = { { *buflen, buf }, 0 };
 
   coap_split_path_impl(s, length, write_option, &tmp);
@@ -409,14 +409,14 @@ coap_split_path(const uint8_t *s, size_t length,
 }
 
 int
-coap_split_query(const uint8_t *s, size_t length, 
-		unsigned char *buf, size_t *buflen) {
+coap_split_query(const uint8_t *s, size_t length,
+                unsigned char *buf, size_t *buflen) {
   struct cnt_str tmp = { { *buflen, buf }, 0 };
   const uint8_t *p;
 
   p = s;
   while (length > 0 && *s != '#') {
-    if (*s == '&') {		/* start new query element */
+    if (*s == '&') {                /* start new query element */
       write_option(p, s - p, &tmp);
       p = s + 1;
     }
@@ -462,7 +462,7 @@ coap_clone_uri(const coap_uri_t *uri) {
     return  NULL;
 
   result = (coap_uri_t *)coap_malloc( uri->query.length + uri->host.length +
-				      uri->path.length + sizeof(coap_uri_t) + 1);
+                                      uri->path.length + sizeof(coap_uri_t) + 1);
 
   if ( !result )
     return NULL;
@@ -525,9 +525,9 @@ coap_string_t *coap_get_query(const coap_pdu_t *request) {
     const uint8_t *seg= coap_opt_value(q);
     for (i = 0; i < seg_len; i++) {
       if (is_unescaped_in_query(seg[i]))
-	length += 1;
+        length += 1;
       else
-	length += 3;
+        length += 3;
     }
     length += 1;
   }
@@ -540,19 +540,19 @@ coap_string_t *coap_get_query(const coap_pdu_t *request) {
       unsigned char *s = query->s;
       coap_option_iterator_init(request, &opt_iter, f);
       while ((q = coap_option_next(&opt_iter))) {
-	if (s != query->s)
-	  *s++ = '&';
-	uint16_t seg_len = coap_opt_length(q), i;
-	const uint8_t *seg= coap_opt_value(q);
-	for (i = 0; i < seg_len; i++) {
-	  if (is_unescaped_in_query(seg[i])) {
-	    *s++ = seg[i];
-	  } else {
-	    *s++ = '%';
-	    *s++ = hex[seg[i]>>4];
-	    *s++ = hex[seg[i]&0x0F];
-	  }
-	}
+        if (s != query->s)
+          *s++ = '&';
+        uint16_t seg_len = coap_opt_length(q), i;
+        const uint8_t *seg= coap_opt_value(q);
+        for (i = 0; i < seg_len; i++) {
+          if (is_unescaped_in_query(seg[i])) {
+            *s++ = seg[i];
+          } else {
+            *s++ = '%';
+            *s++ = hex[seg[i]>>4];
+            *s++ = hex[seg[i]&0x0F];
+          }
+        }
       }
     }
   }
@@ -575,9 +575,9 @@ coap_string_t *coap_get_uri_path(const coap_pdu_t *request) {
     const uint8_t *seg= coap_opt_value(q);
     for (i = 0; i < seg_len; i++) {
       if (is_unescaped_in_path(seg[i]))
-	length += 1;
+        length += 1;
       else
-	length += 3;
+        length += 3;
     }
     /* bump for the leading "/" */
     length += 1;

--- a/tests/test_error_response.c
+++ b/tests/test_error_response.c
@@ -16,8 +16,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-coap_pdu_t *pdu;	      /* Holds the request PDU for most tests */
-coap_opt_filter_t opts;	      /* option filter used for generating responses */
+coap_pdu_t *pdu;              /* Holds the request PDU for most tests */
+coap_opt_filter_t opts;              /* option filter used for generating responses */
 
 /************************************************************************
  ** PDU decoder
@@ -337,19 +337,19 @@ t_init_error_response_tests(void) {
   CU_pSuite suite[1];
 
   suite[0] = CU_add_suite("error response generator",
-			  t_error_response_tests_create,
-			  t_error_response_tests_remove);
-  if (!suite[0]) {			/* signal error */
+                          t_error_response_tests_create,
+                          t_error_response_tests_remove);
+  if (!suite[0]) {                        /* signal error */
     fprintf(stderr, "W: cannot add error response generator test suite (%s)\n",
-	    CU_get_error_msg());
+            CU_get_error_msg());
 
     return NULL;
   }
 
-#define ERROR_RESPONSE_TEST(s,t)					\
-  if (!CU_ADD_TEST(s,t)) {						\
+#define ERROR_RESPONSE_TEST(s,t)                                        \
+  if (!CU_ADD_TEST(s,t)) {                                                \
     fprintf(stderr, "W: cannot add error response generator test (%s)\n", \
-	    CU_get_error_msg());					\
+            CU_get_error_msg());                                        \
   }
 
   ERROR_RESPONSE_TEST(suite[0], t_error_response1);

--- a/tests/test_error_response.h
+++ b/tests/test_error_response.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2013 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <CUnit/CUnit.h>

--- a/tests/test_options.c
+++ b/tests/test_options.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2012,2015 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include "coap_config.h"
@@ -54,7 +54,7 @@ static void
 t_parse_option3(void) {
   /* delta == 3, length == 12, value == 0 */
   coap_str_const_t teststr = { 13, (const uint8_t *)"\x3c\x00\x01\x02\x03\x04"
-		                       "\x05\x06\x07\x08\x09\x0a\x0b" };
+                                       "\x05\x06\x07\x08\x09\x0a\x0b" };
 
   size_t result;
   coap_option_t option;
@@ -190,7 +190,7 @@ t_parse_option13(void) {
   teststr.s[2] = 0x0b;
   teststr.s[3] = 0x00;
   teststr.s[4] = 0xe7;
-  
+
   size_t result;
   coap_option_t option;
 
@@ -217,7 +217,7 @@ t_parse_option14(void) {
   data[1] = 0xff;
   data[2] = 0xfe;
   data[3] = 0xf2;
-  
+
   size_t result;
   coap_option_t option;
 
@@ -238,10 +238,10 @@ t_encode_option1(void) {
   char teststr[] = { 0x00 };
   unsigned char buf[40];
   size_t result;
-  
+
   result = coap_opt_setheader((coap_opt_t *)buf, sizeof(buf), 0, 0);
   CU_ASSERT(result == sizeof(teststr));
-  
+
   CU_ASSERT(memcmp(buf, teststr, result) == 0);
 }
 
@@ -250,10 +250,10 @@ t_encode_option2(void) {
   uint8_t teststr[] = { 0x5d, 0xff };
   unsigned char buf[40];
   size_t result;
-  
+
   result = coap_opt_setheader((coap_opt_t *)buf, sizeof(buf), 5, 268);
   CU_ASSERT(result == sizeof(teststr));
-  
+
   CU_ASSERT(memcmp(buf, teststr, result) == 0);
 }
 
@@ -262,7 +262,7 @@ t_encode_option3(void) {
   uint8_t teststr[] = { 0xd1, 0x01 };
   unsigned char buf[40];
   size_t result;
-  
+
   result = coap_opt_setheader((coap_opt_t *)buf, sizeof(buf), 14, 1);
   CU_ASSERT(result == sizeof(teststr));
 
@@ -274,7 +274,7 @@ t_encode_option4(void) {
   uint8_t teststr[] = { 0xdd, 0xff, 0xab };
   unsigned char buf[40];
   size_t result;
-  
+
   result = coap_opt_setheader((coap_opt_t *)buf, sizeof(buf), 268, 184);
   CU_ASSERT(result == sizeof(teststr));
 
@@ -286,7 +286,7 @@ t_encode_option5(void) {
   uint8_t teststr[] = { 0xed, 0x13, 0x00, 0xff };
   unsigned char buf[40];
   size_t result;
-  
+
   result = coap_opt_setheader((coap_opt_t *)buf, sizeof(buf), 5133, 268);
   CU_ASSERT(result == sizeof(teststr));
 
@@ -298,7 +298,7 @@ t_encode_option6(void) {
   uint8_t teststr[] = { 0xee, 0xfe, 0xf2, 0xfe, 0xf2 };
   unsigned char buf[40];
   size_t result;
-  
+
   result = coap_opt_setheader((coap_opt_t *)buf, sizeof(buf), 65535, 65535);
   CU_ASSERT(result == sizeof(teststr));
 
@@ -311,10 +311,10 @@ t_encode_option7(void) {
   const size_t valoff = 1;
   unsigned char buf[40];
   size_t result;
-  
-  result = coap_opt_encode((coap_opt_t *)buf, sizeof(buf), 3, 
-			   (unsigned char *)teststr + valoff, 
-			   sizeof(teststr) - valoff);
+
+  result = coap_opt_encode((coap_opt_t *)buf, sizeof(buf), 3,
+                           (unsigned char *)teststr + valoff,
+                           sizeof(teststr) - valoff);
 
   CU_ASSERT(result == sizeof(teststr));
 
@@ -326,14 +326,14 @@ t_encode_option8(void) {
   /* value does not fit in message buffer */
   unsigned char buf[40];
   size_t result;
-  
-  result = coap_opt_encode((coap_opt_t *)buf, 8, 15, 
-			   (const uint8_t *)"something", 9);
+
+  result = coap_opt_encode((coap_opt_t *)buf, 8, 15,
+                           (const uint8_t *)"something", 9);
 
   CU_ASSERT(result == 0);
 
-  result = coap_opt_encode((coap_opt_t *)buf, 1, 15, 
-			   (const uint8_t *)"something", 9);
+  result = coap_opt_encode((coap_opt_t *)buf, 1, 15,
+                           (const uint8_t *)"something", 9);
 
   CU_ASSERT(result == 0);
 }
@@ -343,10 +343,10 @@ t_encode_option9(void) {
   uint8_t teststr[] = { 0xe1, 0x00, 0x00 };
   unsigned char buf[40] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
   size_t result;
-  
+
   result = coap_opt_setheader((coap_opt_t *)buf, sizeof(buf), 269, 1);
   CU_ASSERT(result == sizeof(teststr));
-  
+
   CU_ASSERT(memcmp(buf, teststr, result) == 0);
 }
 
@@ -376,9 +376,9 @@ t_access_option2(void) {
 
 static void
 t_access_option3(void) {
-  const uint8_t teststr[] = { 0xed, 0x18, 0x0a, 0x00, 'a', 'b', 'c', 'd', 
-			   'e',  'f',  'g',  'h',  'i', 'j', 'k', 'l',
-			   'm'
+  const uint8_t teststr[] = { 0xed, 0x18, 0x0a, 0x00, 'a', 'b', 'c', 'd',
+                           'e',  'f',  'g',  'h',  'i', 'j', 'k', 'l',
+                           'm'
   };
 
   CU_ASSERT(coap_opt_delta((const coap_opt_t *)teststr) == 6423);
@@ -436,20 +436,20 @@ t_access_option7(void) {
 
 #define TEST_MAX_SIZE 1000
 
-#ifdef _MSC_VER 
-#  define ALIGNED(x) 
-#else 
-#  define ALIGNED(x) __attribute__ ((aligned (x))) 
-#endif 
+#ifdef _MSC_VER
+#  define ALIGNED(x)
+#else
+#  define ALIGNED(x) __attribute__ ((aligned (x)))
+#endif
 
 static void
 t_iterate_option1(void) {
   /* CoAP PDU without token, options, or data */
-  uint8_t teststr[] ALIGNED(8) = { 
-    0x00, 0x00, 0x00, 0x00 
+  uint8_t teststr[] ALIGNED(8) = {
+    0x00, 0x00, 0x00, 0x00
   };
 
-  coap_pdu_t pdu = { 
+  coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
     .token = teststr,
     .used_size = 0
@@ -470,11 +470,11 @@ t_iterate_option1(void) {
 static void
 t_iterate_option2(void) {
   /* CoAP PDU with token but without options and data */
-  uint8_t teststr[3] ALIGNED(8) = { 
+  uint8_t teststr[3] ALIGNED(8) = {
     't', 'o', 'k'
   };
 
-  coap_pdu_t pdu = { 
+  coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
     .token_length = 3,
     .token = teststr,
@@ -496,8 +496,8 @@ t_iterate_option2(void) {
 static void
 t_iterate_option3(void) {
   /* CoAP PDU with token and options */
-  uint8_t teststr[] ALIGNED(8) = { 
-    't', 'o', 'k', 0x13, 
+  uint8_t teststr[] ALIGNED(8) = {
+    't', 'o', 'k', 0x13,
     'o',  'p',  't',  0x00, 0xd1, 0x10, 'x'
   };
 
@@ -538,13 +538,13 @@ t_iterate_option3(void) {
 static void
 t_iterate_option4(void) {
   /* CoAP PDU with token, options, and data */
-  uint8_t teststr[] ALIGNED(8) = { 
-    't', 'o', 'k', 0x13, 
+  uint8_t teststr[] ALIGNED(8) = {
+    't', 'o', 'k', 0x13,
     'o',  'p',  't',  0x00, 0xd1, 0x10, 'x', 0xff,
     'd',  'a',  't',  'a'
   };
 
-  coap_pdu_t pdu = { 
+  coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
     .token_length = 3,
     .token = teststr,
@@ -581,12 +581,12 @@ t_iterate_option4(void) {
 static void
 t_iterate_option5(void) {
   /* CoAP PDU with malformed option */
-  uint8_t teststr[] ALIGNED(8) = { 
-    0x52, 'o', 'p', 0xee, 
+  uint8_t teststr[] ALIGNED(8) = {
+    0x52, 'o', 'p', 0xee,
     0x12, 0x03, 0x00
   };
 
-  coap_pdu_t pdu = { 
+  coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
     .token_length = 0,
     .token = teststr,
@@ -614,12 +614,12 @@ static void
 t_iterate_option6(void) {
   /* option filter */
   /* CoAP PDU with token, options, and data */
-  uint8_t teststr[] ALIGNED(8) = { 
+  uint8_t teststr[] ALIGNED(8) = {
     0x80, 0x20, 0x00, 0x00,
     0xc0, 0x00
   };
 
-  coap_pdu_t pdu = { 
+  coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
     .token_length = 0,
     .token = teststr,
@@ -630,7 +630,7 @@ t_iterate_option6(void) {
   coap_opt_filter_t filter;
 
   coap_option_filter_clear(filter);
-  coap_option_setb(filter, 10);	/* option nr 10 only */
+  coap_option_setb(filter, 10);        /* option nr 10 only */
   result = coap_option_iterator_init(&pdu, &oi, filter);
 
   CU_ASSERT_PTR_EQUAL(result, &oi);
@@ -659,12 +659,12 @@ t_iterate_option6(void) {
 static void
 t_iterate_option7(void) {
   /* option filter */
-  uint8_t teststr[] ALIGNED(8) = { 
+  uint8_t teststr[] ALIGNED(8) = {
     0x80, 0x20, 0x00, 0x00,
     0xc0, 0x00, 0x10, 0x10, 0x00
   };
 
-  coap_pdu_t pdu = { 
+  coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
     .token_length = 0,
     .token = teststr,
@@ -706,12 +706,12 @@ t_iterate_option7(void) {
 static void
 t_iterate_option8(void) {
   /* option filter */
-  uint8_t teststr[] ALIGNED(8) = { 
+  uint8_t teststr[] ALIGNED(8) = {
     0x80, 0x20, 0x00, 0x00,
     0xc0, 0x00, 0x10, 0x10, 0x00
   };
 
-  coap_pdu_t pdu = { 
+  coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
     .token_length = 0,
     .token = teststr,
@@ -737,12 +737,12 @@ t_iterate_option8(void) {
 static void
 t_iterate_option9(void) {
   /* options filter: option number too large for filter */
-  uint8_t teststr[] ALIGNED(8) = { 
+  uint8_t teststr[] ALIGNED(8) = {
     0x80, 0x20, 0x00, 0x00,
     0xc0, 0x00, 0x10, 0x10, 0x00
   };
 
-  coap_pdu_t pdu = { 
+  coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
     .token_length = 0,
     .token = teststr,
@@ -768,12 +768,12 @@ t_iterate_option9(void) {
 static void
 t_iterate_option10(void) {
   /* options filter: option numbers in PDU exceed filter size */
-  uint8_t teststr[] ALIGNED(8) = { 
+  uint8_t teststr[] ALIGNED(8) = {
     0x80, 0x20, 0x00, 0x00,
     0xd0, 0x26, 0xe0, 0x10, 0x00
   };
 
-  coap_pdu_t pdu = { 
+  coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
     .token_length = 0,
     .token = teststr,
@@ -906,7 +906,7 @@ t_filter_option3(void) {
 }
 
 /************************************************************************
- ** initialization 
+ ** initialization
  ************************************************************************/
 
 CU_pSuite
@@ -914,17 +914,17 @@ t_init_option_tests(void) {
   CU_pSuite suite[5];
 
   suite[0] = CU_add_suite("option parser", NULL, NULL);
-  if (!suite[0]) {			/* signal error */
-    fprintf(stderr, "W: cannot add option parser test suite (%s)\n", 
-	    CU_get_error_msg());
+  if (!suite[0]) {                        /* signal error */
+    fprintf(stderr, "W: cannot add option parser test suite (%s)\n",
+            CU_get_error_msg());
 
     return NULL;
   }
 
-#define OPTION_TEST(n,s)						      \
-  if (!CU_add_test(suite[0], s, t_parse_option##n)) {	      \
-    fprintf(stderr, "W: cannot add option parser test (%s)\n",	      \
-	    CU_get_error_msg());				      \
+#define OPTION_TEST(n,s)                                       \
+  if (!CU_add_test(suite[0], s, t_parse_option##n)) {          \
+    fprintf(stderr, "W: cannot add option parser test (%s)\n", \
+            CU_get_error_msg());                               \
   }
 
   OPTION_TEST(1, "parse option #1");
@@ -943,10 +943,10 @@ t_init_option_tests(void) {
   OPTION_TEST(14, "parse option #14");
 
   if ((suite[1] = CU_add_suite("option encoder", NULL, NULL))) {
-#define OPTION_ENCODER_TEST(n,s)			      \
-    if (!CU_add_test(suite[1], s, t_encode_option##n)) {		      \
-      fprintf(stderr, "W: cannot add option encoder test (%s)\n",     \
-	      CU_get_error_msg());				      \
+#define OPTION_ENCODER_TEST(n,s)                                  \
+    if (!CU_add_test(suite[1], s, t_encode_option##n)) {          \
+      fprintf(stderr, "W: cannot add option encoder test (%s)\n", \
+              CU_get_error_msg());                                \
     }
 
     OPTION_ENCODER_TEST(1, "encode option #1");
@@ -958,17 +958,17 @@ t_init_option_tests(void) {
     OPTION_ENCODER_TEST(7, "encode option #7");
     OPTION_ENCODER_TEST(8, "encode option #8");
     OPTION_ENCODER_TEST(9, "encode option #9");
-    
+
   } else {
-    fprintf(stderr, "W: cannot add option encoder test suite (%s)\n", 
-	    CU_get_error_msg());
+    fprintf(stderr, "W: cannot add option encoder test suite (%s)\n",
+            CU_get_error_msg());
   }
 
   if ((suite[2] = CU_add_suite("option accessors", NULL, NULL))) {
-#define OPTION_ACCESSOR_TEST(n,s)			      \
-    if (!CU_add_test(suite[2], s, t_access_option##n)) {		      \
-      fprintf(stderr, "W: cannot add option accessor function test (%s)\n",     \
-	      CU_get_error_msg());				      \
+#define OPTION_ACCESSOR_TEST(n,s)                                           \
+    if (!CU_add_test(suite[2], s, t_access_option##n)) {                    \
+      fprintf(stderr, "W: cannot add option accessor function test (%s)\n", \
+              CU_get_error_msg());                                          \
     }
 
     OPTION_ACCESSOR_TEST(1, "access option #1");
@@ -978,17 +978,17 @@ t_init_option_tests(void) {
     OPTION_ACCESSOR_TEST(5, "access option #5");
     OPTION_ACCESSOR_TEST(6, "access option #6");
     OPTION_ACCESSOR_TEST(7, "access option #7");
-    
+
   } else {
-    fprintf(stderr, "W: cannot add option acessor function test suite (%s)\n", 
-	    CU_get_error_msg());
+    fprintf(stderr, "W: cannot add option acessor function test suite (%s)\n",
+            CU_get_error_msg());
   }
 
   if ((suite[3] = CU_add_suite("option iterator", NULL, NULL))) {
-#define OPTION_ITERATOR_TEST(n,s)			      \
-    if (!CU_add_test(suite[3], s, t_iterate_option##n)) {		      \
-      fprintf(stderr, "W: cannot add option iterator test (%s)\n",     \
-	      CU_get_error_msg());				      \
+#define OPTION_ITERATOR_TEST(n,s)                                  \
+    if (!CU_add_test(suite[3], s, t_iterate_option##n)) {          \
+      fprintf(stderr, "W: cannot add option iterator test (%s)\n", \
+              CU_get_error_msg());                                 \
     }
 
     OPTION_ITERATOR_TEST(1, "option iterator #1");
@@ -1001,17 +1001,17 @@ t_init_option_tests(void) {
     OPTION_ITERATOR_TEST(8, "option iterator #8");
     OPTION_ITERATOR_TEST(9, "option iterator #9");
     OPTION_ITERATOR_TEST(10, "option iterator #10");
-    
+
   } else {
-    fprintf(stderr, "W: cannot add option iterator test suite (%s)\n", 
-	    CU_get_error_msg());
+    fprintf(stderr, "W: cannot add option iterator test suite (%s)\n",
+            CU_get_error_msg());
   }
 
   if ((suite[4] = CU_add_suite("option filter", NULL, NULL))) {
-#define OPTION_FILTER_TEST(n,s)			      \
-    if (!CU_add_test(suite[4], s, t_filter_option##n)) {		      \
-      fprintf(stderr, "W: cannot add option filter test (%s)\n",     \
-	      CU_get_error_msg());				      \
+#define OPTION_FILTER_TEST(n,s)                                  \
+    if (!CU_add_test(suite[4], s, t_filter_option##n)) {         \
+      fprintf(stderr, "W: cannot add option filter test (%s)\n", \
+              CU_get_error_msg());                               \
     }
 
     OPTION_FILTER_TEST(1, "option filter #1");
@@ -1020,7 +1020,7 @@ t_init_option_tests(void) {
 
   } else {
     fprintf(stderr, "W: cannot add option filter test suite (%s)\n",
-	    CU_get_error_msg());
+            CU_get_error_msg());
   }
 
   return suite[0];

--- a/tests/test_options.h
+++ b/tests/test_options.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2012 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <CUnit/CUnit.h>

--- a/tests/test_pdu.c
+++ b/tests/test_pdu.c
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-coap_pdu_t *pdu;	      /* Holds the parsed PDU for most tests */
+coap_pdu_t *pdu;              /* Holds the parsed PDU for most tests */
 
 /************************************************************************
  ** PDU decoder
@@ -68,7 +68,7 @@ static void
 t_parse_pdu4(void) {
   /* illegal token length */
   uint8_t teststr[] = {  0x59, 0x69, 0x12, 0x34,
-		      't', 'o', 'k', 'e', 'n', '1', '2', '3', '4' };
+                      't', 'o', 'k', 'e', 'n', '1', '2', '3', '4' };
   int result;
 
   result = coap_pdu_parse(COAP_PROTO_UDP, teststr, sizeof(teststr), pdu);
@@ -84,7 +84,7 @@ static void
 t_parse_pdu5(void) {
   /* PDU with options */
   uint8_t teststr[] = {  0x55, 0x73, 0x12, 0x34, 't', 'o', 'k', 'e',
-		      'n',  0x00, 0xc1, 0x00
+                      'n',  0x00, 0xc1, 0x00
   };
   int result;
 
@@ -106,7 +106,7 @@ static void
 t_parse_pdu6(void) {
   /* PDU with options that exceed the PDU */
   uint8_t teststr[] = {  0x55, 0x73, 0x12, 0x34, 't', 'o', 'k', 'e',
-		      'n',  0x00, 0xc1, 0x00, 0xae, 0xf0, 0x03
+                      'n',  0x00, 0xc1, 0x00, 0xae, 0xf0, 0x03
   };
   int result;
 
@@ -118,8 +118,8 @@ static void
 t_parse_pdu7(void) {
   /* PDU with options and payload */
   uint8_t teststr[] = {  0x55, 0x73, 0x12, 0x34, 't', 'o', 'k', 'e',
-		      'n',  0x00, 0xc1, 0x00, 0xff, 'p', 'a', 'y',
-		      'l', 'o', 'a', 'd'
+                      'n',  0x00, 0xc1, 0x00, 0xff, 'p', 'a', 'y',
+                      'l', 'o', 'a', 'd'
   };
   int result;
 
@@ -143,8 +143,8 @@ static void
 t_parse_pdu8(void) {
   /* PDU without options but with payload */
   uint8_t teststr[] = {  0x50, 0x73, 0x12, 0x34,
-		      0xff, 'p', 'a', 'y', 'l', 'o', 'a',
-		      'd'
+                      0xff, 'p', 'a', 'y', 'l', 'o', 'a',
+                      'd'
   };
   int result;
 
@@ -177,7 +177,7 @@ static void
 t_parse_pdu10(void) {
   /* PDU without payload but with options and payload start marker */
   uint8_t teststr[] = {  0x53, 0x73, 0x12, 0x34, 't', 'o', 'k',
-		      0x30, 0xc1, 0x00, 0xff
+                      0x30, 0xc1, 0x00, 0xff
   };
   int result;
 
@@ -220,7 +220,7 @@ static void
 t_parse_pdu13(void) {
   /* RST with content */
   uint8_t teststr[] = {  0x70, 0x00, 0x12, 0x34,
-		      0xff, 'c', 'o', 'n', 't', 'e', 'n', 't'
+                      0xff, 'c', 'o', 'n', 't', 'e', 'n', 't'
   };
   int result;
 
@@ -232,7 +232,7 @@ static void
 t_parse_pdu14(void) {
   /* ACK with content */
   uint8_t teststr[] = {  0x60, 0x00, 0x12, 0x34,
-		      0xff, 'c', 'o', 'n', 't', 'e', 'n', 't'
+                      0xff, 'c', 'o', 'n', 't', 'e', 'n', 't'
   };
   int result;
 
@@ -268,7 +268,7 @@ t_parse_pdu15(void) {
  224, 224, 224, 224, 224, 224, 224, 224, 224, 224, 224, 224, 224, 224, 224, 224,
  224, 224, 224, 224, 224};
 
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   CU_ASSERT(pdu->data == NULL);
 
@@ -283,7 +283,7 @@ static void log_handler(coap_log_t level, const char *message)
 }
 
 /*
- * To test Issue #214 which allows the token size to be set larger than the 
+ * To test Issue #214 which allows the token size to be set larger than the
  * decoded PDU in coap_pdu_parse_header().  This then causes coap_show_pdu()
  * to access invalid memory.
  * Credit to OSS-Fuzz for finding this, work done by Bhargava Shastry
@@ -302,7 +302,7 @@ t_parse_pdu16(void) {
 
   coap_set_show_pdu_output(0);
   coap_set_log_handler(log_handler);
-  coap_show_pdu(LOG_ERR, testpdu);	/* display PDU */
+  coap_show_pdu(LOG_ERR, testpdu);        /* display PDU */
   coap_set_log_handler(NULL);
 
   coap_delete_pdu(testpdu);
@@ -336,7 +336,7 @@ t_encode_pdu2(void) {
   size_t old_max = pdu->max_size;
   int result;
 
-  coap_pdu_clear(pdu, 3);	/* set very small PDU size */
+  coap_pdu_clear(pdu, 3);        /* set very small PDU size */
 
   pdu->type = COAP_MESSAGE_CON;
   pdu->code = COAP_REQUEST_GET;
@@ -346,7 +346,7 @@ t_encode_pdu2(void) {
 
   CU_ASSERT(result == 0);
 
-  coap_pdu_clear(pdu, old_max);	/* restore PDU size */
+  coap_pdu_clear(pdu, old_max);        /* restore PDU size */
 }
 
 static void
@@ -362,15 +362,15 @@ static void
 t_encode_pdu4(void) {
   /* PDU with options */
   uint8_t teststr[] = { 0x60, 0x99, 0x12, 0x34, 0x3d, 0x05, 0x66, 0x61,
-		     0x6e, 0x63, 0x79, 0x70, 0x72, 0x6f, 0x78, 0x79,
-		     0x2e, 0x63, 0x6f, 0x61, 0x70, 0x2e, 0x6d, 0x65,
-		     0x84, 0x70, 0x61, 0x74, 0x68, 0x00, 0xe8, 0x1e,
-		     0x28, 0x66, 0x61, 0x6e, 0x63, 0x79, 0x6f, 0x70,
-		     0x74
+                     0x6e, 0x63, 0x79, 0x70, 0x72, 0x6f, 0x78, 0x79,
+                     0x2e, 0x63, 0x6f, 0x61, 0x70, 0x2e, 0x6d, 0x65,
+                     0x84, 0x70, 0x61, 0x74, 0x68, 0x00, 0xe8, 0x1e,
+                     0x28, 0x66, 0x61, 0x6e, 0x63, 0x79, 0x6f, 0x70,
+                     0x74
   };
   int result;
 
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   pdu->type = COAP_MESSAGE_ACK;
   pdu->code = 0x99;
@@ -387,7 +387,7 @@ t_encode_pdu4(void) {
   CU_ASSERT_PTR_NULL(pdu->data);
 
   result = coap_add_option(pdu, COAP_OPTION_URI_PATH,
-			   4, (const uint8_t *)"path");
+                           4, (const uint8_t *)"path");
 
   CU_ASSERT(result == 5);
   CU_ASSERT(pdu->max_delta == 11);
@@ -417,11 +417,11 @@ t_encode_pdu5(void) {
   /* PDU with token and options */
   uint8_t teststr[] = { 0x68, 0x84, 0x12, 0x34, '1',  '2',  '3',  '4',
                      '5',  '6',  '7',  '8',  0x18, 0x41, 0x42, 0x43,
-		     0x44, 0x45, 0x46, 0x47, 0x48, 0xd1, 0x03, 0x12
+                     0x44, 0x45, 0x46, 0x47, 0x48, 0xd1, 0x03, 0x12
   };
   int result;
 
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   pdu->type = COAP_MESSAGE_ACK;
   pdu->code = COAP_RESPONSE_CODE(404);
@@ -434,7 +434,7 @@ t_encode_pdu5(void) {
   CU_ASSERT(pdu->used_size == 8);
 
   result = coap_add_option(pdu, COAP_OPTION_IF_MATCH,
-			   8, (const uint8_t *)"ABCDEFGH");
+                           8, (const uint8_t *)"ABCDEFGH");
 
   CU_ASSERT(result == 9);
   CU_ASSERT(pdu->max_delta == 1);
@@ -442,7 +442,7 @@ t_encode_pdu5(void) {
   CU_ASSERT_PTR_NULL(pdu->data);
 
   result = coap_add_option(pdu, COAP_OPTION_ACCEPT,
-			   1, (const uint8_t *)"\x12");
+                           1, (const uint8_t *)"\x12");
 
   CU_ASSERT(result == 3);
   CU_ASSERT(pdu->max_delta == 17);
@@ -457,9 +457,9 @@ static void
 t_encode_pdu6(void) {
   /* PDU with data */
   uint8_t teststr[] = { 0x50, 0x02, 0x12, 0x34, 0xff, '1',  '2',  '3',
-		     '4', '5',  '6',  '7',  '8'
+                     '4', '5',  '6',  '7',  '8'
   };
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   pdu->type = COAP_MESSAGE_NON;
   pdu->code = COAP_REQUEST_POST;
@@ -480,7 +480,7 @@ t_encode_pdu7(void) {
   /* PDU with empty data */
   uint8_t teststr[] = { 0x40, 0x43, 0x12, 0x34 };
   int result;
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   pdu->type = COAP_MESSAGE_CON;
   pdu->code = COAP_RESPONSE_CODE(203);
@@ -503,7 +503,7 @@ t_encode_pdu8(void) {
   /* PDU with token and data */
   uint8_t teststr[] = { 0x42, 0x43, 0x12, 0x34, 0x00, 0x01, 0xff, 0x00 };
   int result;
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   pdu->type = COAP_MESSAGE_CON;
   pdu->code = COAP_RESPONSE_CODE(203);
@@ -529,14 +529,14 @@ static void
 t_encode_pdu9(void) {
   /* PDU with options and data */
   uint8_t teststr[] = { 0x60, 0x44, 0x12, 0x34, 0x48, 's',  'o',  'm',
-		     'e',  'e',  't',  'a',  'g',  0x10, 0xdd, 0x11,
-		     0x04, 's',  'o',  'm',  'e',  'r',  'a',  't',
-		     'h',  'e',  'r',  'l',  'o',  'n',  'g',  'u',
-		     'r',  'i',  0xff, 'd',  'a',  't',  'a'
+                     'e',  'e',  't',  'a',  'g',  0x10, 0xdd, 0x11,
+                     0x04, 's',  'o',  'm',  'e',  'r',  'a',  't',
+                     'h',  'e',  'r',  'l',  'o',  'n',  'g',  'u',
+                     'r',  'i',  0xff, 'd',  'a',  't',  'a'
   };
   int result;
 
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   pdu->type = COAP_MESSAGE_ACK;
   pdu->code = COAP_RESPONSE_CODE(204);
@@ -559,7 +559,7 @@ t_encode_pdu9(void) {
   CU_ASSERT_PTR_NULL(pdu->data);
 
   result = coap_add_option(pdu, COAP_OPTION_PROXY_URI,
-			   17, (const uint8_t *)"someratherlonguri");
+                           17, (const uint8_t *)"someratherlonguri");
 
   CU_ASSERT(result == 20);
   CU_ASSERT(pdu->max_delta == 35);
@@ -580,45 +580,45 @@ static void
 t_encode_pdu10(void) {
   /* PDU with token, options and data */
   uint8_t teststr[] = { 0x62, 0x44, 0x12, 0x34, 0x00, 0x00, 0x8d, 0xf2,
-		     'c',  'o',  'a',  'p',  ':',  '/',  '/',  'e',
-		     'x',  'a',  'm',  'p',  'l',  'e',  '.',  'c',
-		     'o',  'm',  '/',  '1',  '2',  '3',  '4',  '5',
-		     '/',  '%',  '3',  'F',  'x',  'y',  'z',  '/',
-		     '3',  '0',  '4',  '8',  '2',  '3',  '4',  '2',
-		     '3',  '4',  '/',  '2',  '3',  '4',  '0',  '2',
-		     '3',  '4',  '8',  '2',  '3',  '4',  '/',  '2',
-		     '3',  '9',  '0',  '8',  '4',  '2',  '3',  '4',
-		     '-',  '2',  '3',  '/',  '%',  'A',  'B',  '%',
-		     '3',  '0',  '%',  'a',  'f',  '/',  '+',  '1',
-		     '2',  '3',  '/',  'h',  'f',  'k',  's',  'd',
-		     'h',  '/',  '2',  '3',  '4',  '8',  '0',  '-',
-		     '2',  '3',  '4',  '-',  '9',  '8',  '2',  '3',
-		     '5',  '/',  '1',  '2',  '0',  '4',  '/',  '2',
-		     '4',  '3',  '5',  '4',  '6',  '3',  '4',  '5',
-		     '3',  '4',  '5',  '2',  '4',  '3',  '/',  '0',
-		     '1',  '9',  '8',  's',  'd',  'n',  '3',  '-',
-		     'a',  '-',  '3',  '/',  '/',  '/',  'a',  'f',
-		     'f',  '0',  '9',  '3',  '4',  '/',  '9',  '7',
-		     'u',  '2',  '1',  '4',  '1',  '/',  '0',  '0',
-		     '0',  '2',  '/',  '3',  '9',  '3',  '2',  '4',
-		     '2',  '3',  '5',  '3',  '2',  '/',  '5',  '6',
-		     '2',  '3',  '4',  '0',  '2',  '3',  '/',  '-',
-		     '-',  '-',  '-',  '/',  '=',  '1',  '2',  '3',
-		     '4',  '=',  '/',  '0',  '9',  '8',  '1',  '4',
-		     '1',  '-',  '9',  '5',  '6',  '4',  '6',  '4',
-		     '3',  '/',  '2',  '1',  '9',  '7',  '0',  '-',
-		     '-',  '-',  '-',  '-',  '/',  '8',  '2',  '3',
-		     '6',  '4',  '9',  '2',  '3',  '4',  '7',  '2',
-		     'w',  'e',  'r',  'e',  'r',  'e',  'w',  'r',
-		     '0',  '-',  '9',  '2',  '1',  '-',  '3',  '9',
-		     '1',  '2',  '3',  '-',  '3',  '4',  '/',  0x0d,
-		     0x01, '/',  '/',  '4',  '9',  '2',  '4',  '0',
-		     '3',  '-',  '-',  '0',  '9',  '8',  '/',  0xc1,
-		     '*',  0xff, 'd',  'a',  't',  'a'
+                     'c',  'o',  'a',  'p',  ':',  '/',  '/',  'e',
+                     'x',  'a',  'm',  'p',  'l',  'e',  '.',  'c',
+                     'o',  'm',  '/',  '1',  '2',  '3',  '4',  '5',
+                     '/',  '%',  '3',  'F',  'x',  'y',  'z',  '/',
+                     '3',  '0',  '4',  '8',  '2',  '3',  '4',  '2',
+                     '3',  '4',  '/',  '2',  '3',  '4',  '0',  '2',
+                     '3',  '4',  '8',  '2',  '3',  '4',  '/',  '2',
+                     '3',  '9',  '0',  '8',  '4',  '2',  '3',  '4',
+                     '-',  '2',  '3',  '/',  '%',  'A',  'B',  '%',
+                     '3',  '0',  '%',  'a',  'f',  '/',  '+',  '1',
+                     '2',  '3',  '/',  'h',  'f',  'k',  's',  'd',
+                     'h',  '/',  '2',  '3',  '4',  '8',  '0',  '-',
+                     '2',  '3',  '4',  '-',  '9',  '8',  '2',  '3',
+                     '5',  '/',  '1',  '2',  '0',  '4',  '/',  '2',
+                     '4',  '3',  '5',  '4',  '6',  '3',  '4',  '5',
+                     '3',  '4',  '5',  '2',  '4',  '3',  '/',  '0',
+                     '1',  '9',  '8',  's',  'd',  'n',  '3',  '-',
+                     'a',  '-',  '3',  '/',  '/',  '/',  'a',  'f',
+                     'f',  '0',  '9',  '3',  '4',  '/',  '9',  '7',
+                     'u',  '2',  '1',  '4',  '1',  '/',  '0',  '0',
+                     '0',  '2',  '/',  '3',  '9',  '3',  '2',  '4',
+                     '2',  '3',  '5',  '3',  '2',  '/',  '5',  '6',
+                     '2',  '3',  '4',  '0',  '2',  '3',  '/',  '-',
+                     '-',  '-',  '-',  '/',  '=',  '1',  '2',  '3',
+                     '4',  '=',  '/',  '0',  '9',  '8',  '1',  '4',
+                     '1',  '-',  '9',  '5',  '6',  '4',  '6',  '4',
+                     '3',  '/',  '2',  '1',  '9',  '7',  '0',  '-',
+                     '-',  '-',  '-',  '-',  '/',  '8',  '2',  '3',
+                     '6',  '4',  '9',  '2',  '3',  '4',  '7',  '2',
+                     'w',  'e',  'r',  'e',  'r',  'e',  'w',  'r',
+                     '0',  '-',  '9',  '2',  '1',  '-',  '3',  '9',
+                     '1',  '2',  '3',  '-',  '3',  '4',  '/',  0x0d,
+                     0x01, '/',  '/',  '4',  '9',  '2',  '4',  '0',
+                     '3',  '-',  '-',  '0',  '9',  '8',  '/',  0xc1,
+                     '*',  0xff, 'd',  'a',  't',  'a'
   };
   int result;
 
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   pdu->type = COAP_MESSAGE_ACK;
   pdu->code = COAP_RESPONSE_CODE(204);
@@ -630,7 +630,7 @@ t_encode_pdu10(void) {
 
   CU_ASSERT(result > 0);
   result = coap_add_option(pdu, COAP_OPTION_LOCATION_PATH, 255,
-			   (const uint8_t *)"coap://example.com/12345/%3Fxyz/3048234234/23402348234/239084234-23/%AB%30%af/+123/hfksdh/23480-234-98235/1204/243546345345243/0198sdn3-a-3///aff0934/97u2141/0002/3932423532/56234023/----/=1234=/098141-9564643/21970-----/82364923472wererewr0-921-39123-34/");
+                           (const uint8_t *)"coap://example.com/12345/%3Fxyz/3048234234/23402348234/239084234-23/%AB%30%af/+123/hfksdh/23480-234-98235/1204/243546345345243/0198sdn3-a-3///aff0934/97u2141/0002/3932423532/56234023/----/=1234=/098141-9564643/21970-----/82364923472wererewr0-921-39123-34/");
 
   CU_ASSERT(result == 257);
   CU_ASSERT(pdu->max_delta == 8);
@@ -638,7 +638,7 @@ t_encode_pdu10(void) {
   CU_ASSERT_PTR_NULL(pdu->data);
 
   result = coap_add_option(pdu, COAP_OPTION_LOCATION_PATH, 14,
-			   (const uint8_t *)"//492403--098/");
+                           (const uint8_t *)"//492403--098/");
 
   CU_ASSERT(result == 16);
   CU_ASSERT(pdu->max_delta == 8);
@@ -646,7 +646,7 @@ t_encode_pdu10(void) {
   CU_ASSERT_PTR_NULL(pdu->data);
 
   result = coap_add_option(pdu, COAP_OPTION_LOCATION_QUERY,
-			   1, (const uint8_t *)"*");
+                           1, (const uint8_t *)"*");
 
   CU_ASSERT(result == 2);
   CU_ASSERT(pdu->max_delta == 20);
@@ -670,7 +670,7 @@ t_encode_pdu11(void) {
   size_t old_max = pdu->max_size;
   int result;
 
-  coap_pdu_clear(pdu, 8);	/* clear PDU, with small maximum */
+  coap_pdu_clear(pdu, 8);        /* clear PDU, with small maximum */
 
   CU_ASSERT(pdu->data == NULL);
   coap_set_log_level(LOG_CRIT);
@@ -694,7 +694,7 @@ t_encode_pdu12(void) {
   coap_opt_iterator_t oi;
   coap_opt_t *option;
 
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   CU_ASSERT(pdu->data == NULL);
 
@@ -729,7 +729,7 @@ t_encode_pdu13(void) {
   coap_opt_iterator_t oi;
   coap_opt_t *option;
 
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   CU_ASSERT(pdu->data == NULL);
 
@@ -765,7 +765,7 @@ t_encode_pdu14(void) {
   coap_opt_iterator_t oi;
   coap_opt_t *option;
 
-  coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+  coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
   CU_ASSERT(pdu->data == NULL);
 
@@ -808,17 +808,17 @@ t_init_pdu_tests(void) {
   CU_pSuite suite[2];
 
   suite[0] = CU_add_suite("pdu parser", t_pdu_tests_create, t_pdu_tests_remove);
-  if (!suite[0]) {			/* signal error */
+  if (!suite[0]) {                        /* signal error */
     fprintf(stderr, "W: cannot add pdu parser test suite (%s)\n",
-	    CU_get_error_msg());
+            CU_get_error_msg());
 
     return NULL;
   }
 
-#define PDU_TEST(s,t)						      \
-  if (!CU_ADD_TEST(s,t)) {					      \
-    fprintf(stderr, "W: cannot add pdu parser test (%s)\n",	      \
-	    CU_get_error_msg());				      \
+#define PDU_TEST(s,t)                                                      \
+  if (!CU_ADD_TEST(s,t)) {                                              \
+    fprintf(stderr, "W: cannot add pdu parser test (%s)\n",              \
+            CU_get_error_msg());                                      \
   }
 
   PDU_TEST(suite[0], t_parse_pdu1);
@@ -840,10 +840,10 @@ t_init_pdu_tests(void) {
 
   suite[1] = CU_add_suite("pdu encoder", t_pdu_tests_create, t_pdu_tests_remove);
   if (suite[1]) {
-#define PDU_ENCODER_TEST(s,t)						      \
-  if (!CU_ADD_TEST(s,t)) {					      \
-    fprintf(stderr, "W: cannot add pdu encoder test (%s)\n",	      \
-	    CU_get_error_msg());				      \
+#define PDU_ENCODER_TEST(s,t)                                                      \
+  if (!CU_ADD_TEST(s,t)) {                                              \
+    fprintf(stderr, "W: cannot add pdu encoder test (%s)\n",              \
+            CU_get_error_msg());                                      \
   }
     PDU_ENCODER_TEST(suite[1], t_encode_pdu1);
     PDU_ENCODER_TEST(suite[1], t_encode_pdu2);
@@ -860,9 +860,9 @@ t_init_pdu_tests(void) {
     PDU_ENCODER_TEST(suite[1], t_encode_pdu13);
     PDU_ENCODER_TEST(suite[1], t_encode_pdu14);
 
-  } else 			/* signal error */
+  } else                         /* signal error */
     fprintf(stderr, "W: cannot add pdu parser test suite (%s)\n",
-	    CU_get_error_msg());
+            CU_get_error_msg());
 
   return suite[0];
 }

--- a/tests/test_pdu.h
+++ b/tests/test_pdu.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2012 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <CUnit/CUnit.h>

--- a/tests/test_sendqueue.c
+++ b/tests/test_sendqueue.c
@@ -306,8 +306,8 @@ t_sendqueue_tests_create(void) {
     /* destroy all test nodes and set entry to zero */
     for (n = 0; n < sizeof(node)/sizeof(coap_queue_t *); n++) {
       if (node[n]) {
-	coap_delete_node(node[n]);
-	node[n] = NULL;
+        coap_delete_node(node[n]);
+        node[n] = NULL;
       }
     }
     coap_free_context(ctx);
@@ -335,18 +335,18 @@ t_init_sendqueue_tests(void) {
   CU_pSuite suite;
 
   suite = CU_add_suite("sendqueue",
-		       t_sendqueue_tests_create, t_sendqueue_tests_remove);
-  if (!suite) {			/* signal error */
+                       t_sendqueue_tests_create, t_sendqueue_tests_remove);
+  if (!suite) {                        /* signal error */
     fprintf(stderr, "W: cannot add sendqueue test suite (%s)\n",
-	    CU_get_error_msg());
+            CU_get_error_msg());
 
     return NULL;
   }
 
-#define SENDQUEUE_TEST(s,t)					      \
-  if (!CU_ADD_TEST(s,t)) {					      \
-    fprintf(stderr, "W: cannot add sendqueue test (%s)\n",	      \
-	    CU_get_error_msg());				      \
+#define SENDQUEUE_TEST(s,t)                                              \
+  if (!CU_ADD_TEST(s,t)) {                                              \
+    fprintf(stderr, "W: cannot add sendqueue test (%s)\n",              \
+            CU_get_error_msg());                                      \
   }
 
   SENDQUEUE_TEST(suite, t_sendqueue1);

--- a/tests/test_sendqueue.h
+++ b/tests/test_sendqueue.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2013 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <CUnit/CUnit.h>

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -42,7 +42,7 @@ t_session1(void) {
 
   coap_session_reference(session);
   CU_ASSERT(session->ref == 2);
-  
+
   coap_session_release(session);
   CU_ASSERT(session->ref == 1);
 }
@@ -199,18 +199,18 @@ t_init_session_tests(void) {
   CU_pSuite suite;
 
   suite = CU_add_suite("session",
-		       t_session_tests_create, t_session_tests_remove);
-  if (!suite) {			/* signal error */
+                       t_session_tests_create, t_session_tests_remove);
+  if (!suite) {                        /* signal error */
     fprintf(stderr, "W: cannot add session test suite (%s)\n",
-	    CU_get_error_msg());
+            CU_get_error_msg());
 
     return NULL;
   }
 
-#define SESSION_TEST(s,t)					      \
-  if (!CU_ADD_TEST(s,t)) {					      \
-    fprintf(stderr, "W: cannot add session test (%s)\n",	      \
-	    CU_get_error_msg());				      \
+#define SESSION_TEST(s,t)                                              \
+  if (!CU_ADD_TEST(s,t)) {                                              \
+    fprintf(stderr, "W: cannot add session test (%s)\n",              \
+            CU_get_error_msg());                                      \
   }
 
   SESSION_TEST(suite, t_session1);

--- a/tests/test_session.h
+++ b/tests/test_session.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2018 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <CUnit/CUnit.h>

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -71,23 +71,23 @@ t_tls_tests_create(void) {
   coap_startup();
   return 0;
 }
-  
+
 CU_pSuite
 t_init_tls_tests(void) {
   CU_pSuite suite;
 
   suite = CU_add_suite("TLS", t_tls_tests_create, NULL);
-  if (!suite) {			/* signal error */
+  if (!suite) {                        /* signal error */
     fprintf(stderr, "W: cannot add TLS test suite (%s)\n",
-	    CU_get_error_msg());
+            CU_get_error_msg());
 
     return NULL;
   }
 
-#define TLS_TEST(s,t)						      \
-  if (!CU_ADD_TEST(s,t)) {					      \
-    fprintf(stderr, "W: cannot add TLS test (%s)\n",	      \
-	    CU_get_error_msg());				      \
+#define TLS_TEST(s,t)                                                      \
+  if (!CU_ADD_TEST(s,t)) {                                              \
+    fprintf(stderr, "W: cannot add TLS test (%s)\n",              \
+            CU_get_error_msg());                                      \
   }
 
   TLS_TEST(suite, t_tls1);

--- a/tests/test_tls.h
+++ b/tests/test_tls.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2018 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <CUnit/CUnit.h>

--- a/tests/test_uri.c
+++ b/tests/test_uri.c
@@ -257,7 +257,7 @@ t_parse_uri11(void) {
 
     CU_ASSERT(uri.path.length == 45);
     CU_ASSERT_NSTRING_EQUAL(uri.path.s,
-			    "%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF", 45);
+                            "%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF", 45);
 
     CU_ASSERT(uri.query.length == 0);
     CU_ASSERT(uri.query.s == NULL);
@@ -557,7 +557,7 @@ t_parse_uri23(void) {
 }
 
 /*
- * To test Issue #212 which reads off the end of the input buffer when looking 
+ * To test Issue #212 which reads off the end of the input buffer when looking
  * for . or .. in the path.
  * Credit to OSS-Fuzz for finding this, work done by Bhargava Shastry
  */
@@ -580,17 +580,17 @@ t_init_uri_tests(void) {
   CU_pSuite suite;
 
   suite = CU_add_suite("uri parser", NULL, NULL);
-  if (!suite) {			/* signal error */
+  if (!suite) {                        /* signal error */
     fprintf(stderr, "W: cannot add uri parser test suite (%s)\n",
-	    CU_get_error_msg());
+            CU_get_error_msg());
 
     return NULL;
   }
 
-#define URI_TEST(s,t)						      \
-  if (!CU_ADD_TEST(s,t)) {					      \
-    fprintf(stderr, "W: cannot add uri parser test (%s)\n",	      \
-	    CU_get_error_msg());				      \
+#define URI_TEST(s,t)                                                      \
+  if (!CU_ADD_TEST(s,t)) {                                              \
+    fprintf(stderr, "W: cannot add uri parser test (%s)\n",              \
+            CU_get_error_msg());                                      \
   }
 
   URI_TEST(suite, t_parse_uri1);

--- a/tests/test_uri.h
+++ b/tests/test_uri.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2012 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <CUnit/CUnit.h>

--- a/tests/test_wellknown.c
+++ b/tests/test_wellknown.c
@@ -12,7 +12,7 @@
 #include <coap.h>
 
 #include <assert.h>
-#ifdef HAVE_NETINET_IN_H 
+#ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
 #include <stdio.h>
@@ -22,8 +22,8 @@
 #define TEST_PDU_SIZE 120
 #define TEST_URI_LEN    4
 
-coap_context_t *ctx;	   /* Holds the coap context for most tests */
-coap_pdu_t *pdu;	   /* Holds the parsed PDU for most tests */
+coap_context_t *ctx;           /* Holds the coap context for most tests */
+coap_pdu_t *pdu;           /* Holds the parsed PDU for most tests */
 coap_session_t *session;   /* Holds a reference-counted session object
                             * that is passed to coap_wellknown_response(). */
 
@@ -80,7 +80,7 @@ static void
 t_wellknown2(void) {
   coap_print_status_t result;
   coap_resource_t *r;
-  unsigned char buf[10];	/* smaller than teststr */
+  unsigned char buf[10];        /* smaller than teststr */
   size_t buflen, offset, ofs;
 
   char teststr[] = {  /* ,</abcd>;if="one";obs (21 chars) */
@@ -117,7 +117,7 @@ t_wellknown2(void) {
     CU_ASSERT(buflen == sizeof(teststr));
     CU_ASSERT(ofs == 0);
     CU_ASSERT(memcmp(buf, teststr + offset,
-		     COAP_PRINT_OUTPUT_LENGTH(result)) == 0);
+                     COAP_PRINT_OUTPUT_LENGTH(result)) == 0);
   }
 
   /* offset exceeds buffer */
@@ -144,7 +144,7 @@ t_wellknown3(void) {
   /* ,</0000> (TEST_URI_LEN + 4 chars) */
   for (j = 0; j < num_resources; j++) {
     int len = snprintf((char *)uribuf, TEST_URI_LEN + 1,
-		       "%0*d", TEST_URI_LEN, j);
+                       "%0*d", TEST_URI_LEN, j);
     coap_str_const_t uri_path = {.length = len, .s = uribuf};
     r = coap_resource_init(&uri_path, 0);
     coap_add_resource(ctx, r);
@@ -192,10 +192,10 @@ t_wellknown5(void) {
   unsigned char buf[3];
 
   if (!coap_add_option(pdu, COAP_OPTION_BLOCK2,
-		       coap_encode_var_safe(buf, sizeof(buf),
+                       coap_encode_var_safe(buf, sizeof(buf),
                                             ((inblock.num << 4) |
-					     (inblock.m << 3) |
-					     inblock.szx)), buf)) {
+                                             (inblock.m << 3) |
+                                             inblock.szx)), buf)) {
     CU_FAIL("cannot add Block2 option");
     return;
   }
@@ -222,7 +222,7 @@ t_wellknown6(void) {
 
 
   do {
-    coap_pdu_clear(pdu, pdu->max_size);	/* clear PDU */
+    coap_pdu_clear(pdu, pdu->max_size);        /* clear PDU */
 
     pdu->type = COAP_MESSAGE_NON;
     pdu->code = COAP_REQUEST_GET;
@@ -231,8 +231,8 @@ t_wellknown6(void) {
     CU_ASSERT_PTR_NOT_NULL(pdu);
 
     if (!pdu || !coap_add_option(pdu, COAP_OPTION_BLOCK2,
-				 coap_encode_var_safe(buf, sizeof(buf),
-				       ((block.num << 4) | block.szx)), buf)) {
+                                 coap_encode_var_safe(buf, sizeof(buf),
+                                       ((block.num << 4) | block.szx)), buf)) {
       CU_FAIL("cannot create request");
       return;
     }
@@ -292,7 +292,7 @@ t_wkc_tests_create(void) {
     /* ,</0000> (TEST_URI_LEN + 4 chars) */
     for (i = 0; i < sizeof(_buf) / (TEST_URI_LEN + 4); i++) {
       int len = snprintf((char *)buf, TEST_URI_LEN + 1,
-			 "%0*d", TEST_URI_LEN, i);
+                         "%0*d", TEST_URI_LEN, i);
       r = coap_resource_init(buf, len, 0);
       coap_add_resource(ctx, r);
       buf += TEST_URI_LEN + 1;
@@ -315,17 +315,17 @@ t_init_wellknown_tests(void) {
   CU_pSuite suite;
 
   suite = CU_add_suite(".well-known/core", t_wkc_tests_create, t_wkc_tests_remove);
-  if (!suite) {			/* signal error */
+  if (!suite) {                        /* signal error */
     fprintf(stderr, "W: cannot add .well-known/core test suite (%s)\n",
-	    CU_get_error_msg());
+            CU_get_error_msg());
 
     return NULL;
   }
 
-#define WKC_TEST(s,t)						      \
-  if (!CU_ADD_TEST(s,t)) {					      \
-    fprintf(stderr, "W: cannot add .well-known/core test (%s)\n",	      \
-	    CU_get_error_msg());				      \
+#define WKC_TEST(s,t)                                             \
+  if (!CU_ADD_TEST(s,t)) {                                        \
+    fprintf(stderr, "W: cannot add .well-known/core test (%s)\n", \
+            CU_get_error_msg());                                  \
   }
 
   WKC_TEST(suite, t_wellknown1);

--- a/tests/test_wellknown.h
+++ b/tests/test_wellknown.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2013 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
- * README for terms of use. 
+ * README for terms of use.
  */
 
 #include <CUnit/CUnit.h>


### PR DESCRIPTION
"git diff -w" shows no differences

TAB left alone in Makefiles

To bring things in line with coding standards - a general cleanup