### PR TITLE
encode.c: Support encoding/decoding 8 byte options

### DIFF
--- a/include/coap2/encode.h
+++ b/include/coap2/encode.h
@@ -47,7 +47,7 @@ extern int coap_flsll(long long i);
 
 /**
  * Decodes multiple-length byte sequences. @p buf points to an input byte
- * sequence of length @p length. Returns the decoded value.
+ * sequence of length @p length. Returns the up to 4 byte decoded value.
  *
  * @param buf The input byte sequence to decode from
  * @param length The length of the input byte sequence
@@ -57,12 +57,23 @@ extern int coap_flsll(long long i);
 unsigned int coap_decode_var_bytes(const uint8_t *buf, unsigned int length);
 
 /**
+ * Decodes multiple-length byte sequences. @p buf points to an input byte
+ * sequence of length @p length. Returns the up to 8 byte decoded value.
+ *
+ * @param buf The input byte sequence to decode from
+ * @param length The length of the input byte sequence
+ *
+ * @return      The decoded value
+ */
+uint64_t coap_decode_var_bytes8(const uint8_t *buf, unsigned int length);
+
+/**
  * Encodes multiple-length byte sequences. @p buf points to an output buffer of
- * sufficient length to store the encoded bytes. @p value is the value to
- * encode.
+ * sufficient length to store the encoded bytes. @p value is the 4 byte value
+ * to encode.
  * Returns the number of bytes used to encode @p value or 0 on error.
  *
- * @param buf    The output buffer to decode into
+ * @param buf    The output buffer to encode into
  * @param length The output buffer size to encode into (must be sufficient)
  * @param value  The value to encode into the buffer
  *
@@ -71,6 +82,22 @@ unsigned int coap_decode_var_bytes(const uint8_t *buf, unsigned int length);
 unsigned int coap_encode_var_safe(uint8_t *buf,
                                   size_t length,
                                   unsigned int value);
+
+/**
+ * Encodes multiple-length byte sequences. @p buf points to an output buffer of
+ * sufficient length to store the encoded bytes. @p value is the 8 byte value
+ * to encode.
+ * Returns the number of bytes used to encode @p value or 0 on error.
+ *
+ * @param buf    The output buffer to encode into
+ * @param length The output buffer size to encode into (must be sufficient)
+ * @param value  The value to encode into the buffer
+ *
+ * @return       The number of bytes used to encode @p value or @c 0 on error.
+ */
+unsigned int coap_encode_var_safe8(uint8_t *buf,
+                                  size_t length,
+                                  uint64_t value);
 
 /**
  * @deprecated Use coap_encode_var_safe() instead.

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -32,6 +32,7 @@ global:
   coap_debug_send_packet;
   coap_debug_set_packet_loss;
   coap_decode_var_bytes;
+  coap_decode_var_bytes8;
   coap_delete_all;
   coap_delete_all_resources;
   coap_delete_attr;
@@ -48,6 +49,7 @@ global:
   coap_dtls_is_supported;
   coap_dtls_set_log_level;
   coap_encode_var_safe;
+  coap_encode_var_safe8;
   coap_endpoint_get_session;
   coap_endpoint_set_default_mtu;
   coap_endpoint_str;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -30,6 +30,7 @@ coap_context_set_psk
 coap_debug_send_packet
 coap_debug_set_packet_loss
 coap_decode_var_bytes
+coap_decode_var_bytes8
 coap_delete_all
 coap_delete_all_resources
 coap_delete_attr
@@ -46,6 +47,7 @@ coap_dtls_get_log_level
 coap_dtls_is_supported
 coap_dtls_set_log_level
 coap_encode_var_safe
+coap_encode_var_safe8
 coap_endpoint_get_session
 coap_endpoint_set_default_mtu
 coap_endpoint_str

--- a/src/encode.c
+++ b/src/encode.c
@@ -58,3 +58,33 @@ coap_encode_var_safe(uint8_t *buf, size_t length, unsigned int val) {
   return n;
 }
 
+uint64_t
+coap_decode_var_bytes8(const uint8_t *buf,unsigned int len) {
+  unsigned int i;
+  uint64_t n = 0;
+  for (i = 0; i < len; ++i)
+    n = (n << 8) + buf[i];
+
+  return n;
+}
+
+unsigned int
+coap_encode_var_safe8(uint8_t *buf, size_t length, uint64_t val) {
+  unsigned int n, i;
+  uint64_t tval = val;
+
+  for (n = 0; tval && n < sizeof(val); ++n)
+    tval >>= 8;
+
+  if (n > length) {
+    assert (n <= length);
+    return 0;
+  }
+  i = n;
+  while (i--) {
+    buf[i] = val & 0xff;
+    val >>= 8;
+  }
+
+  return n;
+}


### PR DESCRIPTION
Options such as COAP_OPTION_ETAG are up to 8 bytes in size.  While
being opaque, they can internally be represented as an 8 byte number.

include/coap2/encode.h:
libcoap-2.map:
libcoap-2.sym:
src/encode.c:

Create 8 byte versions coap_decode_var_bytes8() and coap_encode_var_safe8().