### PR TITLE
Fix 'make distcheck' by removing the manpage additional generated .3 files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -233,7 +233,7 @@ distclean-local:
 	@rm -f src/*.o src/*.lo
 	rm -f libcoap-$(LIBCOAP_API_VERSION).map
 	rm -f libcoap-$(LIBCOAP_API_VERSION).sym
-	rm -f libcoap-$(LIBCOAP_API_VERSION).pc
+	rm -f libcoap-$(LIBCOAP_NAME_SUFFIX).pc
 	@echo
 	@echo "     ---> Please note the following important advice! <---"
 	@echo "     The files libcoap-$(LIBCOAP_API_VERSION).{map,sym} are removed by the distclean target!"

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -52,7 +52,30 @@ man7_MANS = $(MAN7)
 	$(A2X) --doctype manpage --format manpage $<
 	$(A2X) --doctype manpage --format xhtml $<
 
-# We are limited to 10 names, but synopsis can cover more
+# Man pages built byt a2x based on the NAMES section of the .txt file
+A2X_EXTRA_PAGES := $(shell for fil in $(TXT3); do sed -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $${fil} | \
+	sed -ne '/coap_/{ s/ *, */\n/g; p }' | sed -ne 's/^\(coap_[a-zA-Z_]\+\).*$$/\1.3/p' ; done)
+
+# Extra man pages that need to be installed due to limit of 10
+# names built by a2x
+# These files are created in install-man
+EXTRA_PAGES = \
+	coap_context_set_pki_root_cas.3 \
+	coap_add_data_blocked_response.3 \
+	coap_encode_var_bytes.3 \
+	coap_split_path.3 \
+	coap_split_query.3 \
+	coap_session_get_app_data.3 \
+	coap_session_set_app_data.3 \
+	coap_endpoint_str.3
+
+# a2x builds alternative .3 files up to a limit of 10 names from the
+# NAME section, so that 'man' works against the alternative different
+# function names.
+# However, if there are more alternative names, they need to be defined
+# as per below.
+# Then all the alternative names as well as the extras defined below need
+# to be cleaned up in a 'make unistall'.
 install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_set_pki_root_cas.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_add_data_blocked_response.3
@@ -63,7 +86,12 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_session.3" > coap_session_set_app_data.3
 	@echo ".so man3/coap_logging.3" > coap_endpoint_str.3
 	@echo ".so man3/coap_logging.3" > coap_session_str.3
-	$(INSTALL_DATA) *.3 "$(DESTDIR)$(man3dir)"
+	$(INSTALL_DATA) $(EXTRA_PAGES) $(A2X_EXTRA_PAGES) "$(DESTDIR)$(man3dir)"
+
+# As well as removing the base 'man' pages, remove other .3 files built by
+# a2x, as well as build by install-man specials.
+uninstall-man: uninstall-man3 uninstall-man5 uninstall-man7
+	-(cd $(DESTDIR)$(man3dir) ; rm -f $(EXTRA_PAGES) $(A2X_EXTRA_PAGES) )
 
 CLEANFILES = *.3 *.5 *.7 *.xml *.html docbook-xsl.css
 

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -12,7 +12,7 @@ NAME
 ----
 coap_context, coap_new_context, coap_free_context,
 coap_context_set_pki, coap_context_set_psk, coap_new_endpoint,
-coap_free_endpoint, coap_endpoint_set_default_mtu, coap_endpoint_str
+coap_free_endpoint, coap_endpoint_set_default_mtu
 - Work with CoAP contexts
 
 SYNOPSIS


### PR DESCRIPTION
Makefile.am:
    
Correct the name of the libcoap-*.pc in distclean-local: of Makefile.am
    
man/Makefile.am:
    
Determine additional man pages created by a2x with A2X_EXTRA_PAGES.
Set EXTRA_PAGES for the hand crafted additional man pages.
Clean out the additional installed coap_*.3 man pages using uninstall-man:
in man/Makefile.am
    
man/coap_context.txt.in:
    
Remove spurious reference to coap_endpoint_str

Addresses issue raised in #305 