### PR TITLE
Update etsi_iot_01 and tiny examples to build with current API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,10 @@ man/*.7
 examples/.deps/
 examples/*.o
 examples/coap-client
+examples/coap-etsi_iot_01
 examples/coap-rd
 examples/coap-server
+examples/coap-tiny
 
 # the include/ folder
 include/coap2/coap.h

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -13,8 +13,9 @@ AM_CFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include \
             -I$(top_srcdir)/include/coap$(LIBCOAP_API_VERSION) \
             $(WARNING_CFLAGS) $(DTLS_CFLAGS) -std=c99
 
-# etsi_iot_01 and tiny are missing
+#
 bin_PROGRAMS = coap-client coap-server coap-rd
+check_PROGRAMS = coap-etsi_iot_01 coap-tiny
 
 coap_client_SOURCES = client.c
 coap_client_LDADD =  $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
@@ -24,5 +25,11 @@ coap_server_LDADD = $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SU
 
 coap_rd_SOURCES = coap-rd.c
 coap_rd_LDADD = $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+
+coap_etsi_iot_01_SOURCES = etsi_iot_01.c
+coap_etsi_iot_01_LDADD = $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+
+coap_tiny_SOURCES = tiny.c
+coap_tiny_LDADD = $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
 
 endif # BUILD_EXAMPLES

--- a/examples/etsi_coaptest.sh
+++ b/examples/etsi_coaptest.sh
@@ -36,7 +36,7 @@ testgroups=( CORE LINK BLOCK OBS )
 testnumber=-1
 group=''
 
-source etsi_testcases.sh
+source `dirname $0`/etsi_testcases.sh
 
 function usage {
 echo "Usage:  `basename $0` [-n testnumber] [-g groupname] [-t timeout] [-P server_port] [-p client port] [-d logdir] [-v] -i interface server_address" 1>&2

--- a/examples/etsi_testcases.sh
+++ b/examples/etsi_testcases.sh
@@ -481,8 +481,8 @@ function TD_COAP_LINK_01 {
   if [[ ! $(echo $clientoutput | grep rt) ]] ; then
     echo "no resource with attribute rt found on server"
   else
-    rt="${clientoutput##*rt=\"}"
-    rt="${rt%%\";*}"
+    rt="${clientoutput##*rt=}"
+    rt="${rt%%;*}"
   fi
   echo -e "\nOutput of client:"
   echo -e $clientoutput

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,7 @@ case "${PLATFORM}" in
                make -C examples/lwip
              ;;
     posix|*) config "$WITH_TESTS $WITH_DOCS --enable-examples $WITH_TLS" && \
-               make
+               make && make check
              ;;
 esac
 


### PR DESCRIPTION
These are now included in the standard build (by running 'make check')
to catch any other API changes.  Named as coap-etsi_iot_01 and coap-tiny.
They are not installed.

etsi test case scripts have been corrected to get things working.
However, there does not appear to be all the functionality required to
cover all the test cases.  E.g. /large-create was not defined as a
resource.

.gitignore:

Ignore new binaries

examples/Makefile.am:

Build coap-etsi_iot_01 and coap-tiny (when 'make check' is run).

scripts/build.sh:

Include 'make check' for checking coap-etsi_iot_01 and coap-tiny.

examples/etsi_coaptest.sh:
examples/etsi_testcases.sh:

Minor fix changes

examples/etsi_iot_01.c:
examples/tiny.c:

Updated to use new API

Fixes request raised in #274