### PR TITLE
coap-client: Resend lost blocks

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -384,6 +384,12 @@ message_handler(struct coap_context_t *ctx,
     return;
   }
 
+  /* the previous block was lost, so re-transmit it again. */
+  if (received->code == COAP_RESPONSE_408) {
+      block.num -= 1;
+      received->code = COAP_RESPONSE_231;
+  }
+
   /* output the received data, if any */
   if (COAP_RESPONSE_CLASS(received->code) == 2) {
 

--- a/include/coap2/pdu.h
+++ b/include/coap2/pdu.h
@@ -162,9 +162,11 @@ const char *coap_response_phrase(unsigned char code);
 #define COAP_RESPONSE_200      COAP_RESPONSE_CODE(200)  /* 2.00 OK */
 #define COAP_RESPONSE_201      COAP_RESPONSE_CODE(201)  /* 2.01 Created */
 #define COAP_RESPONSE_304      COAP_RESPONSE_CODE(203)  /* 2.03 Valid */
+#define COAP_RESPONSE_231      COAP_RESPONSE_CODE(231)  /* 2.31 Continue */
 #define COAP_RESPONSE_400      COAP_RESPONSE_CODE(400)  /* 4.00 Bad Request */
 #define COAP_RESPONSE_404      COAP_RESPONSE_CODE(404)  /* 4.04 Not Found */
 #define COAP_RESPONSE_405      COAP_RESPONSE_CODE(405)  /* 4.05 Method Not Allowed */
+#define COAP_RESPONSE_408      COAP_RESPONSE_CODE(408)  /* 4.08 Request Entity Incomplete */
 #define COAP_RESPONSE_415      COAP_RESPONSE_CODE(415)  /* 4.15 Unsupported Media Type */
 #define COAP_RESPONSE_500      COAP_RESPONSE_CODE(500)  /* 5.00 Internal Server Error */
 #define COAP_RESPONSE_501      COAP_RESPONSE_CODE(501)  /* 5.01 Not Implemented */


### PR DESCRIPTION
The server can use the 4.08 error code (Request Entity Incomplete) to signal that it received a block it did not expect, that is it lost blocks in between.

To fix this, revert to the previous acknowledged block number in case of a 4.08 response.

This is a rather crude hack - but right now the client will just abort when it receives a 4.08 response. I wasn't able to transfer a firmware image over a 802.15.4 network without any lost blocks.

If you have some pointers on how to solve this in a proper way, I'm happy to comply.