### PR TITLE
Coverity Scan: Fix CID 1484381, 1484382, 1484383 and 1484385

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -416,6 +416,8 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
   coap_session_state_t state = session->state;
 #endif /* !COAP_DISABLE_TCP */
 
+  /* Fix CID 1484385 */
+  coap_session_reference(session);
   coap_log(LOG_DEBUG, "***%s: session disconnected (reason %d)\n",
            coap_session_str(session), reason);
 #ifndef WITHOUT_OBSERVE
@@ -486,6 +488,7 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
     }
   }
 #endif /* !COAP_DISABLE_TCP */
+  coap_session_release(session);
 }
 
 coap_session_t *

--- a/src/resource.c
+++ b/src/resource.c
@@ -645,6 +645,8 @@ coap_add_observer(coap_resource_t *resource,
 
   assert( session );
 
+  /* Fix CID 1484383 */
+  coap_session_reference(session);
   /* Check if there is already a subscription for this peer. */
   s = coap_find_observer(resource, session, token);
   if (!s) {
@@ -668,6 +670,8 @@ coap_add_observer(coap_resource_t *resource,
       coap_delete_string(s->query);
     s->query = query;
     s->code = code;
+    /* Fix CID 1484383 bump of session ref */
+    coap_session_release(session);
     return s;
   }
 
@@ -678,11 +682,15 @@ coap_add_observer(coap_resource_t *resource,
     /* query is not deleted so it can be used in the calling function
      * which must give up ownership of query only if this function
      * does not return NULL. */
+    /* Fix CID 1484383 bump of session ref */
+    coap_session_release(session);
     return NULL;
   }
 
   coap_subscription_init(s);
   s->session = coap_session_reference( session );
+  /* Fix CID 1484383 bump of session ref */
+  coap_session_release(session);
 
   if (token && token->length) {
     s->token_length = token->length;


### PR DESCRIPTION
All fixed by wrapping potential session free functions using
coap_session_reference() and coap_session_release() wrappers.

src/coap_session.c:

CID 1484385 fix for coap_session_disconnected().

src/net.c:

CID 1484381 fix for coap_dispatch(). Move coap_cancel() to later in the
code as well.
CID 1484382 fix for coap_read_endpoint().

src/resource.c:

CID 1484383 fix for coap_add_observer().

Addresses #382 