### PR TITLE
Pthread configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -567,6 +567,7 @@ fi
 
 # Checks for header files.
 AC_CHECK_HEADERS([assert.h arpa/inet.h limits.h netdb.h netinet/in.h \
+                  pthread.h \
                   stdlib.h string.h strings.h sys/socket.h sys/time.h \
                   time.h unistd.h sys/unistd.h syslog.h sys/ioctl.h])
 
@@ -598,7 +599,7 @@ AC_TYPE_SSIZE_T
 
 # Checks for library functions.
 AC_CHECK_FUNCS([memset select socket strcasecmp strrchr getaddrinfo \
-                strnlen malloc])
+                strnlen malloc pthread_mutex_lock])
 
 # Check if -lsocket -lnsl is required (specifically Solaris)
 AC_SEARCH_LIBS([socket], [socket])

--- a/include/coap2/coap_mutex.h
+++ b/include/coap2/coap_mutex.h
@@ -2,6 +2,7 @@
  * coap_mutex.h -- mutex utilities
  *
  * Copyright (C) 2019 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *               2019 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see README for terms
  * of use.
@@ -15,28 +16,14 @@
 #ifndef COAP_MUTEX_H_
 #define COAP_MUTEX_H_
 
-#if defined(RIOT_VERSION)
+/*
+ * Mutexes are currently only used if there is a constrained stack,
+ * and large static variables (instead of the large variable being on
+ * the stack) need to be protected.
+ */
+#if COAP_CONSTRAINED_STACK
 
-#include <mutex.h>
-
-typedef mutex_t coap_mutex_t;
-#define COAP_MUTEX_INITIALIZER MUTEX_INIT
-#define coap_mutex_lock(a) mutex_lock(a)
-#define coap_mutex_trylock(a) mutex_trylock(a)
-#define coap_mutex_unlock(a) mutex_unlock(a)
-
-#elif defined(WITH_CONTIKI)
-
-/* CONTIKI does not support mutex */
-
-typedef int coap_mutex_t;
-#define COAP_MUTEX_INITIALIZER 0
-#define coap_mutex_lock(a) *(a) = 1
-#define coap_mutex_trylock(a) *(a) = 1
-#define coap_mutex_unlock(a) *(a) = 0
-
-#else /* ! RIOT_VERSION && ! WITH_CONTIKI */
-
+#if defined(HAVE_PTHREAD_H) && defined(HAVE_PTHREAD_MUTEX_LOCK)
 #include <pthread.h>
 
 typedef pthread_mutex_t coap_mutex_t;
@@ -45,6 +32,26 @@ typedef pthread_mutex_t coap_mutex_t;
 #define coap_mutex_trylock(a) pthread_mutex_trylock(a)
 #define coap_mutex_unlock(a) pthread_mutex_unlock(a)
 
-#endif /* ! RIOT_VERSION && ! WITH_CONTIKI */
+#elif defined(RIOT_VERSION)
+/* use RIOT's mutex API */
+#include <mutex.h>
+
+typedef mutex_t coap_mutex_t;
+#define COAP_MUTEX_INITIALIZER MUTEX_INIT
+#define coap_mutex_lock(a) mutex_lock(a)
+#define coap_mutex_trylock(a) mutex_trylock(a)
+#define coap_mutex_unlock(a) mutex_unlock(a)
+
+#else
+/* define stub mutex functions */
+typedef int coap_mutex_t;
+#define COAP_MUTEX_INITIALIZER 0
+#define coap_mutex_lock(a) *(a) = 1
+#define coap_mutex_trylock(a) *(a) = 1
+#define coap_mutex_unlock(a) *(a) = 0
+
+#endif /* !RIOT_VERSION && !HAVE_PTHREAD_H && !HAVE_PTHREAD_MUTEX_LOCK */
+
+#endif /* COAP_CONSTRAINED_STACK */
 
 #endif /* COAP_MUTEX_H_ */


### PR DESCRIPTION
This PR proposes a configure-time check for pthread mutexes as discussed in PR #401 which would then be obsolete.