### PR TITLE
Fixed two minor bugs in endpoint free and session address update

### DIFF
--- a/include/coap2/coap_io.h
+++ b/include/coap2/coap_io.h
@@ -164,9 +164,6 @@ void coap_packet_get_memmapped(struct coap_packet_t *packet,
                                unsigned char **address,
                                size_t *length);
 
-void coap_packet_set_addr( struct coap_packet_t *packet, const coap_address_t *src,
-                           const coap_address_t *dst );
-
 #ifdef WITH_LWIP
 /**
  * Get the pbuf of a packet. The caller takes over responsibility for freeing

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -112,7 +112,6 @@ global:
   coap_package_name;
   coap_package_version;
   coap_packet_get_memmapped;
-  coap_packet_set_addr;
   coap_pdu_clear;
   coap_pdu_encode_header;
   coap_pdu_init;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -110,7 +110,6 @@ coap_opt_value
 coap_package_name
 coap_package_version
 coap_packet_get_memmapped
-coap_packet_set_addr
 coap_pdu_clear
 coap_pdu_encode_header
 coap_pdu_init

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -919,11 +919,6 @@ coap_packet_get_memmapped(coap_packet_t *packet, unsigned char **address, size_t
   *length = packet->length;
 }
 
-void coap_packet_set_addr(coap_packet_t *packet, const coap_address_t *src, const coap_address_t *dst) {
-  coap_address_copy(&packet->src, src);
-  coap_address_copy(&packet->dst, dst);
-}
-
 ssize_t
 coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
   ssize_t len = -1;

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -946,6 +946,9 @@ coap_free_endpoint(coap_endpoint_t *ep) {
       }
     }
 
+    if (ep->context) {
+      LL_DELETE(ep->context->endpoint, ep);
+    }
     coap_mfree_endpoint(ep);
   }
 }

--- a/src/net.c
+++ b/src/net.c
@@ -1147,7 +1147,8 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
       coap_log(LOG_DEBUG, "*  %s: received %zd bytes\n",
                coap_session_str(session), bytes_read);
       session->last_rx_tx = now;
-      coap_packet_set_addr(packet, &session->remote_addr, &session->local_addr);
+      coap_address_copy(&session->remote_addr, &packet->src);
+      coap_address_copy(&session->local_addr, &packet->dst);
       coap_handle_dgram_for_proto(ctx, session, packet);
     }
   } else {


### PR DESCRIPTION
When try to use this library, I found two minor bugs.

1. Sometimes the session remote_addr and local_addr are not updated from the packet received. I just found the address copy function made the wrong direction.
2. Remove the endpoint from context list when free'd in coap_free_endpoint().