### PR TITLE
coap_free_endpoint: fix segfault with incorrect -A argument

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1129,7 +1129,7 @@ coap_free_endpoint(coap_endpoint_t *ep) {
       coap_socket_close(&ep->sock);
     }
 
-    if (ep->context) {
+    if (ep->context && ep->context->endpoint) {
       LL_DELETE(ep->context->endpoint, ep);
     }
     coap_mfree_endpoint(ep);


### PR DESCRIPTION
`coap-server(1)` segfaults when invoked as:

	$ coap-server -A '2001:db8::1'
	Feb 09 18:28:49 WARN coap_socket_bind_udp: bind: Address not available
	Segmentation fault

In this case, the `ep->context->endpoint` is NULL but `coap_free_endpoint` still attempts to access it. To prevent this invocation from causing a segmentation fault, check if `ep->context->endpoint` is NULL before accessing it.