### PR TITLE
Handle platforms that do not have 'struct cmsghdr' defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -584,6 +584,11 @@ AC_SEARCH_LIBS([inet_ntop], [nsl])
 # Check if clock_gettime() requires librt, when available
 AC_SEARCH_LIBS([clock_gettime], [rt])
 
+#check for struct cmsghdr
+AC_CHECK_TYPES([struct cmsghdr],,,[
+AC_INCLUDES_DEFAULT
+#include <sys/socket.h>])
+
 AC_MSG_CHECKING([operating system])
 
 # Set up here some extra platform depended defines and variables.


### PR DESCRIPTION
configure.ac:

Test for the presence of 'struct cmsghdr' and set HAVE_STRUCT_CMSGHDR
if appropriate.

src/coap_io.c:

Revert to recvfrom() and sendto() if HAVE_STRUCT_CMSGHDR is not defined,
instead of using recvmsg() and sendmsg().