### PR TITLE
Add --disable-assert support for the library

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,4 @@
-This is a simple file for all kinds of stuff related on devlopment for
+This is a simple file for all kinds of stuff related on development for
 libcoap. Please append (and remove) any issue you think its worthy.
 
 Classification of issues:
@@ -11,7 +11,6 @@ Classification of issues:
 =================
 * CRITICAL ISSUES
 =================
--> Remove #ifdef HAVE_ASSERT_H and so on from the public headers.
 -> Proxy functionality
  -> A coap-server should be able to act as proxy server
 

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,7 @@ AC_PREREQ([2.64])
 AM_INIT_AUTOMAKE([1.10 -Wall no-define no-dist-gzip dist-bzip2])
 PKG_PROG_PKG_CONFIG([0.20])
 AM_SILENT_RULES([yes])
+AC_HEADER_ASSERT
 
 # Generate one configuration header file for building the library itself with
 # an auto generated template. We need later a second one (include/libcoap.h)

--- a/examples/client.c
+++ b/examples/client.c
@@ -371,12 +371,10 @@ message_handler(struct coap_context_t *ctx,
   unsigned char *databuf;
   coap_tid_t tid;
 
-#ifndef NDEBUG
   coap_log(LOG_DEBUG, "** process incoming %d.%02d response:\n",
            (received->code >> 5), received->code & 0x1F);
   if (coap_get_log_level() < LOG_DEBUG)
     coap_show_pdu(LOG_INFO, received);
-#endif
 
   /* check if this is a response to our original request */
   if (!check_token(received)) {
@@ -1549,11 +1547,9 @@ main(int argc, char **argv) {
     goto finish;
   }
 
-#ifndef NDEBUG
   coap_log(LOG_DEBUG, "sending CoAP request:\n");
   if (coap_get_log_level() < LOG_DEBUG)
     coap_show_pdu(LOG_INFO, pdu);
-#endif
 
   coap_send(session, pdu);
 

--- a/include/coap2/coap_internal.h
+++ b/include/coap2/coap_internal.h
@@ -25,6 +25,14 @@
 #define COAP_INTERNAL_H_
 
 #include "coap_config.h"
+
+/*
+ * Correctly set up assert() based on NDEBUG for libcoap
+ */
+#if defined(HAVE_ASSERT_H) && !defined(assert)
+# include <assert.h>
+#endif
+
 #include "coap.h"
 
 /*

--- a/include/coap2/coap_io.h
+++ b/include/coap2/coap_io.h
@@ -10,7 +10,6 @@
 #ifndef COAP_IO_H_
 #define COAP_IO_H_
 
-#include <assert.h>
 #include <sys/types.h>
 
 #include "address.h"

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -10,7 +10,6 @@
 #ifndef COAP_NET_H_
 #define COAP_NET_H_
 
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #ifndef _WIN32

--- a/include/coap2/resource.h
+++ b/include/coap2/resource.h
@@ -15,8 +15,6 @@
 #ifndef COAP_RESOURCE_H_
 #define COAP_RESOURCE_H_
 
-# include <assert.h>
-
 #ifndef COAP_RESOURCE_CHECK_TIME
 /** The interval in seconds to check if resources have changed. */
 #define COAP_RESOURCE_CHECK_TIME 2

--- a/src/address.c
+++ b/src/address.c
@@ -9,9 +9,6 @@
 #include "coap_internal.h"
 
 #if !defined(WITH_CONTIKI) && !defined(WITH_LWIP)
-#ifdef HAVE_ASSERT_H
-#include <assert.h>
-#endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif

--- a/src/block.c
+++ b/src/block.c
@@ -8,10 +8,6 @@
 
 #include "coap_internal.h"
 
-#if defined(HAVE_ASSERT_H) && !defined(assert)
-# include <assert.h>
-#endif
-
 #ifndef min
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #endif

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -12,10 +12,6 @@
 #define _GNU_SOURCE 1
 #endif
 
-#if defined(HAVE_ASSERT_H) && !defined(assert)
-# include <assert.h>
-#endif
-
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1213,7 +1213,6 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
       }
 
       ((char *)uip_appdata)[len] = 0;
-#ifndef NDEBUG
       if (LOG_DEBUG <= coap_get_log_level()) {
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN 40
@@ -1225,7 +1224,6 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
           coap_log(LOG_DEBUG, "received %zd bytes from %s\n", len, addr_str);
         }
       }
-#endif /* NDEBUG */
 
       packet->length = len;
       memcpy(&packet->payload, uip_appdata, len);

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -964,7 +964,6 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
     goto error;
   }
 
-#ifndef NDEBUG
   if (LOG_DEBUG <= coap_get_log_level()) {
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN 40
@@ -979,7 +978,6 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
         addr_str);
     }
   }
-#endif /* NDEBUG */
 
   ep->sock.flags |= COAP_SOCKET_NOT_EMPTY | COAP_SOCKET_BOUND;
 

--- a/src/encode.c
+++ b/src/encode.c
@@ -8,10 +8,6 @@
 
 #include "coap_internal.h"
 
-#ifndef NDEBUG
-#  include <stdio.h>
-#endif
-
 /* Carsten suggested this when fls() is not available: */
 #ifndef HAVE_FLS
 int coap_fls(unsigned int i) {

--- a/src/mem.c
+++ b/src/mem.c
@@ -9,12 +9,6 @@
 
 #include "coap_internal.h"
 
-#ifdef HAVE_ASSERT_H
-#include <assert.h>
-#else /* HAVE_ASSERT_H */
-#define assert(...)
-#endif /* HAVE_ASSERT_H */
-
 #ifdef HAVE_MALLOC
 #include <stdlib.h>
 

--- a/src/net.c
+++ b/src/net.c
@@ -250,9 +250,7 @@ coap_new_node(void) {
   node = coap_malloc_node();
 
   if (!node) {
-#ifndef NDEBUG
-    coap_log(LOG_WARNING, "coap_new_node: malloc\n");
-#endif
+    coap_log(LOG_WARNING, "coap_new_node: malloc failed\n");
     return NULL;
   }
 
@@ -439,9 +437,7 @@ coap_new_context(
 
 #ifndef WITH_CONTIKI
   if (!c) {
-#ifndef NDEBUG
-    coap_log(LOG_EMERG, "coap_init: malloc:\n");
-#endif
+    coap_log(LOG_EMERG, "coap_init: malloc: failed\n");
     return NULL;
   }
 #endif /* not WITH_CONTIKI */
@@ -2365,7 +2361,6 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
   coap_opt_filter_t opt_filter;
   int is_ping_rst;
 
-#ifndef NDEBUG
   if (LOG_DEBUG <= coap_get_log_level()) {
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN 40
@@ -2380,7 +2375,6 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
             */
     coap_show_pdu(LOG_DEBUG, pdu);
   }
-#endif
 
   memset(opt_filter, 0, sizeof(coap_opt_filter_t));
 

--- a/src/option.c
+++ b/src/option.c
@@ -10,10 +10,6 @@
 
 #include "coap_internal.h"
 
-#if defined(HAVE_ASSERT_H) && !defined(assert)
-# include <assert.h>
-#endif
-
 #include <stdio.h>
 #include <string.h>
 

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -8,10 +8,6 @@
 
 #include "coap_internal.h"
 
-#if defined(HAVE_ASSERT_H) && !defined(assert)
-# include <assert.h>
-#endif
-
 #if defined(HAVE_LIMITS_H)
 #include <limits.h>
 #endif
@@ -122,10 +118,8 @@ coap_pdu_init(uint8_t type, uint8_t code, uint16_t tid, size_t size) {
 coap_pdu_t *
 coap_new_pdu(const struct coap_session_t *session) {
   coap_pdu_t *pdu = coap_pdu_init(0, 0, 0, coap_session_max_pdu_size(session));
-#ifndef NDEBUG
   if (!pdu)
     coap_log(LOG_CRIT, "coap_new_pdu: cannot allocate memory for new PDU\n");
-#endif
   return pdu;
 }
 

--- a/src/resource.c
+++ b/src/resource.c
@@ -898,7 +898,6 @@ coap_remove_failed_observers(coap_context_t *context,
         LL_DELETE(resource->subscribers, obs);
         obs->fail_cnt = 0;
 
-#ifndef NDEBUG
         if (LOG_DEBUG <= coap_get_log_level()) {
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN 40
@@ -909,7 +908,6 @@ coap_remove_failed_observers(coap_context_t *context,
                               addr, INET6_ADDRSTRLEN+8))
             coap_log(LOG_DEBUG, "** removed observer %s\n", addr);
         }
-#endif
         coap_cancel_all_messages(context, obs->session,
                                  obs->token, obs->token_length);
         coap_session_release( obs->session );

--- a/src/str.c
+++ b/src/str.c
@@ -14,9 +14,7 @@ coap_string_t *coap_new_string(size_t size) {
   coap_string_t *s =
             (coap_string_t *)coap_malloc_type(COAP_STRING, sizeof(coap_string_t) + size + 1);
   if ( !s ) {
-#ifndef NDEBUG
-    coap_log(LOG_CRIT, "coap_new_string: malloc\n");
-#endif
+    coap_log(LOG_CRIT, "coap_new_string: malloc: failed\n");
     return NULL;
   }
 

--- a/src/subscribe.c
+++ b/src/subscribe.c
@@ -9,10 +9,6 @@
 
 #include "coap_internal.h"
 
-#if defined(HAVE_ASSERT_H) && !defined(assert)
-# include <assert.h>
-#endif
-
 void
 coap_subscription_init(coap_subscription_t *s) {
   assert(s);

--- a/src/uri.c
+++ b/src/uri.c
@@ -8,10 +8,6 @@
 
 #include "coap_internal.h"
 
-#if defined(HAVE_ASSERT_H) && !defined(assert)
-# include <assert.h>
-#endif
-
 #if defined(HAVE_LIMITS_H)
 #include <limits.h>
 #endif


### PR DESCRIPTION
Let configure enable (the default) or disable assert() code.

configure.ac:

Add in --enable-assert (the default) / --disable-assert support in libcoap.
Previously this was always enabled unless -DNDEBUG was passed in as a compiler
option.  Now NDEBUG is set or unset as appropriate in coap_config.h
This does not affect how assert()s work within the examples etc., only in the
library.

TODO:

HAVE_ASSERT_H is now cleaned up, so remove entry.

include/coap2/coap_internal.h:

Include assert.h for the library.

include/coap2/coap_io.h:
include/coap2/net.h:
include/coap2/resource.h:
src/address.c:
src/block.c:
src/coap_debug.c:
src/encode.c:
src/mem.c:
src/option.c:
src/pdu.c:
src/subscribe.c:
src/uri.c:

Remove un-needed '#include <assert.h>'
Note: address.h and utlist.h still include assert.h as there are assert()
within the header files.

examples/client.c:
src/coap_io.c:
src/coap_session.c:
src/net.c:
src/pdu.c:
src/resource.c:
src/str.c:

Remove any '#ifndef NDEBUG' wrappers for coap_log() output as they were true
before, but may not be now.