### PR TITLE
net.c: Start new coap_context with a random message identifier

### DIFF
--- a/include/coap2/coap_time.h
+++ b/include/coap2/coap_time.h
@@ -47,6 +47,10 @@ COAP_STATIC_INLINE coap_time_t coap_ticks_to_rt(coap_tick_t t) {
   return t / COAP_TICKS_PER_SECOND;
 }
 
+COAP_STATIC_INLINE uint64_t coap_ticks_to_rt_us(coap_tick_t t) {
+  return (uint64_t)t * 1000000 / COAP_TICKS_PER_SECOND;
+}
+
 #elif defined(WITH_CONTIKI)
 
 #include "clock.h"
@@ -73,6 +77,10 @@ COAP_STATIC_INLINE void coap_ticks(coap_tick_t *t) {
 
 COAP_STATIC_INLINE coap_time_t coap_ticks_to_rt(coap_tick_t t) {
   return t / COAP_TICKS_PER_SECOND;
+}
+
+COAP_STATIC_INLINE uint64_t coap_ticks_to_rt_us(coap_tick_t t) {
+  return (uint64_t)t * 1000000 / COAP_TICKS_PER_SECOND;
 }
 
 #else

--- a/src/net.c
+++ b/src/net.c
@@ -2358,6 +2358,8 @@ coap_can_exit(coap_context_t *context) {
 static int coap_started = 0;
 
 void coap_startup(void) {
+  coap_tick_t now;
+  uint64_t us;
   if (coap_started)
     return;
   coap_started = 1;
@@ -2367,13 +2369,10 @@ void coap_startup(void) {
   WSAStartup(wVersionRequested, &wsaData);
 #endif
   coap_clock_init();
-#if defined(WITH_LWIP)
-  prng_init(LWIP_RAND());
-#elif defined(WITH_CONTIKI)
-  prng_init(0);
-#elif !defined(_WIN32)
-  prng_init(0);
-#endif
+  coap_ticks(&now);
+  us = coap_ticks_to_rt_us(now);
+  /* Be accurate to the nearest (approx) us */
+  prng_init(us);
   coap_dtls_startup();
 }
 


### PR DESCRIPTION
This is done by calling prng_init() with a non-zero value in coap_startup().

Change 7fb4ace2b709994bbbebab4c2d367ac76140eee9 modified the parameter to
prng_init() from a computed value to 0 when the code was re-organized.

This change uses the current time in microseconds as the seed to prng_init().

include/coap2/coap_time.h:

Add in coap_ticks_to_rt_us() support for lwIP and Contiki

src/net.c:

Update call to prng_init() in coap_startup() to use time in microsecs as the
seed parameter

See #373 where the issue was raised.