### PR TITLE
dtls_send_to_peer: cannot find local interface reported on coap_session_free

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -173,6 +173,7 @@ void coap_session_free(coap_session_t *session) {
   assert(session->ref == 0);
   if (session->ref)
     return;
+  coap_session_mfree(session);
   if (session->endpoint) {
     if (session->endpoint->sessions)
       LL_DELETE(session->endpoint->sessions, session);
@@ -180,7 +181,6 @@ void coap_session_free(coap_session_t *session) {
     if (session->context->sessions)
       LL_DELETE(session->context->sessions, session);
   }
-  coap_session_mfree(session);
   coap_log(LOG_DEBUG, "***%s: session closed\n", coap_session_str(session));
 
   coap_free_type(COAP_SESSION, session);


### PR DESCRIPTION
In coap_session_free(), as coap_session_mfree() is called after
the session has been deleted out the endpoint or context sessions,
dtls_send_to_peer() is unable to find the session to send out the
Alert/Warning Close Notify message packet.

src/coap_session.c:

Move coap_session_mfree() to before setting deleting session out of endpoint or context sessions in coap_session_free().

Note: TinyDTLS has been separately updated to not report ALRT on a
Close Notify - see https://github.com/eclipse/tinydtls/pull/5.