### PR TITLE
Add in support for GnuTLS >= 3.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ services:
 env:
   - PLATFORM=posix TESTS=yes TLS=no
   - PLATFORM=posix TESTS=yes TLS=openssl
+  - PLATFORM=posix TESTS=yes TLS=gnutls
   - PLATFORM=posix TESTS=yes TLS=tinydtls
   - PLATFORM=contiki TLS=no
   - PLATFORM=lwip TLS=no

--- a/BUILDING
+++ b/BUILDING
@@ -3,9 +3,16 @@ To build the libcoap libraries, you need to do the following
 Unpack the distribution package file
 Change into the top level directory of the unpackaged files
 
-Run the following commands (not for LwIP or Contiki - see below)
+TinyDTLS Only
+=============
 
-General Building
+It is possible that you may need to execute the following two commands once to
+get the TinyDTLS code into your project, so the TinyDTLS library can be used.
+
+git submodule init
+git submodule update
+
+General Building (not for LwIP or Contiki - see below)
 ================
 
 ./autogen.sh
@@ -39,6 +46,9 @@ Some examples are:-
 # With OpenSSL
 ./configure --with-openssl --enable-tests --enable-shared
 
+# With GnuTLS
+./configure --with-gnutls --enable-tests --enable-shared
+
 Note: --disable-documentation disables the building of doxygen and man page
 files.  If you want to only disable one of them, use --disable-doxygen or
 --disable-manpages.  Doxygen requires the program doxygen and man pages require
@@ -57,7 +67,7 @@ LwIP
 ./autogen.sh
 ./configure --disable-tests --disable-documentation --disable-examples --disable-dtls
 cd examples/lwip
-make 
+make
 
 Executable is ./server. See examples/lwip/README for further information
 
@@ -67,6 +77,6 @@ Contiki
 ./autogen.sh
 ./configure --disable-tests --disable-documentation --disable-examples --disable-dtls
 cd examples/contiki
-make 
+make
 
 Executable is ./server.minimal-net. See examples/contiki/README for further information

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,7 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_SOURCES = \
   src/block.c \
   src/coap_event.c \
   src/coap_hashkey.c \
+  src/coap_gnutls.c \
   src/coap_io.c \
   src/coap_notls.c \
   src/coap_openssl.c \

--- a/build-env/Dockerfile.build-env
+++ b/build-env/Dockerfile.build-env
@@ -2,6 +2,6 @@ FROM debian:testing-slim
 
 RUN apt-get update && apt-get install -y autoconf automake gcc clang \
   libtool libtool-bin make pkg-config libcunit1-dev libssl-dev \
-  exuberant-ctags git valgrind \
+  libgnutls28-dev exuberant-ctags git valgrind \
   graphviz doxygen libxml2-utils xsltproc docbook-xml docbook-xsl asciidoc
 RUN apt-get clean

--- a/build-env/Dockerfile.develop
+++ b/build-env/Dockerfile.develop
@@ -17,7 +17,7 @@ RUN git clone --depth 1 https://github.com/cabo/cn-cbor.git && cd cn-cbor && ./b
 FROM debian:testing-slim
 
 RUN apt-get update && apt-get install -y autoconf automake gcc g++ gdb libtool libtool-bin make \
- pkg-config libssl-dev
+ pkg-config libssl-dev libgnutls28-dev
 RUN apt-get install -y iproute2 lsof net-tools inetutils-ping netcat-openbsd less vim
 RUN apt-get clean
 

--- a/configure.ac
+++ b/configure.ac
@@ -310,11 +310,11 @@ AC_ARG_ENABLE([dtls],
               [build_dtls="$enableval"],
               [build_dtls="yes"])
 
-#AC_ARG_WITH([gnutls],
-#            [AS_HELP_STRING([--with-gnutls],
-#                            [Use GnuTLS for DTLS functions])],
-#            [with_gnutls="$withval"],
-#            [with_gnutls="no"])
+AC_ARG_WITH([gnutls],
+            [AS_HELP_STRING([--with-gnutls],
+                            [Use GnuTLS for DTLS functions])],
+            [with_gnutls="$withval"],
+            [with_gnutls="no"])
 
 AC_ARG_WITH([openssl],
             [AS_HELP_STRING([--with-openssl],
@@ -346,11 +346,10 @@ if test "x$build_dtls" = "xyes"; then
 
     # Check for all possible usable and supported SSL crypto libraries
     # GnuTLS
-#    PKG_CHECK_MODULES([GnuTLS],
-#                      [gnutls],
-#                      [have_gnutls="yes"],
-#                      [have_gnutls="no"])
-    have_gnutls="no"
+    PKG_CHECK_MODULES([GnuTLS],
+                      [gnutls],
+                      [have_gnutls="yes"],
+                      [have_gnutls="no"])
 
     # OpenSSL
     PKG_CHECK_MODULES([OpenSSL],
@@ -362,20 +361,20 @@ if test "x$build_dtls" = "xyes"; then
     # TBD ?
 
     # The user wants to use explicit GnuTLS if '--with-gnutls' was set.
-#    if test "x$with_gnutls" = "xyes"; then
+    if test "x$with_gnutls" = "xyes"; then
         # Some more sanity checking.
-#        if test "x$have_gnutls" != "xyes"; then
-#            AC_MSG_ERROR([==> You want to build libcoap with DTLS support by the GnuTLS library but pkg-config file 'gnutls.pc' could not be found!
-#                      Install the package(s) that contains the development files for GnuTLS,
-#                      or use '--with-openssl' or disable the DTLS support using '--disable-dtls'.])
-#        fi
-#        AC_MSG_NOTICE([The use of GnuTLS was explicit requested due configure option '--with-gnutls'!])
+        if test "x$have_gnutls" != "xyes"; then
+            AC_MSG_ERROR([==> You want to build libcoap with DTLS support by the GnuTLS library but pkg-config file 'gnutls.pc' could not be found!
+                      Install the package(s) that contains the development files for GnuTLS,
+                      or use '--with-openssl' or disable the DTLS support using '--disable-dtls'.])
+        fi
+        AC_MSG_NOTICE([The use of GnuTLS was explicit requested due configure option '--with-gnutls'!])
 
         # check for valid GnuTLS version
-#        gnutls_version=`pkg-config --modversion gnutls`
-#        AX_CHECK_GNUTLS_VERSION
-#        have_openssl="no" # don't confuse AC_MSG_RESULT at the end of the script
-#    fi
+        gnutls_version=`pkg-config --modversion gnutls`
+        AX_CHECK_GNUTLS_VERSION
+        have_openssl="no" # don't confuse AC_MSG_RESULT at the end of the script
+    fi
 
     # The user wants to use explicit OpenSSL if '--with-openssl was set'.
     if test "x$with_openssl" = "xyes"; then
@@ -409,17 +408,16 @@ if test "x$build_dtls" = "xyes"; then
 
     # The user hasn't requested the use of a specific cryptography library
     # we try first GnuTLS for usability ...
-#    if test "x$have_gnutls" = "xyes" -a "x$with_gnutls" = "xno" -a "x$with_tinydtls" = "xno"; then
-#        gnutls_version=`pkg-config --modversion gnutls`
-#        AX_CHECK_GNUTLS_VERSION
-#        AC_MSG_NOTICE([Using auto selected library GnuTLS for DTLS support!])
-#        with_gnutls_auto="yes"
-#        have_openssl="no" # don't confuse AC_MSG_RESULT at the end of the script
-#    fi
+    if test "x$have_gnutls" = "xyes" -a "x$with_gnutls" = "xno" -a "x$with_tinydtls" = "xno"; then
+        gnutls_version=`pkg-config --modversion gnutls`
+        AX_CHECK_GNUTLS_VERSION
+        AC_MSG_NOTICE([Using auto selected library GnuTLS for DTLS support!])
+        with_gnutls_auto="yes"
+        have_openssl="no" # don't confuse AC_MSG_RESULT at the end of the script
+    fi
 
     # ... and if not found check OpenSSL is suitable.
-#    if test "x$have_openssl" = "xyes" -a "x$with_openssl" = "xno" -a "x$with_gnutls_auto" = "x" -a "x$with_tinydtls" = "xno"; then
-    if test "x$have_openssl" = "xyes" -a "x$with_openssl" = "xno" -a "x$with_tinydtls" = "xno"; then
+    if test "x$have_openssl" = "xyes" -a "x$with_openssl" = "xno" -a "x$with_gnutls_auto" = "x" -a "x$with_tinydtls" = "xno"; then
         openssl_version=`pkg-config --modversion openssl`
         AX_CHECK_OPENSSL_VERSION
         AC_MSG_NOTICE([Using auto selected library OpenSSL for DTLS support!])
@@ -430,12 +428,9 @@ if test "x$build_dtls" = "xyes"; then
     # Note that tinyDTLS is used only when explicitly requested.
 
     # Giving out an error message if we haven't found at least one crypto library.
-#    if test "x$have_gnutls" = "xno" -a "x$have_openssl" = "xno" -a "x$have_tinydtls" != "xno"; then
-#        AC_MSG_ERROR([==> Option '--enable-dtls' is set but one of the needed cryptography library GnuTLS nor OpenSSL nor tinyDTLS could be found!
-#                      Install at least one of the package(s) that contains the development files for GnuTLS (>= $gnutls_version_required) or OpenSSL(>= $openssl_version_required)
-    if test "x$have_openssl" = "xno" -a "x$have_tinydtls" != "xno"; then
-        AC_MSG_ERROR([==> Option '--enable-dtls' is set but none of the needed cryptography libraries OpenSSL nor tinyDTLS could be found!
-                      Install at least one of the package(s) that contains the development files for OpenSSL(>= $openssl_version_required)
+    if test "x$have_gnutls" = "xno" -a "x$have_openssl" = "xno" -a "x$have_tinydtls" != "xno"; then
+        AC_MSG_ERROR([==> Option '--enable-dtls' is set but one of the needed cryptography library GnuTLS nor OpenSSL nor tinyDTLS could be found!
+                      Install at least one of the package(s) that contains the development files for GnuTLS (>= $gnutls_version_required) or OpenSSL(>= $openssl_version_required)
                       or disable the DTLS support using '--disable-dtls'.])
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -301,7 +301,7 @@ AM_CONDITIONAL(BUILD_MANPAGES, [test "x$build_manpages" = "xyes"])
 # If the user isn't using a selection we first search for GnuTLS and fallback
 # to OpenSSL if the GnuTLS library couldn't be found.
 
-gnutls_version_required=3.2.0
+gnutls_version_required=3.3.0
 openssl_version_required=1.1.0
 
 AC_ARG_ENABLE([dtls],

--- a/examples/client.c
+++ b/examples/client.c
@@ -523,13 +523,15 @@ message_handler(struct coap_context_t *ctx,
 static void
 usage( const char *program, const char *version) {
   const char *p;
+  char buffer[64];
 
   p = strrchr( program, '/' );
   if ( p )
     program = ++p;
 
   fprintf( stderr, "%s v%s -- a small CoAP implementation\n"
-     "(c) 2010-2015 Olaf Bergmann <bergmann@tzi.org>\n\n"
+     "(c) 2010-2018 Olaf Bergmann <bergmann@tzi.org>\n\n"
+     "%s\n\n"
      "Usage: %s [-a addr] [-b [num,]size] [-c certfile] [-C cafile] [-e text]\n"
      "\t\t[-f file] [-k key] [-l loss] [-m method] [-o file]\n"
      "\t\t[-p port] [-r] [-s duration] [-t type]  [-u user]\n"
@@ -591,7 +593,8 @@ usage( const char *program, const char *version) {
      "\tcoap-client -m get coap://[::1]/.well-known/core\n"
      "\tcoap-client -m get -T cafe coap://[::1]/time\n"
      "\techo -n 1000 | coap-client -m put -T cafe coap://[::1]/time -f -\n"
-     ,program, version, program, wait_seconds);
+     ,program, version, coap_string_tls_version(buffer, sizeof(buffer))
+     ,program, wait_seconds);
 }
 
 typedef struct {

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -552,6 +552,7 @@ init_resources(coap_context_t *ctx) {
 static void
 usage( const char *program, const char *version) {
   const char *p;
+  char buffer[64];
 
   p = strrchr( program, '/' );
   if ( p )
@@ -559,11 +560,13 @@ usage( const char *program, const char *version) {
 
   fprintf( stderr, "%s v%s -- CoRE Resource Directory implementation\n"
      "(c) 2011-2012 Olaf Bergmann <bergmann@tzi.org>\n\n"
+     "%s\n\n"
      "usage: %s [-A address] [-p port]\n\n"
      "\t-A address\tinterface address to bind to\n"
      "\t-p port\t\tlisten on specified port\n"
      "\t-v num\t\tverbosity level (default: 3)\n",
-     program, version, program );
+     program, version, coap_string_tls_version(buffer, sizeof(buffer)),
+     program);
 }
 
 static coap_context_t *

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -926,6 +926,7 @@ main(int argc, char **argv) {
   coap_log_t log_level = LOG_WARNING;
   unsigned wait_ms;
   time_t t_last = 0;
+  struct sigaction sa;
 
   clock_offset = time(NULL);
 
@@ -1001,7 +1002,12 @@ main(int argc, char **argv) {
   if (group)
     join(ctx, group);
 
-  signal(SIGINT, handle_sigint);
+  memset (&sa, 0, sizeof(sa));
+  sigemptyset(&sa.sa_mask);
+  sa.sa_handler = handle_sigint;
+  sa.sa_flags = 0;
+  sigaction (SIGINT, &sa, NULL);
+  sigaction (SIGTERM, &sa, NULL);
 
   wait_ms = COAP_RESOURCE_CHECK_TIME * 1000;
 

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -709,6 +709,7 @@ fill_keystore(coap_context_t *ctx) {
 static void
 usage( const char *program, const char *version) {
   const char *p;
+  char buffer[64];
 
   p = strrchr( program, '/' );
   if ( p )
@@ -716,6 +717,7 @@ usage( const char *program, const char *version) {
 
   fprintf( stderr, "%s v%s -- a small CoAP implementation\n"
      "(c) 2010,2011,2015-2018 Olaf Bergmann <bergmann@tzi.org>\n\n"
+     "%s\n\n"
      "Usage: %s [-A address] [-g group] [-p port] [-l loss] [-c certfile]\n"
      "\t\t[-C cafile] [-R root_cafile] [-k key] [-h hint] [-N]\n"
      "\t\t[-v num] [-d max]\n\n"
@@ -756,7 +758,8 @@ usage( const char *program, const char *version) {
      "\t-d max \t\tAllow dynamic creation of up to a total of max resources.\n"
      "\t       \t\tIf max is reached, a 4.06 code is returned until one of the\n"
      "\t       \t\tdynamic resources has been deleted\n",
-    program, version, program );
+    program, version, coap_string_tls_version(buffer, sizeof(buffer)),
+    program);
 }
 
 static coap_context_t *

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -688,6 +688,7 @@ main(int argc, char **argv) {
   char port_str[NI_MAXSERV] = "5683";
   int opt;
   coap_log_t log_level = LOG_WARNING;
+  struct sigaction sa;
 
   while ((opt = getopt(argc, argv, "A:p:v:")) != -1) {
     switch (opt) {
@@ -718,7 +719,12 @@ main(int argc, char **argv) {
 
   init_resources(ctx);
 
-  signal(SIGINT, handle_sigint);
+  memset (&sa, 0, sizeof(sa));
+  sigemptyset(&sa.sa_mask);
+  sa.sa_handler = handle_sigint;
+  sa.sa_flags = 0;
+  sigaction (SIGINT, &sa, NULL);
+  sigaction (SIGTERM, &sa, NULL);
 
   while ( !quit ) {
     FD_ZERO(&readfds);

--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -45,8 +45,9 @@ int coap_tls_is_supported(void);
  * information.
  */
 typedef struct coap_tls_version_t {
-  uint64_t version; /**< (D)TLS Library Version */
+  uint64_t version; /**< (D)TLS runtime Library Version */
   int type; /**< Library type. One of COAP_TLS_LIBRARY_* */
+  uint64_t built_version; /**< (D)TLS Built against Library Version */
 } coap_tls_version_t;
 
 /**

--- a/include/coap2/debug.h
+++ b/include/coap2/debug.h
@@ -145,6 +145,24 @@ void coap_set_show_pdu_output(int use_fprintf);
  */
 void coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu);
 
+/**
+ * Display the current (D)TLS library linked with and built for version.
+ *
+ * @param level The required minimum logging level.
+ */
+void coap_show_tls_version(coap_log_t level);
+
+/**
+ * Build a string containing the current (D)TLS library linked with and
+ * built for version.
+ *
+ * @param buffer The buffer to put the string into.
+ * @param bufsize The size of the buffer to put the string into.
+ *
+ * @return A pointer to the provided buffer.
+ */
+char *coap_string_tls_version(char *buffer, size_t bufsize);
+
 struct coap_address_t;
 
 /**

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -173,11 +173,13 @@ global:
   coap_set_log_level;
   coap_set_show_pdu_output;
   coap_show_pdu;
+  coap_show_tls_version;
   coap_socket_strerror;
   coap_split_path;
   coap_split_query;
   coap_split_uri;
   coap_startup;
+  coap_string_tls_version;
   coap_subscription_init;
   coap_ticks;
   coap_ticks_from_rt_us;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -171,11 +171,13 @@ coap_set_log_handler
 coap_set_log_level
 coap_set_show_pdu_output
 coap_show_pdu
+coap_show_tls_version
 coap_socket_strerror
 coap_split_path
 coap_split_query
 coap_split_uri
 coap_startup
+coap_string_tls_version
 coap_subscription_init
 coap_ticks
 coap_ticks_from_rt_us

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -109,7 +109,8 @@ OPTIONS
    This argument requires (D)TLS with PSK to be available.
 
 *-v* num::
-   The verbosity level to use (default: 3, maximum is 9).
+   The verbosity level to use (default: 3, maximum is 9). Above 7, there is
+   increased verbosity in GnuTLS logging.
 
 *-A* type::
    Accepted media type. 'type' must be either a numeric value reflecting a

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -34,7 +34,8 @@ OPTIONS
    The default port is 5683 if not given any other value.
 
 *-v* num::
-   The verbosity level to use (default: 3, maximum is 9).
+   The verbosity level to use (default: 3, maximum is 9). Above 7, there is
+   increased verbosity in GnuTLS logging.
 
 EXAMPLES
 --------

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -82,7 +82,8 @@ OPTIONS
    all datagrams, 0% no datagrams (debugging only).
 
 *-v* num::
-   The verbosity level to use (default: 3, maximum is 9).
+   The verbosity level to use (default: 3, maximum is 9). Above 7, there is
+   increased verbosity in GnuTLS logging.
 
 *-d* max::
    Enable support for creation of dynamic resources when doing a PUT up to a

--- a/man/coap_attribute.txt.in
+++ b/man/coap_attribute.txt.in
@@ -23,8 +23,9 @@ SYNOPSIS
 *coap_attr_t *coap_find_attr(coap_resource_t *_resource_, coap_str_const_t
 *_name_);*
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -40,8 +40,9 @@ const coap_address_t *_listen_addr_, coap_proto_t _proto_);*
 *void coap_endpoint_set_default_mtu(coap_endpoint_t *_endpoint_,
 unsigned _mtu_);*
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -19,8 +19,9 @@ SYNOPSIS
 
 *struct coap_dtls_pki_t*
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION
@@ -37,7 +38,14 @@ as detect what is the version of the currently loaded TLS library.
 *NOTE:* If OpenSSL is being used, then the minimum supported OpenSSL library
 version is 1.1.0.
 
-Network traffic can be encrypted or un-encrypted with libcoap if there is an
+*NOTE:* If GnuTLS is being used, then the minimum GnuTLS library version is
+3.3.0.
+
+*NOTE:* If GnuTLS is going to interoperate with TinyDTLS, then a minimum
+revision of GnuTLS 3.5.5 which supports CCM algorithms is required
+by TinyDTLS as TinyDTLS currently only supports CCM.
+
+Network traffic can be un-encrypted or encrypted with libcoap if there is an
 underlying TLS library.
 
 If TLS is going to be used for encrypting the network traffic, then the TLS
@@ -53,7 +61,7 @@ will not get built until the new traffic starts, which is done by the libcoap
 library, with the session having a reference count of 1.
 
 For Clients, all the encryption information can be held at the TLS Context and
-CoAP Context levels, or at the TLS Session and CoAP Session levels.  If
+CoAP Context levels, or usually at the TLS Session and CoAP Session levels.  If
 defined at the Context level, then when Sessions are created, they will
 inherit the Context definitions, unless they have separately been defined for
 the Session level, in which case the Session version will get used.
@@ -92,24 +100,22 @@ to provide a PSK.  The Server must have a Hint defined and the Client must
 have an Identity defined.
 
 For PKI setup, if the libcoap PKI configuration options do not handle a specific
-requirement, then an application defined Callback can called to do the
-specific checks.  If Application Callback is defined, then none of the libcoap
-layer Callback checking takes place and it is the responsibility
-of the Application Callback to do all of the checks.
+requirement as defined by the available options, then an application defined
+Callback can called to do the additional specific checks.
 
-The information passed to this Application Callback will be the TLS context and
+The information passed to this Application Callback will be the
 TLS session (as well the configuration information), but the structures
 containing this information will be different as they will be based on the
 underlying TLS library type. coap_get_tls_library_version() is provided to help
 here.
 
-Whether Application Callback is defined or not, libcoap will add in the defined
-Certificate, Private Key and CA Certificate into the TLS environment.  The CA
-Certificate is also added in to the list of valid CAs for Certificate checking.
+Libcoap will add in the defined Certificate, Private Key and CA Certificate
+into the TLS environment.  The CA Certificate is also added in to the list of
+valid CAs for Certificate checking.
 
-Then either Application Callback is called or the internal libcoap Callbacks are
-called.  The internal Callbacks (if no Application Callback) will then check the
-required information as defined in the coap_dtls_pki_t described below.
+The internal Callbacks (and optionally the Application Callback) will then
+check the required information as defined in the coap_dtls_pki_t described
+below.
 
 [source, c]
 ----
@@ -144,10 +150,11 @@ typedef struct coap_dtls_pki_t {
   coap_dtls_sni_callback_t validate_sni_call_back;
   void *sni_call_back_arg;  /* Passed in to the sni call-back function */
 
-  /** Application Setup call-back definition
-   * If not NULL, then application is handling the characteristics of the TLS
-   * connection setup in the defined call-back handler.  If set, then none of
-   * the options or call-backs above are acted on. */
+  /** Addtional Security call-back handler that is invoked when libcoap has
+   * done the standerd, defined validation checks at the TLS level,
+   * If not NULL, called from within the TLS Client Hello connection
+   * setup.
+   */
   coap_dtls_security_setup_t additional_tls_setup_call_back;
 
   char* client_sni;       /* If not NULL, SNI to use in client TLS setup.
@@ -175,7 +182,7 @@ enabled.
 ----
 
 *version* is set to COAP_DTLS_PKI_SETUP_VERSION.  This will then allow support
-different for different versions of the coap_dtls_pki_t structure in the future.
+for different versions of the coap_dtls_pki_t structure in the future.
 
 *SECTION: Peer Certificate Checking*
 

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -10,8 +10,8 @@ coap_handler(3)
 
 NAME
 ----
-coap_handler, coap_register_handler, coap_register_response_handler, 
-coap_register_nack_handler, coap_register_ping_handler, 
+coap_handler, coap_register_handler, coap_register_response_handler,
+coap_register_nack_handler, coap_register_ping_handler,
 coap_register_pong_handler, coap_register_event_handler
 - work with CoAP handlers
 
@@ -34,11 +34,12 @@ coap_ping_handler_t _handler_)*;
 *void coap_register_pong_handler(coap_context_t *_context_,
 coap_pong_handler_t _handler_)*;
 
-*void coap_register_event_handler(coap_context_t *_context_, 
+*void coap_register_event_handler(coap_context_t *_context_,
 coap_event_handler_t _handler_)*;
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION
@@ -69,9 +70,9 @@ typedef void (*coap_method_handler_t)(coap_context_t *context,
                                       coap_pdu_t *response_pdu);
 ----
 
-The *coap_register_response_handler*() function defines a request's response 
-_handler_ for traffic associated with the _context_.  The application can use 
-this for handling any response packets, including sending a RST packet if this 
+The *coap_register_response_handler*() function defines a request's response
+_handler_ for traffic associated with the _context_.  The application can use
+this for handling any response packets, including sending a RST packet if this
 response was unexpected.  If _handler_ is NULL, then the handler is
 de-registered.
 
@@ -99,7 +100,7 @@ typedef void (*coap_nack_handler_t)(coap_context_t *context,
                                     const coap_tid_t id);
 ----
 
-The *coap_register_ping_handler*() function defines a _handler_ for tracking 
+The *coap_register_ping_handler*() function defines a _handler_ for tracking
 CoAP ping traffic associated with the _context_. If _handler_ is NULL, then
 the handler is de-registered.
 

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -43,8 +43,9 @@ SYNOPSIS
 
 *const char *coap_session_str(const coap_session_t *_session_);*
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION
@@ -63,28 +64,28 @@ Logging levels (*coap_log_t*) are defined by (the same as for *syslog*()), which
 are numerically incrementing in value:
 
 *LOG_EMERG*::
-Emergency level.
+Emergency level (0).
 
 *LOG_ALERT*::
-Alert level.
+Alert level (1).
 
 *LOG_CRIT*::
-Critical level.
+Critical level (2).
 
 *LOG_ERR*::
-Error level.
+Error level (3).
 
 *LOG_WARNING*::
-Warning level (the default).
+Warning level (the default) (4).
 
 *LOG_NOTICE*::
-Notice level.
+Notice level (5).
 
 *LOG_INFO*::
-Information level.
+Information level (6).
 
 *LOG_DEBUG*::
-Debug level.
+Debug level (7).
 
 The *coap_set_log_level*() function is used to set the current logging _level_
 for output by any subsequent *coap_log*() calls.  Output is only logged if the
@@ -96,7 +97,8 @@ The *coap_get_log_level*() function is used to get the current logging level.
 The *coap_dtls_set_log_level*() function is used to set the logging _level_
 for output by the DTLS library for specific DTLS information. Usually, both
 *coap_set_log_level*() and *coap_dtls_set_log_level*() would be set to the
-same _level_ value.
+same _level_ value. If the logging level is set to greater than LOG_DEBUG,
+the underlying TLS library may get more verbose in its output.
 
 The *coap_dtls_get_log_level*() function is used to get the current logging
 level for the DTLS library.

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -10,7 +10,7 @@ coap_observe(3)
 
 NAME
 ----
-coap_observe, coap_resource_set_get_observable, coap_resource_notify_observers, 
+coap_observe, coap_resource_set_get_observable, coap_resource_notify_observers,
 coap_resource_get_uri_path, coap_find_observer, coap_delete_observer,
 coap_delete_observers - work with CoAP observe
 
@@ -34,8 +34,9 @@ const coap_binary_t *_token_);*
 
 *void coap_delete_observers(coap_context_t *_context_, coap_session_t *_session_);*
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION
@@ -61,11 +62,11 @@ notify the client that the subscription has been removed.
 The underlying library adds in and removes "subscribers" to the resource as
 appropriate in the server side logic.
 
-Within the server application, it needs to determine that there is a change of 
-state of the resource under observation, and then cause the CoAP library 
-layer to initiate a "fake GET request" so that an observe GET response 
-gets sent back to all the clients that are observing the resource.  The 
-appropriate GET handler within the server application is called to fill in the 
+Within the server application, it needs to determine that there is a change of
+state of the resource under observation, and then cause the CoAP library
+layer to initiate a "fake GET request" so that an observe GET response
+gets sent back to all the clients that are observing the resource.  The
+appropriate GET handler within the server application is called to fill in the
 response packet with the appropriate information. This "fake GET request" is
 triggered by a call to *coap_resource_notify_observers*().
 
@@ -73,10 +74,10 @@ The call to *coap_run_once*() in the main server application i/o loop will do
 all the necessary processing of sending any outstanding "fake GET requests".
 
 Whenever the server sends a copy of the state of the "observed" resource to
-the client, it will use the same token used by the client when the client 
+the client, it will use the same token used by the client when the client
 requested the "observe".  The client will receive this observe response
-in the handler defined by *coap_register_response_handler*(3).  It is the 
-responsibility of the client application to match the supplied token and 
+in the handler defined by *coap_register_response_handler*(3).  It is the
+responsibility of the client application to match the supplied token and
 update the appropriate internal information.
 
 The *coap_resource_set_get_observable*() function enables or disables the
@@ -84,7 +85,7 @@ observable status of the _resource_ by the setting of _mode_.  If _mode_ is
 1, then the _resource_ is observable.  If _mode_ is 0, then the
 _resource_ is no longer observable.
 
-*NOTE:* It is not possible for the Unknown Resource, created by 
+*NOTE:* It is not possible for the Unknown Resource, created by
 *coap_resource_unknown_init*(3), to be observable as the Uri-Path is not known
 when libcoap creates a "fake GET request".  The Unknown Resource PUT
 handler must create a new resource and mark the resource as "observable" if
@@ -101,8 +102,8 @@ confirmable, when generally sending non-confirmable,  every 24 hours.
 libcoap handles this by sending every fifth (COAP_OBS_MAX_NON) response as a
 confirmable response for detection that the client is still responding.
 
-The *coap_resource_notify_observers*() function needs to be called whenever the 
-server application determines that there has been a change to the state of 
+The *coap_resource_notify_observers*() function needs to be called whenever the
+server application determines that there has been a change to the state of
 _resource_, possibly only matching a specific _query_ if _query_ is not NULL.
 
 The *coap_resource_get_uri_path*() function is used to obtain the UriPath of

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -53,8 +53,9 @@ size_t *_buflen_);*
 *int coap_split_query(const uint8_t *_query_, size_t _length_, uint8_t *_buffer_,
 size_t *_buflen_);*
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_recovery.txt.in
+++ b/man/coap_recovery.txt.in
@@ -38,8 +38,9 @@ coap_fixed_point_t _value_)*;
 
 *int coap_debug_set_packet_loss(const char *_loss_level_)*;
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION
@@ -132,7 +133,7 @@ To see what is happening (other than by sniffing the network traffic), the
 logging level needs to be set to LOG_DEBUG in the client by using
 coap_set_log_level(LOG_DEBUG) and coap_dtls_set_log_level(LOG_DEBUG).
 
-The client needs to be sending confirmable requests during the test. 
+The client needs to be sending confirmable requests during the test.
 
 The server can either be stopped, or if packet loss levels are set to 100% by
 using coap_debug_set_packet_loss("100%") when receiving the client requests.

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -10,8 +10,8 @@ coap_resource(3)
 
 NAME
 ----
-coap_resource, coap_resource_init, coap_resource_unknown_init, 
-coap_add_resource, coap_delete_resource, coap_delete_all_resources, 
+coap_resource, coap_resource_init, coap_resource_unknown_init,
+coap_add_resource, coap_delete_resource, coap_delete_all_resources,
 coap_resource_set_mode - Work with CoAP resources
 
 SYNOPSIS
@@ -34,8 +34,9 @@ coap_resource_t _resource_);*
 
 *void coap_resource_set_mode(coap_resource_t *_resource_, int _mode_);*
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION
@@ -68,9 +69,9 @@ CoAP Observe (RFC 7641) is not supported for unknown resources, so a new
 resource with GET handler must be created by the unknown resource callback
 handle matching the URI which then can be Observable.
 
-The *coap_resource_init*() function returns a newly created _resource_ of 
-type _coap_resource_t_ * .  _uri_path_ specifies the uri string path to match 
-against.  _flags_ is used to define whether the 
+The *coap_resource_init*() function returns a newly created _resource_ of
+type _coap_resource_t_ * .  _uri_path_ specifies the uri string path to match
+against.  _flags_ is used to define whether the
 _resource_ is of type Confirmable Message or Non-Confirmable Message for
 any "observe" responses.  See *coap_observe*(3).
 _flags_ can be one of the following definitions or'ed together.

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -50,8 +50,9 @@ _proto_, coap_dtls_pki_t *_setup_data_);*
 
 *const char *coap_session_str(const coap_session_t *_session_);*
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -11,7 +11,7 @@ coap_tls_library(3)
 NAME
 ----
 coap_tls_library, coap_dtls_is_supported, coap_tls_is_supported,
-coap_get_tls_library_version
+coap_get_tls_library_version, coap_string_tls_version, coap_show_tls_version
 - Work with CoAP contexts
 
 SYNOPSIS
@@ -24,14 +24,19 @@ SYNOPSIS
 
 *coap_tls_version_t *coap_get_tls_library_version(void);*
 
-Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-openssl*
-or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*char *coap_string_tls_version(char *_buffer_, size_t _bufsize_);
+
+*void coap_show_tls_version(coap_log_t _level_);*
+
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION
 -----------
 When the libcoap library was built, it will have been compiled using a
-specific TLS implementation type (e.g. OpenSSL, GnuTLS, TinyDTLS or noTLS). 
+specific TLS implementation type (e.g. OpenSSL, GnuTLS, TinyDTLS or noTLS).
 When the libcoap library is linked into an application, it is possible that
 the application needs to dynamically determine whether DTLS or TLS is
 supported, what type of TLS implementation libcoap was compiled with, as well
@@ -40,12 +45,19 @@ as detect what is the version of the currently loaded TLS library is.
 *NOTE:* If OpenSSL is being used, then the minimum OpenSSL library version is
 1.1.0.
 
-Network traffic can be encrypted or un-encrypted with libcoap - how to set 
+*NOTE:* If GnuTLS is being used, then the minimum GnuTLS library version is
+3.3.0.
+
+*NOTE:* If GnuTLS is going to interoperate with TinyDTLS, then a minimum
+revision of GnuTLS 3.5.5 which supports CCM algorithms is required
+by TinyDTLS as TinyDTLS currently only supports CCM.
+
+Network traffic can be encrypted or un-encrypted with libcoap - how to set
 this up is described in *coap_context*(3).
 
 Due to the nature of TLS, there can be Callbacks that are invoked as the TLS
 session negotiates encryption algorithms, encryption keys etc.
-Where possible, by default, the CoAP layer handles all this automatically. 
+Where possible, by default, the CoAP layer handles all this automatically.
 However, there is the flexibility of the Callbacks for imposing additional
 security checks etc. when PKI is being used.  These callbacks need to need to
 match the TLS implementation type.
@@ -59,6 +71,17 @@ enabled, otherwise 0;
 The *coap_get_tls_library_version*() function returns the TLS implementation
 type and library version in a coap_tls_version_t* structure.
 
+The *coap_string_tls_version*() function is used to update the provided buffer
+with information about the current (D)TLS library that libcoap was built
+against, as well as the current linked version of the (D)TLS library.
+_buffer_ defines the buffer to provide the information and _bufsize_ is the
+size of _buffer_.
+
+The *coap_show_tls_version*() function is used log information about the
+current (D)TLS library that libcoap was built against, as well as the current
+linked version of the (D)TLS library. _level_ defines the minimum logging level
+for this information to be output using coap_log().
+
 [source, c]
 ----
 #define COAP_TLS_LIBRARY_NOTLS    0
@@ -67,22 +90,25 @@ type and library version in a coap_tls_version_t* structure.
 #define COAP_TLS_LIBRARY_GNUTLS   3
 
 typedef struct coap_tls_version_t {
-  uint64_t version; /* Library Version as returned by the TLS library */
-  int type; /* One of COAP_TLS_LIBRARY_* */
+  uint64_t version; /* (D)TLS runtime Library Version */
+  int type; /* Library type. One of COAP_TLS_LIBRARY_* */
+  uint64_t built_version; /* (D)TLS Built against Library Version */
 }
 ----
 
 RETURN VALUES
 -------------
 *coap_dtls_is_supported*() and *coap_tls_is_supported*() functions
-return 0 on failure, 1 on success.
+return 0 if there is no support, 1 if support is available.
 
 *coap_get_tls_library_version*() function returns the TLS implementation type
 and library version in a coap_tls_version_t* structure.
 
+*coap_string_tls_version*() function returns a pointer to the provided buffer.
+
 SEE ALSO
 --------
-*coap_context*(3).
+*coap_context*(3) and *coap_logging*(3).
 
 FURTHER INFORMATION
 -------------------

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,6 +10,8 @@ case "x${TLS}" in
                ;;
     xopenssl)  WITH_TLS="--with-openssl"
                ;;
+    xgnutls)   WITH_TLS="--with-gnutls"
+               ;;
     xtinydtls) WITH_TLS="--with-tinydtls --disable-shared"
                ;;
     *)         WITH_TLS="--with-gnutls"

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -31,6 +31,8 @@ case "x${TLS}" in
                ;;
     xopenssl)  WITH_TLS="--with-openssl"
                ;;
+    xgnutls)   WITH_TLS="--with-gnutls"
+               ;;
     xtinydtls) WITH_TLS="--with-tinydtls --disable-shared"
                ;;
     *)         WITH_TLS="--with-gnutls"

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -1,0 +1,1691 @@
+/*
+ * coap_gnutls.c -- GunTLS Datagram Transport Layer Support for libcoap
+ *
+ * Copyright (C) 2017 Dag Bjorklund <dag.bjorklund@comsel.fi>
+ * Copyright (C) 2018 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/*
+ * Naming used to prevent confusion between coap sessions, gnutls sessions etc.
+ * when reading the code.
+ *
+ * c_context  A coap_context_t *
+ * c_session  A coap_session_t *
+ * g_context  A coap_gnutls_context_t * (held in c_context->dtls_context)
+ * g_session  A gnutls_session_t (which has the * in the typedef)
+ * g_env      A coap_gnutls_env_t * (held in c_session->tls)
+ */
+
+#include "coap_config.h"
+
+#ifdef HAVE_LIBGNUTLS
+
+#define MIN_GNUTLS_VERSION "3.3.0"
+
+#include "net.h"
+#include "mem.h"
+#include "debug.h"
+#include "prng.h"
+#include <inttypes.h>
+#include <stdio.h>
+#include <errno.h>
+#include <gnutls/gnutls.h>
+#include <gnutls/x509.h>
+#include <gnutls/dtls.h>
+#include <unistd.h>
+
+#ifdef __GNUC__
+#define UNUSED __attribute__((unused))
+#else /* __GNUC__ */
+#define UNUSED
+#endif /* __GNUC__ */
+
+typedef struct coap_ssl_t {
+  const uint8_t *pdu;
+  unsigned pdu_len;
+  unsigned peekmode;
+  coap_tick_t timeout;
+} coap_ssl_t;
+
+/*
+ * This structure encapsulates the GnuTLS session object.
+ * It handles both TLS and DTLS.
+ * c_session->tls points to this.
+ */
+typedef struct coap_gnutls_env_t {
+  gnutls_session_t g_session;
+  gnutls_psk_client_credentials_t psk_cl_credentials;
+  gnutls_psk_server_credentials_t psk_sv_credentials;
+  gnutls_certificate_credentials_t pki_credentials;
+  coap_ssl_t coap_ssl_data;
+  /* If not set, need to do gnutls_handshake */
+  int established;
+} coap_gnutls_env_t;
+
+#define IS_PSK (1 << 0)
+#define IS_PKI (1 << 1)
+#define IS_CLIENT (1 << 6)
+#define IS_SERVER (1 << 7)
+
+typedef struct sni_entry {
+  char *sni;
+  coap_dtls_key_t pki_key;
+  gnutls_certificate_credentials_t pki_credentials;
+} sni_entry;
+
+typedef struct coap_gnutls_context_t {
+  coap_dtls_pki_t setup_data;
+  int psk_pki_enabled;
+  size_t sni_count;
+  sni_entry *sni_entry_list;
+  gnutls_datum_t alpn_proto;    /* Will be "coap", but that is a const */
+  char *root_ca_file;
+  char *root_ca_path;
+  gnutls_priority_t priority_cache;
+} coap_gnutls_context_t;
+
+#define VARIANTS "NORMAL:+ECDHE-PSK:+PSK"
+
+#define G_ACTION(xx) do { \
+  ret = (xx); \
+} while (ret == GNUTLS_E_AGAIN || ret == GNUTLS_E_INTERRUPTED)
+
+#define G_CHECK(xx,func) do { \
+  if ((ret = (xx)) < 0) { \
+    coap_log(LOG_WARNING, "%s: '%s'\n", func, gnutls_strerror(ret)); \
+    goto fail; \
+  } \
+} while (0)
+
+#define G_ACTION_CHECK(xx,func) do { \
+  G_ACTION(xx); \
+  G_CHECK(xx, func); \
+} while 0
+
+static int dtls_log_level = 0;
+
+static int post_client_hello_gnutls(gnutls_session_t g_session);
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_is_supported(void) {
+  if (gnutls_check_version(MIN_GNUTLS_VERSION) == NULL) {
+    coap_log(LOG_ERR, "GnuTLS " MIN_GNUTLS_VERSION " or later is required\n");
+    return 0;
+  }
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_tls_is_supported(void) {
+  if (gnutls_check_version(MIN_GNUTLS_VERSION) == NULL) {
+    coap_log(LOG_ERR, "GnuTLS " MIN_GNUTLS_VERSION " or later is required\n");
+    return 0;
+  }
+  return 1;
+}
+
+coap_tls_version_t *
+coap_get_tls_library_version(void) {
+  static coap_tls_version_t version;
+  const char *vers = gnutls_check_version(NULL);
+
+  version.version = 0;
+  if (vers) {
+    int p1, p2, p3;
+
+    sscanf (vers, "%d.%d.%d", &p1, &p2, &p3);
+    version.version = (p1 << 16) | (p2 << 8) | p3;
+  }
+  version.built_version = GNUTLS_VERSION_NUMBER;
+  version.type = COAP_TLS_LIBRARY_GNUTLS;
+  return &version;
+}
+
+static void
+coap_gnutls_audit_log_func(gnutls_session_t g_session, const char* text)
+{
+  coap_session_t *c_session =
+                  (coap_session_t *)gnutls_transport_get_ptr(g_session);
+  coap_log(LOG_WARNING, "** %s: %s", coap_session_str(c_session), text);
+}
+
+static void
+coap_gnutls_log_func(int level, const char* text)
+{
+  /* debug logging in gnutls starts at 2 */
+  if (level > 2)
+    level = 2;
+  coap_log(LOG_DEBUG + level - 2, "%s", text);
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_context_set_pki(coap_context_t *c_context,
+                          coap_dtls_pki_t* setup_data,
+                          int role UNUSED)
+{
+  coap_gnutls_context_t *g_context =
+                         ((coap_gnutls_context_t *)c_context->dtls_context);
+
+  if (!g_context || !setup_data)
+    return 0;
+
+  g_context->setup_data = *setup_data;
+  g_context->psk_pki_enabled |= IS_PKI;
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_context_set_pki_root_cas(struct coap_context_t *c_context,
+                                   const char *ca_file,
+                                   const char *ca_path)
+{
+  coap_gnutls_context_t *g_context =
+                         ((coap_gnutls_context_t *)c_context->dtls_context);
+  if (!g_context) {
+    coap_log(LOG_WARNING,
+             "coap_context_set_pki_root_cas: (D)TLS environment "
+             "not set up\n");
+    return 0;
+  }
+
+  if (ca_file == NULL && ca_path == NULL) {
+    coap_log(LOG_WARNING,
+             "coap_context_set_pki_root_cas: ca_file and/or ca_path "
+             "not defined\n");
+    return 0;
+  }
+  if (g_context->root_ca_file) {
+    gnutls_free(g_context->root_ca_file);
+    g_context->root_ca_file = NULL;
+  }
+  if (ca_file) {
+    g_context->root_ca_file = gnutls_strdup(ca_file);
+  }
+  if (g_context->root_ca_path) {
+    gnutls_free(g_context->root_ca_path);
+    g_context->root_ca_path = NULL;
+  }
+  if (ca_path) {
+#if (GNUTLS_VERSION_NUMBER >= 0x030306)
+    g_context->root_ca_path = gnutls_strdup(ca_path);
+#else
+    coap_log(LOG_ERR, "ca_path not supported in GnuTLS < 3.3.6\n");
+#endif
+  }
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_context_set_psk(coap_context_t *c_context,
+                          const char *identity_hint UNUSED,
+                          int role UNUSED
+) {
+  coap_gnutls_context_t *g_context =
+                         ((coap_gnutls_context_t *)c_context->dtls_context);
+
+  g_context->psk_pki_enabled |= IS_PSK;
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_context_check_keys_enabled(coap_context_t *c_context)
+{
+  coap_gnutls_context_t *g_context =
+                         ((coap_gnutls_context_t *)c_context->dtls_context);
+  return g_context->psk_pki_enabled ? 1 : 0;
+}
+
+void coap_dtls_startup(void) {
+  gnutls_global_set_audit_log_function(coap_gnutls_audit_log_func);
+  gnutls_global_set_log_function(coap_gnutls_log_func);
+}
+
+void
+coap_dtls_set_log_level(int level) {
+  dtls_log_level = level;
+  if (level - LOG_DEBUG >= -2) {
+    /* debug logging in gnutls starts at 2 */
+    gnutls_global_set_log_level(2 + level - LOG_DEBUG);
+  }
+  else {
+    gnutls_global_set_log_level(0);
+  }
+}
+
+/*
+ * return current logging level
+ */
+int
+coap_dtls_get_log_level(void) {
+  return dtls_log_level;
+}
+
+/*
+ * return +ve  new g_context
+ *        NULL failure
+ */
+void *
+coap_dtls_new_context(struct coap_context_t *c_context UNUSED) {
+  const char *err;
+  int ret;
+  struct coap_gnutls_context_t *g_context =
+                                (struct coap_gnutls_context_t *)
+                                gnutls_malloc(sizeof(coap_gnutls_context_t));
+
+  if (g_context) {
+    G_CHECK(gnutls_global_init(), "gnutls_global_init");
+    memset(g_context, 0, sizeof(struct coap_gnutls_context_t));
+    g_context->alpn_proto.data = gnutls_malloc(4);
+    if (g_context->alpn_proto.data) {
+      memcpy(g_context->alpn_proto.data, "coap", 4);
+      g_context->alpn_proto.size = 4;
+    }
+    G_CHECK(gnutls_priority_init(&g_context->priority_cache, VARIANTS, &err),
+            "gnutls_priority_init");
+  }
+  return g_context;
+
+fail:
+  if (g_context)
+    coap_dtls_free_context(g_context);
+  return NULL;
+}
+
+void
+coap_dtls_free_context(void *handle) {
+  size_t i;
+  coap_gnutls_context_t *g_context = (coap_gnutls_context_t *)handle;
+
+  gnutls_free(g_context->alpn_proto.data);
+  gnutls_free(g_context->root_ca_file);
+  gnutls_free(g_context->root_ca_path);
+  for (i = 0; i < g_context->sni_count; i++) {
+    gnutls_free(g_context->sni_entry_list[i].sni);
+    if (g_context->psk_pki_enabled & IS_PKI) {
+      gnutls_certificate_free_credentials(
+          g_context->sni_entry_list[i].pki_credentials);
+    }
+  }
+  if (g_context->sni_count)
+    gnutls_free(g_context->sni_entry_list);
+
+  gnutls_priority_deinit(g_context->priority_cache);
+
+  gnutls_global_deinit();
+  gnutls_free(g_context);
+}
+
+/*
+ * gnutls_psk_client_credentials_function return values
+ * (see gnutls_psk_set_client_credentials_function())
+ *
+ * return -1 failed
+ *         0 passed
+ */
+static int
+psk_client_callback(gnutls_session_t g_session,
+                    char **username, gnutls_datum_t *key) {
+  coap_session_t *c_session =
+                  (coap_session_t *)gnutls_transport_get_ptr(g_session);
+  uint8_t identity[64];
+  size_t identity_len;
+  uint8_t psk_key[64];
+  size_t psk_len;
+
+  if (c_session == NULL || c_session->context == NULL ||
+      c_session->context->get_client_psk == NULL) {
+    return -1;
+  }
+
+  psk_len = c_session->context->get_client_psk(c_session,
+                                               NULL,
+                                               0,
+                                               identity,
+                                               &identity_len,
+                                               sizeof (identity) - 1,
+                                               psk_key,
+                                               sizeof(psk_key));
+  if (identity_len < sizeof (identity))
+    identity[identity_len] = 0;
+
+  *username = gnutls_malloc(identity_len+1);
+  memcpy(*username, identity, identity_len+1);
+
+  key->data = gnutls_malloc(psk_len);
+  memcpy(key->data, psk_key, psk_len);
+  key->size = psk_len;
+
+  return 0;
+}
+
+/*
+ * return +ve  SAN or CN derived from certificate
+ *        NULL failed
+ */
+static char* get_san_or_cn(gnutls_session_t g_session)
+{
+  unsigned int cert_list_size = 0;
+  const gnutls_datum_t *cert_list;
+  gnutls_x509_crt_t cert;
+  char dn[256];
+  size_t size;
+  int n;
+  char *cn;
+  int ret;
+
+  if (gnutls_certificate_type_get(g_session) != GNUTLS_CRT_X509)
+    return NULL;
+
+  cert_list = gnutls_certificate_get_peers(g_session, &cert_list_size);
+  if (cert_list_size == 0) {
+    return NULL;
+  }
+
+  G_CHECK(gnutls_x509_crt_init(&cert), "gnutls_x509_crt_init");
+
+  /* Interested only in first cert in chain */
+  G_CHECK(gnutls_x509_crt_import(cert, &cert_list[0], GNUTLS_X509_FMT_DER),
+          "gnutls_x509_crt_import");
+
+  size = sizeof(dn) -1;
+  /* See if there is a Subject Alt Name first */
+  ret = gnutls_x509_crt_get_subject_alt_name(cert, 0, dn, &size, NULL);
+  if (ret >= 0) {
+    dn[size] = '\000';
+    gnutls_x509_crt_deinit(cert);
+    return gnutls_strdup(dn);
+  }
+
+  size = sizeof(dn);
+  G_CHECK(gnutls_x509_crt_get_dn(cert, dn, &size), "gnutls_x509_crt_get_dn");
+
+  gnutls_x509_crt_deinit(cert);
+
+  /* Need to emulate strcasestr() here.  Looking for CN= */
+  n = strlen(dn) - 3;
+  cn = dn;
+  while (n > 0) {
+    if (((cn[0] == 'C') || (cn[0] == 'c')) &&
+        ((cn[1] == 'N') || (cn[1] == 'n')) &&
+        (cn[2] == '=')) {
+      cn += 3;
+      break;
+    }
+    cn++;
+    n--;
+  }
+  if (n > 0) {
+    char *ecn = strchr(cn, ',');
+    if (ecn) {
+      cn[ecn-cn] = '\000';
+    }
+    return gnutls_strdup(cn);
+  }
+  return NULL;
+
+fail:
+  return NULL;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+static int cert_verify_gnutls(gnutls_session_t g_session)
+{
+  unsigned int status = 0;
+  coap_session_t *c_session =
+                (coap_session_t *)gnutls_transport_get_ptr(g_session);
+  coap_gnutls_context_t *g_context =
+             (coap_gnutls_context_t *)c_session->context->dtls_context;
+  char *cn = NULL;
+  int alert = GNUTLS_A_BAD_CERTIFICATE;
+  int ret;
+
+  G_CHECK(gnutls_certificate_verify_peers(g_session, NULL, 0, &status),
+          "gnutls_certificate_verify_peers");
+
+  cn = get_san_or_cn(g_session);
+
+  if (status) {
+    status &= ~(GNUTLS_CERT_INVALID);
+    if (status & (GNUTLS_CERT_NOT_ACTIVATED|GNUTLS_CERT_EXPIRED)) {
+      if (g_context->setup_data.allow_expired_certs) {
+        status &= ~(GNUTLS_CERT_NOT_ACTIVATED|GNUTLS_CERT_EXPIRED);
+        coap_log(LOG_WARNING,
+                 "   %s: %s: overridden: '%s'\n",
+                 coap_session_str(c_session),
+                 "The certificate has an invalid usage date", cn ? cn : "?");
+      }
+    }
+    if (status & (GNUTLS_CERT_REVOCATION_DATA_SUPERSEDED|
+                  GNUTLS_CERT_REVOCATION_DATA_ISSUED_IN_FUTURE)) {
+      if (g_context->setup_data.allow_expired_crl) {
+        status &= ~(GNUTLS_CERT_REVOCATION_DATA_SUPERSEDED|
+                    GNUTLS_CERT_REVOCATION_DATA_ISSUED_IN_FUTURE);
+        coap_log(LOG_WARNING,
+                 "   %s: %s: overridden: '%s'\n",
+                 coap_session_str(c_session),
+                 "The certificate's CRL entry has an invalid usage date",
+                 cn ? cn : "?");
+      }
+    }
+
+    if (status) {
+        coap_log(LOG_WARNING,
+                 "   %s: status 0x%x: '%s'\n",
+                 coap_session_str(c_session),
+                 status, cn ? cn : "?");
+    }
+  }
+
+  if (status)
+    goto fail;
+
+  if (g_context->setup_data.validate_cn_call_back) {
+    unsigned int cert_list_size = 0;
+    const gnutls_datum_t *cert_list;
+    gnutls_x509_crt_t cert;
+    uint8_t der[2048];
+    size_t size;
+
+    cert_list = gnutls_certificate_get_peers(g_session, &cert_list_size);
+    if (cert_list_size == 0) {
+      /* get_san_or_cn() should have caught this */
+      goto fail;
+    }
+
+    G_CHECK(gnutls_x509_crt_init(&cert), "gnutls_x509_crt_init");
+
+    /* Interested only in first cert in chain */
+    G_CHECK(gnutls_x509_crt_import(cert, &cert_list[0], GNUTLS_X509_FMT_DER),
+            "gnutls_x509_crt_import");
+
+    size = sizeof(der);
+    G_CHECK(gnutls_x509_crt_export(cert, GNUTLS_X509_FMT_DER, der, &size),
+            "gnutls_x509_crt_export");
+    gnutls_x509_crt_deinit(cert);
+    if (!g_context->setup_data.validate_cn_call_back(cn,
+           der,
+           size,
+           c_session,
+           0,
+           status ? 0 : 1,
+           g_context->setup_data.cn_call_back_arg)) {
+      alert = GNUTLS_A_ACCESS_DENIED;
+      goto fail;
+    }
+  }
+
+  if (g_context->setup_data.additional_tls_setup_call_back) {
+    /* Additional application setup wanted */
+    if (!g_context->setup_data.additional_tls_setup_call_back(g_session,
+            &g_context->setup_data)) {
+      goto fail;
+    }
+  }
+
+  if (cn)
+    gnutls_free(cn);
+
+  return 1;
+
+fail:
+  if (cn)
+    gnutls_free(cn);
+
+  G_ACTION(gnutls_alert_send(g_session, GNUTLS_AL_FATAL, alert));
+  return 0;
+}
+
+/*
+ * gnutls_certificate_verify_function return values
+ * (see gnutls_certificate_set_verify_function())
+ *
+ * return -1 failed
+ *         0 passed
+ */
+static int cert_verify_callback_gnutls(gnutls_session_t g_session)
+{
+  int ret;
+
+  if (gnutls_auth_get_type(g_session) == GNUTLS_CRD_CERTIFICATE) {
+    if (cert_verify_gnutls(g_session) == 0) {
+      G_ACTION(gnutls_alert_send(g_session,
+                                 GNUTLS_AL_FATAL,
+                                 GNUTLS_A_ACCESS_DENIED));
+      return -1;
+    }
+  }
+  return 0;
+}
+
+/*
+ * return 0   Success (GNUTLS_E_SUCCESS)
+ *        neg GNUTLS_E_* error code
+ */
+static int
+setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
+                      coap_gnutls_context_t *g_context,
+                      coap_dtls_pki_t *setup_data)
+{
+  int ret;
+
+  switch (setup_data->pki_key.key_type) {
+  case COAP_PKI_KEY_PEM:
+    if (setup_data->pki_key.key.pem.public_cert &&
+        setup_data->pki_key.key.pem.public_cert[0] &&
+        setup_data->pki_key.key.pem.private_key &&
+        setup_data->pki_key.key.pem.private_key[0]) {
+      G_CHECK(gnutls_certificate_allocate_credentials(pki_credentials),
+              "gnutls_certificate_allocate_credentials");
+
+      G_CHECK(gnutls_certificate_set_x509_key_file(*pki_credentials,
+                                   setup_data->pki_key.key.pem.public_cert,
+                                   setup_data->pki_key.key.pem.private_key,
+                                   GNUTLS_X509_FMT_PEM),
+                 "gnutls_certificate_set_x509_key_file");
+    }
+    else {
+      coap_log(LOG_ERR,
+               "***setup_pki: (D)TLS: No Client Certificate + Private "
+               "Key defined\n");
+      return GNUTLS_E_INSUFFICIENT_CREDENTIALS;
+    }
+    if (setup_data->pki_key.key.pem.ca_file &&
+        setup_data->pki_key.key.pem.ca_file[0]) {
+      G_CHECK(gnutls_certificate_set_x509_trust_file(*pki_credentials,
+                           setup_data->pki_key.key.pem.ca_file,
+                           GNUTLS_X509_FMT_PEM),
+              "gnutls_certificate_set_x509_trust_file");
+    }
+    break;
+
+  case COAP_PKI_KEY_ASN1:
+    if (setup_data->pki_key.key.asn1.public_cert &&
+        setup_data->pki_key.key.asn1.public_cert_len &&
+        setup_data->pki_key.key.asn1.private_key &&
+        setup_data->pki_key.key.asn1.private_key_len > 0) {
+      gnutls_datum_t cert;
+      gnutls_datum_t key;
+
+      /* Kludge to get around const parameters */
+      memcpy(&cert.data, &setup_data->pki_key.key.asn1.public_cert,
+                         sizeof(cert.data));
+      cert.size = setup_data->pki_key.key.asn1.public_cert_len;
+      memcpy(&key.data, &setup_data->pki_key.key.asn1.private_key,
+                        sizeof(key.data));
+      key.size = setup_data->pki_key.key.asn1.private_key_len;
+      G_CHECK(gnutls_certificate_set_x509_key_mem(*pki_credentials,
+                           &cert,
+                           &key,
+                           GNUTLS_X509_FMT_DER),
+              "gnutls_certificate_set_x509_key_mem");
+    }
+    else {
+      coap_log(LOG_ERR,
+               "***setup_pki: (D)TLS: No Client Certificate + Private "
+               "Key defined\n");
+      return GNUTLS_E_INSUFFICIENT_CREDENTIALS;
+    }
+    if (setup_data->pki_key.key.asn1.ca_cert &&
+        setup_data->pki_key.key.asn1.ca_cert_len > 0) {
+      gnutls_datum_t ca_cert;
+
+      /* Kludge to get around const parameters */
+      memcpy(&ca_cert.data, &setup_data->pki_key.key.asn1.ca_cert,
+                            sizeof(ca_cert.data));
+      ca_cert.size = setup_data->pki_key.key.asn1.ca_cert_len;
+      G_CHECK(gnutls_certificate_set_x509_trust_mem(*pki_credentials,
+                           &ca_cert,
+                           GNUTLS_X509_FMT_DER),
+              "gnutls_certificate_set_x509_trust_mem");
+    }
+    break;
+  default:
+    coap_log(LOG_ERR,
+             "***setup_pki: (D)TLS: Unknown key type %d\n",
+             setup_data->pki_key.key_type);
+    return GNUTLS_E_INSUFFICIENT_CREDENTIALS;
+  }
+
+  if (g_context->root_ca_file) {
+    G_CHECK(gnutls_certificate_set_x509_trust_file(*pki_credentials,
+                         g_context->root_ca_file,
+                         GNUTLS_X509_FMT_PEM),
+            "gnutls_certificate_set_x509_trust_file");
+  }
+  if (g_context->root_ca_path) {
+#if (GNUTLS_VERSION_NUMBER >= 0x030306)
+    G_CHECK(gnutls_certificate_set_x509_trust_dir(*pki_credentials,
+                         g_context->root_ca_path,
+                         GNUTLS_X509_FMT_PEM),
+            "gnutls_certificate_set_x509_trust_dir");
+#endif
+  }
+
+  /* Verify Peer */
+  if (setup_data->verify_peer_cert) {
+    gnutls_certificate_set_verify_function(*pki_credentials,
+                                           cert_verify_callback_gnutls);
+  }
+
+  /* Cert chain checking (can raise GNUTLS_E_CONSTRAINT_ERROR) */
+  if (setup_data->cert_chain_validation) {
+    gnutls_certificate_set_verify_limits(*pki_credentials,
+                                         0,
+                                         setup_data->cert_chain_verify_depth);
+  }
+
+  /* Check for self signed */
+  gnutls_certificate_set_verify_flags(*pki_credentials,
+                                      GNUTLS_VERIFY_DO_NOT_ALLOW_SAME);
+
+  /* CRL checking (can raise GNUTLS_CERT_MISSING_OCSP_STATUS) */
+  if (setup_data->check_cert_revocation == 0) {
+    gnutls_certificate_set_verify_flags(*pki_credentials,
+                                        GNUTLS_VERIFY_DO_NOT_ALLOW_SAME |
+                                        GNUTLS_VERIFY_DISABLE_CRL_CHECKS);
+  }
+
+  return GNUTLS_E_SUCCESS;
+
+fail:
+  return ret;
+}
+
+/*
+ * return 0   Success (GNUTLS_E_SUCCESS)
+ *        neg GNUTLS_E_* error code
+ */
+static int
+post_client_hello_gnutls(gnutls_session_t g_session)
+{
+  coap_session_t *c_session =
+                (coap_session_t *)gnutls_transport_get_ptr(g_session);
+  coap_gnutls_context_t *g_context =
+             (coap_gnutls_context_t *)c_session->context->dtls_context;
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+  int ret = GNUTLS_E_SUCCESS;
+  char *name = NULL;
+
+  if (g_context->setup_data.validate_sni_call_back) {
+    /* DNS names (only type supported) may be at most 256 byte long */
+    size_t len = 256;
+    unsigned int type;
+    unsigned int i;
+    coap_dtls_pki_t sni_setup_data;
+
+    name = gnutls_malloc(len);
+    if (name == NULL)
+      return GNUTLS_E_MEMORY_ERROR;
+
+    for (i=0; ; ) {
+      ret = gnutls_server_name_get(g_session, name, &len, &type, i);
+      if (ret == GNUTLS_E_SHORT_MEMORY_BUFFER) {
+        char *new_name;
+        new_name = gnutls_realloc(name, len);
+        if (new_name == NULL) {
+          ret = GNUTLS_E_MEMORY_ERROR;
+          goto end;
+        }
+        name = new_name;
+        continue; /* retry call with same index */
+      }
+
+      /* check if it is the last entry in list */
+      if (ret == GNUTLS_E_REQUESTED_DATA_NOT_AVAILABLE)
+        break;
+      i++;
+      if (ret != GNUTLS_E_SUCCESS)
+        goto end;
+      /* unknown types need to be ignored */
+      if (type != GNUTLS_NAME_DNS)
+        continue;
+
+    }
+    /* If no extension provided, make it a dummy entry */
+    if (i == 0) {
+      name[0] = '\000';
+      len = 0;
+    }
+
+    /* Is this a cached entry? */
+    for (i = 0; i < g_context->sni_count; i++) {
+      if (strcmp(name, g_context->sni_entry_list[i].sni) == 0) {
+        break;
+      }
+    }
+    if (i == g_context->sni_count) {
+      /*
+       * New SNI request
+       */
+      coap_dtls_key_t *new_entry =
+        g_context->setup_data.validate_sni_call_back(name,
+                                   g_context->setup_data.sni_call_back_arg);
+      if (!new_entry) {
+        G_ACTION(gnutls_alert_send(g_session, GNUTLS_AL_FATAL,
+                                   GNUTLS_A_UNRECOGNIZED_NAME));
+        ret = GNUTLS_E_NO_CERTIFICATE_FOUND;
+        goto end;
+      }
+
+      g_context->sni_entry_list = gnutls_realloc(g_context->sni_entry_list,
+                                     (i+1)*sizeof(sni_entry));
+      g_context->sni_entry_list[i].sni = gnutls_strdup(name);
+      g_context->sni_entry_list[i].pki_key = *new_entry;
+      sni_setup_data = g_context->setup_data;
+      sni_setup_data.pki_key = *new_entry;
+      if ((ret = setup_pki_credentials(
+                           &g_context->sni_entry_list[i].pki_credentials,
+                           g_context,
+                           &sni_setup_data)) < 0) {
+        int keep_ret = ret;
+        G_ACTION(gnutls_alert_send(g_session, GNUTLS_AL_FATAL,
+                                   GNUTLS_A_BAD_CERTIFICATE));
+        ret = keep_ret;
+        goto end;
+      }
+      g_context->sni_count++;
+    }
+    G_CHECK(gnutls_credentials_set(g_env->g_session, GNUTLS_CRD_CERTIFICATE,
+                               g_context->sni_entry_list[i].pki_credentials),
+            "gnutls_credentials_set");
+  }
+
+end:
+  free(name);
+  return ret;
+
+fail:
+  return ret;
+}
+
+/*
+ * return 0   Success (GNUTLS_E_SUCCESS)
+ *        neg GNUTLS_E_* error code
+ */
+static int
+setup_client_ssl_session(coap_session_t *c_session, coap_gnutls_env_t *g_env)
+{
+  coap_gnutls_context_t *g_context =
+             (coap_gnutls_context_t *)c_session->context->dtls_context;
+  int ret;
+
+  g_context->psk_pki_enabled |= IS_CLIENT;
+  if (g_context->psk_pki_enabled & IS_PSK) {
+    char *identity = NULL;
+    gnutls_datum_t psk_key;
+
+    G_CHECK(gnutls_psk_allocate_client_credentials(&g_env->psk_cl_credentials),
+            "gnutls_psk_allocate_client_credentials");
+    psk_client_callback(g_env->g_session, &identity, &psk_key);
+    G_CHECK(gnutls_psk_set_client_credentials(g_env->psk_cl_credentials,
+                                              identity,
+                                              &psk_key,
+                                              GNUTLS_PSK_KEY_RAW),
+            "gnutls_psk_set_client_credentials");
+    G_CHECK(gnutls_credentials_set(g_env->g_session, GNUTLS_CRD_PSK,
+                                   g_env->psk_cl_credentials),
+            "gnutls_credentials_set");
+    gnutls_free(identity);
+    gnutls_free(psk_key.data);
+  }
+
+  if (g_context->psk_pki_enabled & IS_PKI) {
+    coap_dtls_pki_t *setup_data = &g_context->setup_data;
+    G_CHECK(setup_pki_credentials(&g_env->pki_credentials, g_context,
+                                  setup_data),
+            "setup_pki_credentials");
+
+    G_CHECK(gnutls_credentials_set(g_env->g_session, GNUTLS_CRD_CERTIFICATE,
+                                   g_env->pki_credentials),
+            "gnutls_credentials_set");
+
+    if (c_session->proto == COAP_PROTO_TLS)
+      G_CHECK(gnutls_alpn_set_protocols(g_env->g_session,
+                                        &g_context->alpn_proto, 1, 0),
+              "gnutls_alpn_set_protocols");
+
+    /* Issue SNI if requested */
+    if (setup_data->client_sni) {
+      G_CHECK(gnutls_server_name_set(g_env->g_session, GNUTLS_NAME_DNS,
+                                     setup_data->client_sni,
+                                     strlen(setup_data->client_sni)),
+              "gnutls_server_name_set");
+    }
+  }
+  return GNUTLS_E_SUCCESS;
+
+fail:
+  return ret;
+}
+
+/*
+ * gnutls_psk_server_credentials_function return values
+ * (see gnutls_psk_set_server_credentials_function())
+ *
+ * return -1 failed
+ *         0 passed
+ */
+static int
+psk_server_callback(gnutls_session_t g_session,
+                    const char *identity,
+                    gnutls_datum_t *key)
+{
+  coap_session_t *c_session =
+                (coap_session_t *)gnutls_transport_get_ptr(g_session);
+  size_t identity_len = 0;
+  uint8_t buf[64];
+  size_t psk_len;
+
+  if (identity)
+    identity_len = strlen(identity);
+  else
+    identity = "";
+
+  coap_log(LOG_DEBUG, "got psk_identity: '%.*s'\n",
+                      (int)identity_len, identity);
+
+  if (c_session == NULL || c_session->context == NULL ||
+      c_session->context->get_server_psk == NULL)
+    return -1;
+
+  psk_len = c_session->context->get_server_psk(c_session,
+                               (const uint8_t*)identity,
+                               identity_len,
+                               (uint8_t*)buf, sizeof(buf));
+  key->data = gnutls_malloc(psk_len);
+  memcpy(key->data, buf, psk_len);
+  key->size = psk_len;
+  return 0;
+}
+
+/*
+ * return 0   Success (GNUTLS_E_SUCCESS)
+ *        neg GNUTLS_E_* error code
+ */
+static int
+setup_server_ssl_session(coap_session_t *c_session, coap_gnutls_env_t *g_env)
+{
+  coap_gnutls_context_t *g_context =
+             (coap_gnutls_context_t *)c_session->context->dtls_context;
+  int ret = GNUTLS_E_SUCCESS;
+
+  g_context->psk_pki_enabled |= IS_SERVER;
+  if (g_context->psk_pki_enabled & IS_PSK) {
+    G_CHECK(gnutls_psk_allocate_server_credentials(&g_env->psk_sv_credentials),
+            "gnutls_psk_allocate_server_credentials");
+    gnutls_psk_set_server_credentials_function(g_env->psk_sv_credentials,
+                                                      psk_server_callback);
+    G_CHECK(gnutls_credentials_set(g_env->g_session,
+                                   GNUTLS_CRD_PSK,
+                                   g_env->psk_sv_credentials),
+            "gnutls_credentials_set\n");
+  }
+
+  if (g_context->psk_pki_enabled & IS_PKI) {
+    coap_dtls_pki_t *setup_data = &g_context->setup_data;
+    G_CHECK(setup_pki_credentials(&g_env->pki_credentials, g_context,
+                                  setup_data),
+            "setup_pki_credentials");
+
+    if (setup_data->require_peer_cert) {
+      gnutls_certificate_server_set_request(g_env->g_session,
+                                            GNUTLS_CERT_REQUIRE);
+    }
+    else {
+      gnutls_certificate_server_set_request(g_env->g_session, GNUTLS_CERT_IGNORE);
+    }
+
+    gnutls_handshake_set_post_client_hello_function(g_env->g_session,
+                                                    post_client_hello_gnutls);
+
+    G_CHECK(gnutls_credentials_set(g_env->g_session, GNUTLS_CRD_CERTIFICATE,
+                                   g_env->pki_credentials),
+            "gnutls_credentials_set\n");
+  }
+  return GNUTLS_E_SUCCESS;
+
+fail:
+  return ret;
+}
+
+/*
+ * return +ve data amount
+ *        0   no more
+ *        -1  error (error in errno)
+ */
+static ssize_t
+coap_dgram_read(gnutls_transport_ptr_t context, void *out, size_t outl)
+{
+  ssize_t ret = 0;
+  coap_session_t *c_session = (struct coap_session_t *)context;
+  coap_ssl_t *data = &((coap_gnutls_env_t *)c_session->tls)->coap_ssl_data;
+
+  if (!c_session->tls) {
+    errno = EAGAIN;
+    return -1;
+  }
+
+  if (out != NULL) {
+    if (data != NULL && data->pdu_len > 0) {
+      if (outl < data->pdu_len) {
+        memcpy(out, data->pdu, outl);
+        ret = outl;
+        data->pdu += outl;
+        data->pdu_len -= outl;
+      } else {
+        memcpy(out, data->pdu, data->pdu_len);
+        ret = data->pdu_len;
+        if (!data->peekmode) {
+          data->pdu_len = 0;
+          data->pdu = NULL;
+        }
+      }
+    }
+    else {
+      errno = EAGAIN;
+      ret = -1;
+    }
+  }
+  return ret;
+}
+
+/*
+ * return +ve data amount
+ *        0   no more
+ *        -1  error (error in errno)
+ */
+/* callback function given to gnutls for sending data over socket */
+static ssize_t
+coap_dgram_write(gnutls_transport_ptr_t context, const void *send_buffer,
+                  size_t send_buffer_length) {
+  ssize_t result = -1;
+  coap_session_t *c_session = (struct coap_session_t *)context;
+
+  if (c_session) {
+    result = coap_session_send(c_session, send_buffer, send_buffer_length);
+    if (result != (int)send_buffer_length) {
+      coap_log(LOG_WARNING, "coap_network_send failed\n");
+      result = 0;
+    }
+  } else {
+    result = 0;
+  }
+  return result;
+}
+
+/*
+ * return 1  fd has activity
+ *        0  timeout
+ *        -1 error (error in errno)
+ */
+static int
+receive_timeout(gnutls_transport_ptr_t context, unsigned int ms UNUSED) {
+  coap_session_t *c_session = (struct coap_session_t *)context;
+
+  if (c_session) {
+    fd_set readfds, writefds, exceptfds;
+    struct timeval tv;
+    int nfds = c_session->sock.fd +1;
+
+    FD_ZERO(&readfds);
+    FD_ZERO(&writefds);
+    FD_ZERO(&exceptfds);
+    FD_SET (c_session->sock.fd, &readfds);
+    FD_SET (c_session->sock.fd, &writefds);
+    FD_SET (c_session->sock.fd, &exceptfds);
+    /* Polling */
+    tv.tv_sec = 0;
+    tv.tv_usec = 0;
+
+    return select(nfds, &readfds, &writefds, &exceptfds, &tv);
+  }
+  return 1;
+}
+
+static coap_gnutls_env_t *
+coap_dtls_new_gnutls_env(coap_session_t *c_session, int type)
+{
+  coap_gnutls_context_t *g_context =
+          ((coap_gnutls_context_t *)c_session->context->dtls_context);
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+  int flags = type | GNUTLS_DATAGRAM | GNUTLS_NONBLOCK;
+  int ret;
+
+  if (g_env)
+    return g_env;
+
+  g_env = gnutls_malloc(sizeof(coap_gnutls_env_t));
+  if (!g_env)
+    return NULL;
+
+  memset(g_env, 0, sizeof(struct coap_gnutls_env_t));
+
+  G_CHECK(gnutls_init(&g_env->g_session, flags), "gnutls_init");
+
+  gnutls_transport_set_pull_function(g_env->g_session, coap_dgram_read);
+  gnutls_transport_set_push_function(g_env->g_session, coap_dgram_write);
+  gnutls_transport_set_pull_timeout_function(g_env->g_session, receive_timeout);
+  /* So we can track the coap_session_t in callbacks */
+  gnutls_transport_set_ptr(g_env->g_session, c_session);
+
+  if (type == GNUTLS_SERVER) {
+    G_CHECK(setup_server_ssl_session(c_session, g_env),
+            "setup_server_ssl_session");
+  }
+  else {
+    G_CHECK(setup_client_ssl_session(c_session, g_env),
+            "setup_client_ssl_session");
+  }
+
+  G_CHECK(gnutls_priority_set(g_env->g_session, g_context->priority_cache),
+          "gnutls_priority_set");
+  gnutls_handshake_set_timeout(g_env->g_session,
+                               GNUTLS_DEFAULT_HANDSHAKE_TIMEOUT);
+
+  return g_env;
+
+fail:
+  if (g_env)
+    gnutls_free(g_env);
+  return NULL;
+}
+
+static void
+coap_dtls_free_gnutls_env(coap_gnutls_context_t *g_context,
+                          coap_gnutls_env_t *g_env,
+                          int unreliable)
+{
+  if (g_env) {
+    /* It is suggested not to use GNUTLS_SHUT_RDWR in DTLS
+     * connections because the peer's closure message might
+     * be lost */
+    gnutls_bye(g_env->g_session, unreliable ?
+                                       GNUTLS_SHUT_WR : GNUTLS_SHUT_RDWR);
+    gnutls_deinit(g_env->g_session);
+    g_env->g_session = NULL;
+    if (g_context->psk_pki_enabled & IS_PSK) {
+      if (g_context->psk_pki_enabled & IS_CLIENT) {
+        gnutls_psk_free_client_credentials(g_env->psk_cl_credentials);
+      }
+      else {
+        gnutls_psk_free_server_credentials(g_env->psk_sv_credentials);
+      }
+    }
+    if (g_context->psk_pki_enabled & IS_PKI) {
+      gnutls_certificate_free_credentials(g_env->pki_credentials);
+    }
+    gnutls_free(g_env);
+  }
+}
+
+void *coap_dtls_new_server_session(coap_session_t *c_session) {
+  coap_gnutls_env_t *g_env =
+         (coap_gnutls_env_t *)c_session->endpoint->hello.tls;
+
+  /* For the next one */
+  c_session->endpoint->hello.tls = NULL;
+
+  return g_env;
+}
+
+static void log_last_alert(gnutls_session_t g_session) {
+  int last_alert = gnutls_alert_get(g_session);
+
+  coap_log(LOG_WARNING, "Received alert '%d': '%s'\n",
+                        last_alert, gnutls_alert_get_name(last_alert));
+}
+
+/*
+ * return -1  failure
+ *         0  not completed
+ *         1  established
+ */
+static int
+do_gnutls_handshake(coap_session_t *c_session, coap_gnutls_env_t *g_env) {
+  int ret = -1;
+
+  ret = gnutls_handshake(g_env->g_session);
+  switch (ret) {
+  case GNUTLS_E_SUCCESS:
+    g_env->established = 1;
+    coap_log(LOG_DEBUG, "*  %s: GnuTLS established\n",
+                                            coap_session_str(c_session));
+    ret = 1;
+    break;
+  case GNUTLS_E_INTERRUPTED:
+    errno = EINTR;
+    ret = 0;
+    break;
+  case GNUTLS_E_AGAIN:
+    errno = EAGAIN;
+    ret = 0;
+    break;
+  case GNUTLS_E_INSUFFICIENT_CREDENTIALS:
+    coap_log(LOG_WARNING,
+             "Insufficient credentials provided.\n");
+    break;
+  case GNUTLS_E_FATAL_ALERT_RECEIVED:
+    log_last_alert(g_env->g_session);
+    c_session->dtls_event = COAP_EVENT_DTLS_CLOSED;
+    break;
+  case GNUTLS_E_WARNING_ALERT_RECEIVED:
+    log_last_alert(g_env->g_session);
+    c_session->dtls_event = COAP_EVENT_DTLS_ERROR;
+    ret = 0;
+    break;
+  case GNUTLS_E_DECRYPTION_FAILED:
+    coap_log(LOG_WARNING,
+             "do_gnutls_handshake: session establish "
+             "returned %d: '%s'\n",
+             ret, gnutls_strerror(ret));
+    G_ACTION(gnutls_alert_send(g_env->g_session, GNUTLS_AL_FATAL,
+                                                 GNUTLS_A_DECRYPT_ERROR));
+    c_session->dtls_event = COAP_EVENT_DTLS_CLOSED;
+    break;
+  case GNUTLS_E_UNKNOWN_CIPHER_SUITE:
+  case GNUTLS_E_TIMEDOUT:
+    c_session->dtls_event = COAP_EVENT_DTLS_CLOSED;
+    break;
+  default:
+    coap_log(LOG_WARNING,
+             "do_gnutls_handshake: session establish "
+             "returned %d: '%s'\n",
+             ret, gnutls_strerror(ret));
+    break;
+  }
+  return ret;
+}
+
+void *coap_dtls_new_client_session(coap_session_t *c_session) {
+  coap_gnutls_env_t *g_env = coap_dtls_new_gnutls_env(c_session, GNUTLS_CLIENT);
+  int ret;
+
+  if (g_env) {
+    ret = do_gnutls_handshake(c_session, g_env);
+    if (ret == -1) {
+      coap_dtls_free_gnutls_env(c_session->context->dtls_context,
+                                g_env,
+                                COAP_PROTO_NOT_RELIABLE(c_session->proto));
+      return NULL;
+    }
+  }
+  return g_env;
+}
+
+void coap_dtls_free_session(coap_session_t *c_session) {
+  if (c_session && c_session->context) {
+    coap_dtls_free_gnutls_env(c_session->context->dtls_context,
+                c_session->tls, COAP_PROTO_NOT_RELIABLE(c_session->proto));
+    c_session->tls = NULL;
+  }
+}
+
+void coap_dtls_session_update_mtu(coap_session_t *c_session) {
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+  int ret;
+
+  if (g_env)
+    G_CHECK(gnutls_dtls_set_data_mtu(g_env->g_session, c_session->mtu),
+            "gnutls_dtls_set_data_mtu");
+fail:
+  ;;
+}
+
+/*
+ * return +ve data amount
+ *        0   no more
+ *        -1  error
+ */
+int coap_dtls_send(coap_session_t *c_session,
+  const uint8_t *data, size_t data_len) {
+  int ret;
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+
+  assert(g_env != NULL);
+
+  c_session->dtls_event = -1;
+  if (g_env->established) {
+    ret = gnutls_record_send(g_env->g_session, data, data_len);
+
+    if (ret <= 0) {
+      switch (ret) {
+      case GNUTLS_E_AGAIN:
+        ret = 0;
+        break;
+      case GNUTLS_E_FATAL_ALERT_RECEIVED:
+        log_last_alert(g_env->g_session);
+        c_session->dtls_event = COAP_EVENT_DTLS_ERROR;
+        ret = -1;
+        break;
+      default:
+        ret = -1;
+        break;
+      }
+      if (ret == -1) {
+        coap_log(LOG_WARNING, "coap_dtls_send: cannot send PDU\n");
+      }
+    }
+  }
+  else {
+    ret = do_gnutls_handshake(c_session, g_env);
+    ret = gnutls_handshake(g_env->g_session);
+    if (ret != 1) {
+      ret = -1;
+    }
+  }
+
+  if (c_session->dtls_event >= 0) {
+    coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+    if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
+        c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
+      coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
+      ret = -1;
+    }
+  }
+
+  return ret;
+}
+
+int coap_dtls_is_context_timeout(void) {
+  return 1;
+}
+
+coap_tick_t coap_dtls_get_context_timeout(void *dtls_context UNUSED) {
+  return 0;
+}
+
+coap_tick_t coap_dtls_get_timeout(coap_session_t *c_session UNUSED) {
+  return 0;
+}
+
+void coap_dtls_handle_timeout(coap_session_t *c_session UNUSED) {
+}
+
+/*
+ * return +ve data amount
+ *        0   no more
+ *        -1  error
+ */
+int
+coap_dtls_receive(coap_session_t *c_session,
+  const uint8_t *data,
+  size_t data_len
+) {
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+  int ret = 0;
+  coap_ssl_t *ssl_data = &g_env->coap_ssl_data;
+
+  uint8_t pdu[COAP_RXBUFFER_SIZE];
+
+  assert(g_env != NULL);
+
+  if (ssl_data->pdu_len)
+    coap_log(LOG_INFO, "** %s: Previous data not read %u bytes\n",
+             coap_session_str(c_session), ssl_data->pdu_len);
+  ssl_data->pdu = data;
+  ssl_data->pdu_len = (unsigned)data_len;
+
+  c_session->dtls_event = -1;
+  if (g_env->established) {
+    if (c_session->state == COAP_SESSION_STATE_HANDSHAKE) {
+      coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
+                        c_session);
+      gnutls_transport_set_ptr(g_env->g_session, c_session);
+      coap_session_connected(c_session);
+    }
+    ret = gnutls_record_recv(g_env->g_session, pdu, (int)sizeof(pdu));
+    if (ret > 0) {
+      return coap_handle_dgram(c_session->context, c_session, pdu, (size_t)ret);
+    }
+    else if (ret == 0) {
+      c_session->dtls_event = COAP_EVENT_DTLS_CLOSED;
+    }
+    else {
+      coap_log(LOG_WARNING,
+               "coap_dtls_receive: gnutls_record_recv returned %d\n", ret);
+      ret = -1;
+    }
+  }
+  else {
+    ret = do_gnutls_handshake(c_session, g_env);
+    if (ret == 1) {
+      coap_session_connected(c_session);
+    }
+    else {
+      ret = -1;
+    }
+  }
+
+  if (c_session->dtls_event >= 0) {
+    coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+    if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
+        c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
+      coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
+      ret = -1;
+    }
+  }
+
+  return ret;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_hello(coap_session_t *c_session,
+  const uint8_t *data,
+  size_t data_len
+) {
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+  coap_ssl_t *ssl_data = g_env ? &g_env->coap_ssl_data : NULL;
+  int ret;
+
+  if (!g_env) {
+    g_env = coap_dtls_new_gnutls_env(c_session, GNUTLS_SERVER);
+    if (g_env) {
+      c_session->tls = g_env;
+      ssl_data = &g_env->coap_ssl_data;
+      ssl_data->pdu = data;
+      ssl_data->pdu_len = (unsigned)data_len;
+      gnutls_dtls_set_data_mtu(g_env->g_session, c_session->mtu);
+      ret = do_gnutls_handshake(c_session, g_env);
+      if (ret == 1)
+        return 1;
+    }
+    return 0;
+  }
+
+  ssl_data->pdu = data;
+  ssl_data->pdu_len = (unsigned)data_len;
+
+  ret = do_gnutls_handshake(c_session, g_env);
+  if (ret == 1)
+    return 1;
+  return 0;
+}
+
+unsigned int coap_dtls_get_overhead(coap_session_t *c_session UNUSED) {
+  return 37;
+}
+
+/*
+ * return +ve data amount
+ *        0   no more
+ *        -1  error (error in errno)
+ */
+static ssize_t
+coap_sock_read(gnutls_transport_ptr_t context, void *out, size_t outl) {
+  int ret = 0;
+  coap_session_t *c_session = (struct coap_session_t *)context;
+
+  if (out != NULL) {
+    ret = (int)coap_socket_read(&c_session->sock, out, outl);
+    if (ret == 0) {
+      errno = EAGAIN;
+      ret = -1;
+    }
+  }
+  return ret;
+}
+
+/*
+ * return +ve data amount
+ *        0   no more
+ *        -1  error (error in errno)
+ */
+static ssize_t
+coap_sock_write(gnutls_transport_ptr_t context, const void *in, size_t inl) {
+  int ret = 0;
+  coap_session_t *c_session = (struct coap_session_t *)context;
+
+  ret = (int)coap_socket_write(&c_session->sock, in, inl);
+  if (ret == 0) {
+    errno = EAGAIN;
+    ret = -1;
+  }
+  return ret;
+}
+
+void *coap_tls_new_client_session(coap_session_t *c_session, int *connected) {
+  coap_gnutls_env_t *g_env = gnutls_malloc(sizeof(coap_gnutls_env_t));
+  coap_gnutls_context_t *g_context =
+                ((coap_gnutls_context_t *)c_session->context->dtls_context);
+  int flags = GNUTLS_CLIENT;
+  int ret;
+
+  if (!g_env) {
+    return NULL;
+  }
+  memset(g_env, 0, sizeof(struct coap_gnutls_env_t));
+
+  *connected = 0;
+  G_CHECK(gnutls_init(&g_env->g_session, flags), "gnutls_init");
+
+  gnutls_transport_set_pull_function(g_env->g_session, coap_sock_read);
+  gnutls_transport_set_push_function(g_env->g_session, coap_sock_write);
+  gnutls_transport_set_pull_timeout_function(g_env->g_session, receive_timeout);
+  /* So we can track the coap_session_t in callbacks */
+  gnutls_transport_set_ptr(g_env->g_session, c_session);
+
+  setup_client_ssl_session(c_session, g_env);
+
+  gnutls_priority_set(g_env->g_session, g_context->priority_cache);
+  gnutls_handshake_set_timeout(g_env->g_session, GNUTLS_DEFAULT_HANDSHAKE_TIMEOUT);
+
+  ret = do_gnutls_handshake(c_session, g_env);
+  if (ret == 1) {
+    *connected = 1;
+    coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
+    coap_session_connected(c_session);
+  }
+  return g_env;
+
+fail:
+  if (g_env)
+    gnutls_free(g_env);
+  return NULL;
+}
+
+void *coap_tls_new_server_session(coap_session_t *c_session, int *connected) {
+  coap_gnutls_env_t *g_env = gnutls_malloc(sizeof(coap_gnutls_env_t));
+  coap_gnutls_context_t *g_context =
+             ((coap_gnutls_context_t *)c_session->context->dtls_context);
+  int flags = GNUTLS_SERVER;
+  int ret;
+
+  if (!g_env)
+    return NULL;
+  memset(g_env, 0, sizeof(struct coap_gnutls_env_t));
+
+  *connected = 0;
+  G_CHECK(gnutls_init(&g_env->g_session, flags), "gnutls_init");
+
+  gnutls_transport_set_pull_function(g_env->g_session, coap_sock_read);
+  gnutls_transport_set_push_function(g_env->g_session, coap_sock_write);
+  gnutls_transport_set_pull_timeout_function(g_env->g_session, receive_timeout);
+  /* So we can track the coap_session_t in callbacks */
+  gnutls_transport_set_ptr(g_env->g_session, c_session);
+
+  setup_server_ssl_session(c_session, g_env);
+
+  gnutls_priority_set(g_env->g_session, g_context->priority_cache);
+  gnutls_handshake_set_timeout(g_env->g_session,
+                                     GNUTLS_DEFAULT_HANDSHAKE_TIMEOUT);
+
+  c_session->tls = g_env;
+  ret = do_gnutls_handshake(c_session, g_env);
+  if (ret == 1) {
+    *connected = 1;
+  }
+  return g_env;
+
+fail:
+  return NULL;
+}
+
+void coap_tls_free_session(coap_session_t *c_session) {
+  coap_dtls_free_session(c_session);
+  return;
+}
+
+/*
+ * return +ve data amount
+ *        0   no more
+ *        -1  error (error in errno)
+ */
+ssize_t coap_tls_write(coap_session_t *c_session,
+                       const uint8_t *data,
+                       size_t data_len
+) {
+  int ret;
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+
+  assert(g_env != NULL);
+
+  c_session->dtls_event = -1;
+  if (g_env->established) {
+    ret = gnutls_record_send(g_env->g_session, data, data_len);
+
+    if (ret <= 0) {
+      switch (ret) {
+      case GNUTLS_E_AGAIN:
+        ret = 0;
+        break;
+      case GNUTLS_E_FATAL_ALERT_RECEIVED:
+        log_last_alert(g_env->g_session);
+        c_session->dtls_event = COAP_EVENT_DTLS_ERROR;
+        ret = -1;
+        break;
+      default:
+        coap_log(LOG_WARNING,
+                 "coap_tls_write: gnutls_record_send "
+                 "returned %d: '%s'\n",
+                 ret, gnutls_strerror(ret));
+        ret = -1;
+        break;
+      }
+      if (ret == -1) {
+        coap_log(LOG_WARNING, "coap_dtls_send: cannot send PDU\n");
+      }
+    }
+  }
+  else {
+    ret = do_gnutls_handshake(c_session, g_env);
+    if (ret == 1) {
+      coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
+                                     c_session);
+      coap_session_send_csm(c_session);
+    }
+    else {
+      ret = -1;
+    }
+  }
+
+  if (c_session->dtls_event >= 0) {
+    coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+    if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
+        c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
+      coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
+      ret = -1;
+    }
+  }
+
+  return ret;
+}
+
+/*
+ * return +ve data amount
+ *        0   no more
+ *        -1  error (error in errno)
+ */
+ssize_t coap_tls_read(coap_session_t *c_session,
+                      uint8_t *data,
+                      size_t data_len
+) {
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+  int ret;
+
+  if (!g_env)
+    return -1;
+
+  c_session->dtls_event = -1;
+  if (!g_env->established) {
+    ret = do_gnutls_handshake(c_session, g_env);
+    if (ret == 1) {
+      coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
+                                                               c_session);
+      coap_session_send_csm(c_session);
+    }
+  }
+  if (g_env->established) {
+    ret = gnutls_record_recv(g_env->g_session, data, (int)data_len);
+    if (ret <= 0) {
+      switch (ret) {
+      case GNUTLS_E_SUCCESS:
+        c_session->dtls_event = COAP_EVENT_DTLS_CLOSED;
+        break;
+      default:
+      coap_log(LOG_WARNING,
+               "coap_tls_read: gnutls_record_recv "
+               "returned %d: '%s'\n",
+               ret, gnutls_strerror(ret));
+        ret = -1;
+        break;
+      }
+    }
+  }
+
+  if (c_session->dtls_event >= 0) {
+    coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+    if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
+        c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
+      coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
+      ret = -1;
+    }
+  }
+  return ret;
+}
+
+#else /* !HAVE_LIBGNUTLS */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void dummy(void) {
+}
+
+#endif /* !HAVE_LIBGNUTLS */

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -9,7 +9,7 @@
 
 #include "coap_config.h"
 
-#if !defined(HAVE_LIBTINYDTLS) && !defined(HAVE_OPENSSL)
+#if !defined(HAVE_LIBTINYDTLS) && !defined(HAVE_OPENSSL) && !defined(HAVE_LIBGNUTLS)
 
 #include "net.h"
 
@@ -175,7 +175,7 @@ ssize_t coap_tls_read(coap_session_t *session UNUSED,
 
 #undef UNUSED
 
-#else /* !HAVE_LIBTINYDTLS && !HAVE_OPENSSL */
+#else /* !HAVE_LIBTINYDTLS && !HAVE_OPENSSL && !HAVE_LIBGNUTLS */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -186,4 +186,4 @@ ssize_t coap_tls_read(coap_session_t *session UNUSED,
 static inline void dummy(void) {
 }
 
-#endif /* !HAVE_LIBTINYDTLS && !HAVE_OPENSSL */
+#endif /* !HAVE_LIBTINYDTLS && !HAVE_OPENSSL && !HAVE_LIBGNUTLS */

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -142,6 +142,7 @@ coap_tls_version_t *
 coap_get_tls_library_version(void) {
   static coap_tls_version_t version;
   version.version = SSLeay();
+  version.built_version = OPENSSL_VERSION_NUMBER;
   version.type = COAP_TLS_LIBRARY_OPENSSL;
   return &version;
 }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -453,7 +453,23 @@ int coap_tls_is_supported(void) {
 coap_tls_version_t *
 coap_get_tls_library_version(void) {
   static coap_tls_version_t version;
-  version.version = DTLS_VERSION;
+  const char *vers = dtls_package_version();
+
+  version.version = 0;
+  if (vers) {
+    long int p1, p2 = 0, p3 = 0;
+    char* endptr;
+
+    p1 = strtol(vers, &endptr, 10);
+    if (*endptr == '.') {
+      p2 = strtol(endptr+1, &endptr, 10);
+      if (*endptr == '.') {
+        p3 = strtol(endptr+1, &endptr, 10);
+      }
+    }
+    version.version = (p1 << 16) | (p2 << 8) | p3;
+  }
+  version.built_version = version.version;
   version.type = COAP_TLS_LIBRARY_TINYDTLS;
   return &version;
 }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -16,16 +16,20 @@
 #include "debug.h"
 #include "mem.h"
 
+/* We want TinyDTLS versions of these, not libcoap versions */
+#undef PACKAGE_BUGREPORT
+#undef PACKAGE_NAME
+#undef PACKAGE_STRING
+#undef PACKAGE_TARNAME
+#undef PACKAGE_URL
+#undef PACKAGE_VERSION
+
 #include <tinydtls.h>
 #include <dtls.h>
+#include <dtls_debug.h>
 
 static dtls_tick_t dtls_tick_0 = 0;
 static coap_tick_t coap_tick_0 = 0;
-
- /* Prototypes from dtls_debug.h as including that header will conflict
-  * with coap_config.h. */
-void dtls_set_log_level(int);
-int dtls_get_log_level(void);
 
 int
 coap_dtls_is_supported(void) {
@@ -341,12 +345,15 @@ coap_dtls_send(coap_session_t *session,
   size_t data_len
 ) {
   int res;
+  uint8_t *data_rw;
 
   coap_log(LOG_DEBUG, "call dtls_write\n");
 
   coap_event_dtls = -1;
+  /* Need to do this to not get a compiler warning about const parameters */
+  memcpy (&data_rw, &data, sizeof(data_rw));
   res = dtls_write((struct dtls_context_t *)session->context->dtls_context,
-    (session_t *)session->tls, (uint8 *)data, data_len);
+    (session_t *)session->tls, data_rw, data_len);
 
   if (res < 0)
     coap_log(LOG_WARNING, "coap_dtls_send: cannot send PDU\n");
@@ -391,11 +398,14 @@ coap_dtls_receive(coap_session_t *session,
 ) {
   session_t *dtls_session = (session_t *)session->tls;
   int err;
+  uint8_t *data_rw;
 
   coap_event_dtls = -1;
+  /* Need to do this to not get a compiler warning about const parameters */
+  memcpy (&data_rw, &data, sizeof(data_rw));
   err = dtls_handle_message(
     (struct dtls_context_t *)session->context->dtls_context,
-    dtls_session, (uint8 *)data, (int)data_len);
+    dtls_session, data_rw, (int)data_len);
 
   if (err){
     coap_event_dtls = COAP_EVENT_DTLS_ERROR;
@@ -420,12 +430,15 @@ coap_dtls_hello(coap_session_t *session,
   session_t dtls_session;
   struct dtls_context_t *dtls_context =
     (struct dtls_context_t *)session->context->dtls_context;
+  uint8_t *data_rw;
 
   dtls_session_init(&dtls_session);
   put_session_addr(&session->remote_addr, &dtls_session);
   dtls_session.ifindex = session->ifindex;
+  /* Need to do this to not get a compiler warning about const parameters */
+  memcpy (&data_rw, &data, sizeof(data_rw));
   int res = dtls_handle_message(dtls_context, &dtls_session,
-    (uint8 *)data, (int)data_len);
+    data_rw, (int)data_len);
   if (res >= 0) {
     if (dtls_get_peer(dtls_context, &dtls_session))
       res = 1;


### PR DESCRIPTION
src/coap_gnutls.c:

The new GnuTLS interface module, included by "./configure --with-gnutls".
If coap_dtls_set_log_level(level) has a value higher then 7 (LOG_DEBUG), then
there is more verbose logging.

3.3.6 introduces support for coap_dtls_context_set_pki_root_cas() ca_path
parameter.  All other 3.3.0+ functionality is similar to OpenSSL.

3.2.0 was missing too much functionality and hence going with 3.3.0

.travis.yml:
scripts/build.sh:
scripts/dist.sh:
env/Dockerfile.build-env:
env/Dockerfile.develop:

Include building --with-gnutls into Travis.

Makefile.am:

Include src/coap_gnutls.c

configure.ac

Update minimum GnuTLS version to 3.3.0
Revert out commit c362d561fdf649c85fa0bda03f9f81490d575edc disabling gnutls
support.

examples/client.c:
examples/coap-rd.c:
examples/coap-server.c:

Update with showing current running/linked and build TLS library versions.
Support an early quit with ^C in coap-client, and replace signal() with sigaction() in all examples as appropriate.

include/coap2/coap_dtls.h:

Update coap_tls_version_t to include built version.

include/coap2/debug.h:
src/debug.c:
libcoap-2.map:
libcoap-2.sym:

Add in support for a new function coap_show_tls_version() and coap_string_tls_version().

man/coap_attribute.txt.in:
man/coap_context.txt.in:
man/coap_encryption.txt.in:
man/coap_handler.txt.in:
man/coap_logging.txt.in:
man/coap_observe.txt.in:
man/coap_pdu_setup.txt.in:
man/coap_recovery.txt.in:
man/coap_resource.txt.in:
man/coap_session.txt.in:
man/coap_tls_library.txt.in:

Update to include new library -lcoap-2-gnutls.
Trailing spaces removed
coap_encryption(3) updated to include information about GnuTLS, along with
some documentation corrections.
coap_logging(3) updated to reflect additional GnuTLS logging above LOG_DEBUG.

man/coap-client.txt.in:
man/coap-rd.txt.in:
man/coap-server.txt.in:

Report the fact that if logging level is above 7 (LOG_DEBUG) GnuTLS will be
more verbose in the logging

src/coap_io.c:

Set errno to EAGAIN if there is no data to read

src/coap_notls.c:
src/coap_openssl.c:
src/coap_tinydtls.c:

Fix wrappers to include not building if GnuTLS selected.
Update coap_get_tls_library_version() to also return built version.
Update coap_tinydtls.c to return actual TinyDTLS library version.
Update coap_tinydtls.c to remove compiler build warnings.

tests/test_tls.c:

Update to use HAVE_LIBGNUTLS #ifdef
Update to get correct TinyDTLS library version
Update to remove compiler build warnings when building for TinyDTLS.

BUILDING:

Update how to build instructions (including removing some trailing spaces)

Testing carried out:

Primarily with version 3.3.26 inter-operating with 3.2.26 and OpenSSL 1.1.1 for
both coap-client and coap-server.

Some testing has been done between 3.3.0 and 3.3.26.

Interaction with TinyDTLS requires use of CCM, available in 3.5.5

This PR replaces #94 

Windows project files will need to be updated