### PR TITLE
Travis tests/testdriver fails with libtinydtls.so missing error

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -41,7 +41,7 @@ Some examples are:-
 ./configure --enable-tests --disable-documentation --enable-examples --disable-dtls --enable-shared
 
 # With TinyDTLS
-./configure --enable-tests --disable-documentation --enable-examples --with-tinydtls --disable-shared
+./configure --enable-tests --disable-documentation --enable-examples --with-tinydtls --enable-shared
 
 Note: FreeBSD requires gmake instead of make when building TinyDTLS - i.e.
 gmake

--- a/configure.ac
+++ b/configure.ac
@@ -394,10 +394,6 @@ if test "x$build_dtls" = "xyes"; then
 
     # The user wants to use explicit OpenSSL if '--with-tinydtls was set'.
     if test "x$with_tinydtls" = "xyes" ; then
-        if test "x$enable_shared" = "xyes"; then
-            AC_MSG_ERROR([==> You want to build libcoap with DTLS support by tinyDTLS but have enabled shared libraries.
-                      Please pass '--disable-shared' to configure or select a different DTLS library.])
-        fi
         if test -d "$srcdir/ext/tinydtls"; then
            AC_CONFIG_SUBDIRS([ext/tinydtls])
            have_tinydtls="yes"
@@ -446,9 +442,15 @@ if test "x$build_dtls" = "xyes"; then
         AC_DEFINE(HAVE_OPENSSL, [1], [Define if the system has libssl1.1])
     fi
     if test "x$with_tinydtls" = "xyes"; then
-       DTLS_CFLAGS="-I \$(top_srcdir)/ext/tinydtls"
-       DTLS_LIBS="-L\$(top_srcdir)/ext/tinydtls -ltinydtls"
-       AC_DEFINE(HAVE_LIBTINYDTLS, [1], [Define if the system has libtinydtls])
+        DTLS_CFLAGS="-I \$(top_srcdir)/ext/tinydtls"
+        if test "x$enable_shared" = "xyes"; then
+            DTLS_LIBS="-L\$(top_builddir)/ext/tinydtls -ltinydtls"
+        else
+            # Needed as TinyDTLS compiling does not recognize --disable-shared
+            # and still builds libtinydtls.so which gets linked in otherwise
+            DTLS_LIBS="-L\$(top_builddir)/ext/tinydtls -l:libtinydtls.a"
+        fi
+        AC_DEFINE(HAVE_LIBTINYDTLS, [1], [Define if the system has libtinydtls])
     fi
     AC_SUBST(DTLS_CFLAGS)
     AC_SUBST(DTLS_LIBS)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,6 +5,7 @@ if test "x$TESTS" = "xyes" -o "x$TESTS" = "xtrue" ; then
     test -f `pwd`/cunit.pc && echo cat `pwd`/cunit.pc
 fi
 
+TEST_LD_LIBRARY_PATH=
 case "x${TLS}" in
     xno)       WITH_TLS="--disable-dtls"
                ;;
@@ -12,7 +13,10 @@ case "x${TLS}" in
                ;;
     xgnutls)   WITH_TLS="--with-gnutls"
                ;;
-    xtinydtls) WITH_TLS="--with-tinydtls --disable-shared"
+    xtinydtls) WITH_TLS="--with-tinydtls"
+               # Need this as libtinydtls.so has not been installed
+               # as a part of the travis build
+               TEST_LD_LIBRARY_PATH="ext/tinydtls"
                ;;
     *)         WITH_TLS="--with-gnutls"
                ;;
@@ -46,7 +50,7 @@ err=$?
 if test $err = 0 -a -n "$WITH_TESTS" ; then
     EXEC_FILE=tests/testdriver
     # then run valgrind on the actual executable
-    libtool --mode=execute valgrind --track-origins=yes --leak-check=yes --show-reachable=yes --error-exitcode=123 --quiet $EXEC_FILE
+    LD_LIBRARY_PATH=$TEST_LD_LIBRARY_PATH libtool --mode=execute valgrind --track-origins=yes --leak-check=yes --show-reachable=yes --error-exitcode=123 --quiet $EXEC_FILE
     err=$?
 fi
 


### PR DESCRIPTION
When building tinydtls version, Travis fails with the following error

tests/testdriver: error while loading shared libraries: libtinydtls.so:
cannot open shared object file: No such file or directory

The new version of TinyDTLS now builds a libtinydtls.so file which is
linked against in preference to libtinydtls.a when using -ltinydtls,
but Travis does not have an installed version libtinydtls.so to load
during execution of tests/testbriver - hence failure.

scripts/build.sh:

Add in LD_LIBRARY_PATH=ext/tinydtls if building tinydtls.

BUILDING:
configure.ac:

With libtinydtls.so being available, there is no need to enforce
--disable-shared for tinydtls.  Remove this requirement.
If --disable-shared is set, link in with libtinydtls.a.

Fixes issue reported in #318