### PR TITLE
Fix memory leak in GnuTLS client that does not have security defined

### DIFF
--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -1213,7 +1213,9 @@ coap_dtls_free_gnutls_env(coap_gnutls_context_t *g_context,
         g_env->psk_sv_credentials = NULL;
       }
     }
-    if (g_context->psk_pki_enabled & IS_PKI) {
+    if ((g_context->psk_pki_enabled & IS_PKI) ||
+        (g_context->psk_pki_enabled &
+         (IS_PSK | IS_PKI | IS_CLIENT)) == IS_CLIENT) {
       gnutls_certificate_free_credentials(g_env->pki_credentials);
       g_env->pki_credentials = NULL;
     }


### PR DESCRIPTION
If a CoAP client using GnuTLS does not have PSK or PKI security defined
but communicatioes with coaps:// with a CoAP server that has PKI defined,
then there is a memeory leak when the session is closed down.

src/coap_gnutls.c:

Free off PKI credentials if a client and PSK or PKI was not explicitly
defined in coap_dtls_free_gnutls_env().