### PR TITLE
Fix bind() address size for Mac OS X

### DIFF
--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -236,7 +236,10 @@ coap_socket_bind_udp(coap_socket_t *sock,
     break;
   }
 
-  if (bind(sock->fd, &listen_addr->addr.sa, listen_addr->size) == COAP_SOCKET_ERROR) {
+  if (bind(sock->fd, &listen_addr->addr.sa,
+           listen_addr->addr.sa.sa_family == AF_INET ?
+            sizeof(struct sockaddr_in) :
+            listen_addr->size) == COAP_SOCKET_ERROR) {
     coap_log(LOG_WARNING, "coap_socket_bind_udp: bind: %s\n",
              coap_socket_strerror());
     goto error;
@@ -316,7 +319,10 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
       coap_log(LOG_WARNING,
                "coap_socket_connect_tcp1: setsockopt SO_REUSEADDR: %s\n",
                coap_socket_strerror());
-    if (bind(sock->fd, &local_if->addr.sa, local_if->size) == COAP_SOCKET_ERROR) {
+    if (bind(sock->fd, &local_if->addr.sa,
+             local_if->addr.sa.sa_family == AF_INET ?
+              sizeof(struct sockaddr_in) :
+              local_if->size) == COAP_SOCKET_ERROR) {
       coap_log(LOG_WARNING, "coap_socket_connect_tcp1: bind: %s\n",
                coap_socket_strerror());
       goto error;
@@ -453,7 +459,10 @@ coap_socket_bind_tcp(coap_socket_t *sock,
     coap_log(LOG_ALERT, "coap_socket_bind_tcp: unsupported sa_family\n");
   }
 
-  if (bind(sock->fd, &listen_addr->addr.sa, listen_addr->size) == COAP_SOCKET_ERROR) {
+  if (bind(sock->fd, &listen_addr->addr.sa,
+           listen_addr->addr.sa.sa_family == AF_INET ?
+            sizeof(struct sockaddr_in) :
+            listen_addr->size) == COAP_SOCKET_ERROR) {
     coap_log(LOG_ALERT, "coap_socket_bind_tcp: bind: %s\n",
              coap_socket_strerror());
     goto error;
@@ -573,7 +582,10 @@ coap_socket_connect_udp(coap_socket_t *sock,
       coap_log(LOG_WARNING,
                "coap_socket_connect_udp: setsockopt SO_REUSEADDR: %s\n",
                coap_socket_strerror());
-    if (bind(sock->fd, &local_if->addr.sa, local_if->size) == COAP_SOCKET_ERROR) {
+    if (bind(sock->fd, &local_if->addr.sa,
+             local_if->addr.sa.sa_family == AF_INET ?
+              sizeof(struct sockaddr_in) :
+              local_if->size) == COAP_SOCKET_ERROR) {
       coap_log(LOG_WARNING, "coap_socket_connect_udp: bind: %s\n",
                coap_socket_strerror());
       goto error;


### PR DESCRIPTION
It appears that MAC OX X (10.13.2) builds do not like the size of the sa to
be larger than the size of struct sockaddr_in when working with IP v4
addresses.

src/coap_io.c

Update the bind() calls to use the correct address sizes.

Identified in #150