### PR TITLE
Support coap-client with no PKI or PSK defined, but using (D)TLS in GnuTLS

### DIFF
--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -129,7 +129,7 @@ typedef enum coap_asn1_privatekey_type_t {
  * The enum used for determining the PKI key formats.
  */
 typedef enum coap_pki_key_t {
-  COAP_PKI_KEY_PEM,      /**< The PKI key type is PEM */
+  COAP_PKI_KEY_PEM = 0,   /**< The PKI key type is PEM */
   COAP_PKI_KEY_ASN1,      /**< The PKI key type is ASN.1 (DER) */
 } coap_pki_key_t;
 


### PR DESCRIPTION
To reproduce the issue:

Server session
$ coap-server -v9 -n -k secretPSK -c server.pem -C ca.pem -R /etc/ssl/certs

Client session
$ examples/coap-client -v9  coaps://127.0.0.1/

include/coap2/coap_dtls.h:
src/coap_gnutls.c:

If neither coap_new_client_session_pki() or coap_new_client_session_psk()
is called, but coap_new_client_session() is (as done by coap-client if
no PKI or PSK options set), then set up a default PKI session to be
able to talk to a coap server.