### PR TITLE
server (lwip & contiki) run out of sessions

### DIFF
--- a/examples/contiki/README
+++ b/examples/contiki/README
@@ -10,13 +10,21 @@ To run the example, do
 
     $ sudo ip -6 a a aaaa::1/64 dev tap0
 
-and query `coap://[aaaa::1000]/` with any coap tool.
+and query `coap://[aaaa::1000]/time?ticks` with any coap tool,
+or query `coap://[aaaa::1000]/.well-known/core`
 
 This will
 
-* download contike from the upstream git sources
+* download contiki from the upstream git sources
 * build the server application
 * run the server application, creating a virtual network device tap0 (unless
   that exists)
 * configure your network interface to make the server accessible.
 
+* return the appropriate response from the server to the client.
+
+The server creates a resource for 'time' with a query 'ticks'.  This is
+reported for `.well-known/core`. The work flow for adding more resources does
+not differ from regular libcoap usage. If you seem to run out of memory
+creating the resources, tweak the number of pre-allocated resources
+in `coap_config.h.contiki`.

--- a/examples/lwip/README
+++ b/examples/lwip/README
@@ -10,7 +10,8 @@ To run the example, do
 
     $ sudo ip a a dev tap0 192.168.113.1/24
 
-and query `coap://192.168.113.2/` with any coap tool.
+and query `coap://192.168.113.2/time?ticks` with any coap tool,
+or query `coap://[aaaa::1000]/.well-known/core`
 
 This will
 
@@ -19,6 +20,8 @@ This will
 * run the server application, creating a virtual network device tap0 (unless
   that exists)
 * configure your network interface to make the server accessible.
+
+* return the appropriate response from the server to the client.
 
 The server creates a resource for 'time' with a query 'ticks'.  This is
 reported for `.well-known/core`. The work flow for adding more resources does

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -510,6 +510,13 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
     session = coap_make_session(endpoint->proto, COAP_SESSION_TYPE_SERVER,
       NULL, &packet->dst, &packet->src, packet->ifindex, endpoint->context,
       endpoint);
+    if (!endpoint->context->max_idle_sessions && !session && oldest) {
+      /* max_idle_sessions not set, session failed but have an idle entry */
+      coap_session_free(oldest);
+      session = coap_make_session(endpoint->proto, COAP_SESSION_TYPE_SERVER,
+        NULL, &packet->dst, &packet->src, packet->ifindex, endpoint->context,
+        endpoint);
+    }
     if (session) {
       session->last_rx_tx = now;
       if (endpoint->proto == COAP_PROTO_UDP)


### PR DESCRIPTION
As a server, idle sessions are left around in case the client wants to do
further work using the same 5 tuple IP information.
With constrained systems, the number of sessions is limited, and so it is
easy to run out of sessions.

src/coap_session.c:

If there is an idle session, context->max_idle_sessions is not set and
a new session cannot be created, free off the oldest session and retry
the creation again.

examples/contiki/README:
examples/lwip/README:

Tidy up the documentation