### PR TITLE
Order the doxygen Modules and Manual Pages listings alphabetically

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -564,7 +564,7 @@ SORT_MEMBERS_CTORS_1ST = NO
 # appear in their defined order.
 # The default value is: NO.
 
-SORT_GROUP_NAMES       = NO
+SORT_GROUP_NAMES       = YES
 
 # If the SORT_BY_SCOPE_NAME tag is set to YES, the class list will be sorted by
 # fully-qualified names, including namespaces. If set to NO, the class list will

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -33,7 +33,7 @@ man-page-start: man-page-prepare
 	@echo '   <table class="directory">' >> $(top_builddir)/doc/man_tmp/manpage.dox
 
 man-page-build: man-page-start
-	@MAN_FILES=`find $(top_srcdir)/man/ -type f -name "coap*.in"` ;\
+	@MAN_FILES=`find $(top_srcdir)/man/ -type f -name "coap.txt.in" ; find $(top_srcdir)/man/ -type f -name "coap_*.in" | ALL=C sort ; find $(top_srcdir)/man/ -type f -name "coap-*.in" | LC_ALL=C sort` ;\
 	HTML_FILES=`find $(top_builddir)/man/ -type f -name "*.html"` ;\
 	COUNT_MAN_FILES=`echo $${MAN_FILES} | wc -w` ;\
 	COUNT_HTML_FILES=`echo $${HTML_FILES} | wc -w` ;\


### PR DESCRIPTION
doc/Doxyfile.in:

SORT_GOUPNAME = YES to sort Modules

doc/Makefile.am:

Sort the MAN_FILES list.  coap(7) first and examples last.