### PR TITLE
Reserved Identifier fixes

### DIFF
--- a/examples/coap_list.h
+++ b/examples/coap_list.h
@@ -25,8 +25,8 @@
  * of coap-client
  */
 
-#ifndef _COAP_LIST_H_
-#define _COAP_LIST_H_
+#ifndef COAP_LIST_H_
+#define COAP_LIST_H_
 
 #include <coap2/utlist.h>
 
@@ -47,4 +47,4 @@ int coap_delete(coap_list_t *node);
 /* removes all items from given queue and frees the allocated storage */
 void coap_delete_list(coap_list_t *queue);
 
-#endif /* _COAP_LIST_H_ */
+#endif /* COAP_LIST_H_ */

--- a/include/coap2/address.h
+++ b/include/coap2/address.h
@@ -12,8 +12,8 @@
  * @brief Representation of network addresses
  */
 
-#ifndef _COAP_ADDRESS_H_
-#define _COAP_ADDRESS_H_
+#ifndef COAP_ADDRESS_H_
+#define COAP_ADDRESS_H_
 
 #include <assert.h>
 #include <stdint.h>
@@ -174,4 +174,4 @@ coap_is_mcast(const coap_address_t *a) {
 }
 #endif /* !WITH_LWIP && !WITH_CONTIKI */
 
-#endif /* _COAP_ADDRESS_H_ */
+#endif /* COAP_ADDRESS_H_ */

--- a/include/coap2/async.h
+++ b/include/coap2/async.h
@@ -12,8 +12,8 @@
  * @brief State management for asynchronous messages
  */
 
-#ifndef _COAP_ASYNC_H_
-#define _COAP_ASYNC_H_
+#ifndef COAP_ASYNC_H_
+#define COAP_ASYNC_H_
 
 #include "net.h"
 
@@ -146,4 +146,4 @@ coap_touch_async(coap_async_state_t *s) { coap_ticks(&s->created); }
 
 #endif /*  WITHOUT_ASYNC */
 
-#endif /* _COAP_ASYNC_H_ */
+#endif /* COAP_ASYNC_H_ */

--- a/include/coap2/bits.h
+++ b/include/coap2/bits.h
@@ -12,8 +12,8 @@
  * @brief Bit vector manipulation
  */
 
-#ifndef _COAP_BITS_H_
-#define _COAP_BITS_H_
+#ifndef COAP_BITS_H_
+#define COAP_BITS_H_
 
 #include <stdint.h>
 
@@ -75,4 +75,4 @@ bits_getb(const uint8_t *vec, size_t size, uint8_t bit) {
   return (*(vec + (bit >> 3)) & (1 << (bit & 0x07))) != 0;
 }
 
-#endif /* _COAP_BITS_H_ */
+#endif /* COAP_BITS_H_ */

--- a/include/coap2/block.h
+++ b/include/coap2/block.h
@@ -7,8 +7,8 @@
  * of use.
  */
 
-#ifndef _COAP_BLOCK_H_
-#define _COAP_BLOCK_H_
+#ifndef COAP_BLOCK_H_
+#define COAP_BLOCK_H_
 
 #include "encode.h"
 #include "option.h"
@@ -170,4 +170,4 @@ coap_add_data_blocked_response(struct coap_resource_t *resource,
 
 /**@}*/
 
-#endif /* _COAP_BLOCK_H_ */
+#endif /* COAP_BLOCK_H_ */

--- a/include/coap2/coap.h.in
+++ b/include/coap2/coap.h.in
@@ -8,8 +8,8 @@
  * of use.
  */
 
-#ifndef _COAP_H_
-#define _COAP_H_
+#ifndef COAP_H_
+#define COAP_H_
 
 /* Define the address where bug reports for libcoap should be sent. */
 #define LIBCOAP_PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
@@ -56,4 +56,4 @@ extern "C" {
 }
 #endif
 
-#endif /* _COAP_H_ */
+#endif /* COAP_H_ */

--- a/include/coap2/coap.h.windows
+++ b/include/coap2/coap.h.windows
@@ -8,8 +8,8 @@
  * of use.
  */
 
-#ifndef _COAP_H_
-#define _COAP_H_
+#ifndef COAP_H_
+#define COAP_H_
 
 #include "libcoap.h"
 
@@ -56,4 +56,4 @@ extern "C" {
 }
 #endif
 
-#endif /* _COAP_H_ */
+#endif /* COAP_H_ */

--- a/include/coap2/coap_debug.h
+++ b/include/coap2/coap_debug.h
@@ -7,8 +7,8 @@
  * of use.
  */
 
-#ifndef _COAP_DEBUG_H_
-#define _COAP_DEBUG_H_
+#ifndef COAP_DEBUG_H_
+#define COAP_DEBUG_H_
 
 /**
  * @defgroup logging Logging Support
@@ -206,4 +206,4 @@ int coap_debug_set_packet_loss(const char *loss_level);
 int coap_debug_send_packet(void);
 
 
-#endif /* _COAP_DEBUG_H_ */
+#endif /* COAP_DEBUG_H_ */

--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -8,8 +8,8 @@
  * of use.
  */
 
-#ifndef _COAP_DTLS_H_
-#define _COAP_DTLS_H_
+#ifndef COAP_DTLS_H_
+#define COAP_DTLS_H_
 
 #include "net.h"
 #include "coap_session.h"

--- a/include/coap2/coap_event.h
+++ b/include/coap2/coap_event.h
@@ -7,8 +7,8 @@
  * of use.
  */
 
-#ifndef _COAP_EVENT_H_
-#define _COAP_EVENT_H_
+#ifndef COAP_EVENT_H_
+#define COAP_EVENT_H_
 
 #include "libcoap.h"
 

--- a/include/coap2/coap_hashkey.h
+++ b/include/coap2/coap_hashkey.h
@@ -12,8 +12,8 @@
  * @brief definition of hash key type and helper functions
  */
 
-#ifndef _COAP_HASHKEY_H_
-#define _COAP_HASHKEY_H_
+#ifndef COAP_HASHKEY_H_
+#define COAP_HASHKEY_H_
 
 #include "libcoap.h"
 #include "uthash.h"
@@ -37,9 +37,9 @@ void coap_hash_impl(const unsigned char *s, unsigned int len, coap_key_t h);
   coap_hash_impl((String),(Length),(Result))
 
 /* This is used to control the pre-set hash-keys for resources. */
-#define __COAP_DEFAULT_HASH
+#define COAP_DEFAULT_HASH
 #else
-#undef __COAP_DEFAULT_HASH
+#undef COAP_DEFAULT_HASH
 #endif /* coap_hash */
 
 /**
@@ -56,4 +56,4 @@ void coap_hash_impl(const unsigned char *s, unsigned int len, coap_key_t h);
     coap_hash((Str)->s, (Str)->length, (H)); \
   }
 
-#endif /* _COAP_HASHKEY_H_ */
+#endif /* COAP_HASHKEY_H_ */

--- a/include/coap2/coap_io.h
+++ b/include/coap2/coap_io.h
@@ -7,8 +7,8 @@
  * of use.
  */
 
-#ifndef _COAP_IO_H_
-#define _COAP_IO_H_
+#ifndef COAP_IO_H_
+#define COAP_IO_H_
 
 #include <assert.h>
 #include <sys/types.h>
@@ -210,4 +210,4 @@ typedef enum {
   COAP_NACK_TLS_FAILED
 } coap_nack_reason_t;
 
-#endif /* _COAP_IO_H_ */
+#endif /* COAP_IO_H_ */

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -6,8 +6,8 @@
 * README for terms of use.
 */
 
-#ifndef _SESSION_H_
-#define _SESSION_H_
+#ifndef COAP_SESSION_H_
+#define COAP_SESSION_H_
 
 
 #include "coap_io.h"
@@ -490,4 +490,4 @@ coap_fixed_point_t coap_session_get_ack_random_factor(coap_session_t *session);
  */
 coap_tid_t coap_session_send_ping(coap_session_t *session);
 
-#endif  /* _SESSION_H */
+#endif  /* COAP_SESSION_H */

--- a/include/coap2/coap_time.h
+++ b/include/coap2/coap_time.h
@@ -12,8 +12,8 @@
  * @brief Clock Handling
  */
 
-#ifndef _COAP_TIME_H_
-#define _COAP_TIME_H_
+#ifndef COAP_TIME_H_
+#define COAP_TIME_H_
 
 /**
  * @defgroup clock Clock Handling
@@ -159,4 +159,4 @@ COAP_STATIC_INLINE int coap_time_le(coap_tick_t a, coap_tick_t b) {
 
 /** @} */
 
-#endif /* _COAP_TIME_H_ */
+#endif /* COAP_TIME_H_ */

--- a/include/coap2/encode.h
+++ b/include/coap2/encode.h
@@ -7,8 +7,8 @@
  * of use.
  */
 
-#ifndef _COAP_ENCODE_H_
-#define _COAP_ENCODE_H_
+#ifndef COAP_ENCODE_H_
+#define COAP_ENCODE_H_
 
 #if (BSD >= 199103) || defined(WITH_CONTIKI) || defined(_WIN32)
 # include <string.h>
@@ -93,4 +93,4 @@ coap_encode_var_bytes(uint8_t *buf, unsigned int value
   return (int)coap_encode_var_safe(buf, sizeof(value), value);
 }
 
-#endif /* _COAP_ENCODE_H_ */
+#endif /* COAP_ENCODE_H_ */

--- a/include/coap2/libcoap.h
+++ b/include/coap2/libcoap.h
@@ -7,8 +7,8 @@
  * of use.
  */
 
-#ifndef _LIBCOAP_H_
-#define _LIBCOAP_H_
+#ifndef COAP_LIBCOAP_H_
+#define COAP_LIBCOAP_H_
 
 /* The non posix embedded platforms like Contiki, TinyOS, RIOT, ... doesn't have
  * a POSIX compatible header structure so we have to slightly do some platform
@@ -55,4 +55,4 @@ void coap_startup(void);
 
 void coap_cleanup(void);
 
-#endif /* _LIBCOAP_H_ */
+#endif /* COAP_LIBCOAP_H_ */

--- a/include/coap2/mem.h
+++ b/include/coap2/mem.h
@@ -7,8 +7,8 @@
  * of use.
  */
 
-#ifndef _COAP_MEM_H_
-#define _COAP_MEM_H_
+#ifndef COAP_MEM_H_
+#define COAP_MEM_H_
 
 #include <stdlib.h>
 
@@ -113,4 +113,4 @@ COAP_STATIC_INLINE void coap_free(void *pointer) {
 
 #endif /* WITH_LWIP */
 
-#endif /* _COAP_MEM_H_ */
+#endif /* COAP_MEM_H_ */

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -7,8 +7,8 @@
  * of use.
  */
 
-#ifndef _COAP_NET_H_
-#define _COAP_NET_H_
+#ifndef COAP_NET_H_
+#define COAP_NET_H_
 
 #include <assert.h>
 #include <stdlib.h>
@@ -739,4 +739,4 @@ coap_pdu_t *coap_wellknown_response(coap_context_t *context,
  */
 unsigned int coap_calc_timeout(coap_session_t *session, unsigned char r);
 
-#endif /* _COAP_NET_H_ */
+#endif /* COAP_NET_H_ */

--- a/include/coap2/option.h
+++ b/include/coap2/option.h
@@ -12,8 +12,8 @@
  * @brief Helpers for handling options in CoAP PDUs
  */
 
-#ifndef _COAP_OPTION_H_
-#define _COAP_OPTION_H_
+#ifndef COAP_OPTION_H_
+#define COAP_OPTION_H_
 
 #include "bits.h"
 #include "pdu.h"
@@ -458,4 +458,4 @@ int coap_insert_optlist(coap_optlist_t **optlist_chain,
  */
 void coap_delete_optlist(coap_optlist_t *optlist_chain);
 
-#endif /* _OPTION_H_ */
+#endif /* COAP_OPTION_H_ */

--- a/include/coap2/pdu.h
+++ b/include/coap2/pdu.h
@@ -12,8 +12,8 @@
  * @brief Pre-defined constants that reflect defaults for CoAP
  */
 
-#ifndef _COAP_PDU_H_
-#define _COAP_PDU_H_
+#ifndef COAP_PDU_H_
+#define COAP_PDU_H_
 
 #include "uri.h"
 
@@ -540,4 +540,4 @@ int coap_get_data(const coap_pdu_t *pdu,
 
 size_t coap_pdu_encode_header(coap_pdu_t *pdu, coap_proto_t proto);
 
-#endif /* _COAP_PDU_H_ */
+#endif /* COAP_PDU_H_ */

--- a/include/coap2/prng.h
+++ b/include/coap2/prng.h
@@ -12,8 +12,8 @@
  * @brief Pseudo Random Numbers
  */
 
-#ifndef _COAP_PRNG_H_
-#define _COAP_PRNG_H_
+#ifndef COAP_PRNG_H_
+#define COAP_PRNG_H_
 
 /**
  * @defgroup prng Pseudo Random Numbers
@@ -124,4 +124,4 @@ coap_prng_impl( unsigned char *buf, size_t len ) {
 
 /** @} */
 
-#endif /* _COAP_PRNG_H_ */
+#endif /* COAP_PRNG_H_ */

--- a/include/coap2/resource.h
+++ b/include/coap2/resource.h
@@ -12,8 +12,8 @@
  * @brief Generic resource handling
  */
 
-#ifndef _COAP_RESOURCE_H_
-#define _COAP_RESOURCE_H_
+#ifndef COAP_RESOURCE_H_
+#define COAP_RESOURCE_H_
 
 # include <assert.h>
 
@@ -521,4 +521,4 @@ COAP_DEPRECATED int
 coap_resource_set_dirty(coap_resource_t *r,
                         const coap_string_t *query);
 
-#endif /* _COAP_RESOURCE_H_ */
+#endif /* COAP_RESOURCE_H_ */

--- a/include/coap2/str.h
+++ b/include/coap2/str.h
@@ -7,8 +7,8 @@
  * of use.
  */
 
-#ifndef _COAP_STR_H_
-#define _COAP_STR_H_
+#ifndef COAP_STR_H_
+#define COAP_STR_H_
 
 #include <string.h>
 
@@ -118,4 +118,4 @@ namespace libcoap {
 
 /** @} */
 
-#endif /* _COAP_STR_H_ */
+#endif /* COAP_STR_H_ */

--- a/include/coap2/subscribe.h
+++ b/include/coap2/subscribe.h
@@ -9,8 +9,8 @@
  */
 
 
-#ifndef _COAP_SUBSCRIBE_H_
-#define _COAP_SUBSCRIBE_H_
+#ifndef COAP_SUBSCRIBE_H_
+#define COAP_SUBSCRIBE_H_
 
 #include "address.h"
 #include "coap_io.h"
@@ -73,4 +73,4 @@ void coap_subscription_init(coap_subscription_t *);
 
 /** @} */
 
-#endif /* _COAP_SUBSCRIBE_H_ */
+#endif /* COAP_SUBSCRIBE_H_ */

--- a/include/coap2/uri.h
+++ b/include/coap2/uri.h
@@ -7,8 +7,8 @@
  * of use.
  */
 
-#ifndef _COAP_URI_H_
-#define _COAP_URI_H_
+#ifndef COAP_URI_H_
+#define COAP_URI_H_
 
 #include <stdint.h>
 
@@ -144,4 +144,4 @@ coap_string_t *coap_get_uri_path(const struct coap_pdu_t *request);
 
 /** @} */
 
-#endif /* _COAP_URI_H_ */
+#endif /* COAP_URI_H_ */

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -6,8 +6,8 @@
 * README for terms of use.
 */
 
-#ifndef _COAP_SESSION_H_
-#define _COAP_SESSION_H_
+#ifndef COAP_SESSION_C_
+#define COAP_SESSION_C_
 
 
 #include "coap_config.h"
@@ -998,4 +998,4 @@ const char *coap_endpoint_str(const coap_endpoint_t *endpoint) {
   return szEndpoint;
 }
 
-#endif  /* _COAP_SESSION_H_ */
+#endif  /* COAP_SESSION_C_ */


### PR DESCRIPTION
include/coap2/libcoap.h
`_LIBCOAP_H_ to _COAP_LIBCOAP_H_`
src/coap_session.c
`_COAP_SESSION_H_ to _COAP_SESSION_C_`
include/coap2/coap_session.h
`_SESSION_H_ to _COAP_SESSION_H_`

Fixes #291