### PR TITLE
Report event COAP_EVENT_DTLS_CLOSED when idle (D)TLS session times out

### DIFF
--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -1351,6 +1351,7 @@ void coap_dtls_free_session(coap_session_t *c_session) {
                 COAP_PROTO_NOT_RELIABLE(c_session->proto) ?
                  COAP_FREE_BYE_AS_UDP : COAP_FREE_BYE_AS_TCP);
     c_session->tls = NULL;
+    coap_handle_event(c_session->context, COAP_EVENT_DTLS_CLOSED, c_session);
   }
 }
 
@@ -1785,7 +1786,9 @@ ssize_t coap_tls_write(coap_session_t *c_session,
   }
 
   if (c_session->dtls_event >= 0) {
-    coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
+    if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
+      coap_handle_event(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
@@ -1846,7 +1849,9 @@ ssize_t coap_tls_read(coap_session_t *c_session,
   }
 
   if (c_session->dtls_event >= 0) {
-    coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
+    if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
+      coap_handle_event(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1839,6 +1839,8 @@ void coap_dtls_free_session(coap_session_t *session) {
     }
     SSL_free(ssl);
     session->tls = NULL;
+    if (session->context)
+      coap_handle_event(session->context, COAP_EVENT_DTLS_CLOSED, session);
   }
 }
 
@@ -1867,7 +1869,9 @@ int coap_dtls_send(coap_session_t *session,
   }
 
   if (session->dtls_event >= 0) {
-    coap_handle_event(session->context, session->dtls_event, session);
+    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
+    if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
+      coap_handle_event(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
@@ -1968,7 +1972,9 @@ int coap_dtls_receive(coap_session_t *session,
       r = -1;
     }
     if (session->dtls_event >= 0) {
-      coap_handle_event(session->context, session->dtls_event, session);
+      /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
+      if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
+        coap_handle_event(session->context, session->dtls_event, session);
       if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
           session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
         coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
@@ -2140,6 +2146,8 @@ void coap_tls_free_session(coap_session_t *session) {
     }
     SSL_free(ssl);
     session->tls = NULL;
+    if (session->context)
+      coap_handle_event(session->context, COAP_EVENT_DTLS_CLOSED, session);
   }
 }
 
@@ -2184,7 +2192,9 @@ ssize_t coap_tls_write(coap_session_t *session,
   }
 
   if (session->dtls_event >= 0) {
-    coap_handle_event(session->context, session->dtls_event, session);
+    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
+    if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
+      coap_handle_event(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
@@ -2233,7 +2243,9 @@ ssize_t coap_tls_read(coap_session_t *session,
   }
 
   if (session->dtls_event >= 0) {
-    coap_handle_event(session->context, session->dtls_event, session);
+    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
+    if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
+      coap_handle_event(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(session, COAP_NACK_TLS_FAILED);

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -538,8 +538,9 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
      * } dtls_record_handshake_t;
      */
 #define OFF_CONTENT_TYPE      0  /* offset of content_type in dtls_record_handshake_t */
+#define DTLS_CT_ALERT        21  /* Content Type Alert */
+#define DTLS_CT_HANDSHAKE    22  /* Content Type Handshake */
 #define OFF_HANDSHAKE_TYPE   13  /* offset of handshake in dtls_record_handshake_t */
-#define DTLS_CT_HANDSHAKE    22  /* Content Type value */
 #define DTLS_HT_CLIENT_HELLO  1  /* Client Hello handshake type */
 
 #ifdef WITH_LWIP
@@ -558,7 +559,9 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
     }
     if (payload[OFF_CONTENT_TYPE] != DTLS_CT_HANDSHAKE ||
         payload[OFF_HANDSHAKE_TYPE] != DTLS_HT_CLIENT_HELLO) {
-      coap_log(LOG_DEBUG,
+      /* only log if not a late alert */
+      if (payload[OFF_CONTENT_TYPE] != DTLS_CT_ALERT)
+        coap_log(LOG_DEBUG,
          "coap_dtls_hello: ContentType %d Handshake %d dropped\n",
          payload[OFF_CONTENT_TYPE], payload[OFF_HANDSHAKE_TYPE]);
       return NULL;


### PR DESCRIPTION
When an idle server (D)TLS session times out, no event is reported to a
defined event handler.  COAP_EVENT_DTLS_CLOSED is reported whenever there is
a read / write issue, and this fix also reports the event COAP_EVENT_DTLS_CLOSED
when the (D)TLS session is closed.

Some extra code had to be added in to prevent event COAP_EVENT_DTLS_CLOSED
being reported twice.

src/coap_gnutls.c:
src/coap_openssl.c:
src/coap_tinydtls.c:

Report event COAP_EVENT_DTLS_CLOSED when coap_dtls_free_session() and
coap_tls_free_session() are called.

src/coap_session.c:

Do not log spurious (D)TLS Alert packets received after session is closed.