### PR TITLE
Coap sessions not closed if observing clients

### DIFF
--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -134,10 +134,13 @@ coap_session_t *coap_session_reference(coap_session_t *session);
 * Decrement reference counter on a session.
 * Note that the session may be deleted as a result and should not be used
 * after this call.
-*
+* The v2 version was created as a "bugfix" when the associated coap sessions
+* were not fully released when deleting a resource. This fix is more a workaround
+* that a proper solution.
 * @param session The CoAP session.
 */
 void coap_session_release(coap_session_t *session);
+void coap_session_release_v2(coap_session_t *session);
 
 /**
 * Stores @p data with the given session. This function overwrites any value

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -70,6 +70,7 @@ coap_session_reference(coap_session_t *session) {
   return session;
 }
 
+
 void
 coap_session_release(coap_session_t *session) {
   if (session) {
@@ -77,6 +78,17 @@ coap_session_release(coap_session_t *session) {
     if (session->ref > 0)
       --session->ref;
     if (session->ref == 0 && session->type == COAP_SESSION_TYPE_CLIENT)
+      coap_session_free(session);
+  }
+}
+
+void
+coap_session_release_v2(coap_session_t *session) {
+  if (session) {
+    assert(session->ref > 0);
+    if (session->ref > 0)
+      --session->ref;
+    if (session->ref == 0)
       coap_session_free(session);
   }
 }

--- a/src/resource.c
+++ b/src/resource.c
@@ -429,7 +429,7 @@ coap_free_resource(coap_resource_t *resource) {
 
   /* free all elements from resource->subscribers */
   LL_FOREACH_SAFE( resource->subscribers, obs, otmp ) {
-    coap_session_release( obs->session );
+    coap_session_release_v2( obs->session );
     if (obs->query)
       coap_delete_string(obs->query);
     COAP_FREE_TYPE( subscription, obs );


### PR DESCRIPTION
Coap sessions are not always closed when deleting
a resource. If there are clients that observe a specific
resource, then when deleting the resource will not close
the active session.

This fix "forces" coap sessions to close when a resource is
deliberately removed.

Change-Id: Ib0a0503647fdf14991169553adf22306c9c59857