### PR TITLE
Remove reserved identifiers from coap_config.h for specific builds

### DIFF
--- a/coap_config.h.contiki
+++ b/coap_config.h.contiki
@@ -1,5 +1,5 @@
-#ifndef _COAP_CONFIG_H_
-#define _COAP_CONFIG_H_
+#ifndef COAP_CONFIG_H_
+#define COAP_CONFIG_H_
 
 #include "contiki.h"
 #include "contiki-lib.h"
@@ -164,5 +164,5 @@ typedef void FILE;
 #include <stdio.h>
 #define coap_log(fd, ...) printf(__VA_ARGS__)
 
-#endif /* _COAP_CONFIG_H_ */
+#endif /* COAP_CONFIG_H_ */
 

--- a/coap_config.h.lwip
+++ b/coap_config.h.lwip
@@ -1,5 +1,5 @@
-#ifndef _CONFIG_H_
-#define _CONFIG_H_
+#ifndef COAP_CONFIG_H_
+#define COAP_CONFIG_H_
 
 #include <lwip/opt.h>
 #include <lwip/debug.h>
@@ -24,4 +24,4 @@
 
 #define HAVE_LIMITS_H
 
-#endif /* _CONFIG_H_ */
+#endif /* COAP_CONFIG_H_ */

--- a/coap_config.h.windows
+++ b/coap_config.h.windows
@@ -1,5 +1,5 @@
-#ifndef _COAP_CONFIG_H_
-#define _COAP_CONFIG_H_
+#ifndef COAP_CONFIG_H_
+#define COAP_CONFIG_H_
 
 #if defined(_WIN32)
 
@@ -110,4 +110,4 @@
 
 #endif
 
-#endif /* _COAP_CONFIG_H_ */
+#endif /* COAP_CONFIG_H_ */


### PR DESCRIPTION
coap_config.h.contiki:
coap_config.h.lwip:
coap_config.h.windows:

Strip leading _ in the file protection wrappers.

See #294 