### PR TITLE
Update coap_new_client_session_psk() API to support RFC7925 "absolute" identity

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -1115,7 +1115,8 @@ get_session(
   const char *local_port,
   coap_proto_t proto,
   coap_address_t *dst,
-  const char *identity,
+  const uint8_t *identity,
+  unsigned identity_len,
   const uint8_t *key,
   unsigned key_len
 ) {
@@ -1161,7 +1162,7 @@ get_session(
         else if ((identity || key) &&
                  (proto == COAP_PROTO_DTLS || proto == COAP_PROTO_TLS) ) {
           session = coap_new_client_session_psk( ctx, &bind_addr, dst, proto,
-                           identity, key, key_len );
+                           identity, identity_len, key, key_len );
         }
         else {
           session = coap_new_client_session( ctx, &bind_addr, dst, proto );
@@ -1179,7 +1180,7 @@ get_session(
     else if ((identity || key) &&
              (proto == COAP_PROTO_DTLS || proto == COAP_PROTO_TLS) )
       session = coap_new_client_session_psk( ctx, NULL, dst, proto,
-                      identity, key, key_len );
+                      identity, identity_len, key, key_len );
     else
       session = coap_new_client_session( ctx, NULL, dst, proto );
   }
@@ -1365,7 +1366,7 @@ main(int argc, char **argv) {
         uri.scheme==COAP_URI_SCHEME_COAPS ? COAP_PROTO_TLS : COAP_PROTO_TCP
       : uri.scheme==COAP_URI_SCHEME_COAPS ? COAP_PROTO_DTLS : COAP_PROTO_UDP),
     &dst,
-    user_length > 0 ? (const char *)user : NULL,
+    user, (unsigned)user_length,
     key_length > 0  ? key : NULL, (unsigned)key_length
   );
 

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -163,8 +163,12 @@ size_t coap_session_max_pdu_size(coap_session_t *session);
 /**
 * Creates a new client session to the designated server.
 * @param ctx The CoAP context.
-* @param local_if Address of local interface. It is recommended to use NULL to let the operating system choose a suitable local interface. If an address is specified, the port number should be zero, which means that a free port is automatically selected.
-* @param server The server's address. If the port number is zero, the default port for the protocol will be used.
+* @param local_if Address of local interface. It is recommended to use NULL to
+*                 let the operating system choose a suitable local interface.
+*                 If an address is specified, the port number should be zero,
+*                 which means that a free port is automatically selected.
+* @param server The server's address. If the port number is zero, the default
+*               port for the protocol will be used.
 * @param proto Protocol.
 *
 * @return A new CoAP session or NULL if failed. Call coap_session_release to free.
@@ -179,10 +183,16 @@ coap_session_t *coap_new_client_session(
 /**
 * Creates a new client session to the designated server with PSK credentials
 * @param ctx The CoAP context.
-* @param local_if Address of local interface. It is recommended to use NULL to let the operating system choose a suitable local interface. If an address is specified, the port number should be zero, which means that a free port is automatically selected.
-* @param server The server's address. If the port number is zero, the default port for the protocol will be used.
+* @param local_if Address of local interface. It is recommended to use NULL to
+*                 let the operating system choose a suitable local interface.
+*                 If an address is specified, the port number should be zero,
+*                 which means that a free port is automatically selected.
+* @param server The server's address. If the port number is zero, the default
+*               port for the protocol will be used.
 * @param proto Protocol.
 * @param identity PSK client identity
+* @param identity_len PSK client identity length
+                      (does not include the trailing zero byte if a string)
 * @param key PSK shared key
 * @param key_len PSK shared key length
 *
@@ -193,7 +203,8 @@ coap_session_t *coap_new_client_session_psk(
   const coap_address_t *local_if,
   const coap_address_t *server,
   coap_proto_t proto,
-  const char *identity,
+  const uint8_t *identity,
+  unsigned identity_len,
   const uint8_t *key,
   unsigned key_len
 );

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -30,7 +30,8 @@ coap_proto_t _proto_);*
 
 *coap_session_t *coap_new_client_session_psk(coap_context_t *_context_,
 const coap_address_t *_local_if_, const coap_address_t *_server_, coap_proto_t
-_proto_, const char *_identity_, const uint8_t *_key_, unsigned _key_len_);*
+_proto_, const uint8_t *_identity_, unsigned _identity_len_,
+const uint8_t *_key_, unsigned _key_len_);*
 
 *coap_session_t *coap_new_client_session_pki(coap_context_t *_context_,
 const coap_address_t *_local_if_, const coap_address_t *_server_, coap_proto_t
@@ -136,12 +137,17 @@ in the coap_dtls_pki_t structure - see *coap_encrytion*(3).
 The session will initially have a reference count of 1.
 
 The *coap_new_client_session_psk*() function, for a specific _context_, is
-used to configure the TLS context using the client _identity_, Pre-Shared Key
-_key_ with length _key_len_.  All 3 parameters must be defined, NULL is not
-valid.  An empty string is not valid for _identity_.  _key_len_ must be greater
+used to configure the TLS context using the client _identity_ with length
+_identity_len, Pre-Shared Key _key_ with length _key_len_.  All 4 parameters
+must be defined, NULL is not valid.  _key_len_ must be greater
 than 0.  This function also includes the _server_ to connect to,
 optionally the local interface _local_if_ to bind to and the CoAP protocol
 _proto_ to use.  The session will initially have a reference count of 1.
+
+*NOTE:* _identity_ can be binary (RFC 7925 "absolute" identity), but currently
+is always treated as a zero terminated string by OpenSSL or GnuTLS.
+
+*NOTE:* _identity_len_ of 0 is not supported by GnuTLS.
 
 The *coap_session_reference*() is used to increment the reference count of
 the _session_.  Incrementing the reference count by an application means that
@@ -307,7 +313,8 @@ setup_client_session_pki (struct in_addr ip_address,
 
 static coap_session_t *
 setup_client_session_psk (struct in_addr ip_address,
-                          const char *identity,
+                          const uint8_t *identity,
+                          unsigned identity_len,
                           const uint8_t *key,
                           unsigned key_len
 ) {
@@ -325,7 +332,8 @@ setup_client_session_psk (struct in_addr ip_address,
   server.addr.sin.sin_port = htons (5684);
 
   session = coap_new_client_session_psk(context, NULL, &server,
-                                        COAP_PROTO_DTLS, identity, key, key_len);
+                                        COAP_PROTO_DTLS, identity,
+                                        identity_len, key, key_len);
   if (!session) {
     coap_free_context(context);
     return NULL;

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -354,7 +354,7 @@ psk_client_callback(gnutls_session_t g_session,
                     char **username, gnutls_datum_t *key) {
   coap_session_t *c_session =
                   (coap_session_t *)gnutls_transport_get_ptr(g_session);
-  uint8_t identity[64];
+  uint8_t identity[128+1];
   size_t identity_len;
   uint8_t psk_key[64];
   size_t psk_len;
@@ -372,6 +372,8 @@ psk_client_callback(gnutls_session_t g_session,
                                                sizeof (identity) - 1,
                                                psk_key,
                                                sizeof(psk_key));
+
+  /* GnuTLS currently handles this as a zero terminated string */
   if (identity_len < sizeof (identity))
     identity[identity_len] = 0;
 

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -336,6 +336,7 @@ static unsigned coap_dtls_psk_client_callback(SSL *ssl, const char *hint, char *
   if (session == NULL || session->context == NULL || session->context->get_client_psk == NULL)
     return 0;
 
+  /* OpenSSL currently handles this as a zero terminated string */
   psk_len = session->context->get_client_psk(session, (const uint8_t*)hint, hint_len, (uint8_t*)identity, &identity_len, max_identity_len - 1, (uint8_t*)buf, max_len);
   if (identity_len < max_identity_len)
     identity[identity_len] = 0;

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -648,7 +648,8 @@ coap_session_t *coap_new_client_session_psk(
   const coap_address_t *local_if,
   const coap_address_t *server,
   coap_proto_t proto,
-  const char *identity,
+  const uint8_t *identity,
+  unsigned identity_len,
   const uint8_t *key,
   unsigned key_len
 ) {
@@ -657,11 +658,11 @@ coap_session_t *coap_new_client_session_psk(
   if (!session)
     return NULL;
 
-  if (identity && (strlen(identity) > 0)) {
-    size_t identity_len = strlen(identity);
-    session->psk_identity = (uint8_t*)coap_malloc(identity_len);
+  if (identity) {
+    session->psk_identity = (uint8_t*)coap_malloc(identity_len+1);
     if (session->psk_identity) {
       memcpy(session->psk_identity, identity, identity_len);
+      session->psk_identity[identity_len] = '\000';
       session->psk_identity_len = identity_len;
     } else {
       coap_log(LOG_WARNING, "Cannot store session PSK identity\n");

--- a/src/net.c
+++ b/src/net.c
@@ -299,7 +299,7 @@ coap_get_session_client_psk(
 ) {
   (void)hint;
   (void)hint_len;
-  if (session->psk_identity && session->psk_identity_len > 0 && session->psk_key && session->psk_key_len > 0) {
+  if (session->psk_identity && session->psk_key && session->psk_key_len > 0) {
     if (session->psk_identity_len <= max_identity_len && session->psk_key_len <= max_psk_len) {
       memcpy(identity, session->psk_identity, session->psk_identity_len);
       memcpy(psk, session->psk_key, session->psk_key_len);


### PR DESCRIPTION
"absolute" identity is effectively a binary blob of data.

Currently GnuTLS and OpenSSL only support a zero terminated string for
identity, so this is updating the API for when they support this.  TinyDTLS currently supports this.

Also support a zero length identity (not supported by GnuTLS).

The coap_new_client_session_psk() API is updated by making identity uint8_t
and adding in identity_len.

examples/client.c:
include/coap2/coap_session.h:
man/coap_session.txt.in:
src/coap_gnutls.c:
src/coap_openssl.c:
src/coap_session.c:
src/net.c:

Update as appropriate.