### PR TITLE
Fix final data size in last BLOCK2 response for .well-known/core

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -744,7 +744,7 @@ get_default_port(const coap_uri_t *u) {
 static int
 cmdline_uri(char *arg, int create_uri_opts) {
   unsigned char portbuf[2];
-#define BUFSIZE 40
+#define BUFSIZE 100
   unsigned char _buf[BUFSIZE];
   unsigned char *buf = _buf;
   size_t buflen;
@@ -795,6 +795,8 @@ cmdline_uri(char *arg, int create_uri_opts) {
 
     if (uri.path.length) {
       buflen = BUFSIZE;
+      if (uri.path.length > BUFSIZE)
+        coap_log(LOG_WARNING, "URI path will be truncated (max buffer %d)\n", BUFSIZE);
       res = coap_split_path(uri.path.s, uri.path.length, buf, &buflen);
 
       while (res--) {


### PR DESCRIPTION
src/net.c:

Corect the length for the final block size.

Add in an ETAG and SIZE2 option into the response as suggested by RFC7959.

examples/client.c:

Warn if URI path is too long for internal buffer (found when testing that
a large WellKnown response triggered sending BLOCK2 correctly).

Increase internal buffersize to allow longer URIs.

To reproduce issue

coap-client -b 256 coap://127.0.0.1/.well-known/core

As reported by Zafi Ramarosandratana.  See #360 which this fixes.