### PR TITLE
Make sessions list hashed to make lookups faster

### DIFF
--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -495,7 +495,7 @@ hnd_post_rd(coap_context_t  *ctx,
     }
   }
 
-  add_source_address(r, &session->remote_addr );
+  add_source_address(r, &session->addr_info.remote);
 
   {
     rd_t *rd;

--- a/include/coap2/coap_io.h
+++ b/include/coap2/coap_io.h
@@ -37,6 +37,11 @@ struct coap_pdu_t;
 
 typedef uint16_t coap_socket_flags_t;
 
+typedef struct coap_addr_tuple_t {
+  coap_address_t remote;       /**< remote address and port */
+  coap_address_t local;        /**< local address and port */
+} coap_addr_tuple_t;
+
 typedef struct coap_socket_t {
 #if defined(WITH_LWIP)
   struct udp_pcb *pcb;
@@ -184,15 +189,13 @@ struct pbuf *coap_packet_extract_pbuf(struct coap_packet_t *packet);
 struct coap_packet_t {
   struct pbuf *pbuf;
   const struct coap_endpoint_t *local_interface;
-  coap_address_t src;              /**< the packet's source address */
-  coap_address_t dst;              /**< the packet's destination address */
+  coap_addr_tuple_t addr_info; /**< local and remote addresses */
   int ifindex;                /**< the interface index */
 //  uint16_t srcport;
 };
 #else
 struct coap_packet_t {
-  coap_address_t src;              /**< the packet's source address */
-  coap_address_t dst;              /**< the packet's destination address */
+  coap_addr_tuple_t addr_info; /**< local and remote addresses */
   int ifindex;                /**< the interface index */
   size_t length;              /**< length of payload */
   unsigned char payload[COAP_RXBUFFER_SIZE]; /**< payload */

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -307,8 +307,12 @@ static int coap_dtls_generate_cookie(SSL *ssl, unsigned char *cookie, unsigned i
   coap_dtls_context_t *dtls = (coap_dtls_context_t *)SSL_CTX_get_app_data(SSL_get_SSL_CTX(ssl));
   coap_ssl_data *data = (coap_ssl_data*)BIO_get_data(SSL_get_rbio(ssl));
   int r = HMAC_Init_ex(dtls->cookie_hmac, NULL, 0, NULL, NULL);
-  r &= HMAC_Update(dtls->cookie_hmac, (const uint8_t*)&data->session->local_addr.addr, (size_t)data->session->local_addr.size);
-  r &= HMAC_Update(dtls->cookie_hmac, (const uint8_t*)&data->session->remote_addr.addr, (size_t)data->session->remote_addr.size);
+  r &= HMAC_Update(dtls->cookie_hmac,
+                   (const uint8_t*)&data->session->addr_info.local.addr,
+                   (size_t)data->session->addr_info.local.size);
+  r &= HMAC_Update(dtls->cookie_hmac,
+                   (const uint8_t*)&data->session->addr_info.remote.addr,
+                   (size_t)data->session->addr_info.remote.size);
   r &= HMAC_Final(dtls->cookie_hmac, cookie, cookie_len);
   return r;
 }

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -112,13 +112,13 @@ coap_make_session(coap_proto_t proto, coap_session_type_t type,
   else
     coap_address_init(&session->local_if);
   if (local_addr)
-    coap_address_copy(&session->local_addr, local_addr);
+    coap_address_copy(&session->addr_info.local, local_addr);
   else
-    coap_address_init(&session->local_addr);
+    coap_address_init(&session->addr_info.local);
   if (remote_addr)
-    coap_address_copy(&session->remote_addr, remote_addr);
+    coap_address_copy(&session->addr_info.remote, remote_addr);
   else
-    coap_address_init(&session->remote_addr);
+    coap_address_init(&session->addr_info.remote);
   session->ifindex = ifindex;
   session->context = context;
   session->endpoint = endpoint;
@@ -177,10 +177,10 @@ void coap_session_free(coap_session_t *session) {
   coap_session_mfree(session);
   if (session->endpoint) {
     if (session->endpoint->sessions)
-      LL_DELETE(session->endpoint->sessions, session);
+      SESSIONS_DELETE(session->endpoint->sessions, session);
   } else if (session->context) {
     if (session->context->sessions)
-      LL_DELETE(session->context->sessions, session);
+      SESSIONS_DELETE(session->context->sessions, session);
   }
   coap_log(LOG_DEBUG, "***%s: session closed\n", coap_session_str(session));
 
@@ -456,20 +456,20 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
 coap_session_t *
 coap_endpoint_get_session(coap_endpoint_t *endpoint,
   const coap_packet_t *packet, coap_tick_t now) {
-  coap_session_t *session = NULL;
+  coap_session_t *session;
+  coap_session_t *rtmp;
   unsigned int num_idle = 0;
   unsigned int num_hs = 0;
   coap_session_t *oldest = NULL;
   coap_session_t *oldest_hs = NULL;
 
-  LL_FOREACH(endpoint->sessions, session) {
-    if (session->ifindex == packet->ifindex &&
-      coap_address_equals(&session->local_addr, &packet->dst) &&
-      coap_address_equals(&session->remote_addr, &packet->src))
-    {
-      session->last_rx_tx = now;
-      return session;
-    }
+  SESSIONS_FIND(endpoint->sessions, packet->addr_info, session);
+  if (session) {
+    session->last_rx_tx = now;
+    return session;
+  }
+
+  SESSIONS_ITER(endpoint->sessions, session, rtmp) {
     if (session->ref == 0 && session->delayqueue == NULL) {
       if (session->type == COAP_SESSION_TYPE_SERVER) {
         ++num_idle;
@@ -565,8 +565,9 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
     }
   }
   session = coap_make_session(endpoint->proto, COAP_SESSION_TYPE_SERVER,
-    NULL, &packet->dst, &packet->src, packet->ifindex, endpoint->context,
-    endpoint);
+                              NULL, &packet->addr_info.local,
+                              &packet->addr_info.remote,
+                              packet->ifindex, endpoint->context, endpoint);
   if (session) {
     session->last_rx_tx = now;
     if (endpoint->proto == COAP_PROTO_UDP)
@@ -574,7 +575,7 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
     else if (endpoint->proto == COAP_PROTO_DTLS) {
       session->type = COAP_SESSION_TYPE_HELLO;
     }
-    LL_PREPEND(endpoint->sessions, session);
+    SESSIONS_ADD(endpoint->sessions, session);
     coap_log(LOG_DEBUG, "***%s: new incoming session\n",
              coap_session_str(session));
   }
@@ -620,13 +621,13 @@ coap_session_create_client(
   if (proto == COAP_PROTO_UDP || proto == COAP_PROTO_DTLS) {
     if (!coap_socket_connect_udp(&session->sock, &session->local_if, server,
       proto == COAP_PROTO_DTLS ? COAPS_DEFAULT_PORT : COAP_DEFAULT_PORT,
-      &session->local_addr, &session->remote_addr)) {
+      &session->addr_info.local, &session->addr_info.remote)) {
       goto error;
     }
   } else if (proto == COAP_PROTO_TCP || proto == COAP_PROTO_TLS) {
     if (!coap_socket_connect_tcp1(&session->sock, &session->local_if, server,
       proto == COAP_PROTO_TLS ? COAPS_DEFAULT_PORT : COAP_DEFAULT_PORT,
-      &session->local_addr, &session->remote_addr)) {
+      &session->addr_info.local, &session->addr_info.remote)) {
       goto error;
     }
   }
@@ -634,7 +635,7 @@ coap_session_create_client(
   session->sock.flags |= COAP_SOCKET_NOT_EMPTY | COAP_SOCKET_WANT_READ;
   if (local_if)
     session->sock.flags |= COAP_SOCKET_BOUND;
-  LL_PREPEND(ctx->sessions, session);
+  SESSIONS_ADD(ctx->sessions, session);
   return session;
 
 error:
@@ -840,11 +841,12 @@ coap_session_t *coap_new_server_session(
     goto error;
 
   if (!coap_socket_accept_tcp(&ep->sock, &session->sock,
-                              &session->local_addr, &session->remote_addr))
+                              &session->addr_info.local,
+                              &session->addr_info.remote))
     goto error;
   session->sock.flags |= COAP_SOCKET_NOT_EMPTY | COAP_SOCKET_CONNECTED
                        | COAP_SOCKET_WANT_READ;
-  LL_PREPEND(ep->sessions, session);
+  SESSIONS_ADD(ep->sessions, session);
   if (session) {
     coap_log(LOG_DEBUG, "***%s: new incoming session\n",
              coap_session_str(session));
@@ -944,12 +946,12 @@ void coap_endpoint_set_default_mtu(coap_endpoint_t *ep, unsigned mtu) {
 void
 coap_free_endpoint(coap_endpoint_t *ep) {
   if (ep) {
-    coap_session_t *session, *tmp;
+    coap_session_t *session, *rtmp;
 
     if (ep->sock.flags != COAP_SOCKET_EMPTY)
       coap_socket_close(&ep->sock);
 
-    LL_FOREACH_SAFE(ep->sessions, session, tmp) {
+    SESSIONS_ITER_SAFE(ep->sessions, session, rtmp) {
       assert(session->ref == 0);
       if (session->ref == 0) {
         coap_session_free(session);
@@ -968,15 +970,17 @@ coap_session_t *
 coap_session_get_by_peer(coap_context_t *ctx,
   const coap_address_t *remote_addr,
   int ifindex) {
-  coap_session_t *s;
+  coap_session_t *s, *rtmp;
   coap_endpoint_t *ep;
-  LL_FOREACH(ctx->sessions, s) {
-    if (s->ifindex == ifindex && coap_address_equals(&s->remote_addr, remote_addr))
+  SESSIONS_ITER(ctx->sessions, s, rtmp) {
+    if (s->ifindex == ifindex && coap_address_equals(&s->addr_info.remote,
+                                                     remote_addr))
       return s;
   }
   LL_FOREACH(ctx->endpoint, ep) {
-    LL_FOREACH(ep->sessions, s) {
-      if (s->ifindex == ifindex && coap_address_equals(&s->remote_addr, remote_addr))
+    SESSIONS_ITER(ep->sessions, s, rtmp) {
+      if (s->ifindex == ifindex && coap_address_equals(&s->addr_info.remote,
+                                                       remote_addr))
         return s;
     }
   }
@@ -986,14 +990,16 @@ coap_session_get_by_peer(coap_context_t *ctx,
 const char *coap_session_str(const coap_session_t *session) {
   static char szSession[256];
   char *p = szSession, *end = szSession + sizeof(szSession);
-  if (coap_print_addr(&session->local_addr, (unsigned char*)p, end - p) > 0)
+  if (coap_print_addr(&session->addr_info.local,
+                      (unsigned char*)p, end - p) > 0)
     p += strlen(p);
   if (p + 6 < end) {
     strcpy(p, " <-> ");
     p += 5;
   }
   if (p + 1 < end) {
-    if (coap_print_addr(&session->remote_addr, (unsigned char*)p, end - p) > 0)
+    if (coap_print_addr(&session->addr_info.remote,
+                        (unsigned char*)p, end - p) > 0)
       p += strlen(p);
   }
   if (session->ifindex > 0 && p + 1 < end)

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -277,7 +277,7 @@ coap_dtls_new_session(coap_session_t *session) {
     /* create tinydtls session object from remote address and local
     * endpoint handle */
     dtls_session_init(dtls_session);
-    put_session_addr(&session->remote_addr, dtls_session);
+    put_session_addr(&session->addr_info.remote, dtls_session);
     dtls_session->ifindex = session->ifindex;
     coap_log(LOG_DEBUG, "***new session %p\n", (void *)dtls_session);
   }
@@ -434,7 +434,7 @@ coap_dtls_hello(coap_session_t *session,
   uint8_t *data_rw;
 
   dtls_session_init(&dtls_session);
-  put_session_addr(&session->remote_addr, &dtls_session);
+  put_session_addr(&session->addr_info.remote, &dtls_session);
   dtls_session.ifindex = session->ifindex;
   /* Need to do this to not get a compiler warning about const parameters */
   memcpy (&data_rw, &data, sizeof(data_rw));

--- a/src/resource.c
+++ b/src/resource.c
@@ -910,7 +910,8 @@ coap_remove_failed_observers(coap_context_t *context,
 #endif
           unsigned char addr[INET6_ADDRSTRLEN+8];
 
-          if (coap_print_addr(&obs->session->remote_addr, addr, INET6_ADDRSTRLEN+8))
+          if (coap_print_addr(&obs->session->addr_info.remote,
+                              addr, INET6_ADDRSTRLEN+8))
             coap_log(LOG_DEBUG, "** removed observer %s\n", addr);
         }
 #endif


### PR DESCRIPTION
Make endpoint->sessions and context->sessions a hashed chain of sessions
based on a key comprising of local and remote addresses and ports instead of
a linked list that has to be linearly searched.

include/coap2/coap_io.h:
include/coap2/coap_session.h:

Create a new struct coap_addr_tuple_t for the local and remote addresses/ports to be
used as the hash key.  Update coap_packet_t and coap_session_t appropriately.

Create SESSIONS_* macros to Add, Delete, Find and Iterate through the hashed
chain.

examples/coap-rd.c:
src/coap_io.c:
src/coap_io_lwip.c:
src/coap_openssl.c:
src/coap_session.c:
src/coap_tinydtls.c:
src/net.c:
src/resource.c:

Update with the new struct element names and replace the LL_* functions with
SESSIONS_* as appropriate.

Update coap_endpoint_get_session() to use SESSIONS_FIND() for fast lookup.

Future work is to review all the SESSIONS_ITER* and see if they can be sped up
as well.