### PR TITLE
Fix timing window in epoll logic

### DIFF
--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -588,6 +588,28 @@ void coap_read(coap_context_t *ctx, coap_tick_t now);
 
 int coap_run_once( coap_context_t *ctx, unsigned int timeout_ms );
 
+/**
+ * Any now timed out delayed packet is transmitted, along with any packets
+ * associated with requested observable response.
+ *
+ * In addition, it returns when the next expected I/O is expected to take place
+ * (e.g. a packet retransmit).
+ *
+ * Note: If epoll support is compiled into libcoap, coap_io_prepare_epoll() must
+ * be used instead of coap_write().
+ *
+ * Internal function.
+ *
+ * @param ctx The CoAP context
+ * @param now Current time.
+ *
+ * @return timeout Maxmimum number of milliseconds that can be used by a
+ *                 epoll_wait() to wait for network events or 0 if wait should be
+ *                 forever.
+ */
+unsigned int
+coap_io_prepare_epoll(coap_context_t *ctx, coap_tick_t now);
+
 struct epoll_event;
 /**
  * Process all the epoll events
@@ -598,9 +620,8 @@ struct epoll_event;
  * @param events The list of events returned from an epoll_wait() call.
  * @param nevents The number of events.
  *
- * @return 1 if timeout event, else 0
  */
-int coap_io_do_events(coap_context_t *ctx, struct epoll_event* events,
+void coap_io_do_events(coap_context_t *ctx, struct epoll_event* events,
                       size_t nevents);
 
 /**

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -75,6 +75,7 @@ global:
   coap_hash_impl;
   coap_insert_node;
   coap_insert_optlist;
+  coap_io_prepare_epoll;
   coap_is_mcast;
   coap_join_mcast_group;
   coap_log_impl;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -73,6 +73,7 @@ coap_handle_failed_notify
 coap_hash_impl
 coap_insert_node
 coap_insert_optlist
+coap_io_prepare_epoll
 coap_is_mcast
 coap_join_mcast_group
 coap_log_impl

--- a/src/net.c
+++ b/src/net.c
@@ -461,6 +461,7 @@ coap_new_context(
     coap_log(LOG_ERR, "coap_new_context: Unable to epoll_create: %s (%d)\n",
              coap_socket_strerror(),
              errno);
+    goto onerror;
   }
   if (c->epfd != -1) {
     c->eptimerfd = timerfd_create(CLOCK_REALTIME, TFD_NONBLOCK);
@@ -468,6 +469,7 @@ coap_new_context(
       coap_log(LOG_ERR, "coap_new_context: Unable to timerfd_create: %s (%d)\n",
                coap_socket_strerror(),
                errno);
+      goto onerror;
     }
     else {
       int ret;
@@ -485,6 +487,7 @@ coap_new_context(
                   "%s: epoll_ctl ADD failed: %s (%d)\n",
                   "coap_new_context",
                   coap_socket_strerror(), errno);
+        goto onerror;
       }
     }
   }
@@ -1396,6 +1399,12 @@ coap_accept_endpoint(coap_context_t *ctx, coap_endpoint_t *endpoint,
 
 void
 coap_read(coap_context_t *ctx, coap_tick_t now) {
+#ifdef COAP_EPOLL_SUPPORT
+  (void)ctx;
+  (void)now;
+   coap_log(LOG_EMERG,
+            "coap_read() requires libcoap not compiled for using epoll\n");
+#else /* ! COAP_EPOLL_SUPPORT */
   coap_endpoint_t *ep, *tmp;
   coap_session_t *s, *rtmp;
 
@@ -1442,18 +1451,24 @@ coap_read(coap_context_t *ctx, coap_tick_t now) {
       coap_session_release( s );
     }
   }
+#endif /* ! COAP_EPOLL_SUPPORT */
 }
 
-#ifdef COAP_EPOLL_SUPPORT
 /*
  * While this code in part replicates coap_read(), doing the functions
  * directly saves having to iterate through the endpoints / sessions.
  */
-int
+void
 coap_io_do_events(coap_context_t *ctx, struct epoll_event *events, size_t nevents) {
+#ifndef COAP_EPOLL_SUPPORT
+  (void)ctx;
+  (void)events;
+  (void)nevents;
+   coap_log(LOG_EMERG,
+            "coap_io_do_events() requires libcoap compiled for using epoll\n");
+#else /* COAP_EPOLL_SUPPORT */
   coap_tick_t now;
   size_t j;
-  int timer_trig = 0;
 
   coap_ticks(&now);
   for(j = 0; j < nevents; j++) {
@@ -1534,12 +1549,13 @@ coap_io_do_events(coap_context_t *ctx, struct epoll_event *events, size_t nevent
       uint64_t count;
 
       read(ctx->eptimerfd, &count, sizeof(count));
-      timer_trig = 1;
+      /* And process any timed out events */
+      coap_ticks(&now);
+      coap_io_prepare_epoll(ctx, now);
     }
   }
-  return timer_trig;
-}
 #endif /* COAP_EPOLL_SUPPORT */
+}
 
 int
 coap_handle_dgram(coap_context_t *ctx, coap_session_t *session,


### PR DESCRIPTION
It is possible to miss a packet retransmission if it is just about to happen
and the coap_run_once() logic takes the time past the packet retransmission.
The retransmission will take place when coap_run_once() is next run, but that
could be significantly later.

1) Create a new coap_io_prepare_epoll() function that calls coap_write(), but
sets the etimer within this function instead of at the end of coap_run_once().

2) Handle the etimer trigger within coap_io_do_events() rather than loop
checking coap_io_do_events() within coap_run_once().

include/coap2/net.h:

Define coap_io_prepare_epoll().
Update coap_io_do_events() to be type void.

src/coap_io.c:

Add in coap_io_prepare_epoll().
Update coap_run_once() to use new/updated functions.

src/net.c:

Update coap_io_do_events().
Make coap_new_context() always fail if there is an epoll logic setup failure
libcoap compiled for epoll will not continue to run.
Give a runtime warning if coap_read() or coap_io_do_events() are called when
libcoap is compiled or not compiled respectively for using epoll.
[Both coap_read() and coap_io_do_events() need to be in libcoap-2.{map|sym} to
support when compiling with or without epoll support]

libcoap-2.map:
libcoap-2.sym:

Make coap_io_prepare_epoll() application accessible.