### PR TITLE
Corrected build for mem.c and resource.h

### DIFF
--- a/include/coap/encode.h
+++ b/include/coap/encode.h
@@ -87,10 +87,10 @@ unsigned int coap_encode_var_safe(uint8_t *buf,
  *   coap_encode_var_safe(buf, sizeof(buf), 0xfff);
  * would catch this error at run-time and should be used instead.
  */
-COAP_STATIC_INLINE COAP_DEPRECATED int
-coap_encode_var_bytes(uint8_t *buf, unsigned int value
-) {
-  return coap_encode_var_safe(buf, sizeof(value), value);
-}
+//COAP_STATIC_INLINE COAP_DEPRECATED int
+//coap_encode_var_bytes(uint8_t *buf, unsigned int value
+//) {
+//  return coap_encode_var_safe(buf, sizeof(value), value);
+//}
 
 #endif /* _COAP_ENCODE_H_ */

--- a/include/coap/encode.h
+++ b/include/coap/encode.h
@@ -87,10 +87,10 @@ unsigned int coap_encode_var_safe(uint8_t *buf,
  *   coap_encode_var_safe(buf, sizeof(buf), 0xfff);
  * would catch this error at run-time and should be used instead.
  */
-//COAP_STATIC_INLINE COAP_DEPRECATED int
-//coap_encode_var_bytes(uint8_t *buf, unsigned int value
-//) {
-//  return coap_encode_var_safe(buf, sizeof(value), value);
-//}
+COAP_STATIC_INLINE COAP_DEPRECATED int
+coap_encode_var_bytes(uint8_t *buf, unsigned int value
+) {
+  return (int)coap_encode_var_safe(buf, sizeof(value), value);
+}
 
 #endif /* _COAP_ENCODE_H_ */

--- a/src/mem.c
+++ b/src/mem.c
@@ -63,7 +63,7 @@ coap_free_type(coap_memory_tag_t type, void *p) {
 #define COAP_MAX_STRINGS      8
 #endif /* COAP_MAX_STRINGS */
 
-struct coap_string_t {
+struct coap_str_t {
   char data[COAP_MAX_STRING_SIZE];
 };
 
@@ -82,7 +82,7 @@ typedef union {
   char buf[COAP_MAX_PACKET_SIZE];
 } coap_packetbuf_t;
 
-MEMB(string_storage, struct coap_string_t, COAP_MAX_STRINGS);
+MEMB(string_storage, struct coap_str_t, COAP_MAX_STRINGS);
 MEMB(packet_storage, coap_packetbuf_t, COAP_MAX_PACKETS);
 MEMB(session_storage, coap_session_t, COAP_MAX_SESSIONS);
 MEMB(node_storage, coap_queue_t, COAP_PDU_MAXCNT);


### PR DESCRIPTION
Here are two patches that correct the build on my system:
  - in mem.c the string_t structure is already defined elsewhere, so we need to find another name. I don't know why you don't have the problem, maybe because of a different build order
 - In encode.h, there is a change of the sign for the deprecated coap_encore_var_bytes() which fails for restrictive build system environment 