### PR TITLE
Fix COAP_DEPRECATED for Windows C++ builds

### DIFF
--- a/include/coap2/libcoap.h
+++ b/include/coap2/libcoap.h
@@ -40,14 +40,10 @@ typedef USHORT in_port_t;
 #  endif
 #endif
 #ifndef COAP_DEPRECATED
-#  if defined(__cplusplus)
-#    define COAP_DEPRECATED __attribute__ ((deprecated))
+#  if defined(_MSC_VER)
+#    define COAP_DEPRECATED __declspec(deprecated)
 #  else
-#    if defined(_MSC_VER)
-#      define COAP_DEPRECATED __declspec(deprecated)
-#    else
-#      define COAP_DEPRECATED __attribute__ ((deprecated))
-#    endif
+#    define COAP_DEPRECATED __attribute__ ((deprecated))
 #  endif
 #endif
 


### PR DESCRIPTION
include/coap2/libcoap.h:

Simplify COAP_DEPRECATED definition to generically handle Windows
or other builds when setting the define for COAP_DEPRECATED.

Fixes #363