### PR TITLE
coap_io_process: Fix 1ms busy loop and indefinite sleep

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1453,7 +1453,7 @@ main(int argc, char **argv) {
       }
       if (result > 0) {
         if (FD_ISSET(coap_fd, &readfds)) {
-          result = coap_io_process(ctx, COAP_RUN_NONBLOCK);
+          result = coap_io_process(ctx, COAP_IO_NO_WAIT);
         }
       }
     }

--- a/examples/contiki/server.c
+++ b/examples/contiki/server.c
@@ -216,7 +216,7 @@ PROCESS_THREAD(coap_server_process, ev, data)
     PROCESS_YIELD();
     if(ev == tcpip_event) {
       /* There is something to read on the endpoint */
-      coap_io_process(coap_context, COAP_RUN_BLOCK);
+      coap_io_process(coap_context, COAP_IO_WAIT);
     } else if (ev == PROCESS_EVENT_TIMER && etimer_expired(&dirty_timer)) {
       coap_resource_notify_observers(time_resource, NULL);
       etimer_reset(&dirty_timer);

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -730,8 +730,8 @@ coap_join_mcast_group(coap_context_t *ctx, const char *groupname);
  * @{
  */
 
-#define COAP_RUN_BLOCK    0
-#define COAP_RUN_NONBLOCK 1
+#define COAP_IO_WAIT    0
+#define COAP_IO_NO_WAIT ((uint32_t)-1)
 
 /**
  * The main I/O processing function.  All pending network I/O is completed,
@@ -749,16 +749,19 @@ coap_join_mcast_group(coap_context_t *ctx, const char *groupname);
  *
  * @param ctx The CoAP context
  * @param timeout_ms Minimum number of milliseconds to wait for new packets
- *                   before returning. If COAP_RUN_BLOCK, the call will block
- *                   until at least one new packet is received. If
- *                   COAP_RUN_NONBLOCK, the function will return immediately
- *                   following without waiting for any new input not already
- *                   available.
+ *                   before returning after doing any processing.
+ *                   If COAP_IO_WAIT, the call will block until the next
+ *                   internal action (e.g. packet retransmit) if any, or block
+ *                   until the next packet is received whichever is the sooner
+ *                   and do the necessary processing.
+ *                   If COAP_IO_NO_WAIT, the function will return immediately
+ *                   after processing without waiting for any new input
+ *                   packets to arrive.
  *
  * @return Number of milliseconds spent in function or @c -1 if there was
  *         an error
  */
-int coap_io_process(coap_context_t *ctx, unsigned int timeout_ms);
+int coap_io_process(coap_context_t *ctx, uint32_t timeout_ms);
 
 /**
  * @deprecated Use coap_io_process() instead.
@@ -767,17 +770,20 @@ int coap_io_process(coap_context_t *ctx, unsigned int timeout_ms);
  *
  * @param ctx The CoAP context
  * @param timeout_ms Minimum number of milliseconds to wait for new packets
- *                   before returning. If COAP_RUN_BLOCK, the call will block
- *                   until at least one new packet is received. If
- *                   COAP_RUN_NONBLOCK, the function will return immediately
- *                   following without waiting for any new input not already
- *                   available.
+ *                   before returning after doing any processing.
+ *                   If COAP_IO_WAIT, the call will block until the next
+ *                   internal action (e.g. packet retransmit) if any, or block
+ *                   until the next packet is received whichever is the sooner
+ *                   and do the necessary processing.
+ *                   If COAP_IO_NO_WAIT, the function will return immediately
+ *                   after processing without waiting for any new input
+ *                   packets to arrive.
  *
  * @return Number of milliseconds spent in function or @c -1 if there was
  *         an error
  */
 COAP_STATIC_INLINE COAP_DEPRECATED int
-coap_run_once(coap_context_t *ctx, unsigned int timeout_ms)
+coap_run_once(coap_context_t *ctx, uint32_t timeout_ms)
 {
   return coap_io_process(ctx, timeout_ms);
 }
@@ -787,10 +793,14 @@ coap_run_once(coap_context_t *ctx, unsigned int timeout_ms)
  *
  * @param ctx The CoAP context
  * @param timeout_ms Minimum number of milliseconds to wait for new packets
- *                   before returning. If COAP_RUN_BLOCK, the call will block
- *                   until at least one new packet is received. If
- *                   COAP_RUN_NONBLOCK, the function will return immediately
- *                   after processing any existing input packets.
+ *                   before returning after doing any processing.
+ *                   If COAP_IO_WAIT, the call will block until the next
+ *                   internal action (e.g. packet retransmit) if any, or block
+ *                   until the next packet is received whichever is the sooner
+ *                   and do the necessary processing.
+ *                   If COAP_IO_NO_WAIT, the function will return immediately
+ *                   after processing without waiting for any new input
+ *                   packets to arrive.
  * @param nfds      The maximum FD set in readfds, writefds or exceptfds
  *                  plus one,
  * @param readfds   Read FDs to additionally check for in internal select()
@@ -805,7 +815,7 @@ coap_run_once(coap_context_t *ctx, unsigned int timeout_ms)
  *         if there was an error.  If defined, readfds, writefds, exceptfds
  *         are updated as returned by the internal select() call.
  */
-int coap_io_process_with_fds(coap_context_t *ctx, unsigned int timeout_ms,
+int coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
                         int nfds, fd_set *readfds, fd_set *writefds,
                         fd_set *exceptfds);
 

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -18,16 +18,16 @@ SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
 
-*int coap_io_process(coap_context_t *_context_, unsigned int _timeout_ms_)*;
+*int coap_io_process(coap_context_t *_context_, uint32_t _timeout_ms_)*;
 
 *int coap_io_process_with_fds(coap_context_t *_context_,
-unsigned int _timeout_ms_, int _nfds_, fd_set *_readfds_, fd_set *_writefds_,
+uint32_t _timeout_ms_, int _nfds_, fd_set *_readfds_, fd_set *_writefds_,
 fd_set *_exceptfds_)*;
 
 *int coap_context_get_coap_fd(coap_context_t *_context_)*;
 
 *unsigned int coap_io_prepare_io(coap_context_t *_context_,
-coap_socket_t *_sockets[]_, unsigned int _max_sockets_,
+coap_socket_t *_sockets_[], unsigned int _max_sockets_,
 unsigned int *_num_sockets_, coap_tick_t _now_)*;
 
 *void coap_io_do_io(coap_context_t *_context_, coap_tick_t _now_)*;
@@ -35,12 +35,12 @@ unsigned int *_num_sockets_, coap_tick_t _now_)*;
 *unsigned int coap_io_prepare_epoll(coap_context_t *_context_,
 coap_tick_t _now_)*;
 
-*int coap_io_do_epoll(coap_context_t *_context_, struct epoll_event *_events_,
-size_t _nevents_)*
+*void coap_io_do_epoll(coap_context_t *_context_, struct epoll_event *_events_,
+size_t _nevents_)*;
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
-*-lcoap-@LIBCOAP_API_VERSION@-openssl* or
-*-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
 type.
 
 DESCRIPTION
@@ -56,13 +56,15 @@ up to _timeout_ms_ milli-seconds before returning. There are 2 special case
 _timeout_ms_ values.
 [source, c]
 ----
-#define COAP_RUN_BLOCK    0
-#define COAP_RUN_NONBLOCK 1
+#define COAP_IO_WAIT    0
+#define COAP_IO_NO_WAIT ((uint32_t)-1)
 ----
-If _timeout_ms_ is set to COAP_RUN_BLOCK, then *coap_io_process*() will wait
-indefinitely for the first new input packet to come in, or for when to
-re-transmit a packet. If _timeout_ms_ is set to COAP_RUN_NONBLOCK, then there
-is no wait if there is no more input or output to process.
+If _timeout_ms_ is set to COAP_IO_WAIT, then *coap_io_process*() will block
+until the next internal action (e.g. packet retransmit) if any, or block until
+the next packet is received whichever is the sooner and do the necessary
+processing. If _timeout_ms_ is set to COAP_IO_NO_WAIT, then *coap_io_process*()
+will return immediately after processing without waiting for any new input
+packets to arrive.
 
 There are two methods of how to call *coap_io_process*().
 
@@ -73,7 +75,7 @@ _timeout_ms_, but more frequently if there is input / retransmission traffic.
 2. Wait on the file descriptor returned by *coap_context_get_coap_fd*()
 using *select*() or an event returned by epoll_wait(). If 'read' is available on
 the file descriptor, call *coap_io_process*() with _timeout_ms_ set to
-COAP_RUN_NONBLOCK. +
+COAP_IO_NO_WAIT. +
 *NOTE*: This second method is only available for environments that support epoll
 (mostly Linux) with libcoap compiled to use *epoll* (the default) as libcoap
 will then be using *epoll* internally to process all the file descriptors of
@@ -176,7 +178,7 @@ int main(int argc, char *argv[]){
 
   coap_context_t *ctx = NULL;
   unsigned wait_ms;
-
+  /* Remove (void) definition if variable is used */
   (void)argc;
   (void)argv;
 
@@ -219,7 +221,7 @@ int main(int argc, char *argv[]){
   unsigned wait_ms;
   fd_set readfds;
   int nfds = 0;
-
+  /* Remove (void) definition if variable is used */
   (void)argc;
   (void)argv;
 
@@ -269,7 +271,7 @@ int main(int argc, char *argv[]){
   int coap_fd;
   fd_set m_readfds;
   int nfds;
-
+  /* Remove (void) definition if variable is used */
   (void)argc;
   (void)argv;
 
@@ -280,6 +282,7 @@ int main(int argc, char *argv[]){
   }
   coap_fd = coap_context_get_coap_fd(ctx);
   if (coap_fd == -1) {
+    /* epoll is not supported */
     exit(1);
   }
   FD_ZERO(&m_readfds);
@@ -301,7 +304,7 @@ int main(int argc, char *argv[]){
     }
     if (result > 0) {
       if (FD_ISSET(coap_fd, &readfds)) {
-        result = coap_io_process(ctx, COAP_RUN_NONBLOCK);
+        result = coap_io_process(ctx, COAP_IO_NO_WAIT);
         if (result < 0) {
           /* There is an internal issue */
           break;
@@ -340,7 +343,7 @@ int main(int argc, char *argv[]){
   struct epoll_event events[MAX_EVENTS];
   int nevents;
   int i;
-
+  /* Remove (void) definition if variable is used */
   (void)argc;
   (void)argv;
 
@@ -377,7 +380,7 @@ int main(int argc, char *argv[]){
     }
     for (i = 0; i < nevents; i++) {
       if (events[i].data.fd == coap_fd) {
-        result = coap_io_process(ctx, COAP_RUN_NONBLOCK);
+        result = coap_io_process(ctx, COAP_IO_NO_WAIT);
         if (result < 0) {
           /* There is an internal issue */
           break;


### PR DESCRIPTION
Replace COAP_RUN_BLOCK with COAP_IO_WAIT and COAP_RUN_NOBLOCK with
COAP_IO_NO_WAIT for naming clarity.

Instead of COAP_IO_NO_WAIT being 1, make it -1 to fix 1ms busy loop.
Handle the case when coap_io_prepare_io returns 0 to prevent indefinite
select() wait.
 
include/coap2/net.h:
 
Make the timeout_ms parameter uint32_t in coap_io_process*() functions to
make sure special case of COAP_IO_NO_BLOCK is correctly handled on different
architectures.
Update COAP_IO_NO_BLOCK to -1. 
 
src/coap_io.c:

Fix the 1ms busy loop and potential infinite wait in the non epoll case.

man/coap_io.txt.in:
 
Update documentation to reflect the changes.

examples/coap-server.c:
examples/contiki/server.c:

Update to use COAP_IO WAIT and COAP_IO_NO_WAIT as appropriate.

Extends #462 fix.