### PR TITLE
Remove deprecated str typedef to remove namespace pollution

### DIFF
--- a/include/coap2/coap_hashkey.h
+++ b/include/coap2/coap_hashkey.h
@@ -43,7 +43,7 @@ void coap_hash_impl(const unsigned char *s, unsigned int len, coap_key_t h);
 #endif /* coap_hash */
 
 /**
- * Calls coap_hash() with given @c str object as parameter.
+ * Calls coap_hash() with given @c coap_string_t object as parameter.
  *
  * @param Str Must contain a pointer to a coap string object.
  * @param H   A coap_key_t object to store the result.

--- a/include/coap2/str.h
+++ b/include/coap2/str.h
@@ -35,12 +35,6 @@ typedef struct coap_str_const_t {
   const uint8_t *s; /**< string data */
 } coap_str_const_t;
 
-/**
- * @deprecated Use coap_string_t instead.
- */
-COAP_DEPRECATED
-typedef coap_string_t str;
-
 #define COAP_SET_STR(st,l,v) { (st)->length = (l), (st)->s = (v); }
 
 /**


### PR DESCRIPTION
As str structure has been replaced by coap_string_t, remove it from the code
as it is no longer required, has been deprecated for some time and can cause
clashes with other str definitions.

Tidy up comment referring to str.