### PR TITLE
DISABLE_TCP: Make TCP enabled code checking more rigorous

### DIFF
--- a/Makefile.libcoap
+++ b/Makefile.libcoap
@@ -1,4 +1,4 @@
-libcoap_src = pdu.c net.c coap_debug.c encode.c uri.c subscribe.c resource.c str.c option.c async.c block.c mem.c coap_io.c coap_session.c coap_notls.c coap_hashkey.c address.c
+libcoap_src = pdu.c net.c coap_debug.c encode.c uri.c subscribe.c resource.c str.c option.c async.c block.c mem.c coap_io.c coap_session.c coap_notls.c coap_hashkey.c address.c coap_tcp.c
 
 libcoap_dir := $(filter %libcoap,$(APPDS))
 vpath %c $(libcoap_dir)/src

--- a/examples/client.c
+++ b/examples/client.c
@@ -829,6 +829,13 @@ cmdline_uri(char *arg, int create_uri_opts) {
       return -1;
     }
 
+    if (uri.scheme==COAP_URI_SCHEME_COAP_TCP && !coap_tcp_is_supported()) {
+      /* coaps+tcp caught above */
+      coap_log(LOG_EMERG,
+            "coap+tcp URI scheme not supported in this version of libcoap\n");
+      return -1;
+    }
+
     if (uri.port != get_default_port(&uri) && create_uri_opts) {
       coap_insert_optlist(&optlist,
                   coap_new_optlist(COAP_OPTION_URI_PORT,

--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -39,7 +39,7 @@ CFLAGS += -I$(top_srcdir)/include/coap2
 
 vpath %.c $(top_srcdir)/src
 
-COAPOBJS = net.o coap_debug.o option.o resource.o pdu.o encode.o subscribe.o coap_io_lwip.o block.o uri.o str.o coap_session.o coap_notls.o coap_hashkey.o address.o
+COAPOBJS = net.o coap_debug.o option.o resource.o pdu.o encode.o subscribe.o coap_io_lwip.o block.o uri.o str.o coap_session.o coap_notls.o coap_hashkey.o address.o coap_tcp.o
 
 CFLAGS += -g3 -Wall -Wextra -pedantic -O0 -fpack-struct
 # not sorted out yet

--- a/src/uri.c
+++ b/src/uri.c
@@ -79,7 +79,6 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
   }
 
   /* There might be and addition "+tcp", indicating reliable transport: */
-#if !COAP_DISABLE_TCP
   if (len>=4 && p[0] == '+' && p[1] == 't' && p[2] == 'c' && p[3] == 'p' ) {
     p += 4;
     len -= 4;
@@ -88,7 +87,6 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
     else
       uri->scheme = COAP_URI_SCHEME_COAP_TCP;
   }
-#endif /* !COAP_DISABLE_TCP */
   q = (const uint8_t *)"://";
   while (len && *q && *p == *q) {
     ++p; ++q; --len;


### PR DESCRIPTION
In the same way that coap_split_uri() allows coaps:// scheme even if DTLS is
not available, it should allow coap+tcp:// and coaps+tcp:// scheme and let
other functions check whether TCP/TLS is available or not.

examples/client.c:

Verify if TCP is supported for scheme coap+tcp://.

src/coap_session.c:

Verify CoAP protocol is supported in coap_session_create_client().
Add verify for TCP protocol in coap_new_endpoint(), as well as always check
if TLS is supported.

src/uri.c:

Always alow coap+tcp:// and coaps+tcp:// in coap_split_uri() as a parsed
scheme in same way that coaps:// is always allowed.