### PR TITLE
Support integration of tinydtls into libcoap so 2 libraries are not required

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -88,6 +88,23 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_SOURCES = \
   src/subscribe.c \
   src/uri.c
 
+if INTEGRATE_TINYDTLS
+libcoap_@LIBCOAP_NAME_SUFFIX@_la_SOURCES += \
+  ext/tinydtls/dtls.c \
+  ext/tinydtls/crypto.c \
+  ext/tinydtls/ccm.c \
+  ext/tinydtls/hmac.c \
+  ext/tinydtls/netq.c \
+  ext/tinydtls/peer.c \
+  ext/tinydtls/dtls_time.c \
+  ext/tinydtls/session.c \
+  ext/tinydtls/dtls_debug.c \
+  ext/tinydtls/dtls_prng.c \
+  ext/tinydtls/aes/rijndael.c \
+  ext/tinydtls/ecc/ecc.c \
+  ext/tinydtls/sha2/sha2.c
+endif
+
 ## Define the list of public header files and their install location.
 ## The API version is appended to the install folder to being able to
 ## co-install various versions of libcoap.
@@ -199,13 +216,15 @@ libcoap-$(LIBCOAP_API_VERSION).map: check_ctags $(libcoap_include_HEADERS)
 	( echo "VER_$(LIBCOAP_API_VERSION) {" ; \
 	echo "global:" ; \
 	$(CTAGS_PROG) $(CTAGS_IGNORE) -f - --c-kinds=p $(libcoap_include_HEADERS) | awk '/^coap_/ { print "  " $$1 ";" }' | sort -u ; \
+	echo "  dtls_package_version;" ; \
 	echo "local:" ; \
 	echo "  *;" ; \
 	echo "};" ) > $(top_builddir)/$@.new
 	mv $(top_builddir)/$@.new $(top_builddir)/$@
 
 libcoap-$(LIBCOAP_API_VERSION).sym: check_ctags $(libcoap_include_HEADERS)
-	( $(CTAGS_PROG) $(CTAGS_IGNORE) -f - --c-kinds=p $(libcoap_include_HEADERS) | awk '/^coap_/ { print $$1 }' | sort -u ) \
+	( $(CTAGS_PROG) $(CTAGS_IGNORE) -f - --c-kinds=p $(libcoap_include_HEADERS) | awk '/^coap_/ { print $$1 }' | sort -u ; \
+	echo "dtls_package_version" ) \
 	> $(top_builddir)/$@.new
 	mv $(top_builddir)/$@.new $(top_builddir)/$@
 

--- a/configure.ac
+++ b/configure.ac
@@ -309,6 +309,14 @@ AC_ARG_ENABLE([dtls],
               [build_dtls="$enableval"],
               [build_dtls="yes"])
 
+AC_ARG_ENABLE([integrate_tinydtls],
+              [AS_HELP_STRING([--enable-integrate_tinydtls],
+                              [Enable inclusion of libtinydtls objects in libcoap library [default=no]])],
+              [do_integrate_tinydtls="$enableval"],
+              [do_integrate_tinydtls="no"])
+
+AM_CONDITIONAL(INTEGRATE_TINYDTLS, [test "x$do_integrate_tinydtls" = "xyes"])
+
 AC_ARG_WITH([gnutls],
             [AS_HELP_STRING([--with-gnutls],
                             [Use GnuTLS for DTLS functions])],
@@ -394,7 +402,9 @@ if test "x$build_dtls" = "xyes"; then
     # The user wants to use explicit OpenSSL if '--with-tinydtls was set'.
     if test "x$with_tinydtls" = "xyes" ; then
         if test -d "$srcdir/ext/tinydtls"; then
-           AC_CONFIG_SUBDIRS([ext/tinydtls])
+           if test "x$do_integrate_tinydtls" != "xyes"; then
+              AC_CONFIG_SUBDIRS([ext/tinydtls])
+           fi
            have_tinydtls="yes"
          else
            have_tinydtls="no"
@@ -441,15 +451,24 @@ if test "x$build_dtls" = "xyes"; then
         AC_DEFINE(HAVE_OPENSSL, [1], [Define if the system has libssl1.1])
     fi
     if test "x$with_tinydtls" = "xyes"; then
-        DTLS_CFLAGS="-I \$(top_srcdir)/ext/tinydtls"
-        if test "x$enable_shared" = "xyes"; then
-            DTLS_LIBS="-L\$(top_builddir)/ext/tinydtls -ltinydtls"
+        if test "x$do_integrate_tinydtls" = "xyes"; then
+            DTLS_CFLAGS="-I \$(top_srcdir)/ext/tinydtls -DDTLSv12 -DWITH_SHA256"
+            DTLS_LIBS=
         else
-            # Needed as TinyDTLS compiling does not recognize --disable-shared
-            # and still builds libtinydtls.so which gets linked in otherwise
-            DTLS_LIBS="-L\$(top_builddir)/ext/tinydtls -l:libtinydtls.a"
+            DTLS_CFLAGS="-I \$(top_srcdir)/ext/tinydtls"
+            if test "x$enable_shared" = "xyes"; then
+                DTLS_LIBS="-L\$(top_builddir)/ext/tinydtls -ltinydtls"
+            else
+                # Needed as TinyDTLS compiling does not recognize --disable-shared
+                # and still builds libtinydtls.so which gets linked in otherwise
+                DTLS_LIBS="-L\$(top_builddir)/ext/tinydtls -l:libtinydtls.a"
+            fi
         fi
         AC_DEFINE(HAVE_LIBTINYDTLS, [1], [Define if the system has libtinydtls])
+    else
+        if test "x$do_integrate_tinydtls" = "xyes"; then
+          AC_MSG_ERROR([==> Option --enable-integrate_tinydtls is set, but --with-tinydtls is not set.])
+        fi
     fi
     AC_SUBST(DTLS_CFLAGS)
     AC_SUBST(DTLS_LIBS)
@@ -461,7 +480,11 @@ if test "x$with_openssl" = "xyes" -o "x$with_openssl_auto" = "xyes"; then
 elif test "x$with_gnutls" = "xyes" -o "x$with_gnutls_auto" = "xyes"; then
     LIBCOAP_DTLS_LIB_EXTENSION_NAME=-gnutls
 elif test "x$with_tinydtls" = "xyes"; then
-    LIBCOAP_DTLS_LIB_EXTENSION_NAME=-tinydtls
+    if test "x$do_integrate_tinydtls" = "xyes"; then
+        LIBCOAP_DTLS_LIB_EXTENSION_NAME=-tinydtls-int
+    else
+        LIBCOAP_DTLS_LIB_EXTENSION_NAME=-tinydtls
+    fi
 else
     LIBCOAP_DTLS_LIB_EXTENSION_NAME=
 fi
@@ -696,6 +719,11 @@ if test "x$with_openssl" = "xyes" -o "x$with_openssl_auto" = "xyes"; then
 fi
 if test "x$with_tinydtls" = "xyes"; then
     AC_MSG_RESULT([      build DTLS support      : "yes"])
+    if test "x$do_integrate_tinydtls" = "xyes"; then
+        AC_MSG_RESULT([      integrate tinyDTLS      : "yes"])
+    else
+        AC_MSG_RESULT([      integrate tinyDTLS      : "no"])
+    fi
     AC_MSG_RESULT([         -->  tinyDTLS around : "yes"])
     AC_MSG_RESULT([              TINYDTLS_CFLAGS : "$DTLS_CFLAGS"])
     AC_MSG_RESULT([              TINYDTLS_LIBS   : "$DTLS_LIBS"])

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -190,6 +190,7 @@ global:
   coap_wellknown_response;
   coap_write;
   coap_write_block_opt;
+  dtls_package_version;
 local:
   *;
 };

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -188,3 +188,4 @@ coap_wait_ack
 coap_wellknown_response
 coap_write
 coap_write_block_opt
+dtls_package_version

--- a/man/coap_attribute.txt.in
+++ b/man/coap_attribute.txt.in
@@ -24,8 +24,8 @@ SYNOPSIS
 *_name_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -41,8 +41,8 @@ const coap_address_t *_listen_addr_, coap_proto_t _proto_);*
 unsigned _mtu_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -20,8 +20,8 @@ SYNOPSIS
 *struct coap_dtls_pki_t*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -38,8 +38,8 @@ coap_pong_handler_t _handler_)*;
 coap_event_handler_t _handler_)*;
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -44,8 +44,8 @@ SYNOPSIS
 *const char *coap_session_str(const coap_session_t *_session_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -35,8 +35,8 @@ const coap_binary_t *_token_);*
 *void coap_delete_observers(coap_context_t *_context_, coap_session_t *_session_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -54,8 +54,8 @@ size_t *_buflen_);*
 size_t *_buflen_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_recovery.txt.in
+++ b/man/coap_recovery.txt.in
@@ -39,8 +39,8 @@ coap_fixed_point_t _value_)*;
 *int coap_debug_set_packet_loss(const char *_loss_level_)*;
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -35,8 +35,8 @@ coap_resource_t _resource_);*
 *void coap_resource_set_mode(coap_resource_t *_resource_, int _mode_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -51,8 +51,8 @@ _proto_, coap_dtls_pki_t *_setup_data_);*
 *const char *coap_session_str(const coap_session_t *_session_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -29,8 +29,8 @@ SYNOPSIS
 *void coap_show_tls_version(coap_log_t _level_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls-int* depending on your (D)TLS library
 type.
 
 DESCRIPTION


### PR DESCRIPTION
Add in a new configure option --enable-integrate_tinydtls which, if with
option --with-tinydtls, is set, build libcoap with tinydtls integrated so that
2 libraries (libcoap-2-tinydtls.{a|so} and libtinydtls.{a|so} are not needed,
just provide libcoap-2-tinydtls-int.{a|so}.

Makefile.am:

Optionally add in the ext/tinydtls .c files if INTEGRATE_TINYDTLS is set.
Include dtls_package_version in libcoap-2.{map|sym} to allow tests to work.

configure.ac:

Add in --enable-integrate_tinydtls and appropriate tests.
Make the libcoap-2 extension name tinydtls-int instead of just tinydtls.

libcoap-2.{map|sym}

Update with dtls_package_version to allow tests to work.

man/coap_*in:

Include the new library linker option -lcoap-2-tinydtls-int.