### PR TITLE
Windows C4267 errors: Fix size_t conversion warnings in windows builds

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -194,7 +194,7 @@ coap_new_request(coap_context_t *ctx,
       unsigned char buf[4];
       coap_add_option(pdu,
                       COAP_OPTION_SIZE1,
-                      coap_encode_var_safe(buf, sizeof(buf), length),
+                      coap_encode_var_safe8(buf, sizeof(buf), length),
                       buf);
 
       coap_add_block(pdu, length, data, block.num, block.szx);
@@ -314,7 +314,7 @@ resolve_address(const coap_str_const_t *server, struct sockaddr *dst) {
     switch (ainfo->ai_family) {
     case AF_INET6:
     case AF_INET:
-      len = ainfo->ai_addrlen;
+      len = (int)ainfo->ai_addrlen;
       memcpy(dst, ainfo->ai_addr, len);
       goto finish;
     default:
@@ -572,7 +572,7 @@ message_handler(struct coap_context_t *ctx,
 
           coap_add_option(pdu,
                           COAP_OPTION_SIZE1,
-                          coap_encode_var_safe(buf, sizeof(buf), payload.length),
+                          coap_encode_var_safe8(buf, sizeof(buf), payload.length),
                           buf);
 
           coap_add_block(pdu,
@@ -906,7 +906,7 @@ set_blocksize(void) {
     opt = method == COAP_REQUEST_GET ? COAP_OPTION_BLOCK2 : COAP_OPTION_BLOCK1;
 
     block.m = (opt == COAP_OPTION_BLOCK1) &&
-      ((1u << (block.szx + 4)) < payload.length);
+      ((1ull << (block.szx + 4)) < payload.length);
 
     opt_length = coap_encode_var_safe(buf, sizeof(buf),
           (block.num << 4 | block.m << 3 | block.szx));
@@ -1078,7 +1078,7 @@ decode_segment(const uint8_t *seg, size_t length, unsigned char *buf) {
 static int
 check_segment(const uint8_t *s, size_t length) {
 
-  size_t n = 0;
+  int n = 0;
 
   while (length) {
     if (*s == '%') {
@@ -1458,7 +1458,7 @@ get_session(
       coap_address_t bind_addr;
       if ( rp->ai_addrlen <= sizeof( bind_addr.addr ) ) {
         coap_address_init( &bind_addr );
-        bind_addr.size = rp->ai_addrlen;
+        bind_addr.size = (socklen_t)rp->ai_addrlen;
         memcpy( &bind_addr.addr, rp->ai_addr, rp->ai_addrlen );
         session = open_session(ctx, proto, &bind_addr, dst,
                                identity, identity_len, key, key_len);

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -723,7 +723,7 @@ get_context(const char *node, const char *port) {
 
     if (rp->ai_addrlen <= sizeof(addr.addr)) {
       coap_address_init(&addr);
-      addr.size = rp->ai_addrlen;
+      addr.size = (socklen_t)rp->ai_addrlen;
       memcpy(&addr.addr, rp->ai_addr, rp->ai_addrlen);
       addrs = addr;
       if (addr.addr.sa.sa_family == AF_INET) {

--- a/include/coap2/block.h
+++ b/include/coap2/block.h
@@ -133,7 +133,7 @@ int coap_write_block_opt(coap_block_t *block,
  * @return          @c 1 on success, @c 0 otherwise.
  */
 int coap_add_block(coap_pdu_t *pdu,
-                   unsigned int len,
+                   size_t len,
                    const uint8_t *data,
                    unsigned int block_num,
                    unsigned char block_szx);

--- a/include/coap2/coap_hashkey.h
+++ b/include/coap2/coap_hashkey.h
@@ -31,7 +31,7 @@ typedef unsigned char coap_key_t[4];
  * @param len The length of @p s.
  * @param h   The result buffer to store the calculated hash key.
  */
-void coap_hash_impl(const unsigned char *s, unsigned int len, coap_key_t h);
+void coap_hash_impl(const unsigned char *s, size_t len, coap_key_t h);
 
 #define coap_hash(String,Length,Result) \
   coap_hash_impl((String),(Length),(Result))

--- a/src/block.c
+++ b/src/block.c
@@ -122,7 +122,7 @@ coap_write_block_opt(coap_block_t *block, uint16_t type,
 }
 
 int
-coap_add_block(coap_pdu_t *pdu, unsigned int len, const uint8_t *data,
+coap_add_block(coap_pdu_t *pdu, size_t len, const uint8_t *data,
                unsigned int block_num, unsigned char block_szx) {
   unsigned int start;
   start = block_num << (block_szx + 4);
@@ -131,7 +131,7 @@ coap_add_block(coap_pdu_t *pdu, unsigned int len, const uint8_t *data,
     return 0;
 
   return coap_add_data(pdu,
-                       min(len - start, (1U << (block_szx + 4))),
+                       min(len - start, (1ULL << (block_szx + 4))),
                        data + start);
 }
 
@@ -223,7 +223,7 @@ coap_add_data_blocked_response(coap_resource_t *resource,
 
     coap_add_option(response,
                     COAP_OPTION_SIZE2,
-                    coap_encode_var_safe(buf, sizeof(buf), length),
+                    coap_encode_var_safe8(buf, sizeof(buf), length),
                     buf);
 
     coap_add_block(response, length, data,
@@ -244,7 +244,7 @@ coap_add_data_blocked_response(coap_resource_t *resource,
 
     coap_add_option(response,
                     COAP_OPTION_SIZE2,
-                    coap_encode_var_safe(buf, sizeof(buf), length),
+                    coap_encode_var_safe8(buf, sizeof(buf), length),
                     buf);
 
     coap_add_block(response, length, data,

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -468,7 +468,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
   int content_format = -1;
   size_t data_len;
   unsigned char *data;
-  int outbuflen = 0;
+  size_t outbuflen = 0;
 
   /* Save time if not needed */
   if (level > coap_get_log_level())
@@ -601,7 +601,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
     snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  " :: ");
 
     if (is_binary(content_format)) {
-      int keep_data_len = data_len;
+      size_t keep_data_len = data_len;
       uint8_t *keep_data = data;
 
       outbuflen = strlen(outbuf);

--- a/src/coap_hashkey.c
+++ b/src/coap_hashkey.c
@@ -9,7 +9,7 @@
 #include "coap_internal.h"
 
 void
-coap_hash_impl(const unsigned char *s, unsigned int len, coap_key_t h) {
+coap_hash_impl(const unsigned char *s, size_t len, coap_key_t h) {
   size_t j;
 
   while (len--) {

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -877,7 +877,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
       if (!dst_found) {
         /* Not expected, but cmsg_level and cmsg_type don't match above and
            may need a new case */
-        packet->ifindex = sock->fd;
+        packet->ifindex = (int)sock->fd;
         if (getsockname(sock->fd, &packet->addr_info.local.addr.sa,
             &packet->addr_info.local.size) < 0) {
           coap_log(LOG_DEBUG, "Cannot determine local port\n");
@@ -1263,7 +1263,7 @@ coap_io_process_with_fds(coap_context_t *ctx, unsigned int timeout_ms,
     tv.tv_sec = (long)(timeout / 1000);
   }
 
-  result = select(nfds, &readfds, &writefds, &exceptfds, timeout > 0 ? &tv : NULL);
+  result = select((int)nfds, &readfds, &writefds, &exceptfds, timeout > 0 ? &tv : NULL);
 
   if (result < 0) {   /* error */
 #ifdef _WIN32

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -372,7 +372,7 @@ coap_dtls_verify_cookie(SSL *ssl,
     return 0;
 }
 
-static unsigned
+static unsigned int
 coap_dtls_psk_client_callback(
   SSL *ssl,
   const char *hint,
@@ -439,7 +439,7 @@ coap_dtls_psk_client_callback(
     c_session->psk_key = coap_new_bin_const(psk_info->key.s, psk_len);
     memcpy(psk, psk_info->key.s, psk_len);
 
-    return psk_len;
+    return (unsigned int)psk_len;
   }
   psk_len = c_session->context->get_client_psk(c_session,
                                                (const uint8_t*)hint,
@@ -453,7 +453,7 @@ coap_dtls_psk_client_callback(
   return (unsigned)psk_len;
 }
 
-static unsigned
+static unsigned int
 coap_dtls_psk_server_callback(
   SSL *ssl,
   const char *identity,
@@ -500,7 +500,7 @@ coap_dtls_psk_server_callback(
       return 0;
     memcpy(psk, psk_key->s, psk_key->length);
     coap_session_refresh_psk_key(c_session, psk_key);
-    return psk_key->length;
+    return (unsigned int)psk_key->length;
   }
 
   return (unsigned)c_session->context->get_server_psk(c_session,
@@ -1267,7 +1267,7 @@ setup_pki_ssl(SSL *ssl,
         setup_data->pki_key.key.asn1.public_cert_len > 0) {
       if (!(SSL_use_certificate_ASN1(ssl,
                            setup_data->pki_key.key.asn1.public_cert,
-                           setup_data->pki_key.key.asn1.public_cert_len))) {
+                           (int)setup_data->pki_key.key.asn1.public_cert_len))) {
         coap_log(LOG_WARNING,
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "%s Certificate\n",
@@ -1289,7 +1289,7 @@ setup_pki_ssl(SSL *ssl,
       int pkey_type = map_key_type(setup_data->pki_key.key.asn1.private_key_type);
       if (!(SSL_use_PrivateKey_ASN1(pkey_type, ssl,
                         setup_data->pki_key.key.asn1.private_key,
-                        setup_data->pki_key.key.asn1.private_key_len))) {
+                        (long)setup_data->pki_key.key.asn1.private_key_len))) {
         coap_log(LOG_WARNING,
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "%s Private Key\n",
@@ -1310,7 +1310,7 @@ setup_pki_ssl(SSL *ssl,
         setup_data->pki_key.key.asn1.ca_cert_len > 0) {
       /* Need to use a temp variable as it gets incremented*/
       const uint8_t *p = setup_data->pki_key.key.asn1.ca_cert;
-      X509* x509 = d2i_X509(NULL, &p, setup_data->pki_key.key.asn1.ca_cert_len);
+      X509* x509 = d2i_X509(NULL, &p, (long)setup_data->pki_key.key.asn1.ca_cert_len);
       X509_STORE *st;
       SSL_CTX *ctx = SSL_get_SSL_CTX(ssl);
 
@@ -1372,7 +1372,7 @@ get_san_or_cn_from_cert(X509* x509) {
     X509_NAME_oneline(X509_get_subject_name(x509), buffer, sizeof(buffer));
 
     /* Need to emulate strcasestr() here.  Looking for CN= */
-    n = strlen(buffer) - 3;
+    n = (int)strlen(buffer) - 3;
     cn = buffer;
     while (n > 0) {
       if (((cn[0] == 'C') || (cn[0] == 'c')) &&
@@ -1830,7 +1830,7 @@ tls_client_hello_call_back(SSL *ssl,
   if ((session->psk_key) ||
       (session->context->spsk_setup_data.psk_info.key.s &&
        session->context->spsk_setup_data.psk_info.key.length)) {
-    int len = SSL_client_hello_get0_ciphers(ssl, &out);
+    size_t len = SSL_client_hello_get0_ciphers(ssl, &out);
     STACK_OF(SSL_CIPHER) *peer_ciphers = NULL;
     STACK_OF(SSL_CIPHER) *scsvc = NULL;
 

--- a/src/net.c
+++ b/src/net.c
@@ -1942,7 +1942,7 @@ coap_wellknown_response(coap_context_t *context, coap_session_t *session,
        changes over time */
     coap_add_option(resp,
                     COAP_OPTION_ETAG,
-                    coap_encode_var_safe(buf, sizeof(buf), wkc_len),
+                    coap_encode_var_safe8(buf, sizeof(buf), wkc_len),
                     buf);
   }
 
@@ -1966,7 +1966,7 @@ coap_wellknown_response(coap_context_t *context, coap_session_t *session,
 
   coap_add_option(resp,
                   COAP_OPTION_SIZE2,
-                  coap_encode_var_safe(buf, sizeof(buf), wkc_len),
+                  coap_encode_var_safe8(buf, sizeof(buf), wkc_len),
                   buf);
 
   len = need_block2 ?


### PR DESCRIPTION
examples/client.c:
examples/coap-rd.c:
examples/coap-server.c:
include/coap2/block.h:
include/coap2/coap_hashkey.h:
src/block.c:
src/coap_debug.c:
src/coap_hashkey.c:
src/coap_io.c:
src/coap_openssl.c:
src/net.c:

Fix C4267 windows compilation warnings when using Visual Studio where
size_t variable parameters are being converted  in both size and sign.

There still are some C4116 warnings to fix.