### PR TITLE
str.h: Fix coap_make_str_const() for C++

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -467,7 +467,7 @@ hnd_put(coap_context_t *ctx UNUSED_PARAM,
       buf[sizeof(buf) - 1] = '\0';
       coap_add_attr(resource,
                     coap_make_str_const("ct"),
-                    coap_make_str_const(buf),
+                    coap_make_str_const((char*)buf),
                     0);
     } else {
       dynamic_count--;

--- a/include/coap2/str.h
+++ b/include/coap2/str.h
@@ -81,27 +81,21 @@ coap_str_const_t *coap_new_str_const(const uint8_t *data, size_t size);
  */
 void coap_delete_str_const(coap_str_const_t *string);
 
+#define COAP_MAX_STR_CONST_FUNC 2
 /**
- * Take the specified byte array (text) and create a coap_str_const_t *
+ * Take the specified string and create a coap_str_const_t *
  *
- * WARNING: The byte array must be in the local scope and not a
- * parameter in the function call as sizeof() will return the size of the
- * pointer, not the size of the byte array, leading to unxepected results.
+ * Note: the array is 2 deep as there are up to two callings of
+ * coap_make_str_const in a function call. e.g. coap_add_attr().
+ * Caution: If there are local variable assignments, these will cycle around
+ * the var[COAP_MAX_STR_CONST_FUNC] set.  No current examples do this.
  *
- * @param string The const byte array to convert to a coap_str_const_t *
+ * @param string The const string to convert to a coap_str_const_t *
+ *
+ * @return       A pointer to one of two static variables containing the
+ *               coap_str_const_t * result
  */
-#ifdef __cplusplus
-namespace libcoap {
-  struct CoAPStrConst : coap_str_const_t {
-    operator coap_str_const_t *() { return this; }
-  };
-}
-#define coap_make_str_const(CStr)                                       \
-  libcoap::CoAPStrConst{sizeof(CStr)-1, reinterpret_cast<const uint8_t *>(CStr)}
-#else /* __cplusplus */
-#define coap_make_str_const(string)                                     \
-  (&(coap_str_const_t){sizeof(string)-1,(const uint8_t *)(string)})
-#endif  /* __cplusplus */
+coap_str_const_t *coap_make_str_const(const char *string);
 
 /**
  * Compares the two strings for equality

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -76,6 +76,7 @@ global:
   coap_is_mcast;
   coap_join_mcast_group;
   coap_log_impl;
+  coap_make_str_const;
   coap_malloc_endpoint;
   coap_malloc_type;
   coap_memory_init;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -74,6 +74,7 @@ coap_insert_optlist
 coap_is_mcast
 coap_join_mcast_group
 coap_log_impl
+coap_make_str_const
 coap_malloc_endpoint
 coap_malloc_type
 coap_memory_init

--- a/src/resource.c
+++ b/src/resource.c
@@ -294,7 +294,8 @@ coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen
   return result;
 }
 
-static coap_str_const_t *null_path = coap_make_str_const("");
+static coap_str_const_t null_path_value = {0, (const uint8_t*)""};
+static coap_str_const_t *null_path = &null_path_value;
 
 coap_resource_t *
 coap_resource_init(coap_str_const_t *uri_path, int flags) {

--- a/src/str.c
+++ b/src/str.c
@@ -48,3 +48,13 @@ void coap_delete_str_const(coap_str_const_t *s) {
   coap_free_type(COAP_STRING, s);
 }
 
+coap_str_const_t *coap_make_str_const(const char *string)
+{
+  static int ofs = 0;
+  static coap_str_const_t var[COAP_MAX_STR_CONST_FUNC];
+  if (++ofs == COAP_MAX_STR_CONST_FUNC) ofs = 0;
+  var[ofs].length = strlen(string);
+  var[ofs].s = (const uint8_t *)string;
+  return &var[ofs];
+}
+


### PR DESCRIPTION
As pointed out in issue #368 [1], C++ officially forbids aggregate
initialization for non-aggegrates. This change therefore introduces
an alternative version (which works for both C and C++) to provide
the required functionality.

examples/coap-server.c:

Fix parameter type in coap_add_attr() call.

src/resource.c:

Static variables can no longer make use of coap_make_str_const().

Fixes #368.

[1] https://github.com/obgm/libcoap/issues/368