### PR TITLE
Fix mcast registrations when using TCP

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -866,70 +866,6 @@ finish:
   return ctx;
 }
 
-static int
-join(coap_context_t *ctx, char *group_name){
-  struct ipv6_mreq mreq;
-  struct addrinfo   *reslocal = NULL, *resmulti = NULL, hints, *ainfo;
-  int result = -1;
-
-  /* we have to resolve the link-local interface to get the interface id */
-  memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_INET6;
-  hints.ai_socktype = SOCK_DGRAM;
-
-  result = getaddrinfo("::", NULL, &hints, &reslocal);
-  if (result != 0) {
-    fprintf(stderr, "join: cannot resolve link-local interface: %s\n",
-            gai_strerror(result));
-    goto finish;
-  }
-
-  /* get the first suitable interface identifier */
-  for (ainfo = reslocal; ainfo != NULL; ainfo = ainfo->ai_next) {
-    if (ainfo->ai_family == AF_INET6) {
-      mreq.ipv6mr_interface =
-                ((struct sockaddr_in6 *)ainfo->ai_addr)->sin6_scope_id;
-      break;
-    }
-  }
-
-  memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_INET6;
-  hints.ai_socktype = SOCK_DGRAM;
-
-  /* resolve the multicast group address */
-  result = getaddrinfo(group_name, NULL, &hints, &resmulti);
-
-  if (result != 0) {
-    fprintf(stderr, "join: cannot resolve multicast address: %s\n",
-            gai_strerror(result));
-    goto finish;
-  }
-
-  for (ainfo = resmulti; ainfo != NULL; ainfo = ainfo->ai_next) {
-    if (ainfo->ai_family == AF_INET6) {
-      mreq.ipv6mr_multiaddr =
-                ((struct sockaddr_in6 *)ainfo->ai_addr)->sin6_addr;
-      break;
-    }
-  }
-
-  if (ctx->endpoint) {
-    result = setsockopt(ctx->endpoint->sock.fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, (char *)&mreq, sizeof(mreq));
-    if ( result == COAP_SOCKET_ERROR ) {
-      fprintf( stderr, "join: setsockopt: %s\n", coap_socket_strerror() );
-    }
-  } else {
-    result = -1;
-  }
-
- finish:
-  freeaddrinfo(resmulti);
-  freeaddrinfo(reslocal);
-
-  return result;
-}
-
 static ssize_t
 cmdline_read_key(char *arg, unsigned char *buf, size_t maxlen) {
   size_t len = strnlen(arg, maxlen);
@@ -1030,7 +966,7 @@ main(int argc, char **argv) {
 
   /* join multicast group if requested at command line */
   if (group)
-    join(ctx, group);
+    coap_join_mcast_group(ctx, group);
 
 #ifdef _WIN32
   signal(SIGINT, handle_sigint);

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -739,4 +739,15 @@ coap_pdu_t *coap_wellknown_response(coap_context_t *context,
  */
 unsigned int coap_calc_timeout(coap_session_t *session, unsigned char r);
 
+/**
+ * Function interface for joining a multicast group for listening
+ *
+ * @param ctx   The current context
+ * @param groupname The name of the group that is to be joined for listening
+ *
+ * @return       0 on success, -1 on error
+ */
+int
+coap_join_mcast_group(coap_context_t *ctx, const char *groupname);
+
 #endif /* COAP_NET_H_ */

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -74,6 +74,7 @@ global:
   coap_insert_node;
   coap_insert_optlist;
   coap_is_mcast;
+  coap_join_mcast_group;
   coap_log_impl;
   coap_malloc_endpoint;
   coap_malloc_type;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -72,6 +72,7 @@ coap_hash_impl
 coap_insert_node
 coap_insert_optlist
 coap_is_mcast
+coap_join_mcast_group
 coap_log_impl
 coap_malloc_endpoint
 coap_malloc_type

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -61,10 +61,10 @@ verbosity level is set to '5'.
 
 * Example
 ----
-coap-rd -A 2001:db8:81a8:0:6ef0:dead:feed:beef  -g FF02:FD
+coap-rd -A 2001:db8:81a8:0:6ef0:dead:feed:beef  -g FF02::FD
 ----
 Set listening address to '2001:db8:81a8:0:6ef0:dead:feed:beef' and join the
-All CoAP Nodes multicast group 'FF02:FD'.
+All CoAP Nodes multicast group 'FF02::FD'.
 
 FILES
 ------


### PR DESCRIPTION
As coap-server now sets up 2 (or 4) endpoints, UDP and TCP based, all
subsequent endpoints are pre-pended to the ctx->endpoint list. Thus
ctx->endpoint will always be TCP based.  Setting IPV6_JOIN_GROUP on a TCP
socket is a no-no.

As join() is complex function, it should be within libcoap so as to not require
detailed knowledge of how internal structures work (which really should be 
opaque to the application writer).

include/coap2/net.h:
src/net.c:
libcoap-2.map:
libcoap-2.sym:
Create coap_join_mcast_group() in src/net.c (as it is a network layer
function using the (fixed) join() code. (Iterate through the ctx->endpoint list 
looking for UDP based endpoints and only do the IPV6_JOIN_GROUP on them.)
There is no support for WITH_CONTIKI or WITH_LWIP at this point (returns -1).

examples/coap-server.c:
Remove join() code and replace call to join() with coap_join_mcast_group()

examples/coap-rd.c:
Remove join() code and replace call to join() with coap_join_mcast_group()

man/coap-rd.txt.in:
Correct a typo in the coap-rd man page

