### PR TITLE
Remove man page coap_session_str definition duplications

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -60,7 +60,9 @@ A2X_EXTRA_PAGES = @DOLLAR_SIGN@(shell for fil in $(TXT3) ; do sed -ne '/^NAME/,/
 
 # Extra man pages that need to be installed due to limit of 10
 # names built by a2x
+#
 # These files are created in install-man
+#
 EXTRA_PAGES = \
 	coap_context_set_pki_root_cas.3 \
 	coap_add_data_blocked_response.3 \
@@ -69,13 +71,17 @@ EXTRA_PAGES = \
 	coap_split_query.3 \
 	coap_session_get_app_data.3 \
 	coap_session_set_app_data.3 \
-	coap_endpoint_str.3
+	coap_is_tcp_supported.3 \
+	coap_endpoint_str.3 \
+	coap_session_str.3
 
 # a2x builds alternative .3 files up to a limit of 10 names from the
 # NAME section, so that 'man' works against the alternative different
 # function names.
+#
 # However, if there are more alternative names, they need to be defined
-# as per below.
+# as per below as well as in EXTRA_PAGES above.
+#
 # Then all the alternative names as well as the extras defined below need
 # to be cleaned up in a 'make unistall'.
 install-man: install-man3 install-man5 install-man7
@@ -86,6 +92,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_pdu_setup.3" > coap_split_query.3
 	@echo ".so man3/coap_session.3" > coap_session_get_app_data.3
 	@echo ".so man3/coap_session.3" > coap_session_set_app_data.3
+	@echo ".so man3/coap_session.3" > coap_is_tcp_supported.3
 	@echo ".so man3/coap_logging.3" > coap_endpoint_str.3
 	@echo ".so man3/coap_logging.3" > coap_session_str.3
 	$(INSTALL_DATA) $(EXTRA_PAGES) $(A2X_EXTRA_PAGES) "$(DESTDIR)$(man3dir)"

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -17,8 +17,8 @@ coap_new_client_session_pki,
 coap_session_reference,
 coap_session_release,
 coap_session_set_mtu,
-coap_session_max_pdu_size,
-coap_session_str - Work with CoAP sessions
+coap_session_max_pdu_size
+- Work with CoAP sessions
 
 SYNOPSIS
 --------
@@ -48,7 +48,7 @@ _proto_, coap_dtls_pki_t *_setup_data_);*
 
 *void *coap_session_get_app_data(const coap_session_t *_session_);*
 
-*const char *coap_session_str(const coap_session_t *_session_);*
+*int coap_tcp_is_supported(void);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
 *-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*
@@ -123,6 +123,12 @@ COAP_PROTO_TCP
 COAP_PROTO_TLS
 ----
 
+The *coap_tcp_is_supported*() function returns 1 if support for TCP is
+enabled, otherwise 0. Likewise *coap_dtls_is_supported*() and
+*coap_tls_is_supported*() can be used for checking whether the underlying
+(D)TLS protocol support is available.  See *coap_tls_library(3)* for further
+information.
+
 The *coap_new_client_session*() function initiates a new client session
 associated with _context_ to the specified _server_ using the CoAP protocol
 _proto_.  If the port is not specified in _server_, then the default CoAP
@@ -175,9 +181,6 @@ for the _session_ which can then be retrieved at a later date.
 The *coap_session_get_app_data*() function is used to retrieve the data
 pointer previously defined by *coap_session_set_app_data*().
 
-The *coap_session_str*() function is used to get a string containing the
-information about the _session_.
-
 RETURN VALUES
 -------------
 *coap_new_client_session*(), *coap_new_client_session_psk2*(),
@@ -190,8 +193,8 @@ session or NULL if there is a creation failure.
 
 *coap_session_max_pdu_size*() function returns the MTU size.
 
-*coap_session_str*() function returns a description string of the
-session.
+The *coap_tcp_is_supported*() function returns 1 if support for TCP is
+enabled, otherwise 0.
 
 EXAMPLES
 --------

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -12,7 +12,7 @@ NAME
 ----
 coap_tls_library, coap_dtls_is_supported, coap_tls_is_supported,
 coap_get_tls_library_version, coap_string_tls_version, coap_show_tls_version
-- Work with CoAP contexts
+- Work with CoAP TLS libraries
 
 SYNOPSIS
 --------
@@ -112,7 +112,7 @@ and library version in a coap_tls_version_t* structure.
 
 SEE ALSO
 --------
-*coap_context*(3) and *coap_logging*(3).
+*coap_encryption*(3).
 
 FURTHER INFORMATION
 -------------------


### PR DESCRIPTION
coap_session_str(3) is defined in both coap_session.txt.in and
coap_logging.txt.in.  This fix removes the duplicate so that it is
only part of coap_logging.txt.in.

man/Makefile.am:

Correct EXTRA_PAGES definition.

man/coap_session.txt.in:

Remove references to coap_session_str definitions.