### PR TITLE
Add in PSK support for SNI, Identity and Hint checking to enable PSK changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -146,7 +146,8 @@ CTAGS_IGNORE=-I " \
 coap_dtls_context_check_keys_enabled \
 coap_dtls_context_set_pki \
 coap_dtls_context_set_pki_root_cas \
-coap_dtls_context_set_psk \
+coap_dtls_context_set_cpsk \
+coap_dtls_context_set_spsk \
 coap_dtls_free_context \
 coap_dtls_free_session \
 coap_dtls_get_context_timeout \
@@ -169,6 +170,8 @@ coap_packet_extract_pbuf \
 coap_pdu_from_pbuf \
 coap_session_mfree \
 coap_session_new_dtls_session \
+coap_session_refresh_psk_hint \
+coap_session_refresh_psk_key \
 coap_socket_accept_tcp \
 coap_socket_bind_tcp \
 coap_socket_bind_udp \

--- a/include/coap2/coap_debug.h
+++ b/include/coap2/coap_debug.h
@@ -72,7 +72,7 @@ coap_log_t coap_get_log_level(void);
 void coap_set_log_level(coap_log_t level);
 
 /**
- * Logging call-back handler definition.
+ * Logging callback handler definition.
  *
  * @param level One of the LOG_* values.
  * @param message Zero-terminated string message to log.

--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -12,7 +12,10 @@
 #define COAP_DTLS_H_
 
 #include "coap_time.h"
+#include "str.h"
 
+struct coap_str_const_t;
+struct coap_bin_const_t;
 struct coap_context_t;
 struct coap_session_t;
 struct coap_dtls_pki_t;
@@ -22,6 +25,10 @@ struct coap_dtls_pki_t;
  * API functions for interfacing with DTLS libraries.
  * @{
  */
+
+#ifndef COAP_DTLS_HINT_LENGTH
+#define COAP_DTLS_HINT_LENGTH 128
+#endif
 
 /**
  * Check whether DTLS is available.
@@ -68,7 +75,7 @@ coap_tls_version_t *coap_get_tls_library_version(void);
  * but the application needs to do some additional checks/changes/updates.
  *
  * @param tls_session The security session definition - e.g. SSL * for OpenSSL.
- *                    NULL if server call-back.
+ *                    NULL if server callback.
  *                    This will be dependent on the underlying TLS library -
  *                    see coap_get_tls_library_version()
  * @param setup_data A structure containing setup data originally passed into
@@ -80,7 +87,7 @@ typedef int (*coap_dtls_security_setup_t)(void* tls_session,
                                         struct coap_dtls_pki_t *setup_data);
 
 /**
- * CN Validation call-back that can be set up by coap_context_set_pki().
+ * CN Validation callback that can be set up by coap_context_set_pki().
  * Invoked when libcoap has done the validation checks at the TLS level,
  * but the application needs to check that the CN is allowed.
  * CN is the SubjectAltName in the cert, if not present, then the leftmost
@@ -101,7 +108,7 @@ typedef int (*coap_dtls_cn_callback_t)(const char *cn,
              const uint8_t *asn1_public_cert,
              size_t asn1_length,
              struct coap_session_t *coap_session,
-             unsigned depth,
+             unsigned int depth,
              int validated,
              void *arg);
 
@@ -169,7 +176,7 @@ typedef struct coap_dtls_key_t {
 } coap_dtls_key_t;
 
 /**
- * Server Name Indication (SNI) Validation call-back that can be set up by
+ * Server Name Indication (SNI) Validation callback that can be set up by
  * coap_context_set_pki().
  * Invoked if the SNI is not previously seen and prior to sending a certificate
  * set back to the client so that the appropriate certificate set can be used
@@ -181,7 +188,7 @@ typedef struct coap_dtls_key_t {
  *
  * @return New set of certificates to use, or @c NULL if SNI is to be rejected.
  */
-typedef coap_dtls_key_t *(*coap_dtls_sni_callback_t)(const char *sni,
+typedef coap_dtls_key_t *(*coap_dtls_pki_sni_callback_t)(const char *sni,
              void* arg);
 
 
@@ -213,23 +220,23 @@ typedef struct coap_dtls_pki_t {
                                     * decrement the reserved[] count.
                                     */
 
-  /** CN check call-back function.
+  /** CN check callback function.
    * If not NULL, is called when the TLS connection has passed the configured
    * TLS options above for the application to verify if the CN is valid.
    */
   coap_dtls_cn_callback_t validate_cn_call_back;
-  void *cn_call_back_arg;  /**< Passed in to the CN call-back function */
+  void *cn_call_back_arg;  /**< Passed in to the CN callback function */
 
-  /** SNI check call-back function.
+  /** SNI check callback function.
    * If not @p NULL, called if the SNI is not previously seen and prior to
    * sending a certificate set back to the client so that the appropriate
    * certificate set can be used based on the requesting SNI.
    */
-  coap_dtls_sni_callback_t validate_sni_call_back;
-  void *sni_call_back_arg;  /**< Passed in to the sni call-back function */
+  coap_dtls_pki_sni_callback_t validate_sni_call_back;
+  void *sni_call_back_arg;  /**< Passed in to the sni callback function */
 
-  /** Additional Security call-back handler that is invoked when libcoap has
-   * done the standerd, defined validation checks at the TLS level,
+  /** Additional Security callback handler that is invoked when libcoap has
+   * done the standard, defined validation checks at the TLS level,
    * If not @p NULL, called from within the TLS Client Hello connection
    * setup.
    */
@@ -241,6 +248,158 @@ typedef struct coap_dtls_pki_t {
 
   coap_dtls_key_t pki_key;  /**< PKI key definition */
 } coap_dtls_pki_t;
+
+/**
+ * The structure that holds the Client PSK information.
+ */
+typedef struct coap_dtls_cpsk_key_t {
+  const uint8_t *identity;
+  unsigned int identity_len;
+  const uint8_t *key;
+  unsigned int key_len;
+} coap_dtls_cpsk_key_t;
+
+/**
+ * Identity Hint Validation callback that can be set up by
+ * coap_new_client_session_psk2().
+ * Invoked when libcoap has done the validation checks at the TLS level,
+ * but the application needs to check that the Identity Hint is allowed,
+ * and thus needs to use the appropriate pre-shared key (PSK) for the Identity
+ * Hint for the (D)TLS session.
+ * Note: Identity Hint is not supported in (D)TLS1.3.
+ *
+ * @param hint  The server provided Identity Hint
+ * @param coap_session  The CoAP session associated with the Identity Hint
+ * @param arg  The same as was passed into coap_new_client_session_psk2()
+ *             in setup_data->ih_call_back_arg
+ *
+ * @return New coap_dtls_cpsk_key_t object or @c NULL on error.
+ */
+typedef const coap_dtls_cpsk_key_t *(*coap_dtls_ih_callback_t)(
+                                struct coap_str_const_t *hint,
+                                struct coap_session_t *coap_session,
+                                void *arg);
+
+#define COAP_DTLS_CL_PSK_SETUP_VERSION 1 /**< Latest Client PSK setup version */
+
+/**
+ * The structure used for defining the Client PSK setup data to be used.
+ */
+typedef struct coap_dtls_cpsk_t {
+  uint8_t version; /** Set to 1 to support this version of the struct */
+
+  /* Options to enable different TLS functionality in libcoap */
+  uint8_t reserved[7];             /**< Reserved - must be set to 0 for
+                                        future compatibility */
+                                   /* Size of 7 chosen to align to next
+                                    * parameter, so if newly defined option
+                                    * it can use one of the reserverd slot so
+                                    * no need to change
+                                    * COAP_DTLS_CL_PSK_SETUP_VERSION and just
+                                    * decrement the reserved[] count.
+                                    */
+
+  /** Identity Hint check callback function.
+   * If not NULL, is called when the Identity Hint (TLS1.2 or earlier) is
+   * provided by the server.
+   * The appropriate Identity and PSK to use can then be returned.
+   */
+  coap_dtls_ih_callback_t validate_ih_call_back;
+  void *ih_call_back_arg;  /**< Passed in to the Identity Hint callback
+                                function */
+
+  char* client_sni;    /**< If not NULL, SNI to use in client TLS setup.
+                            Owned by the client app and must remain valid
+                            during the call to coap_new_client_session_psk2() */
+
+  coap_dtls_cpsk_key_t psk_key;  /**< Client PSK definition */
+} coap_dtls_cpsk_t;
+
+/**
+ * The structure that holds the Server pre-shared key (PSK) information.
+ */
+typedef struct coap_dtls_spsk_key_t {
+  const uint8_t *hint;
+  unsigned int hint_len;
+  const uint8_t *key;
+  unsigned int key_len;
+} coap_dtls_spsk_key_t;
+
+/**
+ * Identity Validation callback that can be set up by
+ * coap_context_set_psk2().
+ * Invoked when libcoap has done the validation checks at the TLS level,
+ * but the application needs to check that the Identity is allowed,
+ * and needs to use the appropriate PSK for the (D)TLS session.
+ *
+ * @param identity  The client provided Identity
+ * @param coap_session  The CoAP session associated with the Identity Hint
+ * @param arg  The value as passed into coap_context_set_psk2()
+ *             in setup_data->id_call_back_arg
+ *
+ * @return New coap_bin_const_t object containing the PSK or @c NULL on error.
+ *         Note: This information will be duplicated into an internal
+ *               structure.
+ */
+typedef const coap_dtls_spsk_key_t *(*coap_dtls_id_callback_t)(
+                                 struct coap_bin_const_t *identity,
+                                 struct coap_session_t *coap_session,
+                                 void *arg);
+/**
+ * PSK SNI callback that can be set up by coap_context_set_psk2().
+ * Invoked when libcoap has done the validation checks at the TLS level,
+ * but the application needs to check that the SNI is allowed,
+ * and needs to use the appropriate PSK for the (D)TLS session.
+ *
+ * @param sni  The client provided SNI
+ * @param coap_session  The CoAP session associated with the SNI
+ * @param arg  The same as was passed into coap_context_set_psk2()
+ *             in setup_data->sni_call_back_arg
+ *
+ * @return New coap_dtls_spsk_key_t object or @c NULL on error.
+ */
+typedef const coap_dtls_spsk_key_t *(*coap_dtls_psk_sni_callback_t)(
+                                 struct coap_str_const_t *sni,
+                                 struct coap_session_t *coap_session,
+                                 void *arg);
+
+#define COAP_DTLS_SVR_PSK_SETUP_VERSION 1 /**< Latest PSK setup version */
+
+/**
+ * The structure used for defining the Server PSK setup data to be used.
+ */
+typedef struct coap_dtls_spsk_t {
+  uint8_t version; /** Set to 1 to support this version of the struct */
+
+  /* Options to enable different TLS functionality in libcoap */
+  uint8_t reserved[7];             /**< Reserved - must be set to 0 for
+                                        future compatibility */
+                                   /* Size of 7 chosen to align to next
+                                    * parameter, so if newly defined option
+                                    * it can use one of the reserverd slot so
+                                    * no need to change
+                                    * COAP_DTLS_SVR_PSK_SETUP_VERSION and just
+                                    * decrement the reserved[] count.
+                                    */
+
+  /** Identity check callback function.
+   * If not @p NULL, is called when the Identity is provided by the client.
+   *  The appropriate PSK to use can then be returned.
+   */
+  coap_dtls_id_callback_t validate_id_call_back;
+  void *id_call_back_arg;  /**< Passed in to the Identity callback function */
+
+  /** SNI check callback function.
+   * If not @p NULL, called if the SNI is not previously seen and prior to
+   * sending a PSK back to the client so that the appropriate
+   * PSK can be used based on the requesting SNI.
+   */
+  coap_dtls_psk_sni_callback_t validate_sni_call_back;
+  void *sni_call_back_arg;  /**< Passed in to the SNI callback function */
+
+  coap_dtls_spsk_key_t psk_key;  /**< Server PSK definition */
+} coap_dtls_spsk_t;
+
 
 /** @} */
 
@@ -269,30 +428,38 @@ typedef enum coap_dtls_role_t {
 } coap_dtls_role_t;
 
 /**
- * Set the DTLS context's default PSK information.
+ * Set the DTLS context's default server PSK information.
  * This does the PSK specifics following coap_dtls_new_context().
- * If @p COAP_DTLS_ROLE_SERVER, then identity hint will also get set.
- * If @p COAP_DTLS_ROLE_SERVER, then the information will get put into the
- * TLS library's context (from which sessions are derived).
- * If @p COAP_DTLS_ROLE_CLIENT, then the information will get put into the
- * TLS library's session.
  *
  * Internal function.
  *
  * @param coap_context The CoAP context.
- * @param identity_hint The default PSK server identity hint sent to a client.
- *                      Required parameter.  If @p NULL, will be set to "".
- *                      Empty string is a valid hint.
- *                      This parameter is ignored if COAP_DTLS_ROLE_CLIENT
- * @param role  One of @p COAP_DTLS_ROLE_CLIENT or @p COAP_DTLS_ROLE_SERVER
+ * @param setup_data A structure containing setup data originally passed into
+ *                   coap_context_set_psk2().
  *
  * @return @c 1 if successful, else @c 0.
  */
 
 int
-coap_dtls_context_set_psk(struct coap_context_t *coap_context,
-                          const char *identity_hint,
-                          coap_dtls_role_t role);
+coap_dtls_context_set_spsk(struct coap_context_t *coap_context,
+                          coap_dtls_spsk_t *setup_data);
+
+/**
+ * Set the DTLS context's default client PSK information.
+ * This does the PSK specifics following coap_dtls_new_context().
+ *
+ * Internal function.
+ *
+ * @param coap_context The CoAP context.
+ * @param setup_data A structure containing setup data originally passed into
+ *                   coap_new_client_session_psk2().
+ *
+ * @return @c 1 if successful, else @c 0.
+ */
+
+int
+coap_dtls_context_set_cpsk(struct coap_context_t *coap_context,
+                          coap_dtls_cpsk_t *setup_data);
 
 /**
  * Set the DTLS context's default server PKI information.

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -87,18 +87,33 @@ typedef struct coap_session_t {
   coap_tick_t csm_tx;
   coap_dtls_cpsk_t cpsk_setup_data; /**< client provided PSK initial setup
                                          data */
-  uint8_t *psk_identity;            /**< If client, current identity for server.
-                                         If NULL, then in cpsk_setup_data
-                                         If server, client provided identity */
-  size_t psk_identity_len;
-  uint8_t *psk_key;                 /**< If client, current key for server.
-                                         If NULL, then in cpsk_setup_data
-                                         If server, client current key */
-  size_t psk_key_len;
-  uint8_t *psk_hint;                /**< If client, server provided hint.
-                                         If server, client current hint
-                                         If NULL, then in context->spsk_setup_data */
-  size_t psk_hint_len;
+  coap_bin_const_t *psk_identity;   /**< If client, this field contains the
+                                      current identity for server; When this
+                                      field is NULL, the current identity is
+                                      contained in cpsk_setup_data
+
+                                      If server, this field contains the client
+                                      provided identity.
+
+                                      Value maintained internally */
+  coap_bin_const_t *psk_key;        /**< If client, this field contains the
+                                      current pre-shared key for server;
+                                      When this field is NULL, the current
+                                      key is contained in cpsk_setup_data
+
+                                      If server, this field contains the
+                                      client's current key.
+
+                                      Value maintained internally */
+  coap_bin_const_t *psk_hint;       /**< If client, this field contains the
+                                      server provided identity hint.
+
+                                      If server, this field contains the
+                                      current hint for the client; When this
+                                      field is NULL, the current hint is
+                                      contained in context->spsk_setup_data
+
+                                      Value maintained internally */
   void *app;                        /**< application-specific data */
   unsigned int max_retransmit;      /**< maximum re-transmit count (default 4) */
   coap_fixed_point_t ack_timeout;   /**< timeout waiting for ack (default 2 secs) */
@@ -261,7 +276,7 @@ int coap_session_refresh_psk_hint(coap_session_t *session,
  * @return @c 1 if successful, else @c 0.
  */
 int coap_session_refresh_psk_key(coap_session_t *session,
-                                 const struct coap_dtls_spsk_key_t *psk_key);
+                                 const struct coap_bin_const_t *psk_key);
 
 /**
 * Creates a new client session to the designated server with PKI credentials

--- a/include/coap2/str.h
+++ b/include/coap2/str.h
@@ -46,6 +46,14 @@ typedef struct coap_binary_t {
 } coap_binary_t;
 
 /**
+ * Coap binary data definition with const data
+ */
+typedef struct coap_bin_const_t {
+  size_t length;    /**< length of binary data */
+  const uint8_t *s; /**< binary data */
+} coap_bin_const_t;
+
+/**
  * Returns a new string object with at least size+1 bytes storage allocated.
  * The string must be released using coap_delete_string().
  *
@@ -83,7 +91,27 @@ void coap_delete_str_const(coap_str_const_t *string);
 
 #define COAP_MAX_STR_CONST_FUNC 2
 /**
- * Take the specified string and create a coap_str_const_t *
+ * Take the specified byte array (text) and create a coap_bin_const_t *
+ * Returns a new const binary object with at least size bytes storage
+ * allocated, and the provided data copied into the binary object.
+ * The binary data must be released using coap_delete_bin_const().
+ *
+ * @param data The data to put in the new string object.
+ * @param size The size to allocate for the binary data.
+ *
+ * @return       A pointer to the new object or @c NULL on error.
+ */
+coap_bin_const_t *coap_new_bin_const(const uint8_t *data, size_t size);
+
+/**
+ * Deletes the given const binary data and releases any memory allocated.
+ *
+ * @param binary The binary data to free off.
+ */
+void coap_delete_bin_const(coap_bin_const_t *binary);
+
+/**
+ * Take the specified byte array (text) and create a coap_str_const_t *
  *
  * Note: the array is 2 deep as there are up to two callings of
  * coap_make_str_const in a function call. e.g. coap_add_attr().
@@ -108,7 +136,22 @@ coap_str_const_t *coap_make_str_const(const char *string);
  */
 #define coap_string_equal(string1,string2) \
         ((string1)->length == (string2)->length && ((string1)->length == 0 || \
-         memcmp((string1)->s, (string2)->s, (string1)->length) == 0))
+         ((string1)->s && (string2)->s && \
+          memcmp((string1)->s, (string2)->s, (string1)->length) == 0)))
+
+/**
+ * Compares the two binary data for equality
+ *
+ * @param binary1 The first binary data.
+ * @param binary2 The second binary data.
+ *
+ * @return         @c 1 if the binary data is equal
+ *                 @c 0 otherwise.
+ */
+#define coap_binary_equal(binary1,binary2) \
+        ((binary1)->length == (binary2)->length && ((binary1)->length == 0 || \
+         ((binary1)->s && (binary2)->s && \
+          memcmp((binary1)->s, (binary2)->s, (binary1)->length) == 0)))
 
 /** @} */
 

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -29,6 +29,7 @@ global:
   coap_context_set_pki;
   coap_context_set_pki_root_cas;
   coap_context_set_psk;
+  coap_context_set_psk2;
   coap_debug_send_packet;
   coap_debug_set_packet_loss;
   coap_decode_var_bytes;
@@ -36,6 +37,7 @@ global:
   coap_delete_all;
   coap_delete_all_resources;
   coap_delete_attr;
+  coap_delete_bin_const;
   coap_delete_node;
   coap_delete_observer;
   coap_delete_observers;
@@ -87,9 +89,11 @@ global:
   coap_memory_init;
   coap_network_read;
   coap_network_send;
+  coap_new_bin_const;
   coap_new_client_session;
   coap_new_client_session_pki;
   coap_new_client_session_psk;
+  coap_new_client_session_psk2;
   coap_new_context;
   coap_new_endpoint;
   coap_new_error_response;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -27,6 +27,7 @@ coap_context_set_keepalive
 coap_context_set_pki
 coap_context_set_pki_root_cas
 coap_context_set_psk
+coap_context_set_psk2
 coap_debug_send_packet
 coap_debug_set_packet_loss
 coap_decode_var_bytes
@@ -34,6 +35,7 @@ coap_decode_var_bytes8
 coap_delete_all
 coap_delete_all_resources
 coap_delete_attr
+coap_delete_bin_const
 coap_delete_node
 coap_delete_observer
 coap_delete_observers
@@ -85,9 +87,11 @@ coap_malloc_type
 coap_memory_init
 coap_network_read
 coap_network_send
+coap_new_bin_const
 coap_new_client_session
 coap_new_client_session_pki
 coap_new_client_session_psk
+coap_new_client_session_psk2
 coap_new_context
 coap_new_endpoint
 coap_new_error_response

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -56,7 +56,7 @@ man7_MANS = $(MAN7)
 
 # Man pages built byt a2x based on the NAMES section of the .txt file
 A2X_EXTRA_PAGES = @DOLLAR_SIGN@(shell for fil in $(TXT3) ; do sed -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $${fil} | \
-	sed -ne '/coap_/{ s/ *, */\n/g; p }' | sed -ne 's/^\(coap_[a-zA-Z_]\+\).*$$/\1.3/p' ; done)
+	sed -ne '/coap_/{ s/ *, */\n/g; p }' | sed -ne 's/^\(coap_[a-zA-Z_0-9]\+\).*$$/\1.3/p' ; done)
 
 # Extra man pages that need to be installed due to limit of 10
 # names built by a2x

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -18,7 +18,7 @@ SYNOPSIS
               [*-m* method] [*-o* file] [*-p* port] [*-r*] [*-s duration*]
               [*-t* type] [*-v* num] [*-A* type] [*-B* seconds] [*-K* interval]
               [*-N*] [*-O* num,text] [*-P* addr[:port]] [*-T* token] [*-U*]
-              [[*-k* key] [*-u* user]]
+              [[*-h* match_hint_file] [*-k* key] [*-u* user]]
               [[*-c* certfile] [*-C* cafile] [*-R* root_cafile]] URI
 
 DESCRIPTION
@@ -61,7 +61,7 @@ OPTIONS - General
    numbers or number ranges (debugging only).
 
 *-l* loss%::
-   Randomly failed to send datagams with the specified probability - 100%
+   Randomly failed to send datagrams with the specified probability - 100%
    all datagrams, 0% no datagrams (debugging only).
 
 *-m* method::
@@ -133,6 +133,15 @@ OPTIONS - General
 OPTIONS - PSK
 -------------
 (If supported by underlying (D)TLS library)
+
+*-h* match_hint_file::
+   This option denotes a file that contains one or more lines of Identity
+   Hints to match for new user and new pre-shared key (PSK) (comma separated)
+   to be used.
+   E.g., entry per line +
+   hint_to_match,new_user,new_key +
+   A line that starts with # is treated as a comment. +
+   Note: *-k key* and *-u user* still need to be defined for the default case.
 
 *-k* key::
    Pre-shared key for the specified user (*-u* option also required).

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -30,7 +30,7 @@ OPTIONS
    Join specified multicast 'group' on startup.
 
 *-p* port::
-   The 'port' on the given address the server will be waitung for connections.
+   The 'port' on the given address the server will be waiting for connections.
    The default port is 5683 if not given any other value.
 
 *-v* num::

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -16,7 +16,8 @@ SYNOPSIS
 --------
 *coap-server* [*-d* max] [*-g* group] [*-l* loss] [*-p* port] [*-v* num]
               [*-A* address] [*-N*]
-              [[*-k* key] [*-h* hint]]
+              [[*-h* hint] [*-i* match_identity_file] [*-k* key]
+              [*-s* match_sni_file]]
               [[*-c* certfile] [*-n*] [*-C* cafile] [*-R* root_cafile]]
 
 DESCRIPTION
@@ -32,21 +33,21 @@ OPTIONS - General
    dynamic resources has been deleted.
 
 *-g* group::
-   Join specified multicast 'group' on startup.
-
-*-p* port::
-   The 'port' on the given address will be listening for incoming connections.
-   If (D)TLS is supported, then 'port' + 1 will also be listened on for
-   (D)TLS connections.
-   The default port is 5683 if not given any other value.
+   Join specified multicast 'group' on start up.
 
 *-l* list::
    Fail to send some datagrams specified by a comma separated list of
    numbers or number ranges (debugging only).
 
 *-l* loss%::
-   Randomly failed to send datagams with the specified probability - 100%
+   Randomly failed to send datagrams with the specified probability - 100%
    all datagrams, 0% no datagrams (debugging only).
+
+*-p* port::
+   The 'port' on the given address will be listening for incoming connections.
+   If (D)TLS is supported, then 'port' + 1 will also be listened on for
+   (D)TLS connections.
+   The default port is 5683 if not given any other value.
 
 *-v* num::
    The verbosity level to use (default 3, maximum is 9). Above 7, there is
@@ -66,14 +67,33 @@ OPTIONS - PSK
 (If supported by underlying (D)TLS library)
 
 *-h* hint::
-   Pre-shared key hint to use for inbound connections. The default is 'CoAP'.
+   Identity hint to use for inbound connections. The default is 'CoAP'.
    This cannot be empty if defined.
+
+*-i* match_identiity_file::
+   This option denotes a file that contains one or more lines of client Hints
+   and (user) Identities to match for a new Pre-Shared key (PSK)
+   (comma separated) to be used.
+   E.g., entry per line +
+   hint_to_match,identity_to_match,new_key +
+   A line that starts with # is treated as a comment. +
+   Note: -k still needs to be defined for the default case +
 
 *-k* key::
    Pre-shared key to use for inbound connections. This cannot be empty if
    defined.
    *Note:* if *-c cafile* is defined, you need to define *-k key* as well to
    have the server support both PSK and PKI.
+
+*-s* match_sni_file::
+   This option denotes a file that contains one or more lines of Subject Name
+   Identifier (SNI) to match for new Identity Hint and new Pre-Shared Key
+   (PSK) (comma separated) to be used.
+   E.g., entry per line +
+   sni_to_match,new_hint,new_key +
+   A line that starts with # is treated as a comment. +
+   Note: -k still needs to be defined for the default case +
+   Note: the new Pre-Shared Key will get updated if there is also a -i match
 
 OPTIONS - PKI
 -------------

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -11,7 +11,7 @@ coap_context(3)
 NAME
 ----
 coap_context, coap_new_context, coap_free_context,
-coap_context_set_pki, coap_context_set_psk, coap_new_endpoint,
+coap_context_set_pki, coap_context_set_psk2, coap_new_endpoint,
 coap_free_endpoint, coap_endpoint_set_default_mtu
 - Work with CoAP contexts
 
@@ -29,8 +29,8 @@ coap_dtls_pki_t *_setup_data_);*
 *int coap_context_set_pki_root_cas(coap_context_t *_context_,
 const char *_ca_file_, const char *_ca_dir_);*
 
-*int coap_context_set_psk(coap_context_t *_context_, const char *_hint_,
-const uint8_t *_key_, size_t _key_len_);*
+*int coap_context_set_psk2(coap_context_t *_context_,
+coap_dtls_spsk_t *setup_data);*
 
 *coap_endpoint_t *coap_new_endpoint(coap_context_t *_context_,
 const coap_address_t *_listen_addr_, coap_proto_t _proto_);*
@@ -80,7 +80,7 @@ In principle the set-up sequence for CoAP Servers looks like
 ----
 coap_new_context()
 coap_context_set_pki_root_cas() - if the root CAs need to be updated and PKI
-coap_context_set_pki() and/or coap_context_set_psk() - if encryption is required
+coap_context_set_pki() and/or coap_context_set_psk2() - if encryption is required
 coap_new_endpoint()
 ----
 
@@ -93,7 +93,7 @@ In principle the set-up sequence for CoAP Clients looks like
 ----
 coap_new_context()
 coap_context_set_pki_root_cas() if the root CAs need to be updated and PKI
-coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk()
+coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk2()
 ----
 
 Multiple client sessions are supported per Context.
@@ -111,7 +111,7 @@ attached Sessions and Endpoints.
 
 The *coap_context_set_pki*() function, for a specific _context_, is used to
 configure the TLS context using the _setup_data_ variables as defined in the
-coap_dtls_pki_t structure  - see *coap_encrytion(*3).
+coap_dtls_pki_t structure  - see *coap_encryption*(3).
 
 The *coap_context_set_pki_root_cas*() function is used to define a set of
 root CAs to be used instead of the default set of root CAs provided as a part
@@ -120,11 +120,11 @@ list of CAs.  _ca_file can be NULL.  _ca_dir_ points to a directory
 containing a set of PEM encoded files containing rootCAs.  _ca_dir_ can be
 NULL. One or both of _ca_file_ and _ca_dir_ must be set.
 
-The *coap_context_set_psk*() function is used to configure the TLS context
-using the server _hint_, PreShared Key _key_ with length _key_len_.
-All parameters must be defined, NULL is not valid.  An empty string is valid
-for _hint_.  _key_len_ must be greater than 0.  This function can only be used
-for Servers as it provides a _hint_, not an _identity_.
+The *coap_context_set_psk2*() function is used to configure the TLS context
+using the _setup_data_ variables as defined in the
+coap_dtls_spsk_t structure  - see *coap_encryption*(3).
+This function can only be used for servers as _setup_data_ provides
+a _hint_, not an _identity_.
 
 The *coap_new_endpoint*() function creates a new endpoint for _context_ that
 is listening for new traffic on the IP address and port number defined by
@@ -153,7 +153,7 @@ RETURN VALUES
 NULL if there is a creation failure.
 
 *coap_context_set_pki*(), *coap_context_set_pki_root_cas*() and
-*coap_context_set_psk*() functions return 1 on success, 0 on failure.
+*coap_context_set_psk2*() functions return 1 on success, 0 on failure.
 
 *coap_new_endpoint*() function returns a newly created endpoint or
 NULL if there is a creation failure.
@@ -185,8 +185,7 @@ setup_server_context (void) {
     return NULL;
   }
 
-  /* See coap_resource(3) */
-  init_resources(context);
+  /* Initialize resources - See coap_resource(3) init_resources() example */
 
   return context;
 }
@@ -198,7 +197,7 @@ setup_server_context (void) {
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 typedef struct valid_cns_t {
-  int count;
+  size_t count;
   char **cn_list;
 } valid_cns_t;
 
@@ -209,13 +208,19 @@ static int
 verify_cn_callback(const char *cn,
                    const uint8_t *asn1_public_cert,
                    size_t asn1_length,
-                   coap_session_t *session,
+                   coap_session_t *c_session,
                    unsigned depth,
                    int validated,
                    void *arg
 ) {
-  valid_cns_t *valid_cn_list = ( valid_cns_t*)arg;
-  int i;
+  valid_cns_t *valid_cn_list = (valid_cns_t*)arg;
+  size_t i;
+  /* Remove (void) definition if variable is used */
+  (void)asn1_public_cert;
+  (void)asn1_length;
+  (void)c_session;
+  (void)depth;
+  (void)validated;
 
   /* Check that the CN is valid */
   for (i = 0; i < valid_cn_list->count; i++) {
@@ -232,7 +237,7 @@ typedef struct sni_def_t {
 } sni_def_t;
 
 typedef struct valid_snis_t {
-  int count;
+  size_t count;
   sni_def_t *sni_list;
 } valid_snis_t;
 
@@ -240,11 +245,11 @@ typedef struct valid_snis_t {
  * Subject Name Identifier (SNI) callback verifier
  */
 static coap_dtls_key_t *
-verify_sni_callback(const char *sni,
-                    void *arg
+verify_pki_sni_callback(const char *sni,
+                        void *arg
 ) {
   valid_snis_t *valid_sni_list = (valid_snis_t *)arg;
-  int i;
+  size_t i;
 
   /* Check that the SNI is valid */
   for (i = 0; i < valid_sni_list->count; i++) {
@@ -293,7 +298,7 @@ setup_server_context_pki (const char *public_cert_file,
   dtls_pki.allow_expired_crl       = 1;
   dtls_pki.validate_cn_call_back   = verify_cn_callback;
   dtls_pki.cn_call_back_arg        = valid_cn_list;
-  dtls_pki.validate_sni_call_back  = verify_sni_callback;
+  dtls_pki.validate_sni_call_back  = verify_pki_sni_callback;
   dtls_pki.sni_call_back_arg       = valid_sni_list;
   dtls_pki.additional_tls_setup_call_back = NULL;
   dtls_pki.client_sni              = NULL;
@@ -317,8 +322,7 @@ setup_server_context_pki (const char *public_cert_file,
     return NULL;
   }
 
-  /* See coap_resource(3) */
-  init_resources(context);
+  /* Initialize resources - See coap_resource(3) init_resources() example */
 
   return context;
 }
@@ -329,14 +333,81 @@ setup_server_context_pki (const char *public_cert_file,
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+typedef struct id_def_t {
+  char* id;
+  coap_bin_const_t key;
+} id_def_t;
+
+typedef struct valid_ids_t {
+  int count;
+  id_def_t *id_list;
+} valid_ids_t;
+
+/*
+ * PSK Identity Pre-Shared Key selection Callback function
+ */
+static const coap_bin_const_t *
+verify_id_callback(coap_bin_const_t *identity,
+                   coap_session_t *c_session,
+                   void *arg
+) {
+  valid_ids_t *valid_id_list = (valid_ids_t*)arg;
+  int i;
+  /* Remove (void) definition if variable is used */
+  (void)c_session;
+
+  /* Check that the Identity is valid */
+  for (i = 0; i < valid_id_list->count; i++) {
+    if (!strcasecmp((const char*)identity->s, valid_id_list->id_list[i].id)) {
+      return &valid_id_list->id_list[i].key;
+    }
+  }
+  return NULL;
+}
+
+typedef struct sni_psk_def_t {
+  char* sni;
+  coap_dtls_spsk_info_t psk_info;
+} sni_psk_def_t;
+
+typedef struct valid_psk_snis_t {
+  int count;
+  sni_psk_def_t *sni_list;
+} valid_psk_snis_t;
+
+/*
+ * PSK Subject Name Identifier (SNI) callback verifier
+ */
+static const coap_dtls_spsk_info_t *
+verify_psk_sni_callback(const char *sni,
+                        coap_session_t *c_session,
+                        void *arg
+) {
+  valid_psk_snis_t *valid_sni_list = (valid_psk_snis_t *)arg;
+  int i;
+  /* Remove (void) definition if variable is used */
+  (void)c_session;
+
+  /* Check that the SNI is valid */
+  for (i = 0; i < valid_sni_list->count; i++) {
+    if (!strcasecmp(sni, valid_sni_list->sni_list[i].sni)) {
+      return &valid_sni_list->sni_list[i].psk_info;
+    }
+  }
+  return NULL;
+}
+
 static coap_context_t *
 setup_server_context_psk (const char *hint,
                           const uint8_t *key,
-                          unsigned key_len
+                          unsigned int key_len,
+                          valid_ids_t *valid_id_list,
+                          valid_psk_snis_t *valid_sni_list
 ) {
   coap_endpoint_t *endpoint;
   coap_address_t listen_addr;
   coap_context_t *context;
+  coap_dtls_spsk_t dtls_psk;
 
   /* See coap_tls_library(3) */
   if (!coap_dtls_is_supported())
@@ -346,7 +417,20 @@ setup_server_context_psk (const char *hint,
   if (!context)
     return NULL;
 
-  if (coap_context_set_psk(context, hint, key, key_len)) {
+  memset (&dtls_psk, 0, sizeof (dtls_psk));
+
+  /* see coap_encryption(3) */
+  dtls_psk.version                 = COAP_DTLS_SPSK_SETUP_VERSION;
+  dtls_psk.validate_id_call_back   = verify_id_callback;
+  dtls_psk.id_call_back_arg        = valid_id_list;
+  dtls_psk.validate_sni_call_back  = verify_psk_sni_callback;
+  dtls_psk.sni_call_back_arg       = valid_sni_list;
+  dtls_psk.psk_info.hint.s         = (const uint8_t*)hint;
+  dtls_psk.psk_info.hint.length    = hint ? strlen(hint) : 0;
+  dtls_psk.psk_info.key.s          = key;
+  dtls_psk.psk_info.key.length     = key_len;
+
+  if (coap_context_set_psk2(context, &dtls_psk)) {
     coap_free_context(context);
     return NULL;
   }
@@ -361,11 +445,87 @@ setup_server_context_psk (const char *hint,
     return NULL;
   }
 
-  /* See coap_resource(3) */
-  init_resources(context);
+  /* Initialize resources - See coap_resource(3) init_resources() example */
 
   return context;
 }
+----
+
+*CoAP Client DTLS PSK Setup*
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <stdio.h>
+
+#ifndef min
+#define min(a,b) ((a) < (b) ? (a) : (b))
+#endif
+
+static const coap_dtls_cpsk_info_t *
+verify_ih_callback(coap_str_const_t *hint,
+                   coap_session_t *c_session,
+                   void *arg
+) {
+  coap_dtls_cpsk_info_t *psk_info = (coap_dtls_cpsk_info_t *)arg;
+  char lhint[COAP_DTLS_HINT_LENGTH];
+  /* Remove (void) definition if variable is used */
+  (void)c_session;
+
+  snprintf(lhint, sizeof(lhint), "%.*s", (int)hint->length, hint->s);
+  coap_log(LOG_INFO, "Identity Hint '%s' provided\n", lhint);
+
+  /* Just use the defined information for now as passed in by arg */
+  return psk_info;
+}
+
+static coap_dtls_cpsk_t dtls_psk;
+static char client_sni[256];
+
+static coap_session_t *
+setup_client_session_psk (const char *uri,
+                          struct in_addr ip_address,
+                          const uint8_t *identity,
+                          unsigned int identity_len,
+                          const uint8_t *key,
+                          unsigned int key_len
+) {
+  coap_session_t *session;
+  coap_address_t server;
+  coap_context_t *context = coap_new_context(NULL);
+
+  if (!context)
+    return NULL;
+
+  coap_address_init(&server);
+  server.addr.sa.sa_family = AF_INET;
+  server.addr.sin.sin_addr = ip_address;
+  server.addr.sin.sin_port = htons (5684);
+
+  /* See coap_encryption(3) */
+  memset (&dtls_psk, 0, sizeof(dtls_psk));
+  dtls_psk.version = COAP_DTLS_CPSK_SETUP_VERSION;
+  dtls_psk.validate_ih_call_back = verify_ih_callback;
+  dtls_psk.ih_call_back_arg = &dtls_psk.psk_info;
+  if (uri)
+    memcpy(client_sni, uri, min(strlen(uri), sizeof(client_sni)-1));
+  else
+    memcpy(client_sni, "localhost", 9);
+  dtls_psk.client_sni = client_sni;
+  dtls_psk.psk_info.identity.s = identity;
+  dtls_psk.psk_info.identity.length = identity_len;
+  dtls_psk.psk_info.key.s = key;
+  dtls_psk.psk_info.key.length = key_len;
+  session = coap_new_client_session_psk2(context, NULL, &server,
+                                        COAP_PROTO_DTLS, &dtls_psk);
+  if (!session) {
+    coap_free_context(context);
+    return NULL;
+  }
+  /* The context is in session->context */
+  return session;
+}
+
 ----
 
 SEE ALSO

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -10,12 +10,16 @@ coap_encryption(3)
 
 NAME
 ----
-coap_encryption, coap_dtls_pki_t
-- Work with CoAP tls/dtls
+coap_encryption, coap_dtls_cpsk_t, coap_dtls_spsk_t, coap_dtls_pki_t
+- Work with CoAP TLS/DTLS
 
 SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
+
+*struct coap_dtls_cpsk_t*
+
+*struct coap_dtls_spsk_t*
 
 *struct coap_dtls_pki_t*
 
@@ -60,18 +64,14 @@ incoming traffic based on the Endpoint definition.  The TLS and CoAP session
 will not get built until the new traffic starts, which is done by the libcoap
 library, with the session having a reference count of 1.
 
-For Clients, all the encryption information can be held at the TLS Context and
-CoAP Context levels, or usually at the TLS Session and CoAP Session levels.  If
-defined at the Context level, then when Sessions are created, they will
-inherit the Context definitions, unless they have separately been defined for
-the Session level, in which case the Session version will get used.
-Typically the information will be configured at the Session level for Clients.
+For Clients, all the encryption information will be held internally by the TLS
+Context and/or TLS Session level and internally by the CoAP Session level.
 
 In principle the set-up sequence for CoAP Servers looks like
 ----
 coap_new_context()
 coap_context_set_pki_root_cas() - if the root CAs need to be updated and PKI
-coap_context_set_pki() and/or coap_context_set_psk() - if encryption is required
+coap_context_set_pki() and/or coap_context_set_psk2() - if encryption is required
 coap_new_endpoint()
 ----
 
@@ -84,7 +84,7 @@ In principle the set-up sequence for CoAP Clients looks like
 ----
 coap_new_context()
 coap_context_set_pki_root_cas() - if the root CAs need to be updated and PKI
-coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk()
+coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk2()
 ----
 
 Multiple client sessions are supported per Context.
@@ -92,12 +92,302 @@ Multiple client sessions are supported per Context.
 Due to the nature of TLS, there are Callbacks that are invoked as the TLS
 session negotiates encryption algorithms, encryption keys etc.
 Where possible, the CoAP layer handles all this automatically based on
-different configuration options passed in by the coap_*_pki() functions.
+different configuration options passed in by the coap_context_set_pki(),
+coap_new_client_session_pki(), coap_context_set_psk2() and
+coap_new_client_session_psk2() functions.
+
+PSK CLIENT INFORMATION
+----------------------
+
+For Client PSK setup, the required information needs to be provided in the setup
+calls with optional application callbacks defined to update the Identity and
+PSK. Initially, the Client has to provide an Identity and a Pre-Shared Key.
+
+Libcoap will put the Identity and Pre-Shared Key as appropriate into the TLS
+environment.
+
+*SECTION: PSK Client: coap_dtls_cpsk_t*
+[source, c]
+----
+typedef struct coap_dtls_cpsk_t {
+  coap_dtls_cpsk_version_t version; /** Set to COAP_DTLS_CPSK_SETUP_VERSION
+                                   to support the version of the struct */
+
+  /* Options to enable different TLS functionality in libcoap */
+  uint8_t reserved[7];             /* Reserved - must be set to 0 for
+                                      future compatibility */
+
+  /** Identity Hint check callback function.
+   * If not NULL, is called when the Identity Hint (TLS1.2 or earlier) is
+   * provided by the server.
+   * The appropriate Identity and Pre-Shared Key to use can then be returned.
+   */
+  coap_dtls_ih_callback_t validate_ih_call_back;
+  void *ih_call_back_arg;  /* Passed in to the Identity Hint callback
+                              function */
+
+  char* client_sni;    /*  If not NULL, SNI to use in client TLS setup.
+                           Owned by the client app and must remain valid
+                           during the call to coap_new_client_session_pki().
+                           Note: Not supported by TinyDTLS. */
+
+  coap_dtls_cpsk_info_t psk_info;  /* Client PSK definition */
+} coap_dtls_cpsk_t;
+----
+
+More detailed explanation of the coap_dtls_cpsk_t structure follows.
+
+*WARNING*: For all the parameter definitions that are pointers to other
+locations, these locations must remain valid during the lifetime of all the
+underlying TLS sessions that are, or will get created based on this PSK
+definition.
+
+*SECTION: PSK Client: coap_dtls_cpsk_t: Version*
+[source, c]
+----
+typedef enum
+{
+  COAP_DTLS_CPSK_SETUP_VERSION_V1 = 1,
+  COAP_DTLS_CPSK_SETUP_VERSION =
+             COAP_DTLS_CPSK_SETUP_VERSION_V1, /**< Latest CPSK setup version */
+} coap_dtls_cpsk_version_t;
+----
+
+*version* is set to COAP_DTLS_CPSK_SETUP_VERSION.  This will then allow
+support for different versions of the coap_dtls_cpsk_t structure in the future.
+
+*SECTION: PSK Client: coap_dtls_cpsk_t: Reserved*
+
+*reserved* All must be set to 0.  Future functionality updates will make use of
+these reserved definitions.
+
+*SECTION: PSK Client: coap_dtls_cpsk_t: Identity Hint Callback*
+[source, c]
+----
+/**
+ * Identity Hint Validation callback that can be set up by
+ * coap_new_client_session_psk2().
+ * Invoked when libcoap has done the validation checks at the TLS level,
+ * but the application needs to check that the Identity Hint is allowed, and
+ * needs to use the appropriate PSK information for the (D)TLS session.
+ * Note: Identity Hint is not supported in (D)TLS1.3.
+ *
+ * @param hint  The server provided Identity Hint
+ * @param coap_session  The CoAP session associated with the Identity Hint
+ * @param arg  The same as was passed into coap_new_client_session_psk2()
+ *             in setup_data->ih_call_back_arg
+ *
+ * @return New coap_dtls_cpsk_info_t object or @c NULL on error.
+ */
+typedef const coap_dtls_cpsk_info_t *(*coap_dtls_ih_callback_t)(
+                                struct coap_str_const_t *hint,
+                                coap_session_t *coap_session,
+                                void *arg);
+----
+
+*validate_ih_call_back* points to an application provided Identity Hint callback
+function or NULL. The application can make use of this Identity Hint information
+to decide what Identity and Pre-Shared Key should be used for this session.
+The Callback returns the new coap_dtls_cpsk_info_t on success,
+or NULL if the Identity Hint is unacceptable.
+
+*NOTE:* The Server may not provide a hint, or a zero length hint to indicate
+there is no hint.  In this case the initially provided Identity and
+Pre-Shared Key should be used.
+
+*ih_call_back_arg* points to a user defined set of data that will get passed
+in to the validate_ih_call_back() function's arg parameter and can be used by
+that function.  An example would be a set of Identity Hints that map into new
+Identity / Pre-Shared Key to use.
+
+*SECTION: PSK Client: coap_dtls_cpsk_t: Subject Name Indicator (SNI) Definition*
+
+*client_sni* points to the SNI name that will be added in as a TLS extension,
+if not NULL.  This typically is the DNS name of the server that the client is
+trying to contact.  The server is then able to decide, based on the name in the
+SNI extension, whether, for example, a different Hint and/or Pre-Shared Key is
+to be used.
+
+Note: Not supported by TinyDTLS.
+
+*SECTION: PSK Client: coap_dtls_cpsk_t: PSK Client Definitions*
+[source, c]
+----
+typedef struct coap_dtls_cpsk_info_t {
+  coap_bin_const_t identity; /* The Identity */
+  coap_bin_const_t key;      /* The Pre-Shared Key */
+} coap_dtls_cpsk_info_t;
+----
+
+*identity* defines the Identity to use.
+
+*key* defines the Pre-Shared Key to use
+
+PSK SERVER INFORMATION
+----------------------
 
 For PSK setup, the required information needs to be provided in the setup
-calls with no application Callbacks required. Both the Client and Server have
-to provide a PSK.  The Server must have a Hint defined and the Client must
-have an Identity defined.
+calls with optional application Callbacks defined to update the Identity Hint
+and Pre-SHared Key. Initially, the Server has to provided with an (optional)
+Identity Hint and a (required) Pre-Shared Key.
+
+Libcoap will put the Hint and Pre-Shared Key as appropriate into the TLS
+environment.
+
+*SECTION: PSK Server: coap_dtls_spsk_t*
+[source, c]
+----
+typedef struct coap_dtls_spsk_t {
+  coap_dtls_spsk_version_t version; /** Set to COAP_DTLS_SPSK_SETUP_VERSION
+                                   to support the version of the struct */
+
+  /* Options to enable different TLS functionality in libcoap */
+  uint8_t reserved[7];             /* Reserved - must be set to 0 for
+                                      future compatibility */
+
+  /** Identity check callback function.
+   * If not @p NULL, is called when the Identity is provided by the client.
+   *  The appropriate Pre-Shared Key to use can then be returned.
+   */
+  coap_dtls_id_callback_t validate_id_call_back;
+  void *id_call_back_arg;  /* Passed in to the Identity callback function */
+
+  /** SNI check callback function.
+   * If not @p NULL, called if the SNI is not previously seen and exexuted
+   * prior to sending an Identity Hint back to the client so that the
+   * appropriate PSK information can be used based on the requesting SNI.
+   */
+  coap_dtls_psk_sni_callback_t validate_sni_call_back;
+  void *sni_call_back_arg;  /* Passed in to the SNI callback function */
+
+  coap_dtls_spsk_info_t psk_info;  /* Server PSK definition */
+} coap_dtls_spsk_t;
+----
+
+More detailed explanation of the coap_dtls_spsk_t structure follows.
+
+*WARNING*: For all the parameter definitions that are pointers to other
+locations, these locations must remain valid during the lifetime of all the
+underlying TLS sessions that are, or will get created based on this PSK
+definition.
+
+*SECTION: PSK Server: coap_dtls_spsk_t: Version*
+[source, c]
+----
+typedef enum
+{
+  COAP_DTLS_SPSK_SETUP_VERSION_V1 = 1,
+  COAP_DTLS_SPSK_SETUP_VERSION =
+       COAP_DTLS_SPSK_SETUP_VERSION_V1, /**< Latest SPSK setup version */
+} coap_dtls_spsk_version_t;
+----
+
+*version* is set to COAP_DTLS_SPSK_SETUP_VERSION.  This will then allow
+support for different versions of the coap_dtls_spsk_t structure in the future.
+
+*SECTION: PSK Server: coap_dtls_spsk_t: Reserved*
+
+*reserved* All must be set to 0.  Future functionality updates will make use of
+these reserved definitions.
+
+*SECTION: PSK Server: coap_dtls_spsk_t: Identity Validation Callback*
+[source, c]
+----
+/**
+ * Identity Validation callback that can be set up by
+ * coap_context_set_psk2().
+ * Invoked when libcoap has done the validation checks at the TLS level,
+ * but the application needs to check that the Identity is allowed, and
+ * needs to use the appropriate Pre-Shared Key for the (D)TLS session.
+ *
+ * @param identity  The client provided Identity (should be NULL terminated)
+ * @param coap_session  The CoAP session associated with the Identity Hint
+ * @param arg  The same as was passed into coap_context_set_psk2()
+ *             in setup_data->id_call_back_arg
+ *
+ * @return New coap_bin_const_t Pre-Shared Key object or @c NULL on error.
+ */
+typedef const coap_bin_const_t *(*coap_dtls_id_callback_t)(
+                                 struct coap_bin_const_t *identity,
+                                 struct coap_session_t *coap_session,
+                                 void *arg);
+----
+
+*WARNING:* If both *validate_id_call_back* and *validate_sni_call_back* are
+defined, validate_id_call_back() is invoked after validate_sni_call_back(),
+and so if the Pre-Shared Key is changed in validate_sni_call_back(),
+validate_id_call_back() needs to be sure that the appropriate Pre-Shared Key
+is provided.
+
+*validate_id_call_back* points to an application provided Identity callback
+function or NULL. The application can make use of this Identity information
+to decide what PSK should be used for this session.
+The Callback returns the new coap_bin_const_t Pre-Shared Key on success,
+or NULL if the Identity is unacceptable.
+
+*NOTE:* The Client may be using a binary Identity that contains an embedded
+zero. However OpenSSL and GnuTLS do not currently support this.
+
+*id_call_back_arg* points to a user defined set of data that will get passed
+in to the validate_id_call_back() function and can be used by that function.
+An example would be a set of Identities that map into new Pre-Shared Keys
+to use.
+
+*SECTION: PSK Server: coap_dtls_spsk_t: Subject Name Identifier (SNI) Callback*
+[source, c]
+----
+/**
+ * PSK SNI callback that can be set up by coap_context_set_psk2().
+ * Invoked when libcoap has done the validation checks at the TLS level,
+ * but the application needs to check that the SNI is allowed, and needs
+ * to use the appropriate PSK information for the (D)TLS session.
+ *
+ * @param sni  The client provided SNI
+ * @param coap_session  The CoAP session associated with the SNI
+ * @param arg  The same as was passed into coap_new_client_session_psk2()
+ *             in setup_data->sni_call_back_arg
+ *
+ * @return New coap_dtls_spsk_info_t object or @c NULL on error.
+ */
+typedef const coap_dtls_spsk_info_t *(*coap_dtls_psk_sni_callback_t)(
+                                 const char *sni,
+                                 coap_session_t *coap_session,
+                                 void *arg);
+----
+
+*validate_sni_call_back* points to an application provided SNI callback
+checking function or NULL. The application can make use of this SNI information
+to decide whether the SNI is valid, and hence what new Hint and Pre-Shared Key
+to use.
+Thus it is possible for the coap server to host multiple domains with
+different Hints and PSKs allocated to each SNI domain.
+The Callback returns a coap_dtls_spsk_info_t pointer to the Hint and
+Pre-Shared Key to use for this SNI, or NULL if the connection is to get
+rejected.  Libcoap remembers the association between a specific SNI and Hint +
+Pre-Shared Key set and will only invoke this callback if the SNI is unknown.
+
+Note: Not supported by TinyDTLS.
+
+*sni_call_back_arg* points to a user defined set of data that will get passed
+in to the validate_sni_call_back() function and can be used by that function.
+An example would be a set of SNIs that are allowed with their matching
+Hint + Pre-Shared Key sets.
+
+*SECTION: PSK Server: coap_dtls_spsk_t: PSK Information Definitions*
+[source, c]
+----
+typedef struct coap_dtls_spsk_info_t {
+  coap_bin_const_t hint; /* The identity hint to use */
+  coap_bin_const_t key;  /* The Pre-Shared Key to use */
+} coap_dtls_spsk_info_t;
+----
+
+*identity* defines the Identity Hint to use.
+
+*key* defines the Pre-Shared Key to use
+
+PKI CLIENT AND SERVER INFORMATION
+---------------------------------
 
 For PKI setup, if the libcoap PKI configuration options do not handle a specific
 requirement as defined by the available options, then an application defined
@@ -117,6 +407,7 @@ The internal Callbacks (and optionally the Application Callback) will then
 check the required information as defined in the coap_dtls_pki_t described
 below.
 
+*SECTION: PKI: coap_dtls_pki_t*
 [source, c]
 ----
 typedef struct coap_dtls_pki_t {
@@ -135,23 +426,23 @@ typedef struct coap_dtls_pki_t {
   uint8_t reserved[6];              /* Reserved - must be set to 0 for
                                        future compatibility */
 
-  /** CN check call-back function
+  /** CN check callback function
    * If not NULL, is called when the TLS connection has passed the configured
    * TLS options above for the application to verify if the CN is valid.
    */
   coap_dtls_cn_callback_t validate_cn_call_back;
-  void *cn_call_back_arg;  /* Passed in to the CN call-back function */
+  void *cn_call_back_arg;  /* Passed in to the CN callback function */
 
-  /** SNI check call-back function
+  /** SNI check callback function
    * If not NULL, called if the SNI is not previously seen and prior to sending
-   * a certificate set back to the client so that the appropriate certificate set
-   * can be used based on the requesting SNI.
+   * a certificate set back to the client so that the appropriate certificate
+   * set can be used based on the requesting SNI.
    */
   coap_dtls_sni_callback_t validate_sni_call_back;
-  void *sni_call_back_arg;  /* Passed in to the sni call-back function */
+  void *sni_call_back_arg;  /* Passed in to the SNI callback function */
 
-  /** Additional Security call-back handler that is invoked when libcoap has
-   * done the standerd, defined validation checks at the TLS level,
+  /** Additional Security callback handler that is invoked when libcoap has
+   * done the standard, defined validation checks at the TLS level,
    * If not NULL, called from within the TLS Client Hello connection
    * setup.
    */
@@ -167,15 +458,16 @@ typedef struct coap_dtls_pki_t {
 
 More detailed explanation of the coap_dtls_pki_t structure follows.
 
-*WARNING*: All the parameter definitions that are pointers to other locations,
-these locations must remain valid during the lifetime of all the underlying TLS
-sessions that are, or will get created based on this PKI definition.
+*WARNING*: For all the parameter definitions that are pointers to other
+locations, these locations must remain valid during the lifetime of all the
+underlying TLS sessions that are, or will get created based on this PKI
+definition.
 
 The first parameter in each subsection enables/disables the functionality, the
-remaining parameter(s) control control what happens when the functionality is
+remaining parameter(s) control what happens when the functionality is
 enabled.
 
-*SECTION: coap_dtls_pki_t Version*
+*SECTION: PKI: coap_dtls_pki_t: Version*
 [source, c]
 ----
 #define COAP_DTLS_PKI_SETUP_VERSION 1
@@ -184,7 +476,7 @@ enabled.
 *version* is set to COAP_DTLS_PKI_SETUP_VERSION.  This will then allow support
 for different versions of the coap_dtls_pki_t structure in the future.
 
-*SECTION: Peer Certificate Checking*
+*SECTION: PKI: coap_dtls_pki_t: Peer Certificate Checking*
 
 *verify_peer_cert* Set to 1 to check that the peer's certificate is valid if
 provided, else 0.
@@ -198,7 +490,7 @@ certificate chain) to be a self-signed certificate, else 0.
 *allow_expired_certs* Set to 1 to allow certificates that have either expired,
 or are not yet valid to be allowed, else 0.
 
-*SECTION: Certificate Chain Validation*
+*SECTION: PKI: coap_dtls_pki_t: Certificate Chain Validation*
 
 *cert_chain_validation* Set to 1 to check that the certificate chain is valid,
 else 0.
@@ -207,7 +499,7 @@ else 0.
 is the number of intermediate CAs in the chain. If set to 0, then there can be
 no intermediate CA in the chain.
 
-*SECTION: Certificate Revocation*
+*SECTION: PKI: coap_dtls_pki_t: Certificate Revocation*
 
 *check_cert_revocation* Set to 1 to check whether any certificate in the chain
 has been revoked, else 0.
@@ -217,16 +509,16 @@ has been revoked, else 0.
 *allow_expired_crl* Set to 1 to allow an certificate that has an expired CRL
 definition to be valid, else 0.
 
-*SECTION: Reserved*
+*SECTION: PKI: coap_dtls_pki_t: Reserved*
 
-*reserved* Must be set to 0.  Future functionality updates will make use of
+*reserved* All must be set to 0.  Future functionality updates will make use of
 these reserved definitions.
 
-*SECTION: Common Name (CN) Callback*
+*SECTION: PKI: coap_dtls_pki_t: Common Name (CN) Callback*
 [source, c]
 ----
 /**
- * CN Validation call-back that can be set up by coap_context_set_pki().
+ * CN Validation callback that can be set up by coap_context_set_pki().
  * Invoked when libcoap has done the validation checks at the TLS level,
  * but the application needs to check that the CN is allowed.
  * CN is the SubjectAltName in the cert, if not present, then the leftmost
@@ -247,7 +539,7 @@ typedef int (*coap_dtls_cn_callback_t)(const char *cn,
              const uint8_t *asn1_public_cert,
              size_t asn1_length,
              coap_session_t *session,
-             unsigned depth,
+             unsigned int depth,
              int validated,
              void *arg);
 ----
@@ -257,11 +549,11 @@ checking function or NULL. The application can make use of this CN information
 to decide, for example, that the CN is valid coming from a particular peer.
 The Callback returns 1 on success, 0 if the TLS connection is to be aborted.
 
-*cn_call_back_arg* points to a user defined set of data that will get  passed
+*cn_call_back_arg* points to a user defined set of data that will get passed
 in to the validate_cn_call_back() function and can be used by that function.
 An example would be a set of CNs that are allowed.
 
-*SECTION: Subject Name Identifier (SNI) Callback*
+*SECTION: PKI: coap_dtls_pki_t: Subject Name Identifier (SNI) Callback*
 [source, c]
 ----
 typedef struct coap_dtls_key_t {
@@ -273,7 +565,7 @@ typedef struct coap_dtls_key_t {
 } coap_dtls_key_t;
 
 /**
- * SNI Validation call-back that can be set up by coap_context_set_pki().
+ * SNI Validation callback that can be set up by coap_context_set_pki().
  * Invoked if the SNI is not previously seen and prior to sending a certificate
  * set back to the client so that the appropriate certificate set can be used
  * based on the requesting SNI.
@@ -298,12 +590,12 @@ if the connection it to get rejected.  libcoap remembers the association
 between the SNI and Certificate set and will only invoke this callback if the
 SNI is unknown.
 
-*sni_call_back_arg* points to a user defined set of data that will get  passed
+*sni_call_back_arg* points to a user defined set of data that will get passed
 in to the validate_sni_call_back() function and can be used by that function.
 An example would be a set of SNIs that are allowed with their matching
 certificate sets.
 
-*SECTION: Application Additional Setup Callback*
+*SECTION: PKI: coap_dtls_pki_t: Application Additional Setup Callback*
 [source, c]
 ----
 /**
@@ -328,7 +620,7 @@ function that will do additional checking/changes/updates after libcoap has
 done all of the configured TLS setup checking, or NULL to do no additional
 checking.
 
-*SECTION: Subject Name Indicator (SNI) Definition*
+*SECTION: PKI: coap_dtls_pki_t: Subject Name Indicator (SNI) Definition*
 
 *client_sni* points to the SNI name that will be added in as a TLS extension,
 or set NULL.  This typically is the DNS name of the server that the client is
@@ -336,7 +628,7 @@ trying to contact.  This is only used by a client application and the server
 is then able to decide, based on the name in the SNI extension, whether, for
 example, a different certificate should be provided.
 
-*SECTION: Key Type Definition*
+*SECTION: PKI: coap_dtls_pki_t: Key Type Definition*
 [source, c]
 ----
 typedef enum coap_pki_key_t {
@@ -348,7 +640,7 @@ typedef enum coap_pki_key_t {
 *key_type* defines the format that the certificates / keys are provided in.
 This can be COAP_PKI_KEY_PEM or COAP_PKI_KEY_ASN1.
 
-*SECTION: PEM Key Definitions*
+*SECTION: PKI: coap_dtls_pki_t: PEM Key Definitions*
 [source, c]
 ----
 typedef struct coap_pki_key_pem_t {
@@ -370,7 +662,7 @@ which will be in PEM format.
 *key.pem.private_key* points to the Private Key location on disk which
 will be in PEM format.  This file cannot be password protected.
 
-*SECTION: ASN1 Key Definitions*
+*SECTION: PKI: coap_dtls_pki_t: ASN1 Key Definitions*
 [source, c]
 ----
 typedef struct coap_pki_key_asn1_t {
@@ -440,7 +732,7 @@ typedef struct valid_cns_t {
 } valid_cns_t;
 
 /**
- * CN Validation call-back that is set up by coap_context_set_pki().
+ * CN Validation callback that is set up by coap_context_set_pki().
  * Invoked when libcoap has done the validation checks at the TLS level,
  * but the application needs to check that the CN is allowed.
  * CN is the SubjectAltName in the cert, if not present, then the leftmost
@@ -461,13 +753,19 @@ static int
 verify_cn_callback(const char *cn,
                    const uint8_t *asn1_public_cert,
                    size_t asn1_length,
-                   coap_session_t *session,
+                   coap_session_t *c_session,
                    unsigned depth,
                    int validated,
                    void *arg
 ) {
-  valid_cns_t *valid_cn_list = ( valid_cns_t*)arg;
+  valid_cns_t *valid_cn_list = (valid_cns_t*)arg;
   int i;
+  /* Remove (void) definition if variable is used */
+  (void)asn1_public_cert;
+  (void)asn1_length;
+  (void)c_session;
+  (void)depth;
+  (void)validated;
 
   /* Check that the CN is valid */
   for (i = 0; i < valid_cn_list->count; i++) {
@@ -489,7 +787,7 @@ typedef struct valid_snis_t {
 } valid_snis_t;
 
 /**
- * SNI Validation call-back that is set up by coap_context_set_pki().
+ * SNI Validation callback that is set up by coap_context_set_pki().
  * Invoked if the SNI is not previously seen and prior to sending a certificate
  * set back to the client so that the appropriate certificate set can be used
  * based on the requesting SNI.
@@ -501,8 +799,8 @@ typedef struct valid_snis_t {
  * @return new set of certificates to use, or NULL if SNI is to be rejected.
  */
 static coap_dtls_key_t *
-verify_sni_callback(const char *sni,
-                    void *arg
+verify_pki_sni_callback(const char *sni,
+                        void *arg
 ) {
   valid_snis_t *valid_sni_list = (valid_snis_t *)arg;
   int i;
@@ -554,10 +852,10 @@ setup_server_context_pki (const char *public_cert_file,
   dtls_pki.allow_expired_crl       = 1;
   dtls_pki.validate_cn_call_back   = verify_cn_callback;
   dtls_pki.cn_call_back_arg        = valid_cn_list;
-  dtls_pki.validate_sni_call_back  = verify_sni_callback;
+  dtls_pki.validate_sni_call_back  = verify_pki_sni_callback;
   dtls_pki.sni_call_back_arg       = valid_sni_list;
   dtls_pki.additional_tls_setup_call_back = NULL;
-  dtls_pki.sni                     = NULL;
+  dtls_pki.client_sni              = NULL;
   dtls_pki.pki_key.key_type        = COAP_PKI_KEY_PEM;
   dtls_pki.pki_key.key.pem.ca_file = ca_file;
   dtls_pki.pki_key.key.pem.public_cert = public_cert_file;
@@ -580,10 +878,211 @@ setup_server_context_pki (const char *public_cert_file,
     return NULL;
   }
 
-  /* See coap_resource(3) */
-  init_resources(context);
+  /* Initialize resources - See coap_resource(3) init_resources() example */
 
   return context;
+}
+----
+
+*CoAP Server DTLS PSK Setup*
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+typedef struct id_def_t {
+  char *hint_match;
+  coap_bin_const_t id;
+  coap_bin_const_t key;
+} id_def_t;
+
+typedef struct valid_ids_t {
+  int count;
+  id_def_t *id_list;
+} valid_ids_t;
+
+/*
+ * PSK Identity Pre-Shared Key selection Callback function
+ */
+static const coap_bin_const_t *
+verify_id_callback(coap_bin_const_t *identity,
+                   coap_session_t *c_session,
+                   void *arg
+) {
+  valid_ids_t *valid_id_list = (valid_ids_t*)arg;
+  int i;
+
+  /* Check that the Identity is valid */
+  for (i = 0; i < valid_id_list->count; i++) {
+    if (c_session->psk_hint &&
+        strcmp((const char *)c_session->psk_hint->s,
+               valid_id_list->id_list[i].hint_match)) {
+      continue;
+    }
+    if (coap_binary_equal(identity, &valid_id_list->id_list[i].id)) {
+      return &valid_id_list->id_list[i].key;
+    }
+  }
+  return NULL;
+}
+
+typedef struct sni_psk_def_t {
+  char* sni;
+  coap_dtls_spsk_info_t psk_info;
+} sni_psk_def_t;
+
+typedef struct valid_psk_snis_t {
+  int count;
+  sni_psk_def_t *sni_list;
+} valid_psk_snis_t;
+
+/*
+ * PSK Subject Name Identifier (SNI) callback verifier
+ */
+static const coap_dtls_spsk_info_t *
+verify_psk_sni_callback(const char *sni,
+                        coap_session_t *c_session,
+                        void *arg
+) {
+  valid_psk_snis_t *valid_sni_list = (valid_psk_snis_t *)arg;
+  int i;
+  /* Remove (void) definition if variable is used */
+  (void)c_session;
+
+  /* Check that the SNI is valid */
+  for (i = 0; i < valid_sni_list->count; i++) {
+    if (!strcasecmp(sni, valid_sni_list->sni_list[i].sni)) {
+      return &valid_sni_list->sni_list[i].psk_info;
+    }
+  }
+  return NULL;
+}
+
+static coap_context_t *
+setup_server_context_psk (const char *hint,
+                          const uint8_t *key,
+                          unsigned int key_len,
+                          valid_ids_t *valid_id_list,
+                          valid_psk_snis_t *valid_sni_list
+) {
+  coap_endpoint_t *endpoint;
+  coap_address_t listen_addr;
+  coap_context_t *context;
+  coap_dtls_spsk_t dtls_psk;
+
+  /* See coap_tls_library(3) */
+  if (!coap_dtls_is_supported())
+    return NULL;
+
+  context = coap_new_context(NULL);
+  if (!context)
+    return NULL;
+
+  memset (&dtls_psk, 0, sizeof (dtls_psk));
+
+  /* see coap_encryption(3) */
+  dtls_psk.version                 = COAP_DTLS_SPSK_SETUP_VERSION;
+  dtls_psk.validate_id_call_back   = verify_id_callback;
+  dtls_psk.id_call_back_arg        = valid_id_list;
+  dtls_psk.validate_sni_call_back  = verify_psk_sni_callback;
+  dtls_psk.sni_call_back_arg       = valid_sni_list;
+  dtls_psk.psk_info.hint.s         = (const uint8_t*)hint;
+  dtls_psk.psk_info.hint.length    = hint ? strlen(hint) : 0;
+  dtls_psk.psk_info.key.s          = key;
+  dtls_psk.psk_info.key.length     = key_len;
+
+  if (coap_context_set_psk2(context, &dtls_psk)) {
+    coap_free_context(context);
+    return NULL;
+  }
+
+  coap_address_init(&listen_addr);
+  listen_addr.addr.sa.sa_family = AF_INET;
+  listen_addr.addr.sin.sin_port = htons (5684);
+
+  endpoint = coap_new_endpoint(context, &listen_addr, COAP_PROTO_DTLS);
+  if (!endpoint) {
+    coap_free_context(context);
+    return NULL;
+  }
+
+  /* Initialize resources - See coap_resource(3) init_resources() example */
+
+  return context;
+}
+----
+
+*CoAP Client DTLS PSK Setup*
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <stdio.h>
+
+#ifndef min
+#define min(a,b) ((a) < (b) ? (a) : (b))
+#endif
+
+static const coap_dtls_cpsk_info_t *
+verify_ih_callback(coap_str_const_t *hint,
+                   coap_session_t *c_session,
+                   void *arg
+) {
+  coap_dtls_cpsk_info_t *psk_info = (coap_dtls_cpsk_info_t *)arg;
+  /* Remove (void) definition if variable is used */
+  (void)c_session;
+
+  coap_log(LOG_INFO, "Identity Hint '%.*s' provided\n", (int)hint->length, hint->s);
+
+  /* Just use the defined information for now as passed in by arg */
+  return psk_info;
+}
+
+static coap_dtls_cpsk_t dtls_psk;
+static char client_sni[256];
+
+static coap_session_t *
+setup_client_session_psk (const char *uri,
+                          struct in_addr ip_address,
+                          const uint8_t *identity,
+                          unsigned int identity_len,
+                          const uint8_t *key,
+                          unsigned int key_len
+) {
+  coap_session_t *session;
+  coap_address_t server;
+  /* See coap_context(3) */
+  coap_context_t *context = coap_new_context(NULL);
+
+  if (!context)
+    return NULL;
+
+  coap_address_init(&server);
+  server.addr.sa.sa_family = AF_INET;
+  server.addr.sin.sin_addr = ip_address;
+  server.addr.sin.sin_port = htons (5684);
+
+  /* See coap_encryption(3) */
+  memset (&dtls_psk, 0, sizeof(dtls_psk));
+  dtls_psk.version = COAP_DTLS_CPSK_SETUP_VERSION;
+  dtls_psk.validate_ih_call_back = verify_ih_callback;
+  dtls_psk.ih_call_back_arg = &dtls_psk.psk_info;
+  if (uri)
+    memcpy(client_sni, uri, min(strlen(uri), sizeof(client_sni)-1));
+  else
+    memcpy(client_sni, "localhost", 9);
+  dtls_psk.client_sni = client_sni;
+  dtls_psk.psk_info.identity.s = identity;
+  dtls_psk.psk_info.identity.length = identity_len;
+  dtls_psk.psk_info.key.s = key;
+  dtls_psk.psk_info.key.length = key_len;
+  session = coap_new_client_session_psk2(context, NULL, &server,
+                                        COAP_PROTO_DTLS, &dtls_psk);
+  if (!session) {
+    coap_free_context(context);
+    return NULL;
+  }
+  /* The context is in session->context */
+  return session;
 }
 ----
 

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -182,17 +182,21 @@ EXAMPLES
 *GET Resource Callback Handler*
 
 [source, c]
---
+----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
-void
+#include <stdio.h>
+
+static void
 hnd_get_time(coap_context_t *context, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
 
   unsigned char buf[40];
   size_t len;
   time_t now;
+  /* Remove (void) definition if variable is used */
+  (void)context;
 
   /* ... Additional analysis code for resource, request pdu etc.  ... */
 
@@ -238,24 +242,28 @@ coap_string_t *query, coap_pdu_t *response) {
    */
 
 }
---
+----
 *Packet Response Handler*
 
 [source, c]
---
+----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+static int check_token(coap_pdu_t *received) {
+  /* Remove (void) definition if variable is used */
+  (void)received;
+
+  /* Code to validate the token is what we expect */
+
+  return 1;
+}
 
 static void
 response_handler(coap_context_t *ctx, coap_session_t *session,
 coap_pdu_t *sent, coap_pdu_t *received, const coap_tid_t id) {
-
-  coap_pdu_t *pdu = NULL;
-  coap_opt_t *block_opt;
-  coap_opt_iterator_t opt_iter;
-  unsigned char buf[4];
-  size_t len;
-  unsigned char *databuf;
-  coap_tid_t tid;
+  /* Remove (void) definition if variable is used */
+  (void)ctx;
+  (void)id;
 
   /* check if this is a response to our original request */
   if (!check_token(received)) {
@@ -267,7 +275,7 @@ coap_pdu_t *sent, coap_pdu_t *received, const coap_tid_t id) {
   }
 
   if (received->type == COAP_MESSAGE_RST) {
-    info("got RST\n");
+    coap_log(LOG_INFO, "got RST\n");
     return;
   }
 
@@ -279,7 +287,7 @@ coap_pdu_t *sent, coap_pdu_t *received, const coap_tid_t id) {
   return;
 
 }
---
+----
 
 SEE ALSO
 --------

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -55,7 +55,7 @@ the selected logging level, outputs the appropriate information.
 
 Logging by default is to stderr or stdout depending on the logging level of
 the log entry.  It ia possible to send the logging information to an
-application logging call-back handler for processing by the application.
+application logging callback handler for processing by the application.
 
 The *coap_log*() function is used to log information at the appropriate _level_.
 The rest of the parameters follow the standard *printf*() function format.
@@ -89,7 +89,7 @@ Debug level (7).
 
 The *coap_set_log_level*() function is used to set the current logging _level_
 for output by any subsequent *coap_log*() calls.  Output is only logged if the
-*coap_log*() _level_ definition is smaller than or equal to the curent logging
+*coap_log*() _level_ definition is smaller than or equal to the current logging
 _level_.
 
 The *coap_get_log_level*() function is used to get the current logging level.

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -90,7 +90,7 @@ _resource_ is no longer observable.
 when libcoap creates a "fake GET request".  The Unknown Resource PUT
 handler must create a new resource and mark the resource as "observable" if
 a specific resource needs to be observable.  The application must then
-manage the deleteion of the resource at the appropriate time.
+manage the deletion of the resource at the appropriate time.
 
 *NOTE:* The type (confirmable or non-confirmable) of the triggered observe
 GET response is determined not by the initial GET request, but independently
@@ -137,25 +137,25 @@ EXAMPLES
 *Simple Time Server*
 
 [source, c]
---
+----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
-coap_resource_t *time_resource = NULL;
+#include <stdio.h>
 
-static int check_if_time_resource_has_changed(coap_resource_t *resource) {
-  return 1;
-}
+coap_resource_t *time_resource = NULL;
 
 /* specific GET "time" handler, called from hnd_get_generic() */
 
 static void
 hnd_get_time(coap_context_t *context, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
 
   unsigned char buf[40];
   size_t len;
   time_t now;
+  /* Remove (void) definition if variable is used */
+  (void)context;
 
   /* ... Additional analysis code for resource, request pdu etc.  ... */
 
@@ -206,7 +206,7 @@ coap_string_t *query, coap_pdu_t *response) {
 
 static void
 hnd_get_generic(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
 
   coap_str_const_t *uri_path = coap_resource_get_uri_path(resource);
@@ -258,6 +258,10 @@ int main(int argc, char *argv[]){
   coap_endpoint_t *ep = NULL;
   coap_address_t addr;
   unsigned wait_ms;
+  time_t t_last = 0;
+  /* Remove (void) definition if variable is used */
+  (void)argc;
+  (void)argv;
 
   /* Create the libcoap context */
   ctx = coap_new_context(NULL);
@@ -292,7 +296,6 @@ int main(int argc, char *argv[]){
       time_t t_now = time(NULL);
       if (t_last != t_now) {
         /* Happens once per second */
-        int i;
         t_last = t_now;
         if (time_resource) {
           coap_resource_notify_observers(time_resource, NULL);
@@ -307,12 +310,12 @@ int main(int argc, char *argv[]){
   exit(0);
 
 }
---
+----
 
 *Client Observe Request Setup*
 
 [source, c]
---
+----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 /* Usually, requests are sent confirmable */
@@ -326,7 +329,7 @@ coap_new_request(coap_context_t *context, coap_session_t *session, char request_
 coap_optlist_t **options, unsigned char *data, size_t length, int observe) {
 
   coap_pdu_t *pdu;
-  coap_optlist_t *opt;
+  /* Remove (void) definition if variable is used */
   (void)context;
 
   /* Create the pdu with the appropriate options */
@@ -373,7 +376,7 @@ error:
   return NULL;
 
 }
---
+----
 
 SEE ALSO
 --------

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -233,23 +233,24 @@ EXAMPLES
 *Setup PDU and Transmit*
 
 [source, c]
---
+----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 static int token = 0;
 
-int
+static int
 build_send_pdu(coap_context_t *context, coap_session_t *session,
 uint8_t msgtype, uint8_t request_code, const char *uri, const char *query,
 unsigned char *data, size_t length, int observe) {
 
   coap_pdu_t *pdu;
-  (void)context;
-  char buf[1024];
+  uint8_t buf[1024];
   size_t buflen;
-  char *sbuf = buf;
+  uint8_t *sbuf = buf;
   int res;
   coap_optlist_t *optlist_chain = NULL;
+  /* Remove (void) definition if variable is used */
+  (void)context;
 
   /* Create the pdu with the appropriate options */
   pdu = coap_pdu_init(msgtype, request_code, coap_new_message_id(session),
@@ -320,26 +321,30 @@ unsigned char *data, size_t length, int observe) {
 error:
 
   if (pdu)
-    coap_pdu_delete(pdu);
+    coap_delete_pdu(pdu);
   return 0;
 
 }
---
+----
 
 *Resource Handler Response PDU Update*
 
 [source, c]
---
+----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <stdio.h>
 
 static void
 hnd_get_time(coap_context_t *context, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
 
   unsigned char buf[40];
   size_t len;
   time_t now;
+  /* Remove (void) definition if variable is used */
+  (void)context;
 
   /* ... Additional analysis code for resource, request pdu etc.  ... */
 
@@ -385,7 +390,7 @@ coap_string_t *query, coap_pdu_t *response) {
    */
 
 }
---
+----
 
 SEE ALSO
 --------

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -148,16 +148,23 @@ EXAMPLES
 *Fixed Resources Set Up*
 
 [source, c]
---
+----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 #define INDEX "This is an example server using libcoap\n"
 
-void
+static void
 hnd_get_index(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
   unsigned char buf[3];
+  /* Remove (void) definition if variable is used */
+  (void)ctx;
+  (void)resource;
+  (void)session;
+  (void)request;
+  (void)token;
+  (void)query;
 
   response->code = COAP_RESPONSE_CODE(205);
 
@@ -175,28 +182,52 @@ coap_string_t *query, coap_pdu_t *response) {
 
 }
 
-void
+static void
 hnd_delete_time(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
+  /* Remove (void) definition if variable is used */
+  (void)ctx;
+  (void)resource;
+  (void)session;
+  (void)request;
+  (void)token;
+  (void)query;
 
   /* .. code .. */
 
+  response->code = COAP_RESPONSE_CODE(202);
 }
 
-void
+static void
 hnd_get_time(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
+  /* Remove (void) definition if variable is used */
+  (void)ctx;
+  (void)resource;
+  (void)session;
+  (void)request;
+  (void)token;
+  (void)query;
+  (void)response;
 
   /* .. code .. */
 
 }
 
-void
+static void
 hnd_put_time(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
+  /* Remove (void) definition if variable is used */
+  (void)ctx;
+  (void)resource;
+  (void)session;
+  (void)request;
+  (void)token;
+  (void)query;
+  (void)response;
 
   /* .. code .. */
 
@@ -238,21 +269,27 @@ init_resources(coap_context_t *ctx) {
   coap_add_resource(ctx, r);
 
 }
---
+----
 
 *Dynamic Resources Set Up*
 
 [source, c]
---
+----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 /* Regular DELETE handler - used by resources created by the
  * Unknown Resource PUT handler */
 
-void
+static void
 hnd_delete(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
+  /* Remove (void) definition if variable is used */
+  (void)session;
+  (void)request;
+  (void)token;
+  (void)query;
+  (void)response;
 
   /* .. code .. */
 
@@ -264,17 +301,21 @@ coap_string_t *query, coap_pdu_t *response) {
 /* Regular GET handler - used by resources created by the
  * Unknown Resource PUT handler */
 
-void
+static void
 hnd_get(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
 
   coap_str_const_t *get_uri_path;
   coap_string_t *get_query;
-  coap_opt_iterator_t opt_iter;
-  coap_opt_filter_t filter;
-  coap_opt_t *option;
-  int len;
+  /* Remove (void) definition if variable is used */
+  (void)ctx;
+  (void)resource;
+  (void)session;
+  (void)request;
+  (void)token;
+  (void)query;
+  (void)response;
 
   /*
    * request will be NULL if an Observe triggered request, so the uri_path,
@@ -292,10 +333,16 @@ coap_string_t *query, coap_pdu_t *response) {
 /* Regular PUT handler - used by resources created by the
  * Unknown Resource PUT handler */
 
-void
+static void
 hnd_put(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
+  /* Remove (void) definition if variable is used */
+  (void)ctx;
+  (void)resource;
+  (void)session;
+  (void)token;
+  (void)query;
 
   coap_string_t *put_uri_path;
 
@@ -313,15 +360,27 @@ coap_string_t *query, coap_pdu_t *response) {
 
 }
 
+static int
+check_url_fn(coap_string_t *uri_path, uint8_t code) {
+  /* Remove (void) definition if variable is used */
+  (void)uri_path;
+  (void)code;
+
+  /* Code to determine whether the uri is valid or not */
+
+  return 1;
+}
+
 /* Unknown Resource PUT handler */
 
-void
+static void
 hnd_unknown_put(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_string_t *token,
+coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
 coap_string_t *query, coap_pdu_t *response) {
+  /* Remove (void) definition if variable is used */
+  (void)resource;
 
   coap_resource_t *r;
-  int len;
   coap_string_t *uri_path;
 
   /* get the uri_path - which will get used by coap_resource_init() */
@@ -376,7 +435,7 @@ init_resources(coap_context_t *ctx) {
   coap_add_resource(ctx, r);
 
 }
---
+----
 
 SEE ALSO
 --------

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -12,7 +12,7 @@ NAME
 ----
 coap_session,
 coap_new_client_session,
-coap_new_client_session_psk,
+coap_new_client_session_psk2,
 coap_new_client_session_pki,
 coap_session_reference,
 coap_session_release,
@@ -28,9 +28,9 @@ SYNOPSIS
 const coap_address_t *_local_if_, const coap_address_t *_server_,
 coap_proto_t _proto_);*
 
-*coap_session_t *coap_new_client_session_psk(coap_context_t *_context_,
+*coap_session_t *coap_new_client_session_psk2(coap_context_t *_context_,
 const coap_address_t *_local_if_, const coap_address_t *_server_, coap_proto_t
-_proto_, const char *_identity_, const uint8_t *_key_, unsigned _key_len_);*
+_proto_, coap_dtls_cpsk_t *_setup_data_);*
 
 *coap_session_t *coap_new_client_session_pki(coap_context_t *_context_,
 const coap_address_t *_local_if_, const coap_address_t *_server_, coap_proto_t
@@ -94,7 +94,7 @@ In principle the set-up sequence for CoAP Servers looks like
 ----
 coap_new_context()
 coap_context_set_pki_root_cas() - if the root CAs need to be updated and PKI
-coap_context_set_pki() and/or coap_context_set_psk() - if encryption is required
+coap_context_set_pki() and/or coap_context_set_psk2() - if encryption is required
 coap_new_endpoint()
 ----
 
@@ -107,7 +107,7 @@ In principle the set-up sequence for CoAP Clients looks like
 ----
 coap_new_context()
 coap_context_set_pki_root_cas() if the root CAs need to be updated and PKI
-coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk()
+coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk2()
 ----
 
 Multiple client sessions are supported per Context.
@@ -132,16 +132,23 @@ address or port.  The session will initially have a reference count of 1.
 
 The *coap_new_client_session_pki*() function, for a specific _context_, is
 used to configure the TLS context using the _setup_data_ variables as defined
-in the coap_dtls_pki_t structure - see *coap_encrytion*(3).
-The session will initially have a reference count of 1.
+in the coap_dtls_pki_t structure in the newly created session -
+see *coap_encryption*(3). The connection is to the specified _server_ using
+the CoAP protocol _proto_.  If the port is not specified in _server_, then the
+default CoAP port is used.  Normally _local_if_ would be set to NULL, but by
+specifying _local_if_ the source of the network session can be bound to a
+specific IP address or port. The session will initially have a reference count
+of 1.
 
-The *coap_new_client_session_psk*() function, for a specific _context_, is
-used to configure the TLS context using the client _identity_, Pre-Shared Key
-_key_ with length _key_len_.  All 3 parameters must be defined, NULL is not
-valid.  An empty string is not valid for _identity_.  _key_len_ must be greater
-than 0.  This function also includes the _server_ to connect to,
-optionally the local interface _local_if_ to bind to and the CoAP protocol
-_proto_ to use.  The session will initially have a reference count of 1.
+The *coap_new_client_session_psk2*() function, for a specific _context_, is
+used to configure the TLS context using the _setup_data_ variables as defined
+in the coap_dtls_cpsk_t structure in the newly created session -
+see *coap_encryption*(3). The connection is to the specified _server_ using
+the CoAP protocol _proto_.  If the port is not specified in _server_, then the
+default CoAP port is used.  Normally _local_if_ would be set to NULL, but by
+specifying _local_if_ the source of the network session can be bound to a
+specific IP address or port. The session will initially have a reference count
+of 1.
 
 The *coap_session_reference*() is used to increment the reference count of
 the _session_.  Incrementing the reference count by an application means that
@@ -163,7 +170,7 @@ The *coap_session_max_pdu_size*() funcition is used to get the maximum MTU
 size of the data for the _session_.
 
 The *coap_session_set_app_data*() funstion is used to define a _data_ pointer
-for the _session_ which can then be retieved at a later date.
+for the _session_ which can then be retrieved at a later date.
 
 The *coap_session_get_app_data*() function is used to retrieve the data
 pointer previously defined by *coap_session_set_app_data*().
@@ -173,7 +180,7 @@ information about the _session_.
 
 RETURN VALUES
 -------------
-*coap_new_client_session*(), *coap_new_client_session_psk*(),
+*coap_new_client_session*(), *coap_new_client_session_psk2*(),
 *coap_new_client_session_pki*() functions returns a newly created client
 session or NULL if there is a creation failure.
 
@@ -231,11 +238,20 @@ static int
 verify_cn_callback(const char *cn,
                    const uint8_t *asn1_public_cert,
                    size_t asn1_length,
-                   coap_session_t *session,
-                   unsigned depth,
+                   coap_session_t *c_session,
+                   unsigned int depth,
                    int validated,
                    void *arg
 ) {
+  /* Remove (void) definition if variable is used */
+  (void)cn;
+  (void)asn1_public_cert;
+  (void)asn1_length;
+  (void)c_session;
+  (void)depth;
+  (void)validated;
+  (void)arg;
+
   /* Check that the CN is valid */
 
   /* ... */
@@ -281,7 +297,7 @@ setup_client_session_pki (struct in_addr ip_address,
   dtls_pki.validate_sni_call_back  = NULL;
   dtls_pki.sni_call_back_arg       = NULL;
   dtls_pki.additional_tls_setup_call_back = NULL;
-  dtls_pki.sni                     = NULL;
+  dtls_pki.client_sni              = NULL;
   dtls_pki.pki_key.key_type        = COAP_PKI_KEY_PEM;
   dtls_pki.pki_key.key.pem.ca_file = ca_file;
   dtls_pki.pki_key.key.pem.public_cert = public_cert_file;
@@ -303,13 +319,38 @@ setup_client_session_pki (struct in_addr ip_address,
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <stdio.h>
 #include <netinet/in.h>
 
+#ifndef min
+#define min(a,b) ((a) < (b) ? (a) : (b))
+#endif
+
+static const coap_dtls_cpsk_info_t *
+verify_ih_callback(coap_str_const_t *hint,
+                   coap_session_t *c_session,
+                   void *arg
+) {
+  coap_dtls_cpsk_info_t *psk_info = (coap_dtls_cpsk_info_t *)arg;
+  /* Remove (void) definition if variable is used */
+  (void)c_session;
+
+  coap_log(LOG_INFO, "Identity Hint '%.*s' provided\n", (int)hint->length, hint->s);
+
+  /* Just use the defined information for now as passed in by arg */
+  return psk_info;
+}
+
+static coap_dtls_cpsk_t dtls_psk;
+static char client_sni[256];
+
 static coap_session_t *
-setup_client_session_psk (struct in_addr ip_address,
-                          const char *identity,
+setup_client_session_psk (const char *uri,
+                          struct in_addr ip_address,
+                          const uint8_t *identity,
+                          unsigned int identity_len,
                           const uint8_t *key,
-                          unsigned key_len
+                          unsigned int key_len
 ) {
   coap_session_t *session;
   coap_address_t server;
@@ -324,8 +365,22 @@ setup_client_session_psk (struct in_addr ip_address,
   server.addr.sin.sin_addr = ip_address;
   server.addr.sin.sin_port = htons (5684);
 
-  session = coap_new_client_session_psk(context, NULL, &server,
-                                        COAP_PROTO_DTLS, identity, key, key_len);
+  /* See coap_encryption(3) */
+  memset (&dtls_psk, 0, sizeof(dtls_psk));
+  dtls_psk.version = COAP_DTLS_CPSK_SETUP_VERSION;
+  dtls_psk.validate_ih_call_back = verify_ih_callback;
+  dtls_psk.ih_call_back_arg = &dtls_psk.psk_info;
+  if (uri)
+    memcpy(client_sni, uri, min(strlen(uri), sizeof(client_sni)-1));
+  else
+    memcpy(client_sni, "localhost", 9);
+  dtls_psk.client_sni = client_sni;
+  dtls_psk.psk_info.identity.s = identity;
+  dtls_psk.psk_info.identity.length = identity_len;
+  dtls_psk.psk_info.key.s = key;
+  dtls_psk.psk_info.key.length = key_len;
+  session = coap_new_client_session_psk2(context, NULL, &server,
+                                        COAP_PROTO_DTLS, &dtls_psk);
   if (!session) {
     coap_free_context(context);
     return NULL;
@@ -335,7 +390,7 @@ setup_client_session_psk (struct in_addr ip_address,
 }
 ----
 
-*CoAP Client Setup*
+*CoAP Client Anonymous PKI Setup*
 [source, c]
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
@@ -343,7 +398,7 @@ setup_client_session_psk (struct in_addr ip_address,
 #include <netinet/in.h>
 
 static coap_session_t *
-setup_client_session (struct in_addr ip_address) {
+setup_client_session_dtls (struct in_addr ip_address) {
   coap_session_t *session;
   coap_address_t server;
   /* See coap_context(3) */

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -27,10 +27,13 @@
  *
  * ca_path in coap_dtls_context_set_pki_root_cas() is not supported until 3.3.6
  *
- * hint is not provided if using DH and versions prior to 3.4.4
+ * Identity Hint is not provided if using DH and versions prior to 3.4.4
  *
  * 3.5.5 or later is required to interoperate with TinyDTLS as CCM algorithm
  * support is required.
+ *
+ * TLS 1.3 is properly supported from 3.6.5 onwards
+ * (but is not enabled by default in 3.6.4)
  */
 
 #include "coap_internal.h"
@@ -82,17 +85,25 @@ typedef struct coap_gnutls_env_t {
 #define IS_CLIENT (1 << 6)
 #define IS_SERVER (1 << 7)
 
-typedef struct sni_entry {
+typedef struct pki_sni_entry {
   char *sni;
   coap_dtls_key_t pki_key;
   gnutls_certificate_credentials_t pki_credentials;
-} sni_entry;
+} pki_sni_entry;
+
+typedef struct psk_sni_entry {
+  char *sni;
+  coap_dtls_spsk_info_t psk_info;
+  gnutls_psk_server_credentials_t psk_credentials;
+} psk_sni_entry;
 
 typedef struct coap_gnutls_context_t {
   coap_dtls_pki_t setup_data;
   int psk_pki_enabled;
-  size_t sni_count;
-  sni_entry *sni_entry_list;
+  size_t pki_sni_count;
+  pki_sni_entry *pki_sni_entry_list;
+  size_t psk_sni_count;
+  psk_sni_entry *psk_sni_entry_list;
   gnutls_datum_t alpn_proto;    /* Will be "coap", but that is a const */
   char *root_ca_file;
   char *root_ca_path;
@@ -109,6 +120,12 @@ typedef enum coap_free_bye_t {
 #define VARIANTS "NORMAL:+ECDHE-PSK:+PSK:+ECDHE-ECDSA:+AES-128-CCM-8"
 #else
 #define VARIANTS "NORMAL:+ECDHE-PSK:+PSK"
+#endif
+
+#if (GNUTLS_VERSION_NUMBER >= 0x030604)
+#define VARIANTS_NO_TLS13 VARIANTS ":!VERS-TLS1.3"
+#else
+#define VARIANTS_NO_TLS13 VARIANTS
 #endif
 
 #define G_ACTION(xx) do { \
@@ -131,6 +148,9 @@ static int dtls_log_level = 0;
 
 static int post_client_hello_gnutls_pki(gnutls_session_t g_session);
 static int post_client_hello_gnutls_psk(gnutls_session_t g_session);
+static int psk_server_callback(gnutls_session_t g_session,
+                               const char *identity,
+                               gnutls_datum_t *key);
 
 /*
  * return 0 failed
@@ -374,15 +394,22 @@ coap_dtls_free_context(void *handle) {
   gnutls_free(g_context->alpn_proto.data);
   gnutls_free(g_context->root_ca_file);
   gnutls_free(g_context->root_ca_path);
-  for (i = 0; i < g_context->sni_count; i++) {
-    gnutls_free(g_context->sni_entry_list[i].sni);
-    if (g_context->psk_pki_enabled & IS_PKI) {
-      gnutls_certificate_free_credentials(
-          g_context->sni_entry_list[i].pki_credentials);
-    }
+  for (i = 0; i < g_context->pki_sni_count; i++) {
+    gnutls_free(g_context->pki_sni_entry_list[i].sni);
+    gnutls_certificate_free_credentials(
+        g_context->pki_sni_entry_list[i].pki_credentials);
   }
-  if (g_context->sni_count)
-    gnutls_free(g_context->sni_entry_list);
+  if (g_context->pki_sni_entry_list)
+    gnutls_free(g_context->pki_sni_entry_list);
+
+  for (i = 0; i < g_context->psk_sni_count; i++) {
+    gnutls_free(g_context->psk_sni_entry_list[i].sni);
+    /* YUK - A memory leak in 3.3.0 (fixed by 3.3.26) of hint */
+    gnutls_psk_free_server_credentials(
+          g_context->psk_sni_entry_list[i].psk_credentials);
+  }
+  if (g_context->psk_sni_entry_list)
+    gnutls_free(g_context->psk_sni_entry_list);
 
   gnutls_priority_deinit(g_context->priority_cache);
 
@@ -402,10 +429,14 @@ psk_client_callback(gnutls_session_t g_session,
                     char **username, gnutls_datum_t *key) {
   coap_session_t *c_session =
                   (coap_session_t *)gnutls_transport_get_ptr(g_session);
+  coap_gnutls_context_t *g_context;
+  coap_dtls_cpsk_t *setup_data;
   uint8_t identity[64];
   size_t identity_len;
-  uint8_t psk_key[64];
+  uint8_t psk[64];
   size_t psk_len;
+  const char *hint = gnutls_psk_client_get_hint(g_session);
+  size_t hint_len = 0;
 
   /* Constant passed to get_client_psk callback. The final byte is
    * reserved for a terminating 0. */
@@ -420,31 +451,76 @@ psk_client_callback(gnutls_session_t g_session,
     return -1;
   }
 
+  g_context = (coap_gnutls_context_t *)c_session->context->dtls_context;
+  if (g_context == NULL)
+    return -1;
+
+  setup_data = &c_session->cpsk_setup_data;
+
+  if (hint)
+    hint_len = strlen(hint);
+  else
+    hint = "";
+
+  coap_log(LOG_DEBUG, "got psk_identity_hint: '%.*s'\n", (int)hint_len, hint);
+
+  if (setup_data->validate_ih_call_back) {
+    coap_str_const_t lhint;
+    lhint.length = hint_len;
+    lhint.s = (const uint8_t*)hint;
+    const coap_dtls_cpsk_info_t *psk_info =
+             setup_data->validate_ih_call_back(&lhint,
+                                               c_session,
+                                               setup_data->ih_call_back_arg);
+
+    if (psk_info == NULL)
+      return -1;
+
+    *username = gnutls_malloc(psk_info->identity.length+1);
+    if (*username == NULL)
+      return -1;
+    memcpy(*username, psk_info->identity.s, psk_info->identity.length);
+    (*username)[psk_info->identity.length] = '\000';
+
+    key->data = gnutls_malloc(psk_info->key.length);
+    if (key->data == NULL) {
+      gnutls_free(*username);
+      *username = NULL;
+      return -1;
+    }
+    memcpy(key->data, psk_info->key.s, psk_info->key.length);
+    key->size = psk_info->key.length;
+    return 0;
+  }
+
   psk_len = c_session->context->get_client_psk(c_session,
                                                NULL,
                                                0,
                                                identity,
                                                &identity_len,
                                                max_identity_len,
-                                               psk_key,
-                                               sizeof(psk_key));
+                                               psk,
+                                               sizeof(psk));
   assert(identity_len < sizeof(identity));
 
   /* Reserve dynamic memory to hold the identity and a terminating
    * zero. */
   *username = gnutls_malloc(identity_len+1);
-  if (*username) {
-    memcpy(*username, identity, identity_len);
-    (*username)[identity_len] = '\0';
-  }
+  if (*username == NULL)
+    return -1;
+  memcpy(*username, identity, identity_len);
+  (*username)[identity_len] = '\0';
 
   key->data = gnutls_malloc(psk_len);
-  if (key->data) {
-    memcpy(key->data, psk_key, psk_len);
-    key->size = psk_len;
+  if (key->data == NULL) {
+    gnutls_free(*username);
+    *username = NULL;
+    return -1;
   }
+  memcpy(key->data, psk, psk_len);
+  key->size = psk_len;
 
-  return (*username && key->data) ? 0 : -1;
+  return 0;
 }
 
 /*
@@ -798,7 +874,37 @@ fail:
  *        neg GNUTLS_E_* error code
  */
 static int
-post_client_hello_gnutls_pki(gnutls_session_t g_session)
+setup_psk_credentials(gnutls_psk_server_credentials_t *psk_credentials,
+                      coap_gnutls_context_t *g_context UNUSED,
+                      coap_dtls_spsk_t *setup_data)
+{
+  int ret;
+  char hint[COAP_DTLS_HINT_LENGTH];
+
+  G_CHECK(gnutls_psk_allocate_server_credentials(psk_credentials),
+          "gnutls_psk_allocate_server_credentials");
+  gnutls_psk_set_server_credentials_function(*psk_credentials,
+                                                    psk_server_callback);
+  if (setup_data->psk_info.hint.s) {
+    snprintf(hint, sizeof(hint), "%.*s", (int)setup_data->psk_info.hint.length,
+             setup_data->psk_info.hint.s);
+    G_CHECK(gnutls_psk_set_server_credentials_hint(*psk_credentials, hint),
+          "gnutls_psk_set_server_credentials_hint");
+  }
+
+  return GNUTLS_E_SUCCESS;
+
+fail:
+  return ret;
+}
+
+
+/*
+ * return 0   Success (GNUTLS_E_SUCCESS)
+ *        neg GNUTLS_E_* error code
+ */
+static int
+post_client_hello_gnutls_psk(gnutls_session_t g_session)
 {
   coap_session_t *c_session =
                 (coap_session_t *)gnutls_transport_get_ptr(g_session);
@@ -810,12 +916,12 @@ post_client_hello_gnutls_pki(gnutls_session_t g_session)
 
   g_env->seen_client_hello = 1;
 
-  if (g_context->setup_data.validate_sni_call_back) {
+  if (c_session->context->spsk_setup_data.validate_sni_call_back) {
+    coap_dtls_spsk_t sni_setup_data;
     /* DNS names (only type supported) may be at most 256 byte long */
     size_t len = 256;
     unsigned int type;
     unsigned int i;
-    coap_dtls_pki_t sni_setup_data;
 
     name = gnutls_malloc(len);
     if (name == NULL)
@@ -852,12 +958,126 @@ post_client_hello_gnutls_pki(gnutls_session_t g_session)
     }
 
     /* Is this a cached entry? */
-    for (i = 0; i < g_context->sni_count; i++) {
-      if (strcmp(name, g_context->sni_entry_list[i].sni) == 0) {
+    for (i = 0; i < g_context->psk_sni_count; i++) {
+      if (strcasecmp(name, g_context->psk_sni_entry_list[i].sni) == 0) {
         break;
       }
     }
-    if (i == g_context->sni_count) {
+    if (i == g_context->psk_sni_count) {
+      /*
+       * New SNI request
+       */
+      const coap_dtls_spsk_info_t *new_entry =
+        c_session->context->spsk_setup_data.validate_sni_call_back(name,
+                        c_session,
+                        c_session->context->spsk_setup_data.sni_call_back_arg);
+      if (!new_entry) {
+        G_ACTION(gnutls_alert_send(g_session, GNUTLS_AL_FATAL,
+                                   GNUTLS_A_UNRECOGNIZED_NAME));
+        ret = GNUTLS_E_NO_CERTIFICATE_FOUND;
+        goto end;
+      }
+
+      g_context->psk_sni_entry_list =
+                            gnutls_realloc(g_context->psk_sni_entry_list,
+                                           (i+1)*sizeof(psk_sni_entry));
+      g_context->psk_sni_entry_list[i].sni = gnutls_strdup(name);
+      g_context->psk_sni_entry_list[i].psk_info = *new_entry;
+      sni_setup_data = c_session->context->spsk_setup_data;
+      sni_setup_data.psk_info = *new_entry;
+      if ((ret = setup_psk_credentials(
+                           &g_context->psk_sni_entry_list[i].psk_credentials,
+                           g_context,
+                           &sni_setup_data)) < 0) {
+        int keep_ret = ret;
+        G_ACTION(gnutls_alert_send(g_session, GNUTLS_AL_FATAL,
+                                   GNUTLS_A_BAD_CERTIFICATE));
+        ret = keep_ret;
+        goto end;
+      }
+      g_context->psk_sni_count++;
+    }
+    G_CHECK(gnutls_credentials_set(g_env->g_session, GNUTLS_CRD_PSK,
+                             g_context->psk_sni_entry_list[i].psk_credentials),
+            "gnutls_credentials_set");
+    coap_session_refresh_psk_hint(c_session,
+                                 &g_context->psk_sni_entry_list[i].psk_info.hint);
+    coap_session_refresh_psk_key(c_session,
+                                 &g_context->psk_sni_entry_list[i].psk_info.key);
+  }
+
+end:
+  free(name);
+  return ret;
+
+fail:
+  return ret;
+}
+
+/*
+ * return 0   Success (GNUTLS_E_SUCCESS)
+ *        neg GNUTLS_E_* error code
+ */
+static int
+post_client_hello_gnutls_pki(gnutls_session_t g_session)
+{
+  coap_session_t *c_session =
+                (coap_session_t *)gnutls_transport_get_ptr(g_session);
+  coap_gnutls_context_t *g_context =
+             (coap_gnutls_context_t *)c_session->context->dtls_context;
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+  int ret = GNUTLS_E_SUCCESS;
+  char *name = NULL;
+  if (g_context->setup_data.validate_sni_call_back) {
+    /* DNS names (only type supported) may be at most 256 byte long */
+    size_t len = 256;
+    unsigned int type;
+    unsigned int i;
+    coap_dtls_pki_t sni_setup_data;
+
+    g_env->seen_client_hello = 1;
+
+    name = gnutls_malloc(len);
+    if (name == NULL)
+      return GNUTLS_E_MEMORY_ERROR;
+
+    for (i=0; ; ) {
+      ret = gnutls_server_name_get(g_session, name, &len, &type, i);
+      if (ret == GNUTLS_E_SHORT_MEMORY_BUFFER) {
+        char *new_name;
+        new_name = gnutls_realloc(name, len);
+        if (new_name == NULL) {
+          ret = GNUTLS_E_MEMORY_ERROR;
+          goto end;
+        }
+        name = new_name;
+        continue; /* retry call with same index */
+      }
+
+      /* check if it is the last entry in list */
+      if (ret == GNUTLS_E_REQUESTED_DATA_NOT_AVAILABLE)
+        break;
+      i++;
+      if (ret != GNUTLS_E_SUCCESS)
+        goto end;
+      /* unknown types need to be ignored */
+      if (type != GNUTLS_NAME_DNS)
+        continue;
+
+    }
+    /* If no extension provided, make it a dummy entry */
+    if (i == 0) {
+      name[0] = '\000';
+      len = 0;
+    }
+
+    /* Is this a cached entry? */
+    for (i = 0; i < g_context->pki_sni_count; i++) {
+      if (strcasecmp(name, g_context->pki_sni_entry_list[i].sni) == 0) {
+        break;
+      }
+    }
+    if (i == g_context->pki_sni_count) {
       /*
        * New SNI request
        */
@@ -871,14 +1091,15 @@ post_client_hello_gnutls_pki(gnutls_session_t g_session)
         goto end;
       }
 
-      g_context->sni_entry_list = gnutls_realloc(g_context->sni_entry_list,
-                                     (i+1)*sizeof(sni_entry));
-      g_context->sni_entry_list[i].sni = gnutls_strdup(name);
-      g_context->sni_entry_list[i].pki_key = *new_entry;
+      g_context->pki_sni_entry_list = gnutls_realloc(
+                                            g_context->pki_sni_entry_list,
+                                            (i+1)*sizeof(pki_sni_entry));
+      g_context->pki_sni_entry_list[i].sni = gnutls_strdup(name);
+      g_context->pki_sni_entry_list[i].pki_key = *new_entry;
       sni_setup_data = g_context->setup_data;
       sni_setup_data.pki_key = *new_entry;
       if ((ret = setup_pki_credentials(
-                           &g_context->sni_entry_list[i].pki_credentials,
+                           &g_context->pki_sni_entry_list[i].pki_credentials,
                            g_context,
                            &sni_setup_data, COAP_DTLS_ROLE_CLIENT)) < 0) {
         int keep_ret = ret;
@@ -887,10 +1108,10 @@ post_client_hello_gnutls_pki(gnutls_session_t g_session)
         ret = keep_ret;
         goto end;
       }
-      g_context->sni_count++;
+      g_context->pki_sni_count++;
     }
     G_CHECK(gnutls_credentials_set(g_env->g_session, GNUTLS_CRD_CERTIFICATE,
-                               g_context->sni_entry_list[i].pki_credentials),
+                               g_context->pki_sni_entry_list[i].pki_credentials),
             "gnutls_credentials_set");
   }
 
@@ -907,21 +1128,6 @@ fail:
  *        neg GNUTLS_E_* error code
  */
 static int
-post_client_hello_gnutls_psk(gnutls_session_t g_session)
-{
-  coap_session_t *c_session =
-                (coap_session_t *)gnutls_transport_get_ptr(g_session);
-  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
-
-  g_env->seen_client_hello = 1;
-  return GNUTLS_E_SUCCESS;
-}
-
-/*
- * return 0   Success (GNUTLS_E_SUCCESS)
- *        neg GNUTLS_E_* error code
- */
-static int
 setup_client_ssl_session(coap_session_t *c_session, coap_gnutls_env_t *g_env)
 {
   coap_gnutls_context_t *g_context =
@@ -930,22 +1136,30 @@ setup_client_ssl_session(coap_session_t *c_session, coap_gnutls_env_t *g_env)
 
   g_context->psk_pki_enabled |= IS_CLIENT;
   if (g_context->psk_pki_enabled & IS_PSK) {
-    char *identity = NULL;
-    gnutls_datum_t psk_key;
-
+    coap_dtls_cpsk_t *setup_data = &c_session->cpsk_setup_data;
     G_CHECK(gnutls_psk_allocate_client_credentials(&g_env->psk_cl_credentials),
             "gnutls_psk_allocate_client_credentials");
-    psk_client_callback(g_env->g_session, &identity, &psk_key);
-    G_CHECK(gnutls_psk_set_client_credentials(g_env->psk_cl_credentials,
-                                              identity,
-                                              &psk_key,
-                                              GNUTLS_PSK_KEY_RAW),
-            "gnutls_psk_set_client_credentials");
+    gnutls_psk_set_client_credentials_function(g_env->psk_cl_credentials,
+                                               psk_client_callback);
     G_CHECK(gnutls_credentials_set(g_env->g_session, GNUTLS_CRD_PSK,
                                    g_env->psk_cl_credentials),
             "gnutls_credentials_set");
-    gnutls_free(identity);
-    gnutls_free(psk_key.data);
+    /* Issue SNI if requested */
+    if (setup_data->client_sni) {
+      G_CHECK(gnutls_server_name_set(g_env->g_session, GNUTLS_NAME_DNS,
+                                     setup_data->client_sni,
+                                     strlen(setup_data->client_sni)),
+              "gnutls_server_name_set");
+    }
+    if (setup_data->validate_ih_call_back) {
+      const char *err;
+
+      G_CHECK(gnutls_priority_set_direct(g_env->g_session,
+            VARIANTS_NO_TLS13, &err),
+            "gnutls_priority_set_direct");
+      coap_log(LOG_DEBUG,
+        "CoAP Client restricted to (D)TLS1.2 with Identity Hint callback\n");
+    }
   }
 
   if ((g_context->psk_pki_enabled & IS_PKI) ||
@@ -996,21 +1210,54 @@ psk_server_callback(gnutls_session_t g_session,
 {
   coap_session_t *c_session =
                 (coap_session_t *)gnutls_transport_get_ptr(g_session);
+  coap_gnutls_context_t *g_context;
+  coap_dtls_spsk_t *setup_data;
   size_t identity_len = 0;
   uint8_t buf[64];
   size_t psk_len;
+
+  if (c_session == NULL || c_session->context == NULL ||
+      c_session->context->get_server_psk == NULL)
+    return -1;
+
+  g_context = (coap_gnutls_context_t *)c_session->context->dtls_context;
+  if (g_context == NULL)
+    return -1;
+  setup_data = &c_session->context->spsk_setup_data;
 
   if (identity)
     identity_len = strlen(identity);
   else
     identity = "";
 
+  /* Track the Identity being used */
+  if (c_session->psk_identity)
+    coap_delete_bin_const(c_session->psk_identity);
+  c_session->psk_identity = coap_new_bin_const((const uint8_t *)identity,
+                                               identity_len);
+
   coap_log(LOG_DEBUG, "got psk_identity: '%.*s'\n",
                       (int)identity_len, identity);
 
-  if (c_session == NULL || c_session->context == NULL ||
-      c_session->context->get_server_psk == NULL)
-    return -1;
+  if (setup_data->validate_id_call_back) {
+    coap_bin_const_t lidentity;
+    lidentity.length = identity_len;
+    lidentity.s = (const uint8_t*)identity;
+    const coap_bin_const_t *psk_key =
+             setup_data->validate_id_call_back(&lidentity,
+                                               c_session,
+                                               setup_data->id_call_back_arg);
+
+    if (psk_key == NULL)
+      return -1;
+    key->data = gnutls_malloc(psk_key->length);
+    if (key->data == NULL)
+      return -1;
+    memcpy(key->data, psk_key->s, psk_key->length);
+    key->size = psk_key->length;
+    coap_session_refresh_psk_key(c_session, psk_key);
+    return 0;
+  }
 
   psk_len = c_session->context->get_server_psk(c_session,
                                (const uint8_t*)identity,
@@ -1035,18 +1282,17 @@ setup_server_ssl_session(coap_session_t *c_session, coap_gnutls_env_t *g_env)
 
   g_context->psk_pki_enabled |= IS_SERVER;
   if (g_context->psk_pki_enabled & IS_PSK) {
-    G_CHECK(gnutls_psk_allocate_server_credentials(&g_env->psk_sv_credentials),
-            "gnutls_psk_allocate_server_credentials");
-    gnutls_psk_set_server_credentials_function(g_env->psk_sv_credentials,
-                                                      psk_server_callback);
-
-    gnutls_handshake_set_post_client_hello_function(g_env->g_session,
-                                                 post_client_hello_gnutls_psk);
-
+    G_CHECK(setup_psk_credentials(
+                             &g_env->psk_sv_credentials,
+                             g_context,
+                             &c_session->context->spsk_setup_data),
+            "setup_psk_credentials\n");
     G_CHECK(gnutls_credentials_set(g_env->g_session,
                                    GNUTLS_CRD_PSK,
                                    g_env->psk_sv_credentials),
             "gnutls_credentials_set\n");
+    gnutls_handshake_set_post_client_hello_function(g_env->g_session,
+                                                post_client_hello_gnutls_psk);
   }
 
   if (g_context->psk_pki_enabled & IS_PKI) {
@@ -1060,11 +1306,14 @@ setup_server_ssl_session(coap_session_t *c_session, coap_gnutls_env_t *g_env)
                                             GNUTLS_CERT_REQUIRE);
     }
     else {
-      gnutls_certificate_server_set_request(g_env->g_session, GNUTLS_CERT_IGNORE);
+      gnutls_certificate_server_set_request(g_env->g_session,
+                                            GNUTLS_CERT_IGNORE);
     }
 
-    gnutls_handshake_set_post_client_hello_function(g_env->g_session,
-                                                 post_client_hello_gnutls_pki);
+    if (g_context->setup_data.validate_sni_call_back) {
+      gnutls_handshake_set_post_client_hello_function(g_env->g_session,
+                                                post_client_hello_gnutls_pki);
+    }
 
     G_CHECK(gnutls_credentials_set(g_env->g_session, GNUTLS_CRD_CERTIFICATE,
                                    g_env->pki_credentials),
@@ -1250,6 +1499,7 @@ coap_dtls_free_gnutls_env(coap_gnutls_context_t *g_context,
         g_env->psk_cl_credentials = NULL;
       }
       else {
+        /* YUK - A memory leak in 3.3.0 (fixed by 3.3.26) of hint */
         gnutls_psk_free_server_credentials(g_env->psk_sv_credentials);
         g_env->psk_sv_credentials = NULL;
       }

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -52,9 +52,15 @@ coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx UNUSED,
 }
 
 int
-coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
-                          const char *hint UNUSED,
-                          coap_dtls_role_t role UNUSED
+coap_dtls_context_set_cpsk(coap_context_t *ctx UNUSED,
+                          coap_dtls_cpsk_t* setup_data UNUSED
+) {
+  return 0;
+}
+
+int
+coap_dtls_context_set_spsk(coap_context_t *ctx UNUSED,
+                          coap_dtls_spsk_t* setup_data UNUSED
 ) {
   return 0;
 }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -508,9 +508,15 @@ coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx UNUSED,
 }
 
 int
-coap_dtls_context_set_psk(coap_context_t *ctx UNUSED,
-  const char *hint UNUSED,
-  coap_dtls_role_t role UNUSED
+coap_dtls_context_set_cpsk(coap_context_t *c_context UNUSED,
+  coap_dtls_cpsk_t *setup_data UNUSED
+) {
+  return 1;
+}
+
+int
+coap_dtls_context_set_spsk(coap_context_t *c_context UNUSED,
+  coap_dtls_spsk_t *setup_data UNUSED
 ) {
   return 1;
 }

--- a/src/str.c
+++ b/src/str.c
@@ -51,3 +51,16 @@ coap_str_const_t *coap_make_str_const(const char *string)
   return &var[ofs];
 }
 
+coap_bin_const_t *coap_new_bin_const(const uint8_t *data, size_t size) {
+  coap_string_t *s = coap_new_string(size);
+  if (!s)
+    return NULL;
+  memcpy (s->s, data, size);
+  s->length = size;
+  return (coap_bin_const_t *)s;
+}
+
+void coap_delete_bin_const(coap_bin_const_t *s) {
+  coap_free_type(COAP_STRING, s);
+}
+


### PR DESCRIPTION
Currently, a server cannot differentiate between different presented Identities and so use different PSK keys on a per client basis.  Furthermore, different Identity Hints cannot be presented to clients based on their SNI information received by the server.

This update creates 2 new interfaces - coap_context_set_psk2() and coap_new_client_session_psk2() which allow callbacks to be defined in a similar way to the *_pki() functions.  The existing _psk() functions now just call the *_psk2() with the appropriate parameters set up. 

This update has been split up into 5 parts - each part has fully operational code in its own right.

Testing has been for all combinations of openssl, gnutls and tinydtls, using Openssl 1.1.0g and 1.1.1 and GnuTLS 3.3.0 and 3.6.4 (TinyDTLS does not support SNI).

In addition coap:// has been checked, along with PKI usage to check that there has been no regression.