### PR TITLE
BUILDING: Update adding Windows build information

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -1,7 +1,34 @@
-To build the libcoap libraries, you need to do the following
+For Windows builds - see the Windows Section
 
-Unpack the distribution package file
-Change into the top level directory of the unpackaged files
+Obtaining the Libcoap Source
+============================
+
+To get the libcoap library source, you need to do either the following
+
+* Obtain the latest distribution package file from
+  https://github.com/obgm/libcoap/archive/develop.zip
+  [There is a stable master version at
+   https://github.com/obgm/libcoap/archive/master.zip]
+* Change to the directory that you want to install the libcoap sub-directory
+  into
+* Unpack the distribution package file
+* Change into the top level directory of the unpackaged files
+
+or alternatively, clone the libcoap git repository from github
+
+* Change to the directory that you want to install the libcoap sub-directory
+  into.
+* Then clone the latest (develop) version of the code:-
+   git clone https://github.com/obgm/libcoap.git
+* Change into the top level directory of the cloned files
+* Optionally, change the branch from develop to the stable master branch:-
+   git checkout master
+
+Building Libcoap Libraries and Examples
+=======================================
+
+Follow the appropriate sections below
+
 
 TinyDTLS Only
 =============
@@ -9,16 +36,16 @@ TinyDTLS Only
 It is possible that you may need to execute the following two commands once to
 get the TinyDTLS code into your project, so the TinyDTLS library can be used.
 
-git submodule init
-git submodule update
+ git submodule init
+ git submodule update
 
 General Building (not for LwIP or Contiki - see below)
 ================
 
-./autogen.sh
-./configure
-make
-sudo make install
+ ./autogen.sh
+ ./configure
+ make
+ sudo make install
 
 ./autogen.sh will fail if there is a required package for buildling libcoap
 that is missing. Install the missing package and try ./autogen.sh again.
@@ -32,26 +59,26 @@ disable some building of documentation.
 General configure instructions can be found in INSTALL, which is built
 by ./autogen.sh
 
-./configure --help
+ ./configure --help
 gives the specific options available to libcoap.
 
 Some examples are:-
 
 # No DTLS
-./configure --enable-tests --disable-documentation --enable-examples --disable-dtls --enable-shared
+ ./configure --enable-tests --disable-documentation --enable-examples --disable-dtls --enable-shared
 
 # With TinyDTLS
-./configure --enable-tests --disable-documentation --enable-examples --with-tinydtls --enable-shared
+ ./configure --enable-tests --disable-documentation --enable-examples --with-tinydtls --enable-shared
 
 Note: FreeBSD requires gmake instead of make when building TinyDTLS - i.e.
-gmake
-sudo gmake install
+ gmake
+ sudo gmake install
 
 # With OpenSSL
-./configure --with-openssl --enable-tests --enable-shared
+ ./configure --with-openssl --enable-tests --enable-shared
 
 # With GnuTLS
-./configure --with-gnutls --enable-tests --enable-shared
+ ./configure --with-gnutls --enable-tests --enable-shared
 
 Note: --disable-documentation disables the building of doxygen and man page
 files.  If you want to only disable one of them, use --disable-doxygen or
@@ -61,26 +88,46 @@ the program a2x to build the appropriate files.
 If you need to rebuild the libcoap-*.{map,sym} files to update any exposed
 function changes, run
 
-make update-map-file
+ make update-map-file
 
 prior to running 'make'.
 
 LwIP
 ====
 
-./autogen.sh
-./configure --disable-tests --disable-documentation --disable-examples --disable-dtls
-cd examples/lwip
-make
+ ./autogen.sh
+ ./configure --disable-tests --disable-documentation --disable-examples --disable-dtls
+ cd examples/lwip
+ make
 
 Executable is ./server. See examples/lwip/README for further information
 
 Contiki
 =======
 
-./autogen.sh
-./configure --disable-tests --disable-documentation --disable-examples --disable-dtls
-cd examples/contiki
-make
+ ./autogen.sh
+ ./configure --disable-tests --disable-documentation --disable-examples --disable-dtls
+ cd examples/contiki
+ make
 
-Executable is ./server.minimal-net. See examples/contiki/README for further information
+Executable is ./server.minimal-net. See examples/contiki/README for further
+information
+
+Windows
+=======
+
+Install OpenSSL (minimum version 1.1.0) including the development libraries if
+not already installed.
+
+Within Visual Studio, "Clone or check out code" using the repository
+https://github.com/obgm/libcoap.git
+
+You may need to update the SDK version of the libcoap Windows Project files to
+match that of the SDK version of the Visual Studio you are using.  In Solution
+Explorer with the view set to libcoap.sln, right click "Solution 'libcoap'"
+and then "Retarget solution".
+
+You may need to edit win32\libcoap.props to update the OpenSSLRootDir and
+OpenSSLRootDirDbg variables to point to the top level directory where OpenSSL
+is installed so that the include, lib etc. directories are correctly set up.
+Note: Make sure that you include a trailing \ in the variable definitions.


### PR DESCRIPTION
Add in instructions as to how to build libcoap on a Windows platform
as well as update the other information with how to get the libcoap
code.

See question initially raised in #267