### PR TITLE
coap-client: Support using CA or Root CAs, but not Cert files

### DIFF
--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -261,8 +261,10 @@ typedef struct coap_dtls_pki_t {
 void *
 coap_dtls_new_context(struct coap_context_t *coap_context);
 
-#define COAP_DTLS_ROLE_CLIENT  0 /**< Internal function invoked for client */
-#define COAP_DTLS_ROLE_SERVER  1 /**< Internal function invoked for server */
+typedef enum coap_dtls_role_t {
+  COAP_DTLS_ROLE_CLIENT, /**< Internal function invoked for client */
+  COAP_DTLS_ROLE_SERVER  /**< Internal function invoked for server */
+} coap_dtls_role_t;
 
 /**
  * Set the DTLS context's default PSK information.
@@ -288,7 +290,7 @@ coap_dtls_new_context(struct coap_context_t *coap_context);
 int
 coap_dtls_context_set_psk(struct coap_context_t *coap_context,
                           const char *identity_hint,
-                          int role);
+                          coap_dtls_role_t role);
 
 /**
  * Set the DTLS context's default server PKI information.
@@ -312,7 +314,7 @@ coap_dtls_context_set_psk(struct coap_context_t *coap_context,
 int
 coap_dtls_context_set_pki(struct coap_context_t *coap_context,
                           coap_dtls_pki_t *setup_data,
-                          int role);
+                          coap_dtls_role_t role);
 
 /**
  * Set the dtls context's default Root CA information for a client or server.

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -40,7 +40,7 @@ coap_get_tls_library_version(void) {
 int
 coap_dtls_context_set_pki(coap_context_t *ctx UNUSED,
                           coap_dtls_pki_t* setup_data UNUSED,
-                          int server UNUSED
+                          coap_dtls_role_t role UNUSED
 ) {
   return 0;
 }
@@ -56,7 +56,7 @@ coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx UNUSED,
 int
 coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
                           const char *hint UNUSED,
-                          int server UNUSED
+                          coap_dtls_role_t role UNUSED
 ) {
   return 0;
 }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -490,7 +490,7 @@ coap_get_tls_library_version(void) {
 int
 coap_dtls_context_set_pki(coap_context_t *ctx UNUSED,
   coap_dtls_pki_t* setup_data UNUSED,
-  int server UNUSED
+  coap_dtls_role_t role UNUSED
 ) {
   return 0;
 }
@@ -506,7 +506,7 @@ coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx UNUSED,
 int
 coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
   const char *hint UNUSED,
-  int server UNUSED
+  coap_dtls_role_t role UNUSED
 ) {
   return 1;
 }


### PR DESCRIPTION
By defining the CA file or Root CAs in the client, the server's certificate
can be validated by the options in coap_dtls_pki_t parameter even if the client
does not define a certificate.
[The server must be configured not to require a Client Cert]

examples/client.c:

Add in the support to the coap-client to allow any of Root CA, CA and Cert
to be defined to set up PKI checking.

src/coap_gnutls.c:
src/coap_openssl.c:

Remove the checks in the OpenSSL and GnuTLS underlying support that previously
used to enforce that both CA and Cert had to be set in the client.

Correct some of the PKI setup error messages to reflect whether the failure is
on the client or the server.

include/coap2/coap_dtls.h:
src/coap_gnutls.c:
src/coap_notls.c:
src/coap_openssl.c:
src/coap_tinydtls.c:

Convert COAP_DTLS_ROLE_SERVER and COAP_DTLS_ROLE_CLIENT to enum
coap_dtls_role_t and use as appropriate to differentiate between the roles
in the different DTLS libraries