### PR TITLE
Rename get_common_name_from_cert() to get_san_or_cn_from_cert()

### DIFF
--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -981,7 +981,7 @@ setup_pki_ssl(SSL *ssl,
 }
 
 static char*
-get_common_name_from_cert(X509* x509) {
+get_san_or_cn_from_cert(X509* x509) {
   if (x509) {
     char *cn;
     int n;
@@ -1048,7 +1048,7 @@ tls_verify_call_back(int preverify_ok, X509_STORE_CTX *ctx) {
   int depth = X509_STORE_CTX_get_error_depth(ctx);
   int err = X509_STORE_CTX_get_error(ctx);
   X509 *x509 = X509_STORE_CTX_get_current_cert(ctx);
-  char *cn = get_common_name_from_cert(x509);
+  char *cn = get_san_or_cn_from_cert(x509);
   int keep_preverify_ok = preverify_ok;
 
   if (!preverify_ok) {


### PR DESCRIPTION
src/coap_openssl.c:

Give the function that abstracts the Subject Alternative Name (SAN),
or the CN= if SAN is not available, a better descriptive name to prevent
possible confusion.