### PR TITLE
coap_debug.c: fix format warning when compiling with GCC 8

### DIFF
--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -291,7 +291,7 @@ msg_code_string(uint16_t c) {
   } else if (c >= 224 && c - 224 < (int)(sizeof(signals)/sizeof(const char *))) {
     return signals[c-224];
   } else {
-    snprintf(buf, sizeof(buf), "%u.%02u", c >> 5, c & 0x1f);
+    snprintf(buf, sizeof(buf), "%u.%02u", (c >> 5) & 0x7, c & 0x1f);
     return buf;
   }
 }


### PR DESCRIPTION
When compiling libcoap with format truncation warnings enabled,
GCC warns about the potential issue with "%u.%02u" format string,
since the first argument may produce more than one byte of output:

    error: '%02u' directive output may be truncated writing 2 bytes
    into a region of size between 0 and 3 [-Werror=format-truncation=]

The first argument (class) is limited to 3 bits according to the
specification. Mask the higher bits to fix the warning.