### PR TITLE
For limited stacks, remove large items off the stack and make them static

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,13 +105,14 @@ libcoap_include_HEADERS = \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/bits.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/block.h \
   $(top_builddir)/include/coap$(LIBCOAP_API_VERSION)/coap.h \
+  $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_debug.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_dtls.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_event.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_hashkey.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_io.h \
+  $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_mutex.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_session.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_time.h \
-  $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_debug.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/encode.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/libcoap.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/mem.h \

--- a/coap_config.h.contiki
+++ b/coap_config.h.contiki
@@ -7,6 +7,10 @@
 
 #define WITH_CONTIKI 1
 
+#ifndef COAP_CONSTRAINED_STACK
+#define COAP_CONSTRAINED_STACK 1
+#endif
+
 #define PACKAGE_STRING "libcoap"
 #define PACKAGE_NAME "libcoap"
 

--- a/coap_config.h.lwip
+++ b/coap_config.h.lwip
@@ -7,6 +7,10 @@
 
 #define WITH_LWIP 1
 
+#ifndef COAP_CONSTRAINED_STACK
+#define COAP_CONSTRAINED_STACK 1
+#endif
+
 #define PACKAGE_NAME "libcoap-lwip"
 #define PACKAGE_VERSION "?"
 #define PACKAGE_STRING PACKAGE_NAME PACKAGE_VERSION

--- a/include/coap2/coap_mutex.h
+++ b/include/coap2/coap_mutex.h
@@ -1,0 +1,50 @@
+/*
+ * coap_mutex.h -- mutex utilities
+ *
+ * Copyright (C) 2019 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_mutex.h
+ * @brief COAP mutex mechanism wrapper
+ */
+
+#ifndef COAP_MUTEX_H_
+#define COAP_MUTEX_H_
+
+#if defined(RIOT_VERSION)
+
+#include <mutex.h>
+
+typedef mutex_t coap_mutex_t;
+#define COAP_MUTEX_INITIALIZER MUTEX_INIT
+#define coap_mutex_lock(a) mutex_lock(a)
+#define coap_mutex_trylock(a) mutex_trylock(a)
+#define coap_mutex_unlock(a) mutex_unlock(a)
+
+#elif defined(WITH_CONTIKI)
+
+/* CONTIKI does not support mutex */
+
+typedef int coap_mutex_t;
+#define COAP_MUTEX_INITIALIZER 0
+#define coap_mutex_lock(a) *(a) = 1
+#define coap_mutex_trylock(a) *(a) = 1
+#define coap_mutex_unlock(a) *(a) = 0
+
+#else /* ! RIOT_VERSION && ! WITH_CONTIKI */
+
+#include <pthread.h>
+
+typedef pthread_mutex_t coap_mutex_t;
+#define COAP_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+#define coap_mutex_lock(a) pthread_mutex_lock(a)
+#define coap_mutex_trylock(a) pthread_mutex_trylock(a)
+#define coap_mutex_unlock(a) pthread_mutex_unlock(a)
+
+#endif /* ! RIOT_VERSION && ! WITH_CONTIKI */
+
+#endif /* COAP_MUTEX_H_ */

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -37,6 +37,7 @@
 #include "coap_debug.h"
 #include "encode.h"
 #include "net.h"
+#include "coap_mutex.h"
 
 #ifdef WITH_LWIP
 # define fprintf(fd, ...) LWIP_PLATFORM_DIAG((__VA_ARGS__))
@@ -459,7 +460,14 @@ is_binary(int content_format) {
 
 void
 coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
+#if COAP_CONSTRAINED_STACK
+  static coap_mutex_t static_show_pdu_mutex = COAP_MUTEX_INITIALIZER;
+  static unsigned char buf[1024]; /* need some space for output creation */
+  static char outbuf[COAP_DEBUG_BUF_SIZE];
+#else /* ! COAP_CONSTRAINED_STACK */
   unsigned char buf[1024]; /* need some space for output creation */
+  char outbuf[COAP_DEBUG_BUF_SIZE];
+#endif /* ! COAP_CONSTRAINED_STACK */
   size_t buf_len = 0; /* takes the number of bytes written to buf */
   int encode = 0, have_options = 0, i;
   coap_opt_iterator_t opt_iter;
@@ -467,12 +475,15 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
   int content_format = -1;
   size_t data_len;
   unsigned char *data;
-  char outbuf[COAP_DEBUG_BUF_SIZE];
   int outbuflen = 0;
 
   /* Save time if not needed */
   if (level > coap_get_log_level())
     return;
+
+#if COAP_CONSTRAINED_STACK
+  coap_mutex_lock(&static_show_pdu_mutex);
+#endif /* COAP_CONSTRAINED_STACK */
 
   snprintf(outbuf, sizeof(outbuf), "v:%d t:%s c:%s i:%04x {",
           COAP_DEFAULT_VERSION, msg_type_string(pdu->type),
@@ -646,6 +657,10 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
   outbuflen = strlen(outbuf);
   snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  "\n");
   COAP_DO_SHOW_OUTPUT_LINE;
+
+#if COAP_CONSTRAINED_STACK
+  coap_mutex_unlock(&static_show_pdu_mutex);
+#endif /* COAP_CONSTRAINED_STACK */
 }
 
 void coap_show_tls_version(coap_log_t level)
@@ -750,16 +765,24 @@ coap_log_impl(coap_log_t level, const char *format, ...) {
     return;
 
   if (log_handler) {
-#if defined(WITH_CONTIKI) || defined(WITH_LWIP)
-    char message[128];
-#else
-    char message[8 + 1024 * 2]; /* O/H + Max packet payload size * 2 */
-#endif
+#if COAP_CONSTRAINED_STACK
+    static coap_mutex_t static_log_mutex = COAP_MUTEX_INITIALIZER;
+    static char message[COAP_DEBUG_BUF_SIZE];
+#else /* ! COAP_CONSTRAINED_STACK */
+    char message[COAP_DEBUG_BUF_SIZE];
+#endif /* ! COAP_CONSTRAINED_STACK */
     va_list ap;
     va_start(ap, format);
+#if COAP_CONSTRAINED_STACK
+  coap_mutex_lock(&static_log_mutex);
+#endif /* COAP_CONSTRAINED_STACK */
+
     vsnprintf( message, sizeof(message), format, ap);
     va_end(ap);
     log_handler(level, message);
+#if COAP_CONSTRAINED_STACK
+    coap_mutex_unlock(&static_log_mutex);
+#endif /* COAP_CONSTRAINED_STACK */
   } else {
     char timebuf[32];
     coap_tick_t now;


### PR DESCRIPTION
When there is a limited stack size, having large data items on the stack
can easily cause stack overflows.

This makes integration with any constrained stack O/S a lot easier.

include/coap2/coap_mutex.h:

Create coap_ mutex functions which are platform independent.

Makefile.am:

Include include/coap2/coap_mutex.h for distribution

coap_config.h.contiki:
coap_config.h.lwip:

As CONTIKI and LWIP have constrained stacks, set #define COAP_CONSTRAINED_STACK

src/coap_debug.c:
src/coap_io.c:
src/net.c:

coap_show_pdu()
coap_log_impl()
coap_run_once()
coap_read_session()
coap_read_endpoint()
Move large data items out of the functions' stack and make them static
variables if COAP_CONSTRAINED_STACK is defined.
Protect the usage of these static variables by mutexes.

Note: if "-DCOAP_CONSTRAINED_STACK=0" is used, then the stack will not
be constrained.