### PR TITLE
OpenSSL: Support self-signed certificates at depth 0

### DIFF
--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1418,6 +1418,7 @@ tls_verify_call_back(int preverify_ok, X509_STORE_CTX *ctx) {
       if (setup_data->allow_expired_certs)
         preverify_ok = 1;
       break;
+    case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
     case X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN:
       if (setup_data->allow_self_signed)
         preverify_ok = 1;


### PR DESCRIPTION
When libcoap config allows self-signed certificates (`coap_dtls_pki_t.allow_self_signed == 1`) the library should also accept self-signed certificates at depth 0. This is achieved by allowing [X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT](https://www.openssl.org/docs/man1.1.0/man3/X509_STORE_CTX_get_error_depth.html) case.