### PR TITLE
bugfix: ea72c3d7 outstanding CON requests limitation may drop new request.

### DIFF
--- a/src/resource.c
+++ b/src/resource.c
@@ -760,8 +760,11 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r) {
         continue;
       if (obs->session->con_active >= COAP_DEFAULT_NSTART &&
           ((r->flags & COAP_RESOURCE_FLAGS_NOTIFY_CON) ||
-           (obs->non_cnt >= COAP_OBS_MAX_NON)))
+           (obs->non_cnt >= COAP_OBS_MAX_NON))) {
+        r->partiallydirty = 1;
+        obs->dirty = 1;
         continue;
+      }
 
       coap_tid_t tid = COAP_INVALID_TID;
       obs->dirty = 0;


### PR DESCRIPTION
The r->partiallydirty is set to 0 before the limitation. A new
request will be dropped when last request hasn't receive it's ACK.
Restore r->partiallydirty to 1 in the condition.