### PR TITLE
coap_time.c: Make coap_ticks() more accurate than to the nearest second

### DIFF
--- a/src/coap_time.c
+++ b/src/coap_time.c
@@ -68,13 +68,13 @@ coap_clock_init(void) {
 }
 
 /* creates a Qx.frac from fval */
-#define Q(frac,fval) ((coap_tick_t)(((1 << (frac)) * (fval))))
+#define Q(frac,fval) ((1 << (frac)) * (fval))
 
 /* number of frac bits for sub-seconds */
 #define FRAC 10
 
 /* rounds val up and right shifts by frac positions */
-#define SHR_FP(val,frac) (((val) + (1 << ((frac) - 1))) >> (frac))
+#define SHR_FP(val,frac) (((coap_tick_t)((val) + (1 << ((frac) - 1)))) >> (frac))
 
 void
 coap_ticks(coap_tick_t *t) {


### PR DESCRIPTION
With
define Q(frac,fval) ((coap_tick_t)(((1 << (frac)) * (fval))))
and
tmp = SHR_FP(tv.tv_nsec * Q(FRAC, (COAP_TICKS_PER_SECOND/1000000000.0)), FRAC);

The Q function alwayes returns 0 in error - e.g.

(gdb) p ((coap_tick_t)(((1 << (FRAC))*((COAP_TICKS_PER_SECOND/1000000000.0)))))
$6 = 0
(gdb) p ((((1 << (FRAC))*((COAP_TICKS_PER_SECOND/1000000000.0)))))
$7 = 0.001024

whereas we need the value 0.001024 to multiple with tv_nsec.

This change fixes this by moving the coap_tick_t from Q to SHR_FP.

Found when debugging #374