### PR TITLE
Add SIZE1 Option when sending BLOCK1 Option in packets in Client

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -168,8 +168,15 @@ coap_new_request(coap_context_t *ctx,
   if (length) {
     if ((flags & FLAGS_BLOCK) == 0)
       coap_add_data(pdu, length, data);
-    else
+    else {
+      unsigned char buf[4];
+      coap_add_option(pdu,
+                      COAP_OPTION_SIZE1,
+                      coap_encode_var_safe(buf, sizeof(buf), length),
+                      buf);
+
       coap_add_block(pdu, length, data, block.num, block.szx);
+    }
   }
 
   return pdu;
@@ -538,6 +545,11 @@ message_handler(struct coap_context_t *ctx,
                           COAP_OPTION_BLOCK1,
                           coap_encode_var_safe(buf, sizeof(buf),
                           (block.num << 4) | (block.m << 3) | block.szx), buf);
+
+          coap_add_option(pdu,
+                          COAP_OPTION_SIZE1,
+                          coap_encode_var_safe(buf, sizeof(buf), payload.length),
+                          buf);
 
           coap_add_block(pdu,
                          payload.length,


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc7959#section-4
...
Implementation Notes:

   o  As a quality of implementation consideration, block-wise transfers
      for which the total size considerably exceeds the size of one
      block are expected to include size indications, whenever those can
      be provided without undue effort (preferably with the first block
      exchanged)
...

examples/client.c:

Include SIZE1 Option when sending data using BLOCK1 Option.

Picked up by #362 