### PR TITLE
Support for clients with no PKI or PSK defined for GnuTLS > 3.6 and coaps

### DIFF
--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -709,6 +709,11 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
             "gnutls_certificate_set_x509_trust_dir");
 #endif
   }
+  if (!(g_context->psk_pki_enabled & IS_PKI)) {
+    /* No PKI defined at all - still need a trust set up for 3.6.0 or later */
+    G_CHECK(gnutls_certificate_set_x509_system_trust(*pki_credentials),
+            "gnutls_certificate_set_x509_system_trust");
+  }
 
   /* Verify Peer */
   if (setup_data->verify_peer_cert) {


### PR DESCRIPTION
GnuTLS 3.6.0 or later requires that gnutls_certificate_set_x509_system_trust()
is set up if PSK is not being used and PKI is not defined and the session
is to be DTLS based.

src/coap_gnutls.c:

Add in call to gnutls_certificate_set_x509_system_trust() in
setup_pki_credentials() if PKI has not been set up.

See discussion on #300 