### PR TITLE
Support PSK_WITH_AES_128_CCM_8 and ECDHE_ECDSA_WITH_AES_128_CCM_8 in GnuTLS

### DIFF
--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -88,7 +88,11 @@ typedef struct coap_gnutls_context_t {
   gnutls_priority_t priority_cache;
 } coap_gnutls_context_t;
 
+#if (GNUTLS_VERSION_NUMBER >= 0x030505)
+#define VARIANTS "NORMAL:+ECDHE-PSK:+PSK:+ECDHE-ECDSA:+AES-128-CCM-8"
+#else
 #define VARIANTS "NORMAL:+ECDHE-PSK:+PSK"
+#endif
 
 #define G_ACTION(xx) do { \
   ret = (xx); \


### PR DESCRIPTION
src/coap_gnutls.c:
Add in AES-128-CCM-8 and ECDHE-ECDSA to VARIANTS to include these cipher
suites. to support TinyDTLS and the base PSK requirements of RFC7252.

There is still an issue with TinyDTLS client talking to GnuTLS server. The
server is failing to correctly handle the "FINISHED (20) was received"
packet from the client.  Unclear whether this is GnuTLS or TinyDTLS issue.

GnuTLS client to TinyDTLS server is fine.
OpenSSL client to GnuTLS server is fine.

Should resolve Issue #286