### PR TITLE
Add in internal epoll support to expose a monitor-able file descriptor

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,6 +157,8 @@ coap_dtls_receive \
 coap_dtls_send \
 coap_dtls_session_update_mtu \
 coap_dtls_startup \
+coap_epoll_ctl_mod \
+coap_io_do_events \
 coap_mfree_endpoint \
 coap_packet_extract_pbuf \
 coap_pdu_from_pbuf \

--- a/configure.ac
+++ b/configure.ac
@@ -568,7 +568,12 @@ fi
 # Checks for header files.
 AC_CHECK_HEADERS([assert.h arpa/inet.h limits.h netdb.h netinet/in.h \
                   stdlib.h string.h strings.h sys/socket.h sys/time.h \
-                  time.h unistd.h sys/unistd.h syslog.h sys/ioctl.h])
+                  time.h unistd.h sys/unistd.h syslog.h sys/ioctl.h sys/epoll.h sys/timerfd.h])
+
+# For epoll, need two headers (sys/epoll.h sys/timerfd.h), but set up one #define
+if test "x$ac_cv_header_sys_epoll_h" != "x" -a "x$ac_cv_header_sys_timerfd_h" != "x"; then
+    AC_DEFINE(COAP_EPOLL_SUPPORT, 1, [Define if the system has epoll support])
+fi
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T
@@ -663,6 +668,7 @@ man/coap_attribute.txt
 man/coap_context.txt
 man/coap_encryption.txt
 man/coap_handler.txt
+man/coap_io.txt
 man/coap_keepalive.txt
 man/coap_logging.txt
 man/coap_observe.txt

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -23,6 +23,7 @@ global:
   coap_clear_event_handler;
   coap_clock_init;
   coap_clone_uri;
+  coap_context_get_coap_fd;
   coap_context_set_keepalive;
   coap_context_set_pki;
   coap_context_set_pki_root_cas;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -21,6 +21,7 @@ coap_cleanup
 coap_clear_event_handler
 coap_clock_init
 coap_clone_uri
+coap_context_get_coap_fd
 coap_context_set_keepalive
 coap_context_set_pki
 coap_context_set_pki_root_cas

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -14,6 +14,7 @@ TXT3 = coap_attribute.txt \
 	coap_context.txt \
 	coap_encryption.txt \
 	coap_handler.txt \
+	coap_io.txt \
 	coap_keepalive.txt \
 	coap_logging.txt \
 	coap_observe.txt \

--- a/man/coap.txt.in
+++ b/man/coap.txt.in
@@ -39,8 +39,8 @@ examples directory.
 SEE ALSO
 --------
 *coap_attribute*(3), *coap_context*(3), *coap_encryption*(3), *coap_handler*(3),
-*coap_keepalive*(3), *coap_logging*(3), *coap_observe*(3), *coap_pdu_setup*(3),
-*coap_recovery*(3), *coap_resource*(3), *coap_session*(3)
+*coap_io*(3), *coap_keepalive*(3), *coap_logging*(3), *coap_observe*(3),
+*coap_pdu_setup*(3), *coap_recovery*(3), *coap_resource*(3), *coap_session*(3)
 and *coap_tls_library*(3)
 
 For example executables, see *coap-client*(5), *coap-rd*(5) and *coap-server*(5)

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -1,0 +1,276 @@
+// -*- mode:doc; -*-
+// vim: set syntax=asciidoc,tw=0:
+
+coap_io(3)
+==========
+:doctype: manpage
+:man source:   coap_io
+:man version:  @PACKAGE_VERSION@
+:man manual:   libcoap Manual
+
+NAME
+----
+coap_io, coap_run_once, coap_context_get_coap_fd
+- Work with CoAP I/O to do the packet send and receives
+
+SYNOPSIS
+--------
+*#include <coap@LIBCOAP_API_VERSION@/coap.h>*
+
+*int coap_run_once(coap_context_t *_context_, unsigned int _timeout_ms_)*;
+
+*int coap_context_get_coap_fd(coap_context_t *_context_)*;
+
+Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
+*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+type.
+
+DESCRIPTION
+-----------
+After setting up all the contexts, resources, endpoints sessions etc., the
+underlying CoAP and (D)TLS need to send (and possible re-send) created packets
+as well as receive packets for processing.
+
+The *coap_run_once*() function will process any outstanding packets to send
+for the specified _context_ and wait for processing any input packets for up to
+_timeout_ms_ milli-seconds before returning. Once any outstanding input packets
+have been processed, the function will return. There are 2 special case
+_timeout_ms_ values.
+[source, c]
+----
+#define COAP_RUN_BLOCK    0
+#define COAP_RUN_NONBLOCK 1
+----
+If _timeout_ms_ is set to COAP_RUN_BLOCK, then *coap_run_once*() will wait
+indefinitely for the first new input packet to come in. If _timeout_ms_ is set
+to COAP_RUN_NONBLOCK, then there is no wait if there are no more input packets.
+
+There are two methods of how to call *coap_run_once*().
+
+1. Have *coap_run_once*() called from within a while() loop.  Under idle
+conditions (no input traffic) *coap_run_once*() will then get called every
+_timeout_ms_, but more frequently if there is input traffic.
+
+2. Wait on the file descriptor returned by *coap_context_get_coap_fd*()
+using select() or an event returned by epoll_wait(). If 'read' is available on
+the file descriptor, call *coap_run_once*() with _timeout_ms_ set to
+COAP_RUN_NONBLOCK.  See EXAMPLES below.
+
+NOTE: This method is only available for environments that support epoll
+(mostly Linux) as libcoap will then be using epoll internally to process all
+the file descriptors of the different sessions.
+
+The *coap_context_get_coap_fd*() function obtains from the specified
+_context_ a single file descriptor that can be monitored by a select() or
+as an event returned from a epoll_wait() call.  This file descriptor will get
+updated with information (read, write etc. available) whenever any of the
+internal to libcoap file descriptors (sockets) change state.
+
+RETURN VALUES
+-------------
+*coap_run_once*() returns the time, in milli-seconds, that was spent in the
+function. If -1 is returned, there was an unexpected error.
+
+*coap_context_get_coap_fd*() returns a non-negative number as the file
+descriptor to monitor, or -1 if epoll is not supported by the host
+environment.
+
+EXAMPLES
+--------
+*Method One*
+
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+int main(int argc, char *argv[]){
+
+  coap_context_t *ctx = NULL;
+  unsigned wait_ms;
+
+  /* Create the libcoap context */
+  ctx = coap_new_context(NULL);
+  if (!ctx) {
+    exit(1);
+  }
+
+  /* Other Set up Code */
+
+  wait_ms = COAP_RESOURCE_CHECK_TIME * 1000;
+
+  while (1) {
+    int result = coap_run_once(ctx, wait_ms);
+    if (result < 0) {
+      /* There is an internal issue */
+      break;
+    }
+    /* Do any other housekeeping */
+  }
+  coap_free_context(ctx);
+
+  /* Do any other cleanup */
+
+  exit(0);
+
+}
+----
+
+*Method Two - select*
+
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <errno.h>
+
+int main(int argc, char *argv[]){
+
+  coap_context_t *ctx = NULL;
+  int coap_fd;
+  fd_set m_readfds;
+  int nfds;
+
+  /* Create the libcoap context */
+  ctx = coap_new_context(NULL);
+  if (!ctx) {
+    exit(1);
+  }
+  coap_fd = coap_context_get_coap_fd(ctx);
+  if (coap_fd == -1) {
+    exit(1);
+  }
+  FD_ZERO(&m_readfds);
+  FD_SET(coap_fd, &m_readfds);
+  nfds = coap_fd + 1;
+
+  /* Other Set up Code */
+
+  while (1) {
+    fd_set readfds = m_readfds;
+    int result;
+    /* Wait until any i/o takes place */
+    result = select (nfds, &readfds, NULL, NULL, NULL);
+    if (result == -1) {
+      if (errno != EAGAIN) {
+        coap_log(LOG_DEBUG, "select: %s (%d)\n", coap_socket_strerror(), errno);
+        break;
+      }
+    }
+    if (result > 0) {
+      if (FD_ISSET(coap_fd, &readfds)) {
+        result = coap_run_once(ctx, COAP_RUN_NONBLOCK);
+        if (result < 0) {
+          /* There is an internal issue */
+          break;
+        }
+      }
+    }
+    /* Do any other housekeeping */
+  }
+  coap_free_context(ctx);
+
+  /* Do any other cleanup */
+
+  exit(0);
+
+}
+----
+
+*Method Two - epoll*
+
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <sys/epoll.h>
+
+#include <errno.h>
+
+#define MAX_EVENTS 10
+
+int main(int argc, char *argv[]){
+
+  coap_context_t *ctx = NULL;
+  int coap_fd;
+  int epoll_fd;
+  struct epoll_event ev;
+  struct epoll_event events[MAX_EVENTS];
+  int nevents;
+  int i;
+
+  /* Create the libcoap context */
+  ctx = coap_new_context(NULL);
+  if (!ctx) {
+    exit(1);
+  }
+  coap_fd = coap_context_get_coap_fd(ctx);
+  if (coap_fd == -1) {
+    exit(1);
+  }
+  epoll_fd = epoll_create1(0);
+  if (epoll_fd == -1) {
+    exit(2);
+  }
+  ev.events = EPOLLIN;
+  ev.data.fd = coap_fd;
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, coap_fd, &ev) == -1) {
+    exit(3);
+  }
+
+  /* Other Set up Code */
+
+  while (1) {
+    int result;
+    /* Wait until any i/o takes place */
+    nevents = epoll_wait(epoll_fd, events, MAX_EVENTS, -1);
+    if (nevents == -1) {
+      if (errno != EAGAIN) {
+        coap_log(LOG_DEBUG, "epoll_wait: %s (%d)\n", coap_socket_strerror(), errno);
+        break;
+      }
+    }
+    for (i = 0; i < nevents; i++) {
+      if (events[i].data.fd == coap_fd) {
+        result = coap_run_once(ctx, COAP_RUN_NONBLOCK);
+        if (result < 0) {
+          /* There is an internal issue */
+          break;
+        }
+      }
+      else {
+        /* Process other events */
+      }
+    }
+    /* Do any other housekeeping */
+  }
+
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, coap_fd, &ev) == -1) {
+    coap_log(LOG_DEBUG, "epoll_ctl: %s (%d)\n", coap_socket_strerror(), errno);
+  }
+  coap_free_context(ctx);
+
+  /* Do any other cleanup */
+
+  exit(0);
+
+}
+----
+
+SEE ALSO
+--------
+*coap_context*(3)
+
+FURTHER INFORMATION
+-------------------
+See "RFC7252: The Constrained Application Protocol (CoAP)" for further
+information.
+
+BUGS
+----
+Please report bugs on the mailing list for libcoap:
+libcoap-developers@lists.sourceforge.net
+
+AUTHORS
+-------
+The libcoap project <libcoap-developers@lists.sourceforge.net>


### PR DESCRIPTION
If epoll is available, use it within libcoap to speed things up, as well as
present to applications a file descriptor that can be used in a select() or
returned as an event in a epoll_wait() call.

Whenever coap_new_context() is called. set up a new epoll infrastructure with
epoll_create() and destroy it with coap_free_context().

For each new endpoint or session, add the socket fd to epoll.  When the socket
is closed, remove the socket fd from epoll.

Whenever a socket wants a write, the appropriate epoll event gets EPOLLOUT
added and when the write happens reset the event back to just EPOLLIN.

As there may be a packet retry event sometime in the future, a timerfd is
created and added to the epoll structure (done in coap_new_context) which gets
freed off in coap_free_context. If coap_run_once() determines that there is
a future retry, timerfd is informed of when the event is to occur.  When
timerfd times out, the application file descriptor will indicate a read is
available.

A new function coap_context_get_coap_fd(ctx) returns the application file
descriptor.  The only other API change is that if wait_ms is set to 1 for
coap_run_once(ctx, wait_ms), there is no waiting for a new packet to arrive.

coap_run_once() is called, whether epoll support is available or not, to
process all the underlying required i/o.

If there is no epoll support, coap_run_once() continues to use the old
select() method, otherwise it will use epoll_wait(). If there is epoll
support, a modified version of coap_read() (coap_io_do_events()) is
used instead.

Makefile.am:

Do not expose coap_epoll_ctl_mod() and coap_io_do_events() to applications.

configure.ac:

Test for the presence of sys/epoll.h and sys/timerfd.h and if so setup
COAP_EPOLL_SUPPORT to be used for #ifdef testing.
Include new man page coap_io.txt.

examples/coap-server.c:

Include support for using this new exposed file descriptor.

include/coap2/coap_io.h:

Define COAP_MAX_EPOLL_EVENTS (to limit the number of events processed at once)
and include coap_endpoint_t and coap_session_t in coap_socket_t.
Include (internal) definition for coap_epoll_ctl_mod()

include/coap2/net.h:

Add epfd and eptimerfd to coap_context_t.
Define coap_context_get_coap_fd() for applications to use.
Include (internal) definition for coap_io_do_events().

libcoap-2.map:
libcoap-2.sym:

Include coap_context_get_coap_fd.

configure.ac:
man/Makefile.am:
man/coap.txt.in:
man/coap_io.txt.in: (New)

Include the new coap_in(3) man page that documents coap_run_once() and
coap_context_get_coap_fd().

src/coap_io.c:
src/coap_openssl.c:
src/coap_session.c:
src/net.c:

Add in the epoll support.

src/net.c:

Add in coap_context_get_coap_fd() function.