### PR TITLE
Support FreeBSD 11.2 builds

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -43,6 +43,10 @@ Some examples are:-
 # With TinyDTLS
 ./configure --enable-tests --disable-documentation --enable-examples --with-tinydtls --disable-shared
 
+Note: FreeBSD requires gmake instead of make when building TinyDTLS - i.e.
+gmake
+sudo gmake install
+
 # With OpenSSL
 ./configure --with-openssl --enable-tests --enable-shared
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -798,6 +798,7 @@ coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint
       struct cmsghdr *cmsg;
 
       if (IN6_IS_ADDR_V4MAPPED(&session->local_addr.addr.sin6.sin6_addr)) {
+#if defined(IP_PKTINFO)
         struct in_pktinfo *pktinfo;
         mhdr.msg_control = buf;
         mhdr.msg_controllen = CMSG_SPACE(sizeof(struct in_pktinfo));
@@ -811,6 +812,7 @@ coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint
 
         pktinfo->ipi_ifindex = session->ifindex;
         memcpy(&pktinfo->ipi_spec_dst, session->local_addr.addr.sin6.sin6_addr.s6_addr + 12, sizeof(pktinfo->ipi_spec_dst));
+#endif /* IP_PKTINFO */
       } else {
         struct in6_pktinfo *pktinfo;
         mhdr.msg_control = buf;

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -157,7 +157,7 @@ t_session6(void) {
   saddr.addr.sin6.sin6_addr = in6addr_loopback;
   saddr.addr.sin6.sin6_port = htons(20000);
 
-  session = coap_new_client_session(ctx, &laddr, &saddr, COAP_PROTO_UDP);
+  session = coap_new_client_session(ctx, &saddr, &laddr, COAP_PROTO_UDP);
   CU_ASSERT_PTR_NOT_NULL(session);
   CU_ASSERT_PTR_NOT_NULL(ctx->sessions);
   CU_ASSERT(session->state == COAP_SESSION_STATE_ESTABLISHED);


### PR DESCRIPTION
src/coap_io.c:
ifdef out IPv4 struct in_pktinfo code that does not compile, copying what
has been done later in the same coap_network_send() function.

tests/test_session.c
Correctly reverse the parameters to coap_new_client_session() in t_session6()
so that the test application does not bind to local-address, port 5683 twice.
[It seems that other distrubutions are happy with this when just SO_REUSEADDR
is used on the socket, but FreeBSD needs SO_REUSEPORT enabled as well.]

BUILDING
Record that gmake is required to build TinyDTLS for FreeBSD, not make.

Most of #89 is already in the develop branch - this PR just completes the ability to build and test.
Issue #87 is covered as well