### PR TITLE
 Fix DTLS session loss when multiple connections in a short time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,11 +157,11 @@ coap_dtls_receive \
 coap_dtls_send \
 coap_dtls_session_update_mtu \
 coap_dtls_startup \
-coap_endpoint_new_dtls_session \
 coap_mfree_endpoint \
 coap_packet_extract_pbuf \
 coap_pdu_from_pbuf \
 coap_session_mfree \
+coap_session_new_dtls_session \
 coap_socket_accept_tcp \
 coap_socket_bind_tcp \
 coap_socket_bind_udp \

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -306,7 +306,6 @@ typedef struct coap_endpoint_t {
   coap_socket_t sock;             /**< socket object for the interface, if any */
   coap_address_t bind_addr;       /**< local interface address */
   coap_session_t *sessions;       /**< list of active sessions */
-  coap_session_t hello;           /**< special session of DTLS hello messages */
 } coap_endpoint_t;
 
 /**
@@ -347,24 +346,24 @@ const char *coap_endpoint_str(const coap_endpoint_t *endpoint);
 * @param endpoint Active endpoint the packet was received on.
 * @param packet Received packet.
 * @param now The current time in ticks.
-* @return The CoAP session.
+* @return The CoAP session or @c NULL if error.
 */
 coap_session_t *coap_endpoint_get_session(coap_endpoint_t *endpoint,
   const struct coap_packet_t *packet, coap_tick_t now);
 
 /**
- * Create a new DTLS session for the @p endpoint.
+ * Create a new DTLS session for the @p session.
+ * Note: the @p session is released if no DTLS server session can be created.
  *
  * @ingroup dtls_internal
  *
- * @param endpoint  Endpoint to add DTLS session to
- * @param packet    Received packet information to base session on.
+ * @param session   Session to add DTLS session to
  * @param now       The current time in ticks.
  *
- * @return Created CoAP session or @c NULL if error.
+ * @return CoAP session or @c NULL if error.
  */
-coap_session_t *coap_endpoint_new_dtls_session(coap_endpoint_t *endpoint,
-  const struct coap_packet_t *packet, coap_tick_t now);
+coap_session_t *coap_session_new_dtls_session(coap_session_t *session,
+  coap_tick_t now);
 
 coap_session_t *coap_session_get_by_peer(struct coap_context_t *ctx,
   const struct coap_address_t *remote_addr, int ifindex);

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -95,7 +95,6 @@ struct coap_endpoint_t *
 void
 coap_mfree_endpoint(struct coap_endpoint_t *ep) {
   ep_initialized = 0;
-  coap_session_mfree(&ep->hello);
 }
 
 int
@@ -185,7 +184,6 @@ struct coap_endpoint_t *
 
 void
 coap_mfree_endpoint(struct coap_endpoint_t *ep) {
-  coap_session_mfree(&ep->hello);
   coap_free_type(COAP_ENDPOINT, ep);
 }
 

--- a/src/net.c
+++ b/src/net.c
@@ -1278,7 +1278,7 @@ coap_read_endpoint(coap_context_t *ctx, coap_endpoint_t *endpoint, coap_tick_t n
                coap_session_str(session), bytes_read);
       result = coap_handle_dgram_for_proto(ctx, session, packet);
       if (endpoint->proto == COAP_PROTO_DTLS && session->type == COAP_SESSION_TYPE_HELLO && result == 1)
-        coap_endpoint_new_dtls_session(endpoint, packet, now);
+        coap_session_new_dtls_session(session, now);
     }
   }
 #if COAP_CONSTRAINED_STACK


### PR DESCRIPTION
endpoint->hello is used to hold the 5 tuple etc. information about a new
connection that has come in.  Once the DTLS handshake has been completed
a new coap_session_t is created for the ongoing encrypted work.

However, if a second new DTLS request comes in before the first session
has completed the DTLS handshakes, it will overwrite the endpoint->hello
information causing the first request to stall / get lost.

GnuTLS already has to check that the initial DTLS packet is a Client Hello
before starting up a GnuTLS session, so moving this logic up a level to
the initial DTLS packet makes sense to create a coap_session_t at this
point and getting rid of the temporary endpoint->hello gets rid of this
issue.

Makefile.am:

Replace coap_endpoint_new_dtls_session with coap_session_new_dtls_session

include/coap2/coap_session.h:

Remove coap_session_t hello;
Replace coap_endpoint_new_dtls_session with coap_session_new_dtls_session

src/coap_gnutls.c:

Remove references to endpoint->hello
Remove Client Hello check code (move it to coap_endpoint_get_session())

src/coap_io.c:

Remove reference to freeing off ep->hello

src/coap_session.c:

Remove endpoint->hello code.
Check for Client Hello in coap_endpoint_get_session() if no session, is DTLS
and don't build coap_session if not a Client Hello.
Otherwise, always build a new coap_session.

Timeout Client Hello session if inactive to prevent a DoS.

Replace coap_endpoint_new_dtls_session with coap_session_new_dtls_session

src/coap_net.c:

Replace coap_endpoint_new_dtls_session with coap_session_new_dtls_session