### PR TITLE
Stop valgrind errors when using OpenSSL 1.1.1c

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,7 +50,7 @@ err=$?
 if test $err = 0 -a -n "$WITH_TESTS" ; then
     EXEC_FILE=tests/testdriver
     # then run valgrind on the actual executable
-    LD_LIBRARY_PATH=$TEST_LD_LIBRARY_PATH libtool --mode=execute valgrind --track-origins=yes --leak-check=yes --show-reachable=yes --error-exitcode=123 --quiet $EXEC_FILE
+    LD_LIBRARY_PATH=$TEST_LD_LIBRARY_PATH libtool --mode=execute valgrind --track-origins=yes --leak-check=yes --show-reachable=yes --error-exitcode=123 --quiet --suppressions=tests/valgrind_suppression $EXEC_FILE
     err=$?
 fi
 

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -504,6 +504,7 @@ void *coap_dtls_new_context(struct coap_context_t *coap_context) {
     SSL_CTX_set_app_data(context->dtls.ctx, &context->dtls);
     SSL_CTX_set_read_ahead(context->dtls.ctx, 1);
     SSL_CTX_set_cipher_list(context->dtls.ctx, "TLSv1.2:TLSv1.0");
+    memset(cookie_secret, 0, sizeof(cookie_secret));
     if (!RAND_bytes(cookie_secret, (int)sizeof(cookie_secret))) {
       if (dtls_log_level >= LOG_WARNING)
         coap_log(LOG_WARNING,

--- a/tests/valgrind_suppression
+++ b/tests/valgrind_suppression
@@ -1,0 +1,12 @@
+{
+   rand_drbg_get_nonce_fix__openssl_111c_1
+   Memcheck:Cond
+   ...
+   fun:SSL_CTX_new
+}
+{
+   rand_drbg_get_nonce_fix__openssl_111c_2
+   Memcheck:Cond
+   ...
+   fun:RAND_DRBG_bytes
+}


### PR DESCRIPTION
Issue introduced by OpenSSL 1.1.1c causes valgrind errors to be reported.  See
https://www.mail-archive.com/openssl-commits@openssl.org/msg21701.html and
https://github.com/openssl/openssl/pull/8606 which did not make 1.1.1c

scripts/build.sh:
tests/valgrind_suppression:

Temporarily suppress valgrind errors when SSL_CTS_new() is called when running
the tests.

Note: This suppression will also need to be applied when running valgrind
against other CoAP executables using OpenSSL 1.1.1c to prevent the valgrind
errors getting reported.