### PR TITLE
coap_session.c: Only generate event COAP_EVENT_SESSION_CONNECTED as appropriate

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -316,8 +316,11 @@ coap_tid_t coap_session_send_ping(coap_session_t *session) {
 }
 
 void coap_session_connected(coap_session_t *session) {
-  if (session->state != COAP_SESSION_STATE_ESTABLISHED)
+  if (session->state != COAP_SESSION_STATE_ESTABLISHED) {
     coap_log(LOG_DEBUG, "*** %s: session connected\n", coap_session_str(session));
+    if (session->state == COAP_SESSION_STATE_CSM)
+      coap_handle_event(session->context, COAP_EVENT_SESSION_CONNECTED, session);
+  }
 
   session->state = COAP_SESSION_STATE_ESTABLISHED;
   session->partial_write = 0;
@@ -330,7 +333,6 @@ void coap_session_connected(coap_session_t *session) {
     }
   }
 
-  coap_handle_event(session->context, COAP_EVENT_SESSION_CONNECTED, session);
   while (session->delayqueue && session->state == COAP_SESSION_STATE_ESTABLISHED) {
     ssize_t bytes_written;
     coap_queue_t *q = session->delayqueue;


### PR DESCRIPTION
COAP_EVENT_SESSION_CONNECTED is only for CSM exchange events for reliable
protocols only as per include/coap/coap_event.h

In handling_signaling(), if session->state == COAP_SESSION_STATE_CSM, then
COAP_EVENT_SESSION_CONNECTED needs to be generated. This is done by calling
coap_session_connected().

coap_session_connected() is called from other places, used to flush out
any pending queues after connection has taken place.  It is also called
when CON limiting needs to release any panding queues.

Make coap_session_connected() only call coap_handle_event() if current
session->state == COAP_SESSION_STATE_CSM to limit the event generation.