### PR TITLE
Fix SIGPIPE causing unexpected exit of example applications

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -1569,6 +1569,9 @@ main(int argc, char **argv) {
   sa.sa_flags = 0;
   sigaction (SIGINT, &sa, NULL);
   sigaction (SIGTERM, &sa, NULL);
+  /* So we do not exit on a SIGPIPE */
+  sa.sa_handler = SIG_IGN;
+  sigaction (SIGPIPE, &sa, NULL);
 #endif
 
   while (!quit && !(ready && !doing_getting_block && coap_can_exit(ctx)) ) {

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -983,6 +983,9 @@ main(int argc, char **argv) {
   sa.sa_flags = 0;
   sigaction (SIGINT, &sa, NULL);
   sigaction (SIGTERM, &sa, NULL);
+  /* So we do not exit on a SIGPIPE */
+  sa.sa_handler = SIG_IGN;
+  sigaction (SIGPIPE, &sa, NULL);
 #endif
 
   wait_ms = COAP_RESOURCE_CHECK_TIME * 1000;

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -662,6 +662,9 @@ main(int argc, char **argv) {
   sa.sa_flags = 0;
   sigaction (SIGINT, &sa, NULL);
   sigaction (SIGTERM, &sa, NULL);
+  /* So we do not exit on a SIGPIPE */
+  sa.sa_handler = SIG_IGN;
+  sigaction (SIGPIPE, &sa, NULL);
 
   while ( !quit ) {
     result = coap_run_once( ctx, COAP_RESOURCE_CHECK_TIME * 1000 );

--- a/examples/tiny.c
+++ b/examples/tiny.c
@@ -148,6 +148,9 @@ main(int argc, char **argv) {
   sa.sa_flags = 0;
   sigaction (SIGINT, &sa, NULL);
   sigaction (SIGTERM, &sa, NULL);
+  /* So we do not exit on a SIGPIPE */
+  sa.sa_handler = SIG_IGN;
+  sigaction (SIGPIPE, &sa, NULL);
 
   while ( !quit ) {
 


### PR DESCRIPTION
examples/client.c:
examples/coap-rd.c:
examples/coap-server.c:
examples/etsi_iot_01.c:
examples/tiny.c:

Make the applications ignore SIGPIPE.

examples/coap-rd.c:

Support clean exit for SIGTERM / SIGQUIT for valgrind testing.