### PR TITLE
coap-server: Add in support for SNI to change PKI certificates

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -1329,13 +1329,12 @@ setup_pki(coap_context_t *ctx) {
     dtls_pki.validate_sni_call_back  = NULL;
     dtls_pki.sni_call_back_arg       = NULL;
     memset(client_sni, 0, sizeof(client_sni));
-    if (uri.host.length)
-      memcpy(client_sni, uri.host.s,
-             min(uri.host.length, sizeof(client_sni) - 1));
-    else
-      memcpy(client_sni, "localhost", 9);
-    dtls_pki.client_sni = client_sni;
   }
+  if (uri.host.length)
+    memcpy(client_sni, uri.host.s, min(uri.host.length, sizeof(client_sni)-1));
+  else
+    memcpy(client_sni, "localhost", 9);
+  dtls_pki.client_sni = client_sni;
   dtls_pki.pki_key.key_type = COAP_PKI_KEY_PEM;
   dtls_pki.pki_key.key.pem.public_cert = cert_file;
   dtls_pki.pki_key.key.pem.private_key = cert_file;
@@ -1412,8 +1411,8 @@ get_session(
         coap_address_init( &bind_addr );
         bind_addr.size = rp->ai_addrlen;
         memcpy( &bind_addr.addr, rp->ai_addr, rp->ai_addrlen );
-        if ((root_ca_file || ca_file || cert_file) &&
-            (proto == COAP_PROTO_DTLS || proto == COAP_PROTO_TLS)) {
+        if (proto == COAP_PROTO_DTLS || proto == COAP_PROTO_TLS) {
+          /* Do this, even if certs are not defined */
           coap_dtls_pki_t *dtls_pki = setup_pki(ctx);
           session = coap_new_client_session_pki(ctx, &bind_addr, dst, proto, dtls_pki);
         }
@@ -1433,8 +1432,8 @@ get_session(
     }
     freeaddrinfo( result );
   } else {
-    if ((root_ca_file || ca_file || cert_file) &&
-        (proto == COAP_PROTO_DTLS || proto == COAP_PROTO_TLS)) {
+    if (proto == COAP_PROTO_DTLS || proto == COAP_PROTO_TLS) {
+      /* Do this, even if certs are not defined */
       coap_dtls_pki_t *dtls_pki = setup_pki(ctx);
       session = coap_new_client_session_pki(ctx, NULL, dst, proto, dtls_pki);
     }

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -17,8 +17,12 @@ SYNOPSIS
 *coap-server* [*-d* max] [*-g* group] [*-l* loss] [*-p* port] [*-v* num]
               [*-A* address] [*-N*]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
-              [*-s* match_sni_file]]
+              [*-s* match_psk_sni_file]]
               [[*-c* certfile] [*-n*] [*-C* cafile] [*-R* root_cafile]]
+              [*-S* match_pki_sni_file]]
+              [[*-k* key] [*-h* hint]]
+              [[*-c* certfile] [*-n*] [*-C* cafile] [*-R* root_cafile]
+              [*-S* match_sni_file]]
 
 DESCRIPTION
 -----------
@@ -29,8 +33,8 @@ OPTIONS - General
 -----------------
 *-d* max::
    Enable support for creation of dynamic resources when doing a PUT up to a
-   limit of max.  If max is reached, a 4.06 code is returned until one of the
-   dynamic resources has been deleted.
+   limit of 'max'.  If 'max' is reached, a 4.06 code is returned until one of
+   the dynamic resources has been deleted.
 
 *-g* group::
    Join specified multicast 'group' on start up.
@@ -85,7 +89,7 @@ OPTIONS - PSK
    *Note:* if *-c cafile* is defined, you need to define *-k key* as well to
    have the server support both PSK and PKI.
 
-*-s* match_sni_file::
+*-s* match_psk_sni_file::
    This option denotes a file that contains one or more lines of Subject Name
    Identifier (SNI) to match for new Identity Hint and new Pre-Shared Key
    (PSK) (comma separated) to be used.
@@ -123,6 +127,14 @@ OPTIONS - PKI
   this list and is "trusted" for the verification.
   Alternatively, this can point to a directory containing a set of CA PEM files.
 
+*-S* match_pki_sni_file::
+   This option denotes a file that contains one or more lines of Subject Name
+   Identifier (SNI) to match for new Certificate File and new CA File (comma
+   separated) to be used. E.g., entry per line +
+   sni_to_match,new_cert_file,new_ca_file +
+   A line that starts with # is treated as a comment. +
+   Note: *-c certfile* and *-C cafile* still needs to be defined for the
+   default case
 
 EXAMPLES
 --------


### PR DESCRIPTION
examples/coap-server.c:

Add in -S option to support changing certificate/ca if there is as SNI match.

man/coap-server.txt.in:

Update man page with new -S option.