### PR TITLE
Client crashes in gnutls psk setup

### DIFF
--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -404,7 +404,7 @@ psk_client_callback(gnutls_session_t g_session,
   *username = gnutls_malloc(identity_len+1);
   if (*username) {
     memcpy(*username, identity, identity_len);
-    *username[identity_len] = '\0';
+    username[identity_len] = '\0';
   }
 
   key->data = gnutls_malloc(psk_len);


### PR DESCRIPTION
src/coap_gnutls.c:

Correct typo when null terminating username.