### PR TITLE
async: Fix session->ref assertion failure and timeout values

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -148,6 +148,9 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_LDFLAGS =					\
 ## Collect symbols here we want to ignore while building the helper files
 ## libcoap-$(LIBCOAP_API_VERSION).{map,sym} for the linker.
 CTAGS_IGNORE=-I " \
+coap_delete_all \
+coap_delete_all_async \
+coap_delete_all_resources \
 coap_dtls_context_check_keys_enabled \
 coap_dtls_context_set_pki \
 coap_dtls_context_set_pki_root_cas \

--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -39,7 +39,7 @@ CFLAGS += -I$(top_srcdir)/include/coap2
 
 vpath %.c $(top_srcdir)/src
 
-COAPOBJS = net.o coap_debug.o option.o resource.o pdu.o encode.o subscribe.o coap_io_lwip.o block.o uri.o str.o coap_session.o coap_notls.o coap_hashkey.o address.o coap_tcp.o
+COAPOBJS = net.o coap_debug.o option.o resource.o pdu.o encode.o subscribe.o coap_io_lwip.o block.o uri.o str.o coap_session.o coap_notls.o coap_hashkey.o address.o coap_tcp.o async.o
 
 CFLAGS += -g3 -Wall -Wextra -pedantic -O0 -fpack-struct
 # not sorted out yet

--- a/include/coap2/async.h
+++ b/include/coap2/async.h
@@ -143,6 +143,16 @@ coap_touch_async(coap_async_state_t *s) { coap_ticks(&s->created); }
 
 /** @} */
 
+/**
+ * Removes and frees off all of the async entries for the given context.
+ *
+ * Internal function.
+ *
+ * @param state The context to remove all async entries from.
+ */
+void
+coap_delete_all_async(coap_context_t *context);
+
 #endif /*  WITHOUT_ASYNC */
 
 #endif /* COAP_ASYNC_H_ */

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -68,6 +68,8 @@ int coap_delete_node(coap_queue_t *node);
 /**
  * Removes all items from given @p queue and frees the allocated storage.
  *
+ * Internal function.
+ *
  * @param queue The queue to delete.
  */
 void coap_delete_all(coap_queue_t *queue);

--- a/include/coap2/resource.h
+++ b/include/coap2/resource.h
@@ -260,6 +260,8 @@ int coap_delete_resource(coap_context_t *context, coap_resource_t *resource);
 /**
  * Deletes all resources from given @p context and frees their storage.
  *
+ * Internal function.
+ *
  * @param context The CoAP context with the resources to be deleted.
  */
 void coap_delete_all_resources(coap_context_t *context);

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -36,8 +36,6 @@ global:
   coap_debug_set_packet_loss;
   coap_decode_var_bytes;
   coap_decode_var_bytes8;
-  coap_delete_all;
-  coap_delete_all_resources;
   coap_delete_attr;
   coap_delete_bin_const;
   coap_delete_node;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -34,8 +34,6 @@ coap_debug_send_packet
 coap_debug_set_packet_loss
 coap_decode_var_bytes
 coap_decode_var_bytes8
-coap_delete_all
-coap_delete_all_resources
 coap_delete_attr
 coap_delete_bin_const
 coap_delete_node

--- a/src/async.c
+++ b/src/async.c
@@ -105,6 +105,16 @@ coap_free_async(coap_async_state_t *s) {
   }
 }
 
+void
+coap_delete_all_async(coap_context_t *context) {
+  coap_async_state_t *astate, *tmp;
+
+  LL_FOREACH_SAFE(context->async_state, astate, tmp) {
+    coap_free_async(astate);
+  }
+  context->async_state = NULL;
+}
+
 #else
 void does_not_exist(void);        /* make some compilers happy */
 #endif /* WITHOUT_ASYNC */

--- a/src/net.c
+++ b/src/net.c
@@ -586,6 +586,10 @@ coap_free_context(coap_context_t *context) {
 
   coap_delete_all_resources(context);
 
+#ifndef WITHOUT_ASYNC
+  coap_delete_all_async(context);
+#endif /* WITHOUT_ASYNC */
+
   LL_FOREACH_SAFE(context->endpoint, ep, tmp) {
     coap_free_endpoint(ep);
   }


### PR DESCRIPTION
Calling coap_free_context() does not free off any async entries, and so
raises assertion errors when coming to freeing off sessions if any async
entries exist.

async_data_t is a union, but the size of val and ptr are not the same - so
usage can have uninitialized data - hence bad timeout values.

Makefile.am:

Do not expose coap_delete_all*() functions.

Makefile.libcoap:

Include async.c for the Contiki build.

examples/coap-server.c:

Fix async_data_t issue.

examples/etsi_iot_01.c:

Fix 32 bit compiler warnings using same logic as coap-server for holding the
async timeout value.

examples/lwip/Makefile:

Include async.c for the LwIP build.

include/coap2/async.h

Define coap_delete_all_async() function.

include/coap2/net.h
include/coap2/resource.h

Document coap_delete_all*() functions as internal.

libcoap-2.map
libcoap-2.sym

Update from non-exposed coap_delete_all*() functions.

src/async.c

Provide coap_delete_all_async() function.

src/net.c

Call coap_delete_all_async() from within coap_free_context().

This should see the issue seen in #467 