### PR TITLE
coap_openssl.c: OpenSSL < 1.1.1 fails to build with --disable-tcp

### DIFF
--- a/doc/main.md
+++ b/doc/main.md
@@ -4,7 +4,7 @@ libcoap                         {#mainpage}
 A C implementation of the Constrained Application Protocol (RFC 7252)
 =====================================================================
 
-Copyright (C) 2010--2019 by Olaf Bergmann <bergmann@tzi.org> and others
+Copyright (C) 2010--2020 by Olaf Bergmann <bergmann@tzi.org> and others
 
 About libcoap
 =============

--- a/include/coap2/coap_tcp_internal.h
+++ b/include/coap2/coap_tcp_internal.h
@@ -18,11 +18,27 @@
 #include "coap_io.h"
 
 /**
- * @defgroup tcp TCP Support
- * Internal API functions for interfacing with the system TCP stack.
+ * @defgroup tcp TCP Support (Internal)
+ * API functions for interfacing with the system TCP stack.
  * @{
  */
 
+/**
+ * Create a new TCP socket and initiate the connection
+ *
+ * Internal function.
+ *
+ * @param sock Where socket information is to be filled in
+ * @param local_if The local address to use or NULL
+ * @param server The address to connect to
+ * @param default_port The port to use if not set in @p server
+ * @param local_addr Filled in after connection initiation with
+ *                   the local address
+ * @param remote_addr Filled in after connection initiation with
+ *                    the remote address
+ *
+ * @return @c 1 if succesful, @c 0 if failure of some sort
+*/
 int
 coap_socket_connect_tcp1(coap_socket_t *sock,
                          const coap_address_t *local_if,
@@ -31,16 +47,52 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
                          coap_address_t *local_addr,
                          coap_address_t *remote_addr);
 
+/**
+ * Complete the TCP Connection
+ *
+ * Internal function.
+ *
+ * @param sock The socket information to use
+ * @param local_addr Filled in with the final local address
+ * @param remote_addr Filled in with the final remote address
+ *
+ * @return @c 1 if succesful, @c 0 if failure of some sort
+*/
 int
 coap_socket_connect_tcp2(coap_socket_t *sock,
                          coap_address_t *local_addr,
                          coap_address_t *remote_addr);
 
+/**
+ * Create a new TCP socket and then listen for new incoming TCP sessions
+ *
+ * Internal function.
+ *
+ * @param sock Where socket information is to be filled in
+ * @param listen_addr The address to be listening for new incoming sessions
+ * @param bound_addr Filled in with the address that the TCP layer
+ *                   is listening on for new incoming TCP sessions
+ *
+ * @return @c 1 if succesful, @c 0 if failure of some sort
+*/
 int
 coap_socket_bind_tcp(coap_socket_t *sock,
                      const coap_address_t *listen_addr,
                      coap_address_t *bound_addr);
 
+/**
+ * Accept a new incoming TCP session
+ *
+ * Internal function.
+ *
+ * @param server The socket information to use to accept the TCP connection
+ * @param new_client Filled in socket information with the new incoming
+ *                   session information
+ * @param local_addr Filled in with the local address
+ * @param remote_addr Filled in with the remote address
+ *
+ * @return @c 1 if succesful, @c 0 if failure of some sort
+*/
 int
 coap_socket_accept_tcp(coap_socket_t *server,
                        coap_socket_t *new_client,

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1739,6 +1739,7 @@ psk_tls_server_name_call_back(SSL *ssl,
         SSL_CTX_set_info_callback(ctx, coap_dtls_info_callback);
         SSL_CTX_set_options(ctx, SSL_OP_NO_QUERY_MTU);
       }
+#if !COAP_DISABLE_TCP
       else {
         /* Set up TLS context */
         ctx = SSL_CTX_new(TLS_method());
@@ -1750,6 +1751,7 @@ psk_tls_server_name_call_back(SSL *ssl,
         SSL_CTX_set_info_callback(ctx, coap_dtls_info_callback);
         SSL_CTX_set_alpn_select_cb(ctx, server_alpn_callback, NULL);
       }
+#endif /* !COAP_DISABLE_TCP */
 
       o_context->psk_sni_entry_list =
             OPENSSL_realloc(o_context->psk_sni_entry_list,

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -289,7 +289,7 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
   return COAP_PDU_DELAYED;
 }
 
-#if !COAP_DISABLE_TCP 
+#if !COAP_DISABLE_TCP
 void coap_session_send_csm(coap_session_t *session) {
   coap_pdu_t *pdu;
   uint8_t buf[4];
@@ -325,7 +325,7 @@ coap_tid_t coap_session_send_ping(coap_session_t *session) {
     uint16_t tid = coap_new_message_id (session);
     ping = coap_pdu_init(COAP_MESSAGE_CON, 0, tid, 0);
   }
-#if !COAP_DISABLE_TCP 
+#if !COAP_DISABLE_TCP
   else {
     ping = coap_pdu_init(COAP_MESSAGE_CON, COAP_SIGNALING_PING, 0, 1);
   }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -609,7 +609,7 @@ coap_dtls_context_check_keys_enabled(coap_context_t *ctx UNUSED)
   return 1;
 }
 
-#if !COAP_DISABLE_TCP 
+#if !COAP_DISABLE_TCP
 void *coap_tls_new_client_session(coap_session_t *session UNUSED, int *connected UNUSED) {
   return NULL;
 }


### PR DESCRIPTION
Missing COAP_DISABLE_TCP wrapper in OpenSSL 1.1.0 - 1.1.1 specific code

doc/main.md:

Update Copyright year.

include/coap2/coap_tcp_internal.h:

Update documentation for the internal TCP functions