### PR TITLE
Fix #321 was not correctly implemented

### DIFF
--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -404,7 +404,7 @@ psk_client_callback(gnutls_session_t g_session,
   *username = gnutls_malloc(identity_len+1);
   if (*username) {
     memcpy(*username, identity, identity_len);
-    username[identity_len] = '\0';
+    (*username)[identity_len] = '\0';
   }
 
   key->data = gnutls_malloc(psk_len);


### PR DESCRIPTION
While #321 prevented a core dump, that fix still caused memory corruption.

src/coap_gnutls.c:

Correct the code to correctly NULL terminate the created username.