### PR TITLE
Windows: Update code to build on Windows

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -21,6 +21,15 @@
 #if !defined(S_ISDIR)
 #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 #endif
+static char* strndup(const char* s1, size_t n)
+{
+  char* copy = (char*)malloc(n + 1);
+  if (copy) {
+    memcpy(copy, s1, n);
+    copy[n] = 0;
+  }
+  return copy;
+};
 #else
 #include <unistd.h>
 #include <sys/select.h>

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -23,6 +23,18 @@
 #if !defined(S_ISDIR)
 #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 #endif
+#ifndef R_OK
+#define R_OK 4
+#endif
+static char* strndup(const char* s1, size_t n)
+{
+  char* copy = (char*)malloc(n + 1);
+  if (copy) {
+    memcpy(copy, s1, n);
+    copy[n] = 0;
+  }
+  return copy;
+};
 #else
 #include <unistd.h>
 #include <sys/select.h>

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -60,6 +60,10 @@
 #define UNUSED
 #endif /* __GNUC__ */
 
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#endif
+
 /* RFC6091/RFC7250 */
 #ifndef TLSEXT_TYPE_client_certificate_type
 #define TLSEXT_TYPE_client_certificate_type 19


### PR DESCRIPTION
Add in specific _WIN32 definitions for the missing functionality from
recent PR updates.

R_OK (used by access())
strndup()
strcasecmp()