### PR TITLE
Make COAP_REQUEST_* enum for clarity

### DIFF
--- a/include/coap2/pdu.h
+++ b/include/coap2/pdu.h
@@ -76,13 +76,15 @@ struct coap_session_t;
 
 /* CoAP request methods */
 
-#define COAP_REQUEST_GET       1
-#define COAP_REQUEST_POST      2
-#define COAP_REQUEST_PUT       3
-#define COAP_REQUEST_DELETE    4
-#define COAP_REQUEST_FETCH     5 /* RFC 8132 */
-#define COAP_REQUEST_PATCH     6 /* RFC 8132 */
-#define COAP_REQUEST_IPATCH    7 /* RFC 8132 */
+typedef enum coap_request_t {
+  COAP_REQUEST_GET = 1,
+  COAP_REQUEST_POST,      /* 2 */
+  COAP_REQUEST_PUT,       /* 3 */
+  COAP_REQUEST_DELETE,    /* 4 */
+  COAP_REQUEST_FETCH,     /* 5 RFC 8132 */
+  COAP_REQUEST_PATCH,     /* 6 RFC 8132 */
+  COAP_REQUEST_IPATCH,    /* 7 RFC 8132 */
+} coap_request_t;
 
 /*
  * CoAP option types (be sure to update coap_option_check_critical() when
@@ -286,7 +288,7 @@ COAP_DEPRECATED typedef struct {
 
 typedef struct coap_pdu_t {
   uint8_t type;             /**< message type */
-  uint8_t code;             /**< request method (value 1--10) or response code (value 40-255) */
+  uint8_t code;             /**< request method (value 1--31) or response code (value 64-255) */
   uint8_t max_hdr_size;     /**< space reserved for protocol-specific header */
   uint8_t hdr_size;         /**< actaul size used for protocol-specific header */
   uint8_t token_length;     /**< length of Token */

--- a/include/coap2/resource.h
+++ b/include/coap2/resource.h
@@ -366,7 +366,7 @@ coap_print_status_t coap_print_link(const coap_resource_t *resource,
  * @param handler  The handler to register with @p resource.
  */
 void coap_register_handler(coap_resource_t *resource,
-                           unsigned char method,
+                           coap_request_t method,
                            coap_method_handler_t handler);
 
 /** @} */

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -19,7 +19,7 @@ SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
 
-*void coap_register_handler(coap_resource_t *_resource_, unsigned char
+*void coap_register_handler(coap_resource_t *_resource_, coap_request_t
 _method_, coap_method_handler_t _handler_);*
 
 *void coap_register_response_handler(coap_context_t *_context_,

--- a/src/resource.c
+++ b/src/resource.c
@@ -570,7 +570,7 @@ coap_print_link(const coap_resource_t *resource,
 
 void
 coap_register_handler(coap_resource_t *resource,
-                      unsigned char method,
+                      coap_request_t method,
                       coap_method_handler_t handler) {
   assert(resource);
   assert(method > 0 && (size_t)(method-1) < sizeof(resource->handler)/sizeof(coap_method_handler_t));


### PR DESCRIPTION
Make the COAP_REQUEST_* #defines enum coap_request_t for clarity.

This should help prevent mistakes such as in #448.