### PR TITLE
coap-client: The -U option doesn't expect an argument

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -1191,7 +1191,7 @@ main(int argc, char **argv) {
   int create_uri_opts = 1;
   struct sigaction sa;
 
-  while ((opt = getopt(argc, argv, "Nra:b:c:e:f:k:m:p:s:t:o:v:A:B:C:O:P:R:T:u:U:l:K:")) != -1) {
+  while ((opt = getopt(argc, argv, "NrUa:b:c:e:f:k:m:p:s:t:o:v:A:B:C:O:P:R:T:u:l:K:")) != -1) {
     switch (opt) {
     case 'a':
       strncpy(node_str, optarg, NI_MAXHOST - 1);


### PR DESCRIPTION
Thus it must not be postfixed with a colon character in the optstring.
While at it move the option to the beginning of the opstring to the
other options which don't expect an argument.

Without this commit the -U option is unusable.