### PR TITLE
lwIP and Contiki coap2 fixes to allow builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ examples/coap-rd
 examples/coap-server
 
 # the include/ folder
-include/coap/coap.h
+include/coap2/coap.h
 
 # the tests/ folder
 tests/.deps

--- a/autogen.sh
+++ b/autogen.sh
@@ -27,7 +27,7 @@ depcomp
 doc/Doxyfile doc/doxyfile.stamp doc/doxygen_sqlite3.db doc/Makefile doc/Makefile.in
 examples/*.o  examples/coap-client examples/coap-server examples/coap-rd
 examples/Makefile examples/Makefile.in
-include/coap/coap.h
+include/coap2/coap.h
 install-sh
 libcoap-*.pc libtool ltmain.sh
 man/coap*.[357] man/coap*.txt man/Makefile man/Makefile.in


### PR DESCRIPTION
Fixes to 4.2.0-rc1 to allow lwIP and Contiki builds