### PR TITLE
configure.ac: Enable silent compiles by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,7 @@ AC_INIT([libcoap], [libcoap_version], [libcoap-developers@lists.sourceforge.net]
 AC_PREREQ([2.64])
 AM_INIT_AUTOMAKE([1.10 -Wall no-define no-dist-gzip dist-bzip2])
 PKG_PROG_PKG_CONFIG([0.20])
+AM_SILENT_RULES([yes])
 
 # Generate one configuration header file for building the library itself with
 # an auto generated template. We need later a second one (include/libcoap.h)


### PR DESCRIPTION
Add in option so default is to only output the compile line as in

  CC     src/libcoap_2-openssl_la-coap_event.lo

instead of

/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -fPIC
 -fPIE -I./include/coap2 -I./include/coap2 -pedantic -Wall -Wcast-qual -Wextra
 -Wformat-security -Winline -Wmissing-declarations -Wmissing-prototypes
 -Wnested-externs -Wpointer-arith -Wshadow -Wstrict-prototypes -Wswitch-default
 -Wswitch-enum -Wunused -Wwrite-strings  -Wlogical-op -I/opt/openssl/include
 -std=c99 -ggdb3 -DCOAP_CONSTRAINED_STACK -DDTLS_CONSTRAINED_STACK
 -D_GNU_SOURCE -MT src/libcoap_2-openssl_la-coap_event.lo -MD -MP
 -MF src/.deps/libcoap_2-openssl_la-coap_event.Tpo -c
 -o src/libcoap_2-openssl_la-coap_event.lo `test -f 'src/coap_event.c' ||
 echo './'`src/coap_event.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -fPIC -I./include/coap2
 -I./include/coap2 -pedantic -Wall -Wcast-qual -Wextra -Wformat-security
 -Winline -Wmissing-declarations -Wmissing-prototypes -Wnested-externs
 -Wpointer-arith -Wshadow -Wstrict-prototypes -Wswitch-default -Wswitch-enum
 -Wunused -Wwrite-strings -Wlogical-op -I/opt/openssl/include -std=c99 -ggdb3
 -DCOAP_CONSTRAINED_STACK -DDTLS_CONSTRAINED_STACK -D_GNU_SOURCE
 -MT src/libcoap_2-openssl_la-coap_event.lo -MD -MP
 -MF src/.deps/libcoap_2-openssl_la-coap_event.Tpo -c src/coap_event.c -fPIE
 -o src/libcoap_2-openssl_la-coap_event.o
mv -f src/.deps/libcoap_2-openssl_la-coap_event.Tpo
 src/.deps/libcoap_2-openssl_la-coap_event.Plo

making it much easier to find compile time warnings.

Old version of output can still be obtained with

 make V=1

or

 ./configure --disable-silent-rules