### PR TITLE
coap_free_endpoint does not clean up tinydtls encryption sessions

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -915,8 +915,6 @@ coap_free_endpoint(coap_endpoint_t *ep) {
     LL_FOREACH_SAFE(ep->sessions, session, tmp) {
       assert(session->ref == 0);
       if (session->ref == 0) {
-        session->endpoint = NULL;
-        session->context = NULL;
         coap_session_free(session);
       }
     }


### PR DESCRIPTION
Following on from #324 where coap_session_mfree() had to be moved in
coap_session_free() to correctly allow for tinydtls cleanup, session->endpoint
and session->context should not be cleared out prior to call of
coap_sesson_free() in coap_free_endpoint().

src/coap_session.c:

Remove lines setting session->endpoint and session->context to NULL