### PR TITLE
Clarify coap_resource_unknown_init() usage documentation

### DIFF
--- a/include/coap2/resource.h
+++ b/include/coap2/resource.h
@@ -147,10 +147,22 @@ coap_resource_t *coap_resource_init(coap_str_const_t *uri_path,
 
 /**
  * Creates a new resource object for the unknown resource handler with support
- * for PUT.  Additional methods and handlers can be added to the resource
- * with coap_register_handler(), but this is not generally recommended.
- * If this resource is added multiple times to the same coap_context with
- * coap_add_resource(), the previous resource is deleted.
+ * for PUT.
+ *
+ * In the same way that additional handlers can be added to the resource
+ * created by coap_resource_init() by using coap_register_handler(), POST,
+ * GET, DELETE etc. handlers can be added to this resource. It is the
+ * responsibility of the application to manage the unknown resources by either
+ * creating new resources with coap_resource_init() (which should have a
+ * DELETE handler specified for the resource removal) or by maintaining an
+ * active resource list.
+ *
+ * Note: There can only be one unknown resource handler per context - attaching
+ *       a new one overrides the previous definition.
+ *
+ * Note: It is not possible to observe the unknown resource with a GET request
+ *       - a seperate resource needs to be reated by the PUT (or POST) handler,
+ *       and make that resource observable.
  *
  * This function returns the new coap_resource_t object.
  *

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -92,7 +92,8 @@ encoded according to the rules defined in RFC3968 Section 2.1.
 
 The *coap_resource_unknown_init*() returns a newly created _resource_ of
 type _coap_resource_t_ *. _put_handler_ is automatically added to the
-_resource_ to handle PUT requests to resources that are unknown.
+_resource_ to handle PUT requests to resources that are unknown. Additional
+handlers can be added to this resource if required.
 
 The *coap_add_resource*() function registers the given _resource_ with the
 _context_. The _resource_ must have been created by *coap_resource_init*(),
@@ -131,8 +132,7 @@ EXAMPLES
 --
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
-#define INDEX "This is a test server made with libcoap (see https://libcoap.net)\n" \
-              "Copyright (C) 2010--2016 Olaf Bergmann <bergmann@tzi.org>\n\n"
+#define INDEX "This is an example server using libcoap\n"
 
 void
 hnd_get_index(coap_context_t *ctx, coap_resource_t *resource,
@@ -348,6 +348,12 @@ init_resources(coap_context_t *ctx) {
 
   /* Create a resource to handle PUTs to unknown URIs */
   r = coap_resource_unknown_init(hnd_unknown_put);
+  /*
+   * Additional handlers can be added - for example
+   *  coap_register_handler(r, COAP_REQUEST_POST, hnd_post_unknown);
+   *  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_unknown);
+   *  coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_unknown);
+   */
   coap_add_resource(ctx, r);
 
 }

--- a/src/net.c
+++ b/src/net.c
@@ -1922,10 +1922,15 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
        * for a PUT request and can support any other registered handler
        * defined for it
        * Example set up code:-
-       *   r = coap_resource_init_unknown(hnd_put_unknown);
+       *   r = coap_resource_unknown_init(hnd_put_unknown);
+       *   coap_register_handler(r, COAP_REQUEST_POST, hnd_post_unknown);
        *   coap_register_handler(r, COAP_REQUEST_GET, hnd_get_unknown);
        *   coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_unknown);
        *   coap_add_resource(ctx, r);
+       *
+       * Note: It is not possible to observe the unknown_resource, a seperate
+       *       resource must be created (by PUT or POST) which has a GET
+       *       handler to be observed
        */
       resource = context->unknown_resource;
     } else if (pdu->code == COAP_REQUEST_DELETE) {


### PR DESCRIPTION
include/coap2/resource.h
man/coap_resource.txt.in
modified:   src/net.c (comment only)