### PR TITLE
coap_gnutls.c: Fix potential spin in DTLS retransmit timeout loop

### DIFF
--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -30,6 +30,16 @@ struct coap_dtls_pki_t;
 #define COAP_DTLS_HINT_LENGTH 128
 #endif
 
+/* https://tools.ietf.org/html/rfc6347#section-4.2.4.1 */
+#ifndef COAP_DTLS_RETRANSMIT_MS
+#define COAP_DTLS_RETRANSMIT_MS 1000
+#endif
+#ifndef COAP_DTLS_RETRANSMIT_TOTAL_MS
+#define COAP_DTLS_RETRANSMIT_TOTAL_MS 60000
+#endif
+
+#define COAP_DTLS_RETRANSMIT_COAP_TICKS (COAP_DTLS_RETRANSMIT_MS * COAP_TICKS_PER_SECOND / 1000)
+
 /**
  * Check whether DTLS is available.
  *


### PR DESCRIPTION
coap_dtls_get_timeout() may continue to return 'now' if the underlying
GnuTLS library gets confused by duplicate packets and so clears out
the data is to be retransmitted flag.  If there is a DTLS timeout retry, the
underlying logic does not reset 'last retransmit' on retrying the re-send
of the (now) non-existent data, so causing a spin in the coap_write() logic.

src/coap_gnutls.c:

This fix is to return 'now+dtls_timout' on the second and subsequents attempts 
to return 'now'.

include/coap2/coap_dtls.h:

Make use of the new #defines that #353 is using so that this code compiles.