### PR TITLE
endpoint->hello information memory leak when coap_free_endpoint() called

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,8 +157,10 @@ coap_dtls_send \
 coap_dtls_session_update_mtu \
 coap_dtls_startup \
 coap_endpoint_new_dtls_session \
+coap_mfree_endpoint \
 coap_packet_extract_pbuf \
 coap_pdu_from_pbuf \
+coap_session_mfree \
 coap_socket_accept_tcp \
 coap_socket_bind_tcp \
 coap_socket_bind_udp \

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -368,6 +368,7 @@ coap_session_t *coap_session_get_by_peer(struct coap_context_t *ctx,
   const struct coap_address_t *remote_addr, int ifindex);
 
 void coap_session_free(coap_session_t *session);
+void coap_session_mfree(coap_session_t *session);
 
  /**
   * @defgroup cc Rate Control

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -78,7 +78,6 @@ global:
   coap_malloc_endpoint;
   coap_malloc_type;
   coap_memory_init;
-  coap_mfree_endpoint;
   coap_network_read;
   coap_network_send;
   coap_new_client_session;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -76,7 +76,6 @@ coap_log_impl
 coap_malloc_endpoint
 coap_malloc_type
 coap_memory_init
-coap_mfree_endpoint
 coap_network_read
 coap_network_send
 coap_new_client_session

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -94,6 +94,7 @@ struct coap_endpoint_t *
 void
 coap_mfree_endpoint(struct coap_endpoint_t *ep) {
   ep_initialized = 0;
+  coap_session_mfree(&ep->hello);
 }
 
 int
@@ -183,6 +184,7 @@ struct coap_endpoint_t *
 
 void
 coap_mfree_endpoint(struct coap_endpoint_t *ep) {
+  coap_session_mfree(&ep->hello);
   coap_free_type(COAP_ENDPOINT, ep);
 }
 


### PR DESCRIPTION
Information set up in the pseudo session held in endpoint->hello is not freed
off when coap_free_endpoint() is called.

A solution is to split coap_session_free() into two parts with
coap_session_free() calling a new function coap_session_mfree().

Then coap_mfree_endpoint() can call coap_session_mfree() to free off the
endpoint specific hello information.

Makefile.am

Add coap_mfree_endpoint and coap_session_mfree to the CTAGS_IGNORE list.

libcoap-2.{map|sym}

Remove coap_mfree_endpoint as it is not a public function

include/coap2/coap_session.h

Add in new coap_session_mfree() function definition

src/coap_io.c

Call coap_session_mfree() from within coap_mfree_endpoint()

src/coap_session.c

Move some of the functionality out of coap_session_free() into a new
function coap_session_mfree() and  call coap_session_mfree().