### PR TITLE
coap-server: Make sure observe updates are sent off asap

### DIFF
--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -205,6 +205,7 @@ typedef struct coap_context_t {
   unsigned int max_handshake_sessions; /**< Maximum number of simultaneous negotating sessions per endpoint. 0 means use default. */
   unsigned int ping_timeout;           /**< Minimum inactivity time before sending a ping message. 0 means disabled. */
   unsigned int csm_timeout;           /**< Timeout for waiting for a CSM from the remote side. 0 means disabled. */
+  int observe_pending;             /**< Observe response pending */
 
   void *app;                       /**< application-specific data */
 #ifdef COAP_EPOLL_SUPPORT

--- a/include/coap2/resource.h
+++ b/include/coap2/resource.h
@@ -119,6 +119,11 @@ typedef struct coap_resource_t {
   unsigned int observe;
 
   /**
+   * Pointer back to the context that 'owns' this resource.
+   */
+  coap_context_t *context;
+
+  /**
    * This pointer is under user control. It can be used to store context for
    * the coap handler.
    */

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -22,12 +22,12 @@ SYNOPSIS
 int _mode_);*
 
 *int coap_resource_notify_observers(coap_resource_t *_resource_,
-const const_string_t *_query_);*
+const coap_string_t *_query_);*
 
-*const coap_string_t *coap_resource_get_uri_path(coap_resource_t *_resource_);*
+*coap_str_const_t *coap_resource_get_uri_path(coap_resource_t *_resource_);*
 
 *coap_subscription_t *coap_find_observer(coap_resource_t *_resource_,
-coap_session_t *_session_, const const_string_t *_token_);*
+coap_session_t *_session_, const coap_binary_t *_token_);*
 
 *int coap_delete_observer(coap_resource_t *_resource_, coap_session_t *_session_,
 const coap_binary_t *_token_);*
@@ -264,10 +264,12 @@ int main(int argc, char *argv[]){
   coap_endpoint_t *ep = NULL;
   coap_address_t addr;
   unsigned wait_ms;
-  time_t t_last = 0;
+  struct timeval tv_last = {0, 0};
   /* Remove (void) definition if variable is used */
   (void)argc;
   (void)argv;
+
+  memset (&tv_last, 0, sizeof(tv_last));
 
   /* Create the libcoap context */
   ctx = coap_new_context(NULL);
@@ -299,17 +301,21 @@ int main(int argc, char *argv[]){
        * the granularity of the timer in coap_io_process() and hence
        * result == 0)
        */
-      time_t t_now = time(NULL);
-      if (t_last != t_now) {
-        /* Happens once per second */
-        t_last = t_now;
-        if (time_resource) {
+      wait_ms = COAP_RESOURCE_CHECK_TIME * 1000;
+    }
+    if (time_resource) {
+      struct timeval tv_now;
+      if (gettimeofday (&tv_now, NULL) == 0) {
+        if (tv_last.tv_sec != tv_now.tv_sec) {
+          /* Happens once per second */
+          tv_last = tv_now;
           coap_resource_notify_observers(time_resource, NULL);
         }
-      }
-      if (result) {
-        /* result must have been >= wait_ms, so reset wait_ms */
-        wait_ms = COAP_RESOURCE_CHECK_TIME * 1000;
+        /* need to wait until next second starts if wait_ms is too large */
+        unsigned next_sec_ms = 1000 - (tv_now.tv_usec / 1000);
+
+        if (next_sec_ms && next_sec_ms < wait_ms)
+          wait_ms = next_sec_ms;
       }
     }
   }


### PR DESCRIPTION
examples/coap-server.c:

Track time spent in the epoll branch for the select() and coap_io_Process()
calls to correctly adjust wait_ms.

Adjust wait_ms to be the remaining amount in the current second, so that
any 'time' observers get the updated time just after the new second starts.

include/coap2/net.h:

Add in support to track that an observe is pending transmission - primarily
a saving of needing to look up if a observe needs to be sent.

include/coap2/resource.h:

Add in support to track the context that 'owns' a resource.

src/resource.c:

Track the context that 'owns' a resource in coap_add_resource().

Track the fact that when we are making a resource partially dirty by recording
that an observe is pending in coap_notify_observers().

In the epoll case, make sure that timerfd triggers immediately when a pending
observe is set so that the application will return immediately from any select()
etc. call to process the libcoap outstanding activity (in particular pending
observes) in coap_resource_notify_observers().

Only call coap_notify_observers() in coap_check_notify if there are any
observes pending.

man/coap_observe.txt.in:

Minor clarifications in the examples.