### PR TITLE
Replace debug(), info() & warn() macros with appropriate coap_log()

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -329,7 +329,7 @@ message_handler(struct coap_context_t *ctx,
   }
 
   if (received->type == COAP_MESSAGE_RST) {
-    info("got RST\n");
+    coap_log(LOG_INFO, "got RST\n");
     return;
   }
 
@@ -1406,7 +1406,7 @@ main(int argc, char **argv) {
     if ( result >= 0 ) {
       if ( wait_ms > 0 && !wait_ms_reset ) {
         if ( (unsigned)result >= wait_ms ) {
-          info( "timeout\n" );
+          coap_log(LOG_INFO, "timeout\n");
           break;
         } else {
           wait_ms -= result;

--- a/examples/contiki/coap-observer.c
+++ b/examples/contiki/coap-observer.c
@@ -101,7 +101,7 @@ message_handler(struct coap_context_t  *ctx,
   /* send ACK if received message is confirmable (i.e. a separate response) */
   coap_send_ack(ctx, remote, received);
 
-  debug("** process incoming %d.%02d response:\n",
+  coap_log(LOG_DEBUG, "** process incoming %d.%02d response:\n",
         (received->hdr->code >> 5), received->hdr->code & 0x1F);
   coap_show_pdu(LOG_WARNING, received);
 

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -352,7 +352,7 @@ hnd_put_test(coap_context_t  *ctx, struct coap_resource_t *resource,
 
   return;
  error:
-  warn("cannot modify resource\n");
+  coap_log(LOG_WARNING, "cannot modify resource\n");
   response->code = COAP_RESPONSE_CODE(500);
 }
 
@@ -448,7 +448,7 @@ hnd_get_separate(coap_context_t  *ctx, struct coap_resource_t *resource,
       delay = d < COAP_RESOURCE_CHECK_TIME_SEC
         ? COAP_RESOURCE_CHECK_TIME_SEC
         : d;
-      debug("set delay to %lu\n", delay);
+      coap_log(LOG_DEBUG, "set delay to %lu\n", delay);
       break;
     }
   }
@@ -474,7 +474,7 @@ check_async(coap_context_t  *ctx, coap_tick_t now) {
                            : COAP_MESSAGE_NON,
                            COAP_RESPONSE_CODE(205), 0, size);
   if (!response) {
-    debug("check_async: insufficient memory, we'll try later\n");
+    coap_log(LOG_DEBUG, "check_async: insufficient memory, we'll try later\n");
     async->appdata =
       (void *)((unsigned long)async->appdata + 15 * COAP_TICKS_PER_SECOND);
     return;
@@ -493,7 +493,7 @@ check_async(coap_context_t  *ctx, coap_tick_t now) {
   coap_add_data(response, 4, (unsigned char *)"done");
 
   if (coap_send(ctx, &async->peer, response) == COAP_INVALID_TID) {
-    debug("check_async: cannot send response for message %d\n",
+    coap_log(LOG_DEBUG, "check_async: cannot send response for message %d\n",
           response->tid);
   }
 
@@ -513,7 +513,7 @@ make_large(char *filename) {
 
   /* read from specified input file */
   if (stat(filename, &statbuf) < 0) {
-    warn("cannot stat file %s\n", filename);
+    coap_log(LOG_WARNING, "cannot stat file %s\n", filename);
     return NULL;
   }
 
@@ -523,7 +523,7 @@ make_large(char *filename) {
 
   inputfile = fopen(filename, "r");
   if ( !inputfile ) {
-    warn("cannot read file %s\n", filename);
+    coap_log(LOG_WARNING, "cannot read file %s\n", filename);
     coap_free(payload);
     return NULL;
   }

--- a/include/coap2/debug.h
+++ b/include/coap2/debug.h
@@ -125,23 +125,6 @@ void coap_log_impl(coap_log_t level, const char *format, ...);
 } while(0)
 #endif
 
-/* A set of convenience macros for common log levels. */
-/**
- * Obsoleted.
- * @deprecated Use coap_log(LOG_INFO, ...) instead.
- */
-#define info(...) coap_log(LOG_INFO, __VA_ARGS__)
-/**
- * Obsoleted.
- * @deprecated Use coap_log(LOG_WARNING, ...) instead.
- */
-#define warn(...) coap_log(LOG_WARNING, __VA_ARGS__)
-/**
- * Obsoleted.
- * @deprecated Use coap_log(LOG_DEBUG, ...) instead.
- */
-#define debug(...) coap_log(LOG_DEBUG, __VA_ARGS__)
-
 #include "pdu.h"
 
 /**

--- a/src/async.c
+++ b/src/async.c
@@ -42,7 +42,8 @@ coap_register_async(coap_context_t *context, coap_session_t *session,
   if (s != NULL) {
     /* We must return NULL here as the caller must know that he is
      * responsible for releasing @p data. */
-    debug("asynchronous state for transaction %d already registered\n", id);
+    coap_log(LOG_DEBUG,
+         "asynchronous state for transaction %d already registered\n", id);
     return NULL;
   }
 

--- a/src/block.c
+++ b/src/block.c
@@ -80,7 +80,7 @@ coap_write_block_opt(coap_block_t *block, uint16_t type,
 
   start = block->num << (block->szx + 4);
   if (data_length <= start) {
-    debug("illegal block requested\n");
+    coap_log(LOG_DEBUG, "illegal block requested\n");
     return -2;
   }
 
@@ -107,11 +107,13 @@ coap_write_block_opt(coap_block_t *block, uint16_t type,
 
       /* we need to decrease the block size */
       if (avail < 16) {         /* bad luck, this is the smallest block size */
-        debug("not enough space, even the smallest block does not fit");
+        coap_log(LOG_DEBUG,
+                 "not enough space, even the smallest block does not fit");
         return -3;
       }
       newBlockSize = coap_flsll((long long)avail) - 5;
-      debug("decrease block size for %zu to %d\n", avail, newBlockSize);
+      coap_log(LOG_DEBUG,
+               "decrease block size for %zu to %d\n", avail, newBlockSize);
       szx = block->szx;
       block->szx = newBlockSize;
       block->m = 1;

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -198,7 +198,8 @@ coap_socket_bind_udp(coap_socket_t *sock,
   sock->fd = socket(listen_addr->addr.sa.sa_family, SOCK_DGRAM, 0);
 
   if (sock->fd == COAP_INVALID_SOCKET) {
-    coap_log(LOG_WARNING, "coap_socket_bind_udp: socket: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING,
+             "coap_socket_bind_udp: socket: %s\n", coap_socket_strerror());
     goto error;
   }
 
@@ -207,23 +208,32 @@ coap_socket_bind_udp(coap_socket_t *sock,
 #else
   if (ioctl(sock->fd, FIONBIO, &on) == COAP_SOCKET_ERROR) {
 #endif
-    coap_log(LOG_WARNING, "coap_socket_bind_udp: ioctl FIONBIO: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING,
+         "coap_socket_bind_udp: ioctl FIONBIO: %s\n", coap_socket_strerror());
   }
 
   if (setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-    coap_log(LOG_WARNING, "coap_socket_bind_udp: setsockopt SO_REUSEADDR: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING,
+             "coap_socket_bind_udp: setsockopt SO_REUSEADDR: %s\n",
+              coap_socket_strerror());
 
   switch (listen_addr->addr.sa.sa_family) {
   case AF_INET:
     if (setsockopt(sock->fd, IPPROTO_IP, GEN_IP_PKTINFO, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_ALERT, "coap_socket_bind_udp: setsockopt IP_PKTINFO: %s\n", coap_socket_strerror());
+      coap_log(LOG_ALERT,
+               "coap_socket_bind_udp: setsockopt IP_PKTINFO: %s\n",
+                coap_socket_strerror());
     break;
   case AF_INET6:
     /* Configure the socket as dual-stacked */
     if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, OPTVAL_T(&off), sizeof(off)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_ALERT, "coap_socket_bind_udp: setsockopt IPV6_V6ONLY: %s\n", coap_socket_strerror());
+      coap_log(LOG_ALERT,
+               "coap_socket_bind_udp: setsockopt IPV6_V6ONLY: %s\n",
+                coap_socket_strerror());
     if (setsockopt(sock->fd, IPPROTO_IPV6, GEN_IPV6_PKTINFO, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_ALERT, "coap_socket_bind_udp: setsockopt IPV6_PKTINFO: %s\n", coap_socket_strerror());
+      coap_log(LOG_ALERT,
+               "coap_socket_bind_udp: setsockopt IPV6_PKTINFO: %s\n",
+                coap_socket_strerror());
     setsockopt(sock->fd, IPPROTO_IP, GEN_IP_PKTINFO, OPTVAL_T(&on), sizeof(on)); /* ignore error, because the likely cause is that IPv4 is disabled at the os level */
     break;
   default:
@@ -232,13 +242,16 @@ coap_socket_bind_udp(coap_socket_t *sock,
   }
 
   if (bind(sock->fd, &listen_addr->addr.sa, listen_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_bind_udp: bind: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_bind_udp: bind: %s\n",
+             coap_socket_strerror());
     goto error;
   }
 
   bound_addr->size = (socklen_t)sizeof(*bound_addr);
   if (getsockname(sock->fd, &bound_addr->addr.sa, &bound_addr->size) < 0) {
-    coap_log(LOG_WARNING, "coap_socket_bind_udp: getsockname: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING,
+             "coap_socket_bind_udp: getsockname: %s\n",
+              coap_socket_strerror());
     goto error;
   }
 
@@ -267,7 +280,9 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
   sock->fd = socket(server->addr.sa.sa_family, SOCK_STREAM, 0);
 
   if (sock->fd == COAP_INVALID_SOCKET) {
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: socket: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING,
+             "coap_socket_connect_tcp1: socket: %s\n",
+             coap_socket_strerror());
     goto error;
   }
 
@@ -276,7 +291,9 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
 #else
   if (ioctl(sock->fd, FIONBIO, &on) == COAP_SOCKET_ERROR) {
 #endif
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: ioctl FIONBIO: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING,
+             "coap_socket_connect_tcp1: ioctl FIONBIO: %s\n",
+             coap_socket_strerror());
   }
 
   switch (server->addr.sa.sa_family) {
@@ -289,7 +306,9 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
       connect_addr.addr.sin6.sin6_port = htons(default_port);
     /* Configure the socket as dual-stacked */
     if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, OPTVAL_T(&off), sizeof(off)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_WARNING, "coap_socket_connect_tcp1: setsockopt IPV6_V6ONLY: %s\n", coap_socket_strerror());
+      coap_log(LOG_WARNING,
+               "coap_socket_connect_tcp1: setsockopt IPV6_V6ONLY: %s\n",
+               coap_socket_strerror());
     break;
   default:
     coap_log(LOG_ALERT, "coap_socket_connect_tcp1: unsupported sa_family\n");
@@ -299,9 +318,12 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
   if (local_if && local_if->addr.sa.sa_family) {
     coap_address_copy(local_addr, local_if);
     if (setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_WARNING, "coap_socket_connect_tcp1: setsockopt SO_REUSEADDR: %s\n", coap_socket_strerror());
+      coap_log(LOG_WARNING,
+               "coap_socket_connect_tcp1: setsockopt SO_REUSEADDR: %s\n",
+               coap_socket_strerror());
     if (bind(sock->fd, &local_if->addr.sa, local_if->size) == COAP_SOCKET_ERROR) {
-      coap_log(LOG_WARNING, "coap_socket_connect_tcp1: bind: %s\n", coap_socket_strerror());
+      coap_log(LOG_WARNING, "coap_socket_connect_tcp1: bind: %s\n",
+               coap_socket_strerror());
       goto error;
     }
   } else {
@@ -322,16 +344,19 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
       sock->flags |= COAP_SOCKET_WANT_CONNECT | COAP_SOCKET_CONNECTED;
       return 1;
     }
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: connect: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: connect: %s\n",
+             coap_socket_strerror());
     goto error;
   }
 
   if (getsockname(sock->fd, &local_addr->addr.sa, &local_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: getsockname: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: getsockname: %s\n",
+             coap_socket_strerror());
   }
 
   if (getpeername(sock->fd, &remote_addr->addr.sa, &remote_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: getpeername: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: getpeername: %s\n",
+             coap_socket_strerror());
   }
 
   sock->flags |= COAP_SOCKET_CONNECTED;
@@ -362,18 +387,21 @@ coap_socket_connect_tcp2(coap_socket_t *sock,
   }
 
   if (error) {
-    coap_log(LOG_WARNING, "coap_socket_finish_connect_tcp: connect failed: %s\n",
-      coap_socket_format_errno(error));
+    coap_log(LOG_WARNING,
+             "coap_socket_finish_connect_tcp: connect failed: %s\n",
+             coap_socket_format_errno(error));
     coap_socket_close(sock);
     return 0;
   }
 
   if (getsockname(sock->fd, &local_addr->addr.sa, &local_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp: getsockname: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_connect_tcp: getsockname: %s\n",
+             coap_socket_strerror());
   }
 
   if (getpeername(sock->fd, &remote_addr->addr.sa, &remote_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp: getpeername: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_connect_tcp: getpeername: %s\n",
+             coap_socket_strerror());
   }
 
   return 1;
@@ -391,7 +419,8 @@ coap_socket_bind_tcp(coap_socket_t *sock,
   sock->fd = socket(listen_addr->addr.sa.sa_family, SOCK_STREAM, 0);
 
   if (sock->fd == COAP_INVALID_SOCKET) {
-    coap_log(LOG_WARNING, "coap_socket_bind_tcp: socket: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_bind_tcp: socket: %s\n",
+             coap_socket_strerror());
     goto error;
   }
 
@@ -421,25 +450,30 @@ coap_socket_bind_tcp(coap_socket_t *sock,
   case AF_INET6:
     /* Configure the socket as dual-stacked */
     if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, OPTVAL_T(&off), sizeof(off)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_ALERT, "coap_socket_bind_tcp: setsockopt IPV6_V6ONLY: %s\n", coap_socket_strerror());
+      coap_log(LOG_ALERT,
+               "coap_socket_bind_tcp: setsockopt IPV6_V6ONLY: %s\n",
+               coap_socket_strerror());
     break;
   default:
     coap_log(LOG_ALERT, "coap_socket_bind_tcp: unsupported sa_family\n");
   }
 
   if (bind(sock->fd, &listen_addr->addr.sa, listen_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_ALERT, "coap_socket_bind_tcp: bind: %s\n", coap_socket_strerror());
+    coap_log(LOG_ALERT, "coap_socket_bind_tcp: bind: %s\n",
+             coap_socket_strerror());
     goto error;
   }
 
   bound_addr->size = (socklen_t)sizeof(*bound_addr);
   if (getsockname(sock->fd, &bound_addr->addr.sa, &bound_addr->size) < 0) {
-    coap_log(LOG_WARNING, "coap_socket_bind_tcp: getsockname: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_bind_tcp: getsockname: %s\n",
+             coap_socket_strerror());
     goto error;
   }
 
   if (listen(sock->fd, 5) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_ALERT, "coap_socket_bind_tcp: listen: %s\n", coap_socket_strerror());
+    coap_log(LOG_ALERT, "coap_socket_bind_tcp: listen: %s\n",
+             coap_socket_strerror());
     goto  error;
   }
 
@@ -472,7 +506,8 @@ coap_socket_accept_tcp(coap_socket_t *server,
   }
 
   if (getsockname( new_client->fd, &local_addr->addr.sa, &local_addr->size) < 0)
-    coap_log(LOG_WARNING, "coap_socket_accept_tcp: getsockname: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_accept_tcp: getsockname: %s\n",
+             coap_socket_strerror());
 
   #ifdef _WIN32
   if (ioctlsocket(new_client->fd, FIONBIO, &u_on) == COAP_SOCKET_ERROR) {
@@ -505,7 +540,8 @@ coap_socket_connect_udp(coap_socket_t *sock,
   sock->fd = socket(connect_addr.addr.sa.sa_family, SOCK_DGRAM, 0);
 
   if (sock->fd == COAP_INVALID_SOCKET) {
-    coap_log(LOG_WARNING, "coap_socket_connect_udp: socket: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_connect_udp: socket: %s\n",
+             coap_socket_strerror());
     goto error;
   }
 
@@ -514,7 +550,8 @@ coap_socket_connect_udp(coap_socket_t *sock,
 #else
   if (ioctl(sock->fd, FIONBIO, &on) == COAP_SOCKET_ERROR) {
 #endif
-    coap_log(LOG_WARNING, "coap_socket_connect_udp: ioctl FIONBIO: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_connect_udp: ioctl FIONBIO: %s\n",
+             coap_socket_strerror());
   }
 
   switch (connect_addr.addr.sa.sa_family) {
@@ -527,7 +564,9 @@ coap_socket_connect_udp(coap_socket_t *sock,
       connect_addr.addr.sin6.sin6_port = htons(default_port);
     /* Configure the socket as dual-stacked */
     if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, OPTVAL_T(&off), sizeof(off)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_WARNING, "coap_socket_connect_udp: setsockopt IPV6_V6ONLY: %s\n", coap_socket_strerror());
+      coap_log(LOG_WARNING,
+               "coap_socket_connect_udp: setsockopt IPV6_V6ONLY: %s\n",
+               coap_socket_strerror());
     break;
   default:
     coap_log(LOG_ALERT, "coap_socket_connect_udp: unsupported sa_family\n");
@@ -536,9 +575,12 @@ coap_socket_connect_udp(coap_socket_t *sock,
 
   if (local_if && local_if->addr.sa.sa_family) {
     if (setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_WARNING, "coap_socket_connect_udp: setsockopt SO_REUSEADDR: %s\n", coap_socket_strerror());
+      coap_log(LOG_WARNING,
+               "coap_socket_connect_udp: setsockopt SO_REUSEADDR: %s\n",
+               coap_socket_strerror());
     if (bind(sock->fd, &local_if->addr.sa, local_if->size) == COAP_SOCKET_ERROR) {
-      coap_log(LOG_WARNING, "coap_socket_connect_udp: bind: %s\n", coap_socket_strerror());
+      coap_log(LOG_WARNING, "coap_socket_connect_udp: bind: %s\n",
+               coap_socket_strerror());
       goto error;
     }
   }
@@ -546,7 +588,9 @@ coap_socket_connect_udp(coap_socket_t *sock,
   /* special treatment for sockets that are used for multicast communication */
   if (is_mcast) {
     if (getsockname(sock->fd, &local_addr->addr.sa, &local_addr->size) == COAP_SOCKET_ERROR) {
-      coap_log(LOG_WARNING, "coap_socket_connect_udp: getsockname for multicast socket: %s\n", coap_socket_strerror());
+      coap_log(LOG_WARNING,
+              "coap_socket_connect_udp: getsockname for multicast socket: %s\n",
+              coap_socket_strerror());
     }
     coap_address_copy(remote_addr, &connect_addr);
     sock->flags |= COAP_SOCKET_MULTICAST;
@@ -554,16 +598,19 @@ coap_socket_connect_udp(coap_socket_t *sock,
   }
 
   if (connect(sock->fd, &connect_addr.addr.sa, connect_addr.size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_udp: connect: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_connect_udp: connect: %s\n",
+             coap_socket_strerror());
     goto error;
   }
 
   if (getsockname(sock->fd, &local_addr->addr.sa, &local_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_udp: getsockname: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_connect_udp: getsockname: %s\n",
+             coap_socket_strerror());
   }
 
   if (getpeername(sock->fd, &remote_addr->addr.sa, &remote_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_udp: getpeername: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_connect_udp: getpeername: %s\n",
+             coap_socket_strerror());
   }
 
   sock->flags |= COAP_SOCKET_CONNECTED;
@@ -603,7 +650,8 @@ coap_socket_write(coap_socket_t *sock, const uint8_t *data, size_t data_len) {
       sock->flags |= COAP_SOCKET_WANT_WRITE;
       return 0;
     }
-    coap_log(LOG_WARNING, "coap_socket_write: send: %s\n", coap_socket_strerror());
+    coap_log(LOG_WARNING, "coap_socket_write: send: %s\n",
+             coap_socket_strerror());
     return -1;
   }
   if (r < (ssize_t)data_len)
@@ -644,7 +692,8 @@ coap_socket_read(coap_socket_t *sock, uint8_t *data, size_t data_len) {
 #else
     if (errno != ECONNRESET)
 #endif
-      coap_log(LOG_WARNING, "coap_socket_read: recv: %s\n", coap_socket_strerror());
+      coap_log(LOG_WARNING, "coap_socket_read: recv: %s\n",
+               coap_socket_strerror());
     return -1;
   }
   if (r < (ssize_t)data_len)
@@ -1000,7 +1049,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
 
       if (len > COAP_RXBUFFER_SIZE) {
         /* FIXME: we might want to send back a response */
-        warn("discarded oversized packet\n");
+        coap_log(LOG_WARNING, "discarded oversized packet\n");
         return -1;
       }
 
@@ -1013,7 +1062,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
         unsigned char addr_str[INET6_ADDRSTRLEN + 8];
 
         if (coap_print_addr(&packet->src, addr_str, INET6_ADDRSTRLEN + 8)) {
-          debug("received %zd bytes from %s\n", len, addr_str);
+          coap_log(LOG_DEBUG, "received %zd bytes from %s\n", len, addr_str);
         }
       }
 #endif /* NDEBUG */
@@ -1156,7 +1205,8 @@ coap_write(coap_context_t *ctx,
       if (tls_timeout > 0) {
         if (tls_timeout < now + COAP_TICKS_PER_SECOND / 10)
           tls_timeout = now + COAP_TICKS_PER_SECOND / 10;
-        debug("** DTLS global timeout set to %dms\n", (int)((tls_timeout - now) * 1000 / COAP_TICKS_PER_SECOND));
+        coap_log(LOG_DEBUG, "** DTLS global timeout set to %dms\n",
+                 (int)((tls_timeout - now) * 1000 / COAP_TICKS_PER_SECOND));
         if (timeout == 0 || tls_timeout - now < timeout)
           timeout = tls_timeout - now;
       }
@@ -1167,7 +1217,8 @@ coap_write(coap_context_t *ctx,
             if (s->proto == COAP_PROTO_DTLS && s->tls) {
               coap_tick_t tls_timeout = coap_dtls_get_timeout(s);
               while (tls_timeout > 0 && tls_timeout <= now) {
-                coap_log(LOG_DEBUG, "**  %s: DTLS retransmit timeout\n", coap_session_str(s));
+                coap_log(LOG_DEBUG, "** %s: DTLS retransmit timeout\n",
+                         coap_session_str(s));
                 coap_dtls_handle_timeout(s);
                 if (s->tls)
                   tls_timeout = coap_dtls_get_timeout(s);
@@ -1186,7 +1237,7 @@ coap_write(coap_context_t *ctx,
         if (s->proto == COAP_PROTO_DTLS && s->tls) {
           coap_tick_t tls_timeout = coap_dtls_get_timeout(s);
           while (tls_timeout > 0 && tls_timeout <= now) {
-            coap_log(LOG_DEBUG, "**  %s: DTLS retransmit timeout\n", coap_session_str(s));
+            coap_log(LOG_DEBUG, "** %s: DTLS retransmit timeout\n", coap_session_str(s));
             coap_dtls_handle_timeout(s);
             if (s->tls)
               tls_timeout = coap_dtls_get_timeout(s);

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -350,7 +350,8 @@ static unsigned coap_dtls_psk_server_callback(SSL *ssl, const char *identity, un
   else
     identity = "";
 
-  coap_log(LOG_DEBUG, "got psk_identity: '%.*s'\n", (int)identity_len, identity);
+  coap_log(LOG_DEBUG, "got psk_identity: '%.*s'\n",
+           (int)identity_len, identity);
 
   if (session == NULL || session->context == NULL || session->context->get_server_psk == NULL)
     return 0;
@@ -372,11 +373,12 @@ static void coap_dtls_info_callback(const SSL *ssl, int where, int ret) {
 
   if (where & SSL_CB_LOOP) {
     if (dtls_log_level >= LOG_DEBUG)
-      coap_log(LOG_DEBUG, "*   %s: %s:%s\n", coap_session_str(session), pstr, SSL_state_string_long(ssl));
+      coap_log(LOG_DEBUG, "*  %s: %s:%s\n",
+               coap_session_str(session), pstr, SSL_state_string_long(ssl));
   } else if (where & SSL_CB_ALERT) {
     pstr = (where & SSL_CB_READ) ? "read" : "write";
     if (dtls_log_level >= LOG_INFO)
-      coap_log(LOG_INFO, "*   %s: SSL3 alert %s:%s:%s\n",
+      coap_log(LOG_INFO, "*  %s: SSL3 alert %s:%s:%s\n",
                coap_session_str(session),
                pstr,
                SSL_alert_type_string_long(ret),
@@ -387,18 +389,24 @@ static void coap_dtls_info_callback(const SSL *ssl, int where, int ret) {
     if (ret == 0) {
       if (dtls_log_level >= LOG_WARNING) {
         unsigned long e;
-        coap_log(LOG_WARNING, "*   %s: %s:failed in %s\n", coap_session_str(session), pstr, SSL_state_string_long(ssl));
+        coap_log(LOG_WARNING, "*  %s: %s:failed in %s\n",
+                 coap_session_str(session), pstr, SSL_state_string_long(ssl));
         while ((e = ERR_get_error()))
-          coap_log(LOG_WARNING, "*   %s:   %s at %s:%s\n", coap_session_str(session), ERR_reason_error_string(e), ERR_lib_error_string(e), ERR_func_error_string(e));
+          coap_log(LOG_WARNING, "*  %s:   %s at %s:%s\n",
+                   coap_session_str(session), ERR_reason_error_string(e),
+                   ERR_lib_error_string(e), ERR_func_error_string(e));
       }
     } else if (ret < 0) {
       if (dtls_log_level >= LOG_WARNING) {
         int err = SSL_get_error(ssl, ret);
         if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE && err != SSL_ERROR_WANT_CONNECT && err != SSL_ERROR_WANT_ACCEPT && err != SSL_ERROR_WANT_X509_LOOKUP) {
           long e;
-          coap_log(LOG_WARNING, "*   %s: %s:error in %s\n", coap_session_str(session), pstr, SSL_state_string_long(ssl));
+          coap_log(LOG_WARNING, "*  %s: %s:error in %s\n",
+                   coap_session_str(session), pstr, SSL_state_string_long(ssl));
           while ((e = ERR_get_error()))
-            coap_log(LOG_WARNING, "*   %s: %s at %s:%s\n", coap_session_str(session), ERR_reason_error_string(e), ERR_lib_error_string(e), ERR_func_error_string(e));
+            coap_log(LOG_WARNING, "*  %s: %s at %s:%s\n",
+                     coap_session_str(session), ERR_reason_error_string(e),
+                     ERR_lib_error_string(e), ERR_func_error_string(e));
         }
       }
     }
@@ -497,7 +505,8 @@ void *coap_dtls_new_context(struct coap_context_t *coap_context) {
     SSL_CTX_set_cipher_list(context->dtls.ctx, "TLSv1.2:TLSv1.0");
     if (!RAND_bytes(cookie_secret, (int)sizeof(cookie_secret))) {
       if (dtls_log_level >= LOG_WARNING)
-        coap_log(LOG_WARNING, "Insufficient entropy for random cookie generation");
+        coap_log(LOG_WARNING,
+                 "Insufficient entropy for random cookie generation");
       prng(cookie_secret, sizeof(cookie_secret));
     }
     context->dtls.cookie_hmac = HMAC_CTX_new();
@@ -601,7 +610,7 @@ map_key_type(int asn1_private_key_type
   case COAP_ASN1_PKEY_HKDF: return EVP_PKEY_HKDF;
   default:
     coap_log(LOG_WARNING,
-   "*** setup_pki: DTLS: Unknown Private Key type %d for ASN1\n",
+             "*** setup_pki: DTLS: Unknown Private Key type %d for ASN1\n",
              asn1_private_key_type);
     break;
   }
@@ -645,7 +654,7 @@ add_ca_to_cert_store(X509_STORE *st, X509 *x509)
       int r = ERR_GET_REASON(e);
       if (r != X509_R_CERT_ALREADY_IN_HASH_TABLE) {
         /* Not already added */
-        coap_log(LOG_WARNING, "*** setup_pki: (D)TLS: %s at %s:%s\n",
+        coap_log(LOG_WARNING, "***setup_pki: (D)TLS: %s at %s:%s\n",
                  ERR_reason_error_string(e),
                  ERR_lib_error_string(e),
                  ERR_func_error_string(e));
@@ -667,7 +676,8 @@ setup_pki_server(SSL_CTX *ctx,
                                         setup_data->pki_key.key.pem.public_cert,
                                         SSL_FILETYPE_PEM))) {
         coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure Server Certificate\n",
+                 "*** setup_pki: (D)TLS: %s: Unable to configure "
+                 "Server Certificate\n",
                  setup_data->pki_key.key.pem.public_cert);
         return 0;
       }
@@ -684,7 +694,8 @@ setup_pki_server(SSL_CTX *ctx,
                                         setup_data->pki_key.key.pem.private_key,
                                         SSL_FILETYPE_PEM))) {
         coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure Server Private Key\n",
+                 "*** setup_pki: (D)TLS: %s: Unable to configure "
+                 "Server Private Key\n",
                   setup_data->pki_key.key.pem.private_key);
         return 0;
       }
@@ -707,7 +718,8 @@ setup_pki_server(SSL_CTX *ctx,
         SSL_CTX_set_client_CA_list(ctx, cert_names);
       else {
         coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure client CA File\n",
+                 "*** setup_pki: (D)TLS: %s: Unable to configure "
+                 "client CA File\n",
                   setup_data->pki_key.key.pem.ca_file);
         return 0;
       }
@@ -738,7 +750,8 @@ setup_pki_server(SSL_CTX *ctx,
                                  setup_data->pki_key.key.asn1.public_cert_len,
                                  setup_data->pki_key.key.asn1.public_cert))) {
         coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure Server Certificate\n",
+                 "*** setup_pki: (D)TLS: %s: Unable to configure "
+                 "Server Certificate\n",
                  "ASN1");
         return 0;
       }
@@ -756,7 +769,8 @@ setup_pki_server(SSL_CTX *ctx,
                              setup_data->pki_key.key.asn1.private_key,
                              setup_data->pki_key.key.asn1.private_key_len))) {
         coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure Server Private Key\n",
+                 "*** setup_pki: (D)TLS: %s: Unable to configure "
+                 "Server Private Key\n",
                  "ASN1");
         return 0;
       }
@@ -775,7 +789,8 @@ setup_pki_server(SSL_CTX *ctx,
       X509_STORE *st;
       if (!x509 || !SSL_CTX_add_client_CA(ctx, x509)) {
         coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure client CA File\n",
+                 "*** setup_pki: (D)TLS: %s: Unable to configure "
+                 "client CA File\n",
                   "ASN1");
         X509_free(x509);
         return 0;
@@ -808,7 +823,8 @@ setup_pki_ssl(SSL *ssl,
                                    setup_data->pki_key.key.pem.public_cert,
                                    SSL_FILETYPE_PEM))) {
         coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure Client Certificate\n",
+                 "*** setup_pki: (D)TLS: %s: Unable to configure "
+                 "Client Certificate\n",
                  setup_data->pki_key.key.pem.public_cert);
         return 0;
       }
@@ -824,7 +840,8 @@ setup_pki_ssl(SSL *ssl,
                                   setup_data->pki_key.key.pem.private_key,
                                   SSL_FILETYPE_PEM))) {
         coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure Client Private Key\n",
+                 "*** setup_pki: (D)TLS: %s: Unable to configure "
+                 "Client Private Key\n",
                   setup_data->pki_key.key.pem.private_key);
         return 0;
       }
@@ -849,7 +866,8 @@ setup_pki_ssl(SSL *ssl,
           SSL_set_client_CA_list(ssl, cert_names);
         else {
           coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure client CA File\n",
+                   "*** setup_pki: (D)TLS: %s: Unable to configure "
+                   "client CA File\n",
                     setup_data->pki_key.key.pem.ca_file);
           return 0;
         }
@@ -882,7 +900,8 @@ setup_pki_ssl(SSL *ssl,
                            setup_data->pki_key.key.asn1.public_cert,
                            setup_data->pki_key.key.asn1.public_cert_len))) {
         coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure Client Certificate\n",
+                 "*** setup_pki: (D)TLS: %s: Unable to configure "
+                 "Client Certificate\n",
                  "ASN1");
         return 0;
       }
@@ -899,7 +918,8 @@ setup_pki_ssl(SSL *ssl,
                         setup_data->pki_key.key.asn1.private_key,
                         setup_data->pki_key.key.asn1.private_key_len))) {
         coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure Client Private Key\n",
+                 "*** setup_pki: (D)TLS: %s: Unable to configure "
+                 "Client Private Key\n",
                  "ASN1");
         return 0;
       }
@@ -920,7 +940,8 @@ setup_pki_ssl(SSL *ssl,
       if (isserver) {
         if (!x509 || !SSL_add_client_CA(ssl, x509)) {
           coap_log(LOG_WARNING,
- "*** setup_pki: (D)TLS: %s: Unable to configure client CA File\n",
+                   "*** setup_pki: (D)TLS: %s: Unable to configure "
+                   "client CA File\n",
                     "ASN1");
           X509_free(x509);
           return 0;
@@ -1110,7 +1131,7 @@ tls_secret_call_back(SSL *ssl,
   }
   if (!psk_requested) {
     if (session) {
-      coap_log(LOG_DEBUG, "    %s: Using PKI ciphers\n",
+      coap_log(LOG_DEBUG, "   %s: Using PKI ciphers\n",
                 coap_session_str(session));
     }
     else {
@@ -1155,7 +1176,7 @@ tls_secret_call_back(SSL *ssl,
         memcpy(secret, session->context->psk_key, session->context->psk_key_len);
         *secretlen = session->context->psk_key_len;
       }
-      coap_log(LOG_DEBUG, "    %s: Setting PSK ciphers\n",
+      coap_log(LOG_DEBUG, "   %s: Setting PSK ciphers\n",
                coap_session_str(session));
     }
     else {
@@ -1325,7 +1346,7 @@ tls_client_hello_call_back(SSL *ssl,
      * Client has requested PSK and it is supported
      */
     if (session) {
-      coap_log(LOG_DEBUG, "    %s: PSK request\n",
+      coap_log(LOG_DEBUG, "   %s: PSK request\n",
                coap_session_str(session));
     }
     else {
@@ -1431,7 +1452,7 @@ is_x509:
   }
 
   if (session) {
-    coap_log(LOG_DEBUG, "    %s: Using PKI ciphers\n",
+    coap_log(LOG_DEBUG, "   %s: Using PKI ciphers\n",
               coap_session_str(session));
   }
   else {
@@ -1505,7 +1526,8 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
 #if OPENSSL_VERSION_NUMBER < 0x10101000L
       if (SSLeay() >= 0x10101000L) {
         coap_log(LOG_WARNING,
-     "OpenSSL compiled with %lux, linked with %lux, so no certificate checking\n",
+                 "OpenSSL compiled with %lux, linked with %lux, so "
+                 "no certificate checking\n",
                  OPENSSL_VERSION_NUMBER, SSLeay());
       }
       SSL_CTX_set_tlsext_servername_arg(context->dtls.ctx, &context->setup_data);
@@ -1532,7 +1554,8 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
 #if OPENSSL_VERSION_NUMBER < 0x10101000L
       if (SSLeay() >= 0x10101000L) {
         coap_log(LOG_WARNING,
-     "OpenSSL compiled with %lux, linked with %lux, so no certificate checking\n",
+                 "OpenSSL compiled with %lux, linked with %lux, so "
+                 "no certificate checking\n",
                  OPENSSL_VERSION_NUMBER, SSLeay());
       }
       SSL_CTX_set_tlsext_servername_arg(context->tls.ctx, &context->setup_data);
@@ -1977,7 +2000,8 @@ unsigned int coap_dtls_get_overhead(coap_session_t *session) {
 
     default:
       SSL_CIPHER_description(s_ciph, cipher, sizeof(cipher));
-      coap_log(LOG_WARNING, "Unknown overhead for DTLS with cipher %s\n", cipher);
+      coap_log(LOG_WARNING, "Unknown overhead for DTLS with cipher %s\n",
+               cipher);
       ivlen = 8;
       maclen = 16;
       break;
@@ -2121,7 +2145,8 @@ ssize_t coap_tls_write(coap_session_t *session,
         session->sock.flags |= COAP_SOCKET_WANT_WRITE;
       r = 0;
     } else {
-      coap_log(LOG_WARNING, "*** %s: coap_tls_write: cannot send PDU\n", coap_session_str(session));
+      coap_log(LOG_WARNING, "***%s: coap_tls_write: cannot send PDU\n",
+               coap_session_str(session));
       if (err == SSL_ERROR_ZERO_RETURN)
         session->dtls_event = COAP_EVENT_DTLS_CLOSED;
       else if (err == SSL_ERROR_SSL)

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -111,7 +111,8 @@ dtls_application_data(struct dtls_context_t *dtls_context,
   get_session_addr(dtls_session, &remote_addr);
   coap_session = coap_session_get_by_peer(coap_context, &remote_addr, dtls_session->ifindex);
   if (!coap_session) {
-    debug("dropped message that was received on invalid interface\n");
+    coap_log(LOG_DEBUG,
+             "dropped message that was received on invalid interface\n");
     return -1;
   }
 
@@ -189,7 +190,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
   get_session_addr(dtls_session, &remote_addr);
   coap_session = coap_session_get_by_peer(coap_context, &remote_addr, dtls_session->ifindex);
   if (!coap_session) {
-    debug("cannot get PSK, session not found\n");
+    coap_log(LOG_DEBUG, "cannot get PSK, session not found\n");
     goto error;
   }
 
@@ -274,7 +275,7 @@ coap_dtls_new_session(coap_session_t *session) {
     dtls_session_init(dtls_session);
     put_session_addr(&session->remote_addr, dtls_session);
     dtls_session->ifindex = session->ifindex;
-    debug("*** new session %p\n", (void *)dtls_session);
+    coap_log(LOG_DEBUG, "***new session %p\n", (void *)dtls_session);
   }
 
   return dtls_session;
@@ -328,7 +329,7 @@ coap_dtls_free_session(coap_session_t *coap_session) {
       dtls_reset_peer(ctx, peer);
     else
       dtls_close(ctx, (session_t *)coap_session->tls);
-    debug("*** removed session %p\n", coap_session->tls);
+    coap_log(LOG_DEBUG, "***removed session %p\n", coap_session->tls);
     coap_free_type(COAP_DTLS_SESSION, coap_session->tls);
     coap_session->tls = NULL;
   }

--- a/src/debug.c
+++ b/src/debug.c
@@ -79,7 +79,7 @@ coap_set_log_level(coap_log_t level) {
 
 /* this array has the same order as the type log_t */
 static const char *loglevels[] = {
-  "EMRG", "ALRT", "CRIT", "ERR", "WARN", "NOTE", "INFO", "DEBG"
+  "EMRG", "ALRT", "CRIT", "ERR ", "WARN", "NOTE", "INFO", "DEBG"
 };
 
 #ifdef HAVE_TIME_H

--- a/src/mem.c
+++ b/src/mem.c
@@ -129,7 +129,8 @@ coap_malloc_type(coap_memory_tag_t type, size_t size) {
 
   if (size > container->size) {
     coap_log(LOG_WARNING,
-             "coap_malloc_type: Requested memory exceeds maximum object size (type %d, size %d, max %d)\n",
+             "coap_malloc_type: Requested memory exceeds maximum object "
+             "size (type %d, size %d, max %d)\n",
              type, (int)size, container->size);
     return NULL;
   }

--- a/src/option.c
+++ b/src/option.c
@@ -24,12 +24,12 @@
 #include "mem.h"
 #include "utlist.h"
 
-#define ADVANCE_OPT(o,e,step) if ((e) < step) {                        \
-    debug("cannot advance opt past end\n");                        \
-    return 0;                                                        \
-  } else {                                                        \
-    (e) -= step;                                                \
-    (o) = ((o)) + step;                        \
+#define ADVANCE_OPT(o,e,step) if ((e) < step) {           \
+    coap_log(LOG_DEBUG, "cannot advance opt past end\n"); \
+    return 0;                                             \
+  } else {                                                \
+    (e) -= step;                                          \
+    (o) = ((o)) + step;                                   \
   }
 
 /*
@@ -58,7 +58,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
   switch(result->delta) {
   case 15:
     if (*opt != COAP_PAYLOAD_START) {
-      debug("ignored reserved option delta 15\n");
+      coap_log(LOG_DEBUG, "ignored reserved option delta 15\n");
     }
     return 0;
   case 14:
@@ -68,7 +68,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
     ADVANCE_OPT_CHECK(opt,length,1);
     result->delta = ((*opt & 0xff) << 8) + 269;
     if (result->delta < 269) {
-      debug("delta too large\n");
+      coap_log(LOG_DEBUG, "delta too large\n");
       return 0;
     }
     /* fall through */
@@ -83,7 +83,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
 
   switch(result->length) {
   case 15:
-    debug("found reserved option length 15\n");
+    coap_log(LOG_DEBUG, "found reserved option length 15\n");
     return 0;
   case 14:
     /* Handle two-byte value: First, the MSB + 269 is stored as delta value.
@@ -107,7 +107,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
 
   result->value = opt;
   if (length < result->length) {
-    debug("invalid option length\n");
+    coap_log(LOG_DEBUG, "invalid option length\n");
     return 0;
   }
 
@@ -224,7 +224,7 @@ coap_opt_delta(const coap_opt_t *opt) {
 
   switch (n) {
   case 15: /* error */
-    warn("coap_opt_delta: illegal option delta\n");
+    coap_log(LOG_WARNING, "coap_opt_delta: illegal option delta\n");
 
     /* This case usually should not happen, hence we do not have a
      * proper way to indicate an error. */
@@ -252,7 +252,7 @@ coap_opt_length(const coap_opt_t *opt) {
   length = *opt & 0x0f;
   switch (*opt & 0xf0) {
   case 0xf0:
-    debug("illegal option delta\n");
+    coap_log(LOG_DEBUG, "illegal option delta\n");
     return 0;
   case 0xe0:
     ++opt;
@@ -268,7 +268,7 @@ coap_opt_length(const coap_opt_t *opt) {
 
   switch (length) {
   case 0x0f:
-    debug("illegal option length\n");
+    coap_log(LOG_DEBUG, "illegal option length\n");
     return 0;
   case 0x0e:
     length = (*opt++ << 8) + 269;
@@ -288,7 +288,7 @@ coap_opt_value(const coap_opt_t *opt) {
 
   switch (*opt & 0xf0) {
   case 0xf0:
-    debug("illegal option delta\n");
+    coap_log(LOG_DEBUG, "illegal option delta\n");
     return 0;
   case 0xe0:
     ++ofs;
@@ -302,7 +302,7 @@ coap_opt_value(const coap_opt_t *opt) {
 
   switch (*opt & 0x0f) {
   case 0x0f:
-    debug("illegal option length\n");
+    coap_log(LOG_DEBUG, "illegal option length\n");
     return 0;
   case 0x0e:
     ++ofs;
@@ -339,7 +339,8 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[0] = (coap_opt_t)(delta << 4);
   } else if (delta < 269) {
     if (maxlen < 2) {
-      debug("insufficient space to encode option delta %d\n", delta);
+      coap_log(LOG_DEBUG, "insufficient space to encode option delta %d\n",
+               delta);
       return 0;
     }
 
@@ -347,7 +348,8 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[++skip] = (coap_opt_t)(delta - 13);
   } else {
     if (maxlen < 3) {
-      debug("insufficient space to encode option delta %d\n", delta);
+      coap_log(LOG_DEBUG, "insufficient space to encode option delta %d\n",
+               delta);
       return 0;
     }
 
@@ -360,7 +362,8 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[0] |= length & 0x0f;
   } else if (length < 269) {
     if (maxlen < skip + 2) {
-      debug("insufficient space to encode option length %zu\n", length);
+      coap_log(LOG_DEBUG, "insufficient space to encode option length %zu\n",
+               length);
       return 0;
     }
 
@@ -368,7 +371,8 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[++skip] = (coap_opt_t)(length - 13);
   } else {
     if (maxlen < skip + 3) {
-      debug("insufficient space to encode option delta %d\n", delta);
+      coap_log(LOG_DEBUG, "insufficient space to encode option delta %d\n",
+               delta);
       return 0;
     }
 
@@ -410,7 +414,7 @@ coap_opt_encode(coap_opt_t *opt, size_t maxlen, uint16_t delta,
   assert(l <= maxlen);
 
   if (!l) {
-    debug("coap_opt_encode: cannot set option header\n");
+    coap_log(LOG_DEBUG, "coap_opt_encode: cannot set option header\n");
     return 0;
   }
 
@@ -418,7 +422,7 @@ coap_opt_encode(coap_opt_t *opt, size_t maxlen, uint16_t delta,
   opt += l;
 
   if (maxlen < length) {
-    debug("coap_opt_encode: option too large for buffer\n");
+    coap_log(LOG_DEBUG, "coap_opt_encode: option too large for buffer\n");
     return 0;
   }
 

--- a/src/resource.c
+++ b/src/resource.c
@@ -462,8 +462,8 @@ coap_add_resource(coap_context_t *context, coap_resource_t *resource) {
     if (r) {
       coap_log(LOG_WARNING,
         "coap_add_resource: Duplicate uri_path '%*.*s', old resource deleted\n",
-        (int)resource->uri_path->length, (int)resource->uri_path->length,
-        resource->uri_path->s);
+              (int)resource->uri_path->length, (int)resource->uri_path->length,
+              resource->uri_path->s);
       coap_delete_resource(context, r);
     }
     RESOURCES_ADD(context->resources, resource);
@@ -711,7 +711,7 @@ coap_delete_observer(coap_resource_t *resource, coap_session_t *session,
     unsigned int i;
     for ( i = 0; i < s->token_length; i++ )
       snprintf( &outbuf[2 * i], 3, "%02x", s->token[i] );
-    coap_log( LOG_DEBUG, "removed observer tid %s\n", outbuf );
+    coap_log(LOG_DEBUG, "removed observer tid %s\n", outbuf);
   }
 
   if (resource->subscribers && s) {
@@ -775,14 +775,18 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
       if (!response) {
         obs->dirty = 1;
         r->partiallydirty = 1;
-        debug("coap_check_notify: pdu init failed, resource stays partially dirty\n");
+        coap_log(LOG_DEBUG,
+                 "coap_check_notify: pdu init failed, resource stays "
+                 "partially dirty\n");
         continue;
       }
 
       if (!coap_add_token(response, obs->token_length, obs->token)) {
         obs->dirty = 1;
         r->partiallydirty = 1;
-        debug("coap_check_notify: cannot add token, resource stays partially dirty\n");
+        coap_log(LOG_DEBUG,
+                 "coap_check_notify: cannot add token, resource stays "
+                 "partially dirty\n");
         coap_delete_pdu(response);
         continue;
       }
@@ -812,7 +816,9 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
       tid = coap_send( obs->session, response );
 
       if (COAP_INVALID_TID == tid) {
-        debug("coap_check_notify: sending failed, resource stays partially dirty\n");
+        coap_log(LOG_DEBUG,
+                 "coap_check_notify: sending failed, resource stays "
+                 "partially dirty\n");
         obs->dirty = 1;
         r->partiallydirty = 1;
       }
@@ -905,7 +911,7 @@ coap_remove_failed_observers(coap_context_t *context,
           unsigned char addr[INET6_ADDRSTRLEN+8];
 
           if (coap_print_addr(&obs->session->remote_addr, addr, INET6_ADDRSTRLEN+8))
-            debug("** removed observer %s\n", addr);
+            coap_log(LOG_DEBUG, "** removed observer %s\n", addr);
         }
 #endif
         coap_cancel_all_messages(context, obs->session,

--- a/src/uri.c
+++ b/src/uri.c
@@ -290,7 +290,7 @@ make_decoded_option(const uint8_t *s, size_t length,
   size_t written;
 
   if (!buflen) {
-    debug("make_decoded_option(): buflen is 0!\n");
+    coap_log(LOG_DEBUG, "make_decoded_option(): buflen is 0!\n");
     return -1;
   }
 
@@ -310,7 +310,7 @@ make_decoded_option(const uint8_t *s, size_t length,
   buflen -= written;
 
   if (buflen < segmentlen) {
-    debug("buffer too small for option\n");
+    coap_log(LOG_DEBUG, "buffer too small for option\n");
     return -1;
   }
 


### PR DESCRIPTION
This then removes the need for name polution/confict of debug(), info() and
warn() when building other projects that use libcoap and need to #include the
libcoap header files

Updated:
 examples/client.c
 examples/contiki/coap-observer.c
 examples/etsi_iot_01.c
 include/coap2/debug.h
 src/async.c
 src/block.c
 src/coap_io.c
 src/coap_openssl.c
 src/coap_session.c
 src/coap_tinydtls.c
 src/debug.c
 src/mem.c
 src/net.c
 src/option.c
 src/pdu.c
 src/resource.c
 src/uri.c

If the debug() etc. macros are still required, then the change to
include/coap2/debug.h just needs to be reverted.

There are also a couple of space changes - to cause log output to be columnar
e.g "ERR" was padded to "ERR ", so that "EMRG" or "ERR " log output output was
aligned in the same way.

This is a replacement for PR#51, and partially deals with name polution issues
raised in Issue #50.