### PR TITLE
Remove unused message_id from coap_context_t and coap_async_t

### DIFF
--- a/include/coap2/async.h
+++ b/include/coap2/async.h
@@ -43,7 +43,6 @@ typedef struct coap_async_state_t {
    * asynchronous state object.
    */
   void *appdata;
-  uint16_t message_id;       /**< id of last message seen */
   coap_session_t *session;         /**< transaction session */
   coap_tid_t id;                   /**< transaction id */
   struct coap_async_state_t *next; /**< internally used for linking */

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -178,13 +178,6 @@ typedef struct coap_context_t {
                                    *   context, otherwise 0. */
 #endif /* WITH_LWIP */
 
-  /**
-   * The last message id that was used is stored in this field. The initial
-   * value is set by coap_new_context() and is usually a random value. A new
-   * message id can be created with coap_new_message_id().
-   */
-  uint16_t message_id;
-
   coap_response_handler_t response_handler;
   coap_nack_handler_t nack_handler;
   coap_ping_handler_t ping_handler;

--- a/src/net.c
+++ b/src/net.c
@@ -469,9 +469,6 @@ coap_new_context(
   /* set default CSM timeout */
   c->csm_timeout = 30;
 
-  /* initialize message id */
-  prng((unsigned char *)&c->message_id, sizeof(uint16_t));
-
   if (listen_addr) {
     coap_endpoint_t *endpoint = coap_new_endpoint(c, listen_addr, COAP_PROTO_UDP);
     if (endpoint == NULL) {


### PR DESCRIPTION
It appears that message_id was left in coap_context_t and coap_async_t
when coap_session_t was created.

include/coap2/async.h:
include/coap2/net.h:

Remove message_id.

src/net.c:

No longer just set message_id.