### PR TITLE
Convert #define to enum where possible

### DIFF
--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -37,10 +37,12 @@ int coap_dtls_is_supported(void);
  */
 int coap_tls_is_supported(void);
 
-#define COAP_TLS_LIBRARY_NOTLS 0 /**< No DTLS library */
-#define COAP_TLS_LIBRARY_TINYDTLS 1 /**< Using TinyDTLS library */
-#define COAP_TLS_LIBRARY_OPENSSL 2 /**< Using OpenSSL library */
-#define COAP_TLS_LIBRARY_GNUTLS 3 /**< Using GnuTLS library */
+typedef enum coap_tls_library_t {
+  COAP_TLS_LIBRARY_NOTLS = 0, /**< No DTLS library */
+  COAP_TLS_LIBRARY_TINYDTLS,  /**< Using TinyDTLS library */
+  COAP_TLS_LIBRARY_OPENSSL,   /**< Using OpenSSL library */
+  COAP_TLS_LIBRARY_GNUTLS,    /**< Using GnuTLS library */
+} coap_tls_library_t;
 
 /**
  * The structure used for returning the underlying (D)TLS library
@@ -48,7 +50,7 @@ int coap_tls_is_supported(void);
  */
 typedef struct coap_tls_version_t {
   uint64_t version; /**< (D)TLS runtime Library Version */
-  int type; /**< Library type. One of COAP_TLS_LIBRARY_* */
+  coap_tls_library_t type; /**< Library type. One of COAP_TLS_LIBRARY_* */
   uint64_t built_version; /**< (D)TLS Built against Library Version */
 } coap_tls_version_t;
 
@@ -183,13 +185,25 @@ typedef coap_dtls_key_t *(*coap_dtls_sni_callback_t)(const char *sni,
              void* arg);
 
 
-#define COAP_DTLS_PKI_SETUP_VERSION 1 /**< Latest PKI setup version */
+#if defined(_MSC_VER)
+typedef enum
+coap_dtls_pki_version_t : unsigned char
+#else /* !_MSC_VER */
+typedef enum
+__attribute__ ((__packed__))
+#endif /* !_MSC_VER */
+{
+  COAP_DTLS_PKI_SETUP_VERSION_V1 = 1,
+  COAP_DTLS_PKI_SETUP_VERSION =
+              COAP_DTLS_PKI_SETUP_VERSION_V1, /**< Latest PKI setup version */
+} coap_dtls_pki_version_t;
 
 /**
  * The structure used for defining the PKI setup data to be used.
  */
 typedef struct coap_dtls_pki_t {
-  uint8_t version; /** Set to 1 to support this version of the struct */
+  coap_dtls_pki_version_t version; /** Set to COAP_DTLS_PKI_SETUP_VERSION to
+                                   support the version of the struct */
 
   /* Options to enable different TLS functionality in libcoap */
   uint8_t verify_peer_cert;        /**< 1 if peer cert is to be verified */

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -36,23 +36,33 @@ typedef struct coap_fixed_point_t {
 #define COAP_PROTO_NOT_RELIABLE(p) ((p)==COAP_PROTO_UDP || (p)==COAP_PROTO_DTLS)
 #define COAP_PROTO_RELIABLE(p) ((p)==COAP_PROTO_TCP || (p)==COAP_PROTO_TLS)
 
-typedef uint8_t coap_session_type_t;
-/**
- * coap_session_type_t values
- */
-#define COAP_SESSION_TYPE_CLIENT 1  /**< client-side */
-#define COAP_SESSION_TYPE_SERVER 2  /**< server-side */
-#define COAP_SESSION_TYPE_HELLO  3  /**< server-side ephemeral session for responding to a client hello */
+#if defined(_MSC_VER)
+typedef enum
+coap_session_type_t : unsigned char
+#else /* !_MSC_VER */
+typedef enum
+__attribute__ ((__packed__))
+#endif /* !_MSC_VER */
+{
+  COAP_SESSION_TYPE_CLIENT = 1, /**< client-side */
+  COAP_SESSION_TYPE_SERVER, /**< server-side */
+  COAP_SESSION_TYPE_HELLO, /**< server-side ephemeral session for responding to a client hello */
+} coap_session_type_t;
 
-typedef uint8_t coap_session_state_t;
-/**
- * coap_session_state_t values
- */
-#define COAP_SESSION_STATE_NONE                0
-#define COAP_SESSION_STATE_CONNECTING        1
-#define COAP_SESSION_STATE_HANDSHAKE        2
-#define COAP_SESSION_STATE_CSM                3
-#define COAP_SESSION_STATE_ESTABLISHED        4
+#if defined(_MSC_VER)
+typedef enum
+coap_session_state_t : unsigned char
+#else /* !_MSC_VER */
+typedef enum
+__attribute__ ((__packed__))
+#endif /* !_MSC_VER */
+{
+  COAP_SESSION_STATE_NONE = 0,
+  COAP_SESSION_STATE_CONNECTING,
+  COAP_SESSION_STATE_HANDSHAKE,
+  COAP_SESSION_STATE_CSM,
+  COAP_SESSION_STATE_ESTABLISHED,
+} coap_session_state_t;
 
 typedef struct coap_session_t {
   coap_proto_t proto;               /**< protocol used */

--- a/include/coap2/pdu.h
+++ b/include/coap2/pdu.h
@@ -336,15 +336,23 @@ typedef struct coap_pdu_t {
 coap_pdu_t * coap_pdu_from_pbuf(struct pbuf *pbuf);
 #endif
 
-typedef uint8_t coap_proto_t;
 /**
 * coap_proto_t values
 */
-#define COAP_PROTO_NONE         0
-#define COAP_PROTO_UDP          1
-#define COAP_PROTO_DTLS         2
-#define COAP_PROTO_TCP          3
-#define COAP_PROTO_TLS          4
+#if defined(_MSC_VER)
+typedef enum
+coap_proto_t : unsigned char
+#else /* !_MSC_VER */
+typedef enum
+__attribute__ ((__packed__))
+#endif /* !_MSC_VER */
+{
+  COAP_PROTO_NONE = 0,
+  COAP_PROTO_UDP,
+  COAP_PROTO_DTLS,
+  COAP_PROTO_TCP,
+  COAP_PROTO_TLS,
+} coap_proto_t;
 
 /**
  * Creates a new CoAP PDU with at least enough storage space for the given

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -120,7 +120,7 @@ below.
 [source, c]
 ----
 typedef struct coap_dtls_pki_t {
-  uint8_t version;            /* COAP_DTLS_PKI_SETUP_VERSION */
+  coap_dtls_pki_version_t version;  /* Set to COAP_DTLS_PKI_SETUP_VERSION */
 
   /* Options to enable different TLS functionality in libcoap */
   uint8_t verify_peer_cert;         /* 1 if peer cert is to be verified */
@@ -178,7 +178,12 @@ enabled.
 *SECTION: coap_dtls_pki_t Version*
 [source, c]
 ----
-#define COAP_DTLS_PKI_SETUP_VERSION 1
+typedef enum
+{
+  COAP_DTLS_PKI_SETUP_VERSION_V1 = 1,
+  COAP_DTLS_PKI_SETUP_VERSION =
+              COAP_DTLS_PKI_SETUP_VERSION_V1, /**< Latest PKI setup version */
+} coap_dtls_pki_version_t;
 ----
 
 *version* is set to COAP_DTLS_PKI_SETUP_VERSION.  This will then allow support

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -84,14 +84,16 @@ for this information to be output using coap_log().
 
 [source, c]
 ----
-#define COAP_TLS_LIBRARY_NOTLS    0
-#define COAP_TLS_LIBRARY_TINYDTLS 1
-#define COAP_TLS_LIBRARY_OPENSSL  2
-#define COAP_TLS_LIBRARY_GNUTLS   3
+typedef enum coap_tls_library_t {
+  COAP_TLS_LIBRARY_NOTLS = 0, /**< No DTLS library */
+  COAP_TLS_LIBRARY_TINYDTLS,  /**< Using TinyDTLS library */
+  COAP_TLS_LIBRARY_OPENSSL,   /**< Using OpenSSL library */
+  COAP_TLS_LIBRARY_GNUTLS,    /**< Using GnuTLS library */
+} coap_tls_library_t;
 
 typedef struct coap_tls_version_t {
   uint64_t version; /* (D)TLS runtime Library Version */
-  int type; /* Library type. One of COAP_TLS_LIBRARY_* */
+  coap_tls_library_t type; /**< Library type. One of COAP_TLS_LIBRARY_* */
   uint64_t built_version; /* (D)TLS Built against Library Version */
 }
 ----

--- a/src/net.c
+++ b/src/net.c
@@ -646,6 +646,7 @@ coap_session_send_pdu(coap_session_t *session, coap_pdu_t *pdu) {
       bytes_written = coap_tls_write(session, pdu->token - pdu->hdr_size,
                                      pdu->used_size + pdu->hdr_size);
       break;
+    case COAP_PROTO_NONE:
     default:
       break;
   }
@@ -1097,6 +1098,9 @@ coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now
           q->pdu->used_size + q->pdu->hdr_size - session->partial_write
         );
         break;
+      case COAP_PROTO_NONE:
+      case COAP_PROTO_UDP:
+      case COAP_PROTO_DTLS:
       default:
         bytes_written = -1;
         break;


### PR DESCRIPTION
As suggested in #292 , several lists of #define could easily be defined
as enum instead - which allows for extra compiler checking.

The challenge was for where the (#define/enum) parameter defined in a
structure was one byte in size.  Doxygen was picky and got confused, not
maintaining the fact that it was an enum if macros were used to differentiate
between using Microsoft or GCC when changing the enum size default from that
of an int.

include/coap2/coap_dtls.h:
include/coap2/coap_session.h:
include/coap2/pdu.h:

Use enums instead of #define where practical.

src/net.c:

Handle all the enum cases.

man/coap_encryption.txt.in:
man/coap_tls_library.txt.in:

Update man documentation.