### PR TITLE
net.c: Flush out delayqueue if a CON times out

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -321,13 +321,15 @@ void coap_session_connected(coap_session_t *session) {
   while (session->delayqueue && session->state == COAP_SESSION_STATE_ESTABLISHED) {
     ssize_t bytes_written;
     coap_queue_t *q = session->delayqueue;
-    session->delayqueue = q->next;
-    q->next = NULL;
     if (q->pdu->type == COAP_MESSAGE_CON && COAP_PROTO_NOT_RELIABLE(session->proto)) {
       if (session->con_active >= COAP_DEFAULT_NSTART)
         break;
       session->con_active++;
     }
+    /* Take entry off the queue */
+    session->delayqueue = q->next;
+    q->next = NULL;
+
     coap_log(LOG_DEBUG, "**  %s: tid=%d: transmitted after delay\n",
              coap_session_str(session), (int)q->pdu->tid);
     bytes_written = coap_session_send_pdu(session, q->pdu);

--- a/src/net.c
+++ b/src/net.c
@@ -964,8 +964,12 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
     coap_handle_failed_notify(context, node->session, &token);
   }
 #endif /* WITHOUT_OBSERVE */
-  if (node->session->con_active)
+  if (node->session->con_active) {
     node->session->con_active--;
+    if (node->session->state == COAP_SESSION_STATE_ESTABLISHED)
+      /* Flush out any entries on session->delayqueue */
+      coap_session_connected(node->session);
+ }
 
   /* And finally delete the node */
   if (node->pdu->type == COAP_MESSAGE_CON && context->nack_handler)
@@ -2105,7 +2109,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
       if (session->con_active) {
         session->con_active--;
         if (session->state == COAP_SESSION_STATE_ESTABLISHED)
-          /* Flush out any entries on session->sendqueue */
+          /* Flush out any entries on session->delayqueue */
           coap_session_connected(session);
       }
       if (pdu->code == 0)
@@ -2131,7 +2135,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
       if (session->con_active) {
         session->con_active--;
         if (session->state == COAP_SESSION_STATE_ESTABLISHED)
-          /* Flush out any entries on session->sendqueue */
+          /* Flush out any entries on session->delayqueue */
           coap_session_connected(session);
       }
 


### PR DESCRIPTION
This allows a Coap Ping sent after a CON request to then go through the
cycle of retries and then timeout after the original CON fails.