### PR TITLE
option.c: memset the node when a new optlist node is created

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -557,6 +557,7 @@ coap_new_optlist(uint16_t number,
   node = coap_malloc_type(COAP_OPTLIST, sizeof(coap_optlist_t) + length);
 
   if (node) {
+    memset(node, 0, (sizeof(coap_optlist_t) + length));
     node->number = number;
     node->length = length;
     node->data = (uint8_t *)&node[1];


### PR DESCRIPTION
memset the node when a new optlist node is created, because the node->next maybe not NULL, so if it creates a new optlist node, and delete it, and then create it again, error will be occurred