### PR TITLE
Fix -Winline compiler warnings about inlining failed

### DIFF
--- a/Makefile.libcoap
+++ b/Makefile.libcoap
@@ -1,4 +1,4 @@
-libcoap_src = pdu.c net.c coap_debug.c encode.c uri.c subscribe.c resource.c str.c option.c async.c block.c mem.c coap_io.c coap_session.c coap_notls.c coap_hashkey.c
+libcoap_src = pdu.c net.c coap_debug.c encode.c uri.c subscribe.c resource.c str.c option.c async.c block.c mem.c coap_io.c coap_session.c coap_notls.c coap_hashkey.c address.c
 
 libcoap_dir := $(filter %libcoap,$(APPDS))
 vpath %c $(libcoap_dir)/src

--- a/examples/client.c
+++ b/examples/client.c
@@ -944,7 +944,7 @@ cmdline_token(char *arg) {
  *
  * return The numerical representation of @p c.
  */
-static inline uint8_t
+static uint8_t
 hex2char(char c) {
   assert(isxdigit(c));
   if ('a' <= c && c <= 'f')

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -82,7 +82,7 @@ coap_find_payload(coap_resource_t *resource) {
   return p;
 }
 
-static inline void
+static void
 coap_add_payload(coap_resource_t *resource, coap_payload_t *payload){
   assert(payload);
 

--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -39,7 +39,7 @@ CFLAGS += -I$(top_srcdir)/include/coap2
 
 vpath %.c $(top_srcdir)/src
 
-COAPOBJS = net.o coap_debug.o option.o resource.o pdu.o encode.o subscribe.o coap_io_lwip.o block.o uri.o str.o coap_session.o coap_notls.o coap_hashkey.o
+COAPOBJS = net.o coap_debug.o option.o resource.o pdu.o encode.o subscribe.o coap_io_lwip.o block.o uri.o str.o coap_session.o coap_notls.o coap_hashkey.o address.o
 
 CFLAGS += -g3 -Wall -Wextra -pedantic -O0 -fpack-struct
 # not sorted out yet

--- a/include/coap2/address.h
+++ b/include/coap2/address.h
@@ -100,15 +100,7 @@ _coap_address_isany_impl(const coap_address_t *a) {
  *
  * @param addr The coap_address_t object to initialize.
  */
-COAP_STATIC_INLINE void
-coap_address_init(coap_address_t *addr) {
-  assert(addr);
-  memset(addr, 0, sizeof(coap_address_t));
-#if !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
-  /* lwip and Contiki have constant address sizes and doesn't need the .size part */
-  addr->size = sizeof(addr->addr);
-#endif
-}
+void coap_address_init(coap_address_t *addr);
 
 /* Convenience function to copy IPv6 addresses without garbage. */
 

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -11,6 +11,7 @@ global:
   coap_add_optlist_pdu;
   coap_add_resource;
   coap_address_equals;
+  coap_address_init;
   coap_add_token;
   coap_adjust_basetime;
   coap_calc_timeout;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -9,6 +9,7 @@ coap_add_option_later
 coap_add_optlist_pdu
 coap_add_resource
 coap_address_equals
+coap_address_init
 coap_add_token
 coap_adjust_basetime
 coap_calc_timeout

--- a/src/address.c
+++ b/src/address.c
@@ -68,15 +68,15 @@ int coap_is_mcast(const coap_address_t *a) {
   }
  return 0;
 }
-#else /* !defined(WITH_CONTIKI) && !defined(WITH_LWIP) */
-
-#ifdef __clang__
-/* Make compilers happy that do not like empty modules. As this function is
- * never used, we ignore -Wunused-function at the end of compiling this file
- */
-#pragma GCC diagnostic ignored "-Wunused-function"
-#endif
-static inline void dummy(void) {
-}
 
 #endif /* !defined(WITH_CONTIKI) && !defined(WITH_LWIP) */
+
+void coap_address_init(coap_address_t *addr) {
+  assert(addr);
+  memset(addr, 0, sizeof(coap_address_t));
+#if !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
+  /* lwip and Contiki have constant address sizes and don't need the .size part */
+  addr->size = sizeof(addr->addr);
+#endif
+}
+


### PR DESCRIPTION
This is compiler version dependent when doing static inline expansions.

examples/client.c:

Make hex2char() just static.

examples/etsi_iot_01.c:

Make coap_add_payload() just static.

include/coap2/address.h:
src/address.c:

Make coap_address_init() an actual function.

libcoap-2.map:
libcoap-2.sym:

Expose coap_address_init() as a function.