### PR TITLE
OpenSSL: Update ciphers

### DIFF
--- a/include/coap2/coap_debug.h
+++ b/include/coap2/coap_debug.h
@@ -36,8 +36,14 @@
  * Logging type.  One of LOG_* from @b syslog.
  */
 typedef short coap_log_t;
+/*
+   LOG_DEBUG+2 gives ciphers in GnuTLS
+   Use COAP_LOG_CIPHERS to output Cipher Info in OpenSSL etc.
+ */
+#define COAP_LOG_CIPHERS (LOG_DEBUG+2)
 #else
-/** Pre-defined log levels akin to what is used in \b syslog. */
+/** Pre-defined log levels akin to what is used in \b syslog
+    with LOG_CIPHERS added. */
 typedef enum {
   LOG_EMERG=0, /**< Emergency */
   LOG_ALERT,   /**< Alert */
@@ -46,7 +52,8 @@ typedef enum {
   LOG_WARNING, /**< Warning */
   LOG_NOTICE,  /**< Notice */
   LOG_INFO,    /**< Information */
-  LOG_DEBUG    /**< Debug */
+  LOG_DEBUG,   /**< Debug */
+  COAP_LOG_CIPHERS=LOG_DEBUG+2 /**< CipherInfo */
 } coap_log_t;
 #endif
 

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -98,7 +98,7 @@ OPTIONS - General
 
 *-v* num::
    The verbosity level to use (default 3, maximum is 9). Above 7, there is
-   increased verbosity in GnuTLS logging.
+   increased verbosity in GnuTLS and OpenSSL logging.
 
 *-A* type::
    Accepted media type. 'type' must be either a numeric value reflecting a

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -35,7 +35,7 @@ OPTIONS
 
 *-v* num::
    The verbosity level to use (default: 3, maximum is 9). Above 7, there is
-   increased verbosity in GnuTLS logging.
+   increased verbosity in GnuTLS and OpenSSL logging.
 
 EXAMPLES
 --------

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -50,7 +50,7 @@ OPTIONS - General
 
 *-v* num::
    The verbosity level to use (default 3, maximum is 9). Above 7, there is
-   increased verbosity in GnuTLS logging.
+   increased verbosity in GnuTLS and OpenSSL logging.
 
 *-A* addr::
    The local address of the interface which the server has to listen.

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -69,7 +69,7 @@ coap_set_log_level(coap_log_t level) {
 
 /* this array has the same order as the type log_t */
 static const char *loglevels[] = {
-  "EMRG", "ALRT", "CRIT", "ERR ", "WARN", "NOTE", "INFO", "DEBG"
+  "EMRG", "ALRT", "CRIT", "ERR ", "WARN", "NOTE", "INFO", "DEBG", "????", "CIPH"
 };
 
 #ifdef HAVE_TIME_H
@@ -791,7 +791,7 @@ coap_log_impl(coap_log_t level, const char *format, ...) {
     if (print_timestamp(timebuf,sizeof(timebuf), now))
       fprintf(log_fd, "%s ", timebuf);
 
-    if (level <= LOG_DEBUG)
+    if (level <= COAP_LOG_CIPHERS)
       fprintf(log_fd, "%s ", loglevels[level]);
 
     va_start(ap, format);


### PR DESCRIPTION
src/coap_openssl.c:

Remove NULL as a valid cipher from the cipher list.

Add in TLSv1.3 ciphers if OpenSSL 1.1.1 (they are already included in
TLSv1.2 definition, but this is to document this is happening).

Remove the TLSv1.0 deprecated ciphers.

Cipher strings can now be overridden during compilation by
using -DCOAP_OPENSSL_CIPHERS=xxx compiler option where xxx is the 
cipher string as defined in 
https://www.openssl.org/docs/man1.1.0/man1/ciphers.html

Explicit PSK cipher strings can now be overridden during compilation
by using -DCOAP_OPENSSL_PSK_CIPHERS=xxx compiler option where xxx is the
cipher string.

Log the client ciphers presented, and the cipher chosen.

include/coap2/coap_debug.h:
src/coap_debug.c:

Add in LOG_CIPHERS as a debug level (value 9) which matches getting the
cipher information reported in GnuTLS.