### PR TITLE
Fix GnuTLS DTLS retries when Client Hello is not responded to

### DIFF
--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -447,10 +447,12 @@ coap_tick_t coap_dtls_get_context_timeout(void *dtls_context);
  * Internal function.
  *
  * @param coap_session The CoAP session.
+ * @param now The current time in ticks.
  *
- * @return @c 0 If no event is pending or date of the next retransmit.
+ * @return @c 0 If no event is pending or ticks time of the next retransmit.
  */
-coap_tick_t coap_dtls_get_timeout(struct coap_session_t *coap_session);
+coap_tick_t coap_dtls_get_timeout(struct coap_session_t *coap_session,
+                                  coap_tick_t now);
 
 /**
  * Handle a DTLS timeout expiration.

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -64,6 +64,7 @@ typedef struct coap_gnutls_env_t {
   /* If not set, need to do gnutls_handshake */
   int established;
   int seen_client_hello;
+  int doing_dtls_timeout;
 } coap_gnutls_env_t;
 
 #define IS_PSK (1 << 0)
@@ -1123,13 +1124,22 @@ receive_timeout(gnutls_transport_ptr_t context, unsigned int ms UNUSED) {
     fd_set readfds, writefds, exceptfds;
     struct timeval tv;
     int nfds = c_session->sock.fd +1;
+    coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+
+    /* If data has been read in by libcoap ahead of GnuTLS, say it is there */
+    if (c_session->proto == COAP_PROTO_DTLS && g_env &&
+        g_env->coap_ssl_data.pdu_len > 0) {
+      return 1;
+    }
 
     FD_ZERO(&readfds);
     FD_ZERO(&writefds);
     FD_ZERO(&exceptfds);
     FD_SET (c_session->sock.fd, &readfds);
-    FD_SET (c_session->sock.fd, &writefds);
-    FD_SET (c_session->sock.fd, &exceptfds);
+    if (!(g_env && g_env->doing_dtls_timeout)) {
+      FD_SET (c_session->sock.fd, &writefds);
+      FD_SET (c_session->sock.fd, &exceptfds);
+    }
     /* Polling */
     tv.tv_sec = 0;
     tv.tv_usec = 0;
@@ -1178,6 +1188,7 @@ coap_dtls_new_gnutls_env(coap_session_t *c_session, int type)
           "gnutls_priority_set");
   gnutls_handshake_set_timeout(g_env->g_session,
                                GNUTLS_DEFAULT_HANDSHAKE_TIMEOUT);
+  gnutls_dtls_set_timeouts(g_env->g_session, 5000, 60000);
 
   return g_env;
 
@@ -1409,18 +1420,40 @@ int coap_dtls_send(coap_session_t *c_session,
 }
 
 int coap_dtls_is_context_timeout(void) {
-  return 1;
+  return 0;
 }
 
 coap_tick_t coap_dtls_get_context_timeout(void *dtls_context UNUSED) {
   return 0;
 }
 
-coap_tick_t coap_dtls_get_timeout(coap_session_t *c_session UNUSED) {
+coap_tick_t coap_dtls_get_timeout(coap_session_t *c_session, coap_tick_t now) {
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+
+  if (g_env && g_env->g_session) {
+    unsigned int rem_ms = gnutls_dtls_get_timeout(g_env->g_session);
+
+    return now + rem_ms;
+  }
+
   return 0;
 }
 
-void coap_dtls_handle_timeout(coap_session_t *c_session UNUSED) {
+void coap_dtls_handle_timeout(coap_session_t *c_session) {
+  coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
+
+  assert(g_env != NULL);
+  g_env->doing_dtls_timeout = 1;
+  if (((c_session->state == COAP_SESSION_STATE_HANDSHAKE) &&
+       (++c_session->dtls_timeout_count > c_session->max_retransmit)) ||
+      (do_gnutls_handshake(c_session, g_env) < 0)) {
+    /* Too many retries */
+    g_env->doing_dtls_timeout = 0;
+    coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
+  }
+  else {
+    g_env->doing_dtls_timeout = 0;
+  }
 }
 
 /*
@@ -1569,6 +1602,13 @@ coap_sock_read(gnutls_transport_ptr_t context, void *out, size_t outl) {
 #else
     ret = recv(c_session->sock.fd, out, outl, 0);
 #endif
+    if (ret > 0) {
+      coap_log(LOG_DEBUG, "*  %s: setup: received %d bytes\n",
+               coap_session_str(c_session), ret);
+    } else if (ret < 0 && errno != EAGAIN) {
+      coap_log(LOG_DEBUG,  "*  %s: setup: failed to receive any bytes (%s)\n",
+               coap_session_str(c_session), coap_socket_strerror());
+    }
     if (ret == 0) {
       /* graceful shutdown */
       c_session->sock.flags &= ~COAP_SOCKET_CAN_READ;
@@ -1593,6 +1633,13 @@ coap_sock_write(gnutls_transport_ptr_t context, const void *in, size_t inl) {
   coap_session_t *c_session = (struct coap_session_t *)context;
 
   ret = (int)coap_socket_write(&c_session->sock, in, inl);
+  if (ret > 0) {
+    coap_log(LOG_DEBUG, "*  %s: setup: sent %d bytes\n",
+             coap_session_str(c_session), ret);
+  } else if (ret < 0) {
+    coap_log(LOG_DEBUG,  "*  %s: setup: failed to send %d bytes (%s)\n",
+             coap_session_str(c_session), ret, coap_socket_strerror());
+  }
   if (ret == 0) {
     errno = EAGAIN;
     ret = -1;

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1287,13 +1287,13 @@ coap_write(coap_context_t *ctx,
         if (ep->proto == COAP_PROTO_DTLS) {
           LL_FOREACH(ep->sessions, s) {
             if (s->proto == COAP_PROTO_DTLS && s->tls) {
-              coap_tick_t tls_timeout = coap_dtls_get_timeout(s);
+              coap_tick_t tls_timeout = coap_dtls_get_timeout(s, now);
               while (tls_timeout > 0 && tls_timeout <= now) {
                 coap_log(LOG_DEBUG, "** %s: DTLS retransmit timeout\n",
                          coap_session_str(s));
                 coap_dtls_handle_timeout(s);
                 if (s->tls)
-                  tls_timeout = coap_dtls_get_timeout(s);
+                  tls_timeout = coap_dtls_get_timeout(s, now);
                 else {
                   tls_timeout = 0;
                   timeout = 1;
@@ -1307,12 +1307,12 @@ coap_write(coap_context_t *ctx,
       }
       LL_FOREACH(ctx->sessions, s) {
         if (s->proto == COAP_PROTO_DTLS && s->tls) {
-          coap_tick_t tls_timeout = coap_dtls_get_timeout(s);
+          coap_tick_t tls_timeout = coap_dtls_get_timeout(s, now);
           while (tls_timeout > 0 && tls_timeout <= now) {
             coap_log(LOG_DEBUG, "** %s: DTLS retransmit timeout\n", coap_session_str(s));
             coap_dtls_handle_timeout(s);
             if (s->tls)
-              tls_timeout = coap_dtls_get_timeout(s);
+              tls_timeout = coap_dtls_get_timeout(s, now);
             else {
               tls_timeout = 0;
               timeout = 1;

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -121,7 +121,8 @@ coap_tick_t coap_dtls_get_context_timeout(void *dtls_context UNUSED) {
   return 0;
 }
 
-coap_tick_t coap_dtls_get_timeout(coap_session_t *session UNUSED) {
+coap_tick_t
+coap_dtls_get_timeout(coap_session_t *session UNUSED, coap_tick_t now UNUSED) {
   return 0;
 }
 

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1886,7 +1886,7 @@ coap_tick_t coap_dtls_get_context_timeout(void *dtls_context) {
   return 0;
 }
 
-coap_tick_t coap_dtls_get_timeout(coap_session_t *session) {
+coap_tick_t coap_dtls_get_timeout(coap_session_t *session, coap_tick_t now UNUSED) {
   SSL *ssl = (SSL *)session->tls;
   coap_ssl_data *ssl_data;
 

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -381,8 +381,9 @@ coap_tick_t coap_dtls_get_context_timeout(void *dtls_context) {
   return 0;
 }
 
-coap_tick_t coap_dtls_get_timeout(coap_session_t *session) {
+coap_tick_t coap_dtls_get_timeout(coap_session_t *session, coap_tick_t now) {
   (void)session;
+  (void)now;
   return 0;
 }
 


### PR DESCRIPTION
GnuTLS currently does not retry to send the Client Hello packets if there was
no (Server Hello) response.  This was never correctly implemented.

src/coap_gnutls.c:

Fix receive_timout() so that it differentiates between DTLS and TLS.
If DTLS, if data has already been read in, indicate this.
if this is a coap_dtls_handle_timeout() call, only check readfds
(writefds will always be true, causing confusion).

Set DTLS timeouts where appropriate.

Update coap_dtls_*_timeout() functions to return the correct values.

include/coap2/coap_dtls.h:
src/coap_gnutls.c:
src/coap_io.c:
src/coap_notls.c:
src/coap_openssl.c:
src/coap_tinydtls.c:

Add in coap_tick_t now parameter to coap_dtls_get_timeout() for better
accuracy.