### PR TITLE
PKCS11: Add in PKCS11 support for PKI

### DIFF
--- a/HOWTO.dual.gnutls
+++ b/HOWTO.dual.gnutls
@@ -1,0 +1,98 @@
+############################################################################
+#
+# GnuTLS dual versions
+#
+# Works with CentOS 7
+#
+############################################################################
+#
+# Add in alternative GnuTLS support into /usr/local, and put all the
+# libraries into /usr/local/lib.
+#
+# Need the latest of the following packages
+#
+# gmp    (used 6.2.0)  https://gmplib.org/#DOWNLOAD
+# nettle (used 3.6)    https://ftp.gnu.org/gnu/nettle/
+# gnutls (used 3.6.13) https://www.gnutls.org/download.html
+#
+
+GMP_VER=6.2.0
+NETTLE_VER=3.6
+GNUTLS_VER=3.6.13
+
+#
+# gmp
+#
+tar xovf gmp-${GMP_VER}.tar.xz
+cd gmp-${GMP_VER}
+./configure
+make
+sudo make install
+cd ..
+
+#
+# nettle (by default wants to go into /usr/local/lib64 which gets messy)
+#
+tar zxovf nettle-${NETTLE_VER}.tar.gz
+cd nettle-${NETTLE_VER}
+PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --libdir=/usr/local/lib \
+  LDFLAGS="-L/usr/local/lib"
+make
+sudo make install
+cd ..
+
+tar xovf gnutls-${GNUTLS_VER}.tar.xz
+cd gnutls-${GNUTLS_VER}
+#
+#
+# You may need to make the following change if you have an old version of
+# p11-kit
+#
+# $ diff -Nau a/lib/pkcs11_privkey.c b/lib/pkcs11_privkey.c
+# --- a/lib/pkcs11_privkey.c        2020-05-26 11:49:27.374385645 +0100
+# +++ b/lib/pkcs11_privkey.c        2020-05-26 11:58:24.300510455 +0100
+# @@ -265,13 +265,13 @@
+#  # define CKG_MGF1_SHA384 0x00000003UL
+#  # define CKG_MGF1_SHA512 0x00000004UL
+#
+# +#endif
+#  struct ck_rsa_pkcs_pss_params {
+#         ck_mechanism_type_t hash_alg;
+#         /* ck_rsa_pkcs_mgf_type_t is not defined in old versions of p11-kit */
+#         unsigned long mgf;
+#         unsigned long s_len;
+#  };
+# -#endif
+#
+#  static const struct hash_mappings_st hash_mappings[] =
+#  {
+#
+#
+PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --with-included-unistring \
+  --disable-hardware-acceleration --disable-tests --with-included-libtasn1 \
+  --disable-doc LDFLAGS="-L/usr/local/lib"
+make
+sudo make install
+cd ..
+
+############################################################################
+#
+# libcoap build with updated GnuTLS
+#
+############################################################################
+
+# Get the latest libcoap
+git clone https://github.com/obgm/libcoap.git
+
+# Build code
+cd libcoap
+./autogen.sh
+# Update --enable- / --disable- options as appropriate
+# libcoap libraries are put into /usr/lib64 for ease of linking
+PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --libdir=/usr/lib64 \
+  --with-gnutls --enable-tests --enable-examples --disable-doxygen \
+  --enable-manpages
+make
+sudo make install
+cd ..
+

--- a/HOWTO.dual.openssl
+++ b/HOWTO.dual.openssl
@@ -1,0 +1,50 @@
+############################################################################
+#
+# OpenSSL dual versions
+#
+# Works with CentOS 7
+#
+############################################################################
+#
+# Add in alternative OpenSSL support into /opt/openssl.  /opt/openssl is
+# chosen instead of the default of /usr/local so that existing utilities
+# continue to use the original version of OpenSSL and so only specific
+# applications that requires the newer version of OpenSSL will pick up the
+# new code.
+#
+# Download latest stable version of openssl.X.Y.Z.tar.gz from
+# https://www.openssl.org/source/
+
+tar zxovf openssl.X.Y.Z.tar.gz
+cd openssl.X.Y.X
+./config --prefix=/opt/openssl --openssldir=/opt/openssl
+make
+sudo make install_sw
+
+# The following should not clash the existing OpenSSL lib*.so.1.0 usage unless
+# the previous OpenSSL version is 1.1.0 or later.
+# It just makes things for running executables a lot simpler.
+sudo cp /opt/openssl/lib/lib*.so.1.1 /lib64
+cd ..
+
+############################################################################
+#
+# libcoap build with updated OpenSSL
+#
+############################################################################
+
+# Get the latest libcoap
+git clone https://github.com/obgm/libcoap.git
+
+# Build code
+cd libcoap
+./autogen.sh
+# Update --enable- / --disable- options as appropriate
+# libcoap libraries are put into /usr/lib64 for ease of linking
+PKG_CONFIG_PATH=/opt/openssl/lib/pkgconfig ./configure --libdir=/usr/lib64 \
+  --with-openssl --enable-tests --enable-examples --disable-doxygen \
+  --disable-manpages
+make
+sudo make install
+cd ..
+

--- a/HOWTO.dual.softhsm2
+++ b/HOWTO.dual.softhsm2
@@ -1,0 +1,86 @@
+############################################################################
+#
+# SoftHSMv2 dual versions
+#
+# Works with CentOS 7
+#
+# The opensc package needs to be installed.
+#
+############################################################################
+#
+# Install a software HSM module for doing the PKCS11 testing of libcoap.
+# Real hardware can be used if you have the appropriate library module.
+#
+# It is assumed that the opensc package is installed.
+#
+# When installing SoftHSMv2 from your system's package manager, check that the
+# OpenSSL version is at least 1.1.0.  If not, then you will need to dual
+# install SoftHSMv2 as below; otherwise you can use the existing SoftHSMv2.
+#
+# SoftHSMv2 is built using OpenSSL, but GnuTLS can use the PKCS11 interface.
+# Note that if the default OpenSSL version is less than 1.1.0, you will need
+# to install a dual stack version of OpenSSL as per HOWTO.dual.openssl.
+#
+# Creates module /usr/local/lib/softhsm/libsofthsm2.so
+#
+
+# Add line below to /etc/security/limits.conf to support memory locking
+
+*               -        memlock         unlimited
+
+# Get the latest SoftHSM
+git clone https://github.com/opendnssec/SoftHSMv2.git
+
+# Build code
+cd SoftHSMv2/
+sh autogen.sh
+PKG_CONFIG_PATH=/opt/openssl/lib/pkgconfig ./configure --enable-silent-rules \
+  --with-crypto-backend=openssl --disable-gost LDFLAGS=-L/opt/openssl/lib \
+  CPPFLAGS=-I/opt/openssl/include --with-openssl=/opt/openssl
+make
+# You may need to comment out constexpr lines (fixes for gcc10) in
+#  src/lib/crypto/PublicKey.h src/lib/crypto/PrivateKey.h if you get
+# compile errors.
+sudo make install
+cd ..
+
+# Make sure p11-kit softhsm modules have the correct module: fully qualified
+# path where the entry is of the form (in particular for GnuTLS) :-
+# /usr/share/p11-kit/modules/softhsm*
+#
+#  module: /usr/local/lib/softhsm/libsofthsm2.so
+
+# If /var/lib/softhsm/tokens is owned by user ods (because softhsm2 package is
+# alread installed), make the logged in <user> a part of the group ods so
+# that the tokens can be accessed.
+sudo usermod -a -G ods <user>
+# log out and then log back in again
+# Confirm that you have ods in your group
+id
+
+############################################################################
+#
+# libp11 (needed for OpenSSL as it provides the PKCS11 engine)
+#
+############################################################################
+#
+# Install a pkcs11 library for OpenSSL to use as an engine.
+# [GnuTLS has this built in]
+#
+
+# Get the latest libp11
+git clone https://github.com/OpenSC/libp11.git
+
+# Build code
+cd libp11
+./bootstrap
+PKG_CONFIG_PATH=/opt/openssl/lib/pkgconfig ./configure \
+  --with-pkcs11-module=/usr/local/lib/softhsm/libsofthsm2.so
+make
+sudo make install
+cd ..
+
+# Verify that pkcs11 is available
+
+/opt/openssl/bin/openssl engine pkcs11 -t
+

--- a/HOWTO.pkcs11
+++ b/HOWTO.pkcs11
@@ -1,0 +1,109 @@
+#
+# Using PKCS11 with libcoap.
+#
+# This HOWTO works for CentOS 7.
+#
+# As CentOS 7 uses OpenSSL prior to 1.1.0, dual OpenSSL support needs to be
+# set up and used for libcoap.  See HOWTO.dual.openssl for setting this up.
+#
+# It also is possible that you want to use GnuTLS - and want to use a later
+# version.  HOWTO.dual.gnutls for setting this up.
+#
+# OpenSSL and GnuTLS are currently supported
+#
+
+############################################################################
+#
+# Testing examples
+#
+############################################################################
+#
+# Update PKCS11 token with certificates and keys
+#
+# Assumption is that you already have the following PEM files
+#  ca-cert.pem     - The certificate of the CA that signed Server and Client
+#  server-cert.pem - Contains the server certificate in PEM format
+#  server-key.pem  - Contains the server private key in PEM format
+#  client-cert.pem - Contains the server certificate in PEM format
+#  client-key.pem  - Contains the server private key in PEM format
+#
+# Tokens will be stored under /var/lib/softhsm/tokens/
+#
+
+# Initialize Soft HSM token
+#  Note: slot 0 is re-allocated to slot XXX.  This is presented as a decimal
+# number, the hex equivalent (leading 0x) can be used for any slot options..
+# Set SO PIN to 4321, user PIN to 1234
+softhsm2-util --init-token --slot 0 --label "token-0" --pin 1234 --so-pin 4321
+
+# CA Certificate (different id to Server/Client Public Certificate)
+openssl x509 -in ca-cert.pem -out ca-cert.der -outform DER
+pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so --pin 1234 \
+  --write-object ./ca-cert.der --type cert --id cc00 --label "ca-cert" \
+  --token-label "token-0"
+
+# Server Private Key
+openssl pkcs8 -topk8 -inform PEM -outform PEM -in server-key.pem \
+  -out server-key.pk8 -nocrypt
+softhsm2-util --import server-key.pk8 --label "server-key" --id aa00 \
+  --pin 1234 --token "token-0"
+
+# Server Public Certificate
+# (Use different id to private key, but not the same as CA/Client cert)
+openssl x509 -in server-cert.pem -out server-cert.der -outform DER
+pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so --pin 1234 \
+  --write-object ./server-cert.der --type cert --id aa01 \
+  --label "server-cert" --token-label "token-0"
+
+# Client Private Key
+openssl pkcs8 -topk8 -inform PEM -outform PEM -in client-key.pem \
+  -out client-key.pk8 -nocrypt
+softhsm2-util --import client-key.pk8 --label "client-key" --id bb00 \
+  --pin 1234 --token "token-0"
+
+# Client Public Certificate
+# (Use different id to private key, but not the same as CA/Client cert)
+openssl x509 -in client-cert.pem -out client-cert.der -outform DER
+pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so --pin 1234 \
+  --write-object ./client-cert.der --type cert --id bb01 \
+  --label "client-cert" --token-label "token-0"
+
+# Verify token is correctly populated
+pkcs11-tool --module=/usr/local/lib/softhsm/libsofthsm2.so -t
+pkcs11-tool --module=/usr/local/lib/softhsm/libsofthsm2.so --list-objects \
+  --pin 1234 --token-label "token-0"
+
+#
+# Run coap-server using PKCS11
+#
+coap-server -C 'pkcs11:token=token-0;id=%cc%00?pin-value=1234' \
+  -c 'pkcs11:token=token-0;id=%aa%01?pin-value=1234' \
+  -j 'pkcs11:token=token-0;id=%aa%00?pin-value=1234' -v9 -n
+
+# or
+coap-server -C 'pkcs11:token=token-0;id=%cc%00' \
+  -c 'pkcs11:token=token-0;id=%aa%01' \
+  -j 'pkcs11:token=token-0;id=%aa%00' -J 1234 -v9 -n
+
+# or
+coap-server -C 'pkcs11:token=token-0;object=ca-cert' \
+  -c 'pkcs11:token=token-0;object=server-cert' \
+  -j 'pkcs11:token=token-0;object=server-key' -J 1234 -v9 -n
+
+#
+# Run coap-client using PKCS11
+#
+coap-client -C 'pkcs11:token=token-0;id=%cc%00?pin-value=1234' \
+  -c 'pkcs11:token=token-0;id=%bb%01?pin-value=1234' \
+  -j 'pkcs11:token=token-0;id=%bb%00?pin-value=1234' -v9 coaps://[::1]
+
+# or
+coap-client -C 'pkcs11:token=token-0;id=%cc%00' \
+  -c 'pkcs11:token=token-0;id=%bb%01' \
+  -j 'pkcs11:token=token-0;id=%bb%00' -J 1234 -v9 coaps://[::1]
+
+# or
+coap-client -C 'pkcs11:token=token-0;object=ca-cert' \
+  -c 'pkcs11:token=token-0;object=client-cert' \
+  -j 'pkcs11:token=token-0;object=client-key' -J 1234 -v9 coaps://[::1]
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -171,6 +171,7 @@ coap_dtls_new_server_session \
 coap_dtls_receive \
 coap_dtls_send \
 coap_dtls_session_update_mtu \
+coap_dtls_shutdown \
 coap_dtls_startup \
 coap_epoll_ctl_mod \
 coap_io_do_events \

--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -150,8 +150,9 @@ typedef enum coap_asn1_privatekey_type_t {
  */
 typedef enum coap_pki_key_t {
   COAP_PKI_KEY_PEM = 0,        /**< The PKI key type is PEM file */
-  COAP_PKI_KEY_ASN1,           /**< The PKI key type is ASN.1 (DER) */
+  COAP_PKI_KEY_ASN1,           /**< The PKI key type is ASN.1 (DER) buffer */
   COAP_PKI_KEY_PEM_BUF,        /**< The PKI key type is PEM buffer */
+  COAP_PKI_KEY_PKCS11,         /**< The PKI key type is PKCS11 (DER) */
 } coap_pki_key_t;
 
 /**
@@ -195,6 +196,18 @@ typedef struct coap_pki_key_asn1_t {
 } coap_pki_key_asn1_t;
 
 /**
+ * The structure that holds the PKI PKCS11 definitions.
+ */
+typedef struct coap_pki_key_pkcs11_t {
+  const char *ca;            /**< pkcs11: URI for Common CA Certificate */
+  const char *public_cert;   /**< pkcs11: URI for Public Cert */
+  const char *private_key;   /**< pkcs11: URI for Private Key */
+  const char *user_pin;      /**< User pin to access PKCS11.  If NULL, then
+                                  pin-value= parameter must be set in
+                                  pkcs11: URI as a query. */
+} coap_pki_key_pkcs11_t;
+
+/**
  * The structure that holds the PKI key information.
  */
 typedef struct coap_dtls_key_t {
@@ -202,7 +215,8 @@ typedef struct coap_dtls_key_t {
   union {
     coap_pki_key_pem_t pem;          /**< for PEM file keys */
     coap_pki_key_pem_buf_t pem_buf;  /**< for PEM memory keys */
-    coap_pki_key_asn1_t asn1;        /**< for ASN.1 (DER) file keys */
+    coap_pki_key_asn1_t asn1;        /**< for ASN.1 (DER) memory keys */
+    coap_pki_key_pkcs11_t pkcs11;    /**< for PKCS11 keys */
   } key;
 } coap_dtls_key_t;
 
@@ -399,7 +413,7 @@ typedef const coap_dtls_spsk_info_t *(*coap_dtls_psk_sni_callback_t)(
                                  struct coap_session_t *coap_session,
                                  void *arg);
 
-#define COAP_DTLS_SPSK_SETUP_VERSION 1 /**< Latest CPSK setup version */
+#define COAP_DTLS_SPSK_SETUP_VERSION 1 /**< Latest SPSK setup version */
 
 /**
  * The structure used for defining the Server PSK setup data to be used.
@@ -793,6 +807,14 @@ ssize_t coap_tls_read(struct coap_session_t *coap_session,
  *
  */
 void coap_dtls_startup(void);
+
+/**
+ * Close down the underlying (D)TLS Library layer.
+ *
+ * Internal function.
+ *
+ */
+void coap_dtls_shutdown(void);
 
 /** @} */
 

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -19,7 +19,8 @@ SYNOPSIS
               [*-t* type] [*-v* num] [*-A* type] [*-B* seconds] [*-K* interval]
               [*-N*] [*-O* num,text] [*-P* addr[:port]] [*-T* token] [*-U*]
               [[*-h* match_hint_file] [*-k* key] [*-u* user]]
-              [[*-c* certfile] [*-C* cafile] [*-R* root_cafile]] URI
+              [[*-c* certfile] [*-j* keyfile] [*-C* cafile] [*-J* pkcs11_pin]
+              [*-R* root_cafile]] URI
 
 DESCRIPTION
 -----------
@@ -30,8 +31,8 @@ command line. The URI must have the scheme 'coap', 'coap+tcp', 'coaps' or
 built with support for secure (D)TLS communication.
 
 If 'coaps' or 'coap+tcp' is being used, provided the CoAP server supports PKI
-and is configured with a Certificate and Private Key, the coap-client does not
-need to have a Pre-Shared Key (-k) or Certificate (-c) configured.
+and is configured with a certificate and private key, the coap-client does not
+need to have a Pre-Shared Key (-k) or certificate (-c) configured.
 
 The URI's host part may be a DNS name or a literal IP address. Note that, for
 IPv6 address references, angle brackets are required (c.f. EXAMPLES).
@@ -153,17 +154,30 @@ OPTIONS - PKI
 -------------
 (If supported by underlying (D)TLS library)
 
+*Note:* If any one of *certfile*, *keyfile* or *cafile* is in PKCS11 URI
+naming format (pkcs11: prefix), then any remaining non PKCS11 URI file
+definitions have to be in DER, not PEM, format.  Otherwise all of
+*certfile*, *keyfile* or *cafile* are in PEM format.
+
 *-c* certfile::
-   Use the specified PEM file which contains the CERTIFICATE and PRIVATE
-   KEY information.
+   PEM file or PKCS11 URI for the certificate. The private key can be in the
+   PEM file, or use the same PKCS11 URI. If not, the private key is defined
+   by *-j keyfile*.
+
+*-j* keyfile::
+   PEM file or PKCS11 URI for the private key for the certificate in *-c
+   certfile* if the parameter is different from certfile in *-c certfile*.
 
 *-C* cafile::
-  PEM file containing the CA Certificate that was used to sign the certfile
-  defined using *-c certfile*.
+  PEM file or PKCS11 URI for the CA certificate that was used to sign the
+  certfile defined using *-c certfile*.
   This will trigger the validation of the server certificate.
   If certfile is self-signed (as defined by *-c certfile*), then you need to
   have on the command line the same filename for both the certfile and cafile
-  (as in  *-c certfile -C certfile*) to trigger validation.
+  (as in *-c certfile -C certfile*) to trigger validation.
+
+*-J* pkcs11_pin::
+  The user pin to unlock access to the PKCS11 token.
 
 *-R* root_cafile::
   PEM file containing the set of trusted root CAs that are to be used to

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -18,8 +18,8 @@ SYNOPSIS
               [*-A* address] [*-N*]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
               [*-s* match_psk_sni_file]]
-              [[*-c* certfile] [*-n*] [*-C* cafile] [*-R* root_cafile]
-              [*-S* match_pki_sni_file]]
+              [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
+              [*-J* pkcs11_pin] [*-R* root_cafile] [*-S* match_pki_sni_file]]
 
 DESCRIPTION
 -----------
@@ -82,8 +82,8 @@ OPTIONS - PSK
 
 *-k* key::
    Pre-shared key to use for inbound connections. This cannot be empty if
-   defined.
-   *Note:* if *-c cafile* is defined, you need to define *-k key* as well to
+   defined. +
+   Note: if *-c cafile* is defined, you need to define *-k key* as well to
    have the server support both PSK and PKI.
 
 *-s* match_psk_sni_file::
@@ -100,23 +100,36 @@ OPTIONS - PKI
 -------------
 (If supported by underlying (D)TLS library)
 
+*Note:* If any one of *certfile*, *keyfile* or *cafile* is in PKCS11 URI
+naming format (pkcs11: prefix), then any remaining non PKCS11 URI file
+definitions have to be in DER, not PEM, format.  Otherwise all of
+*certfile*, *keyfile* or *cafile* are in PEM format.
+
 *-c* certfile::
-   Use the specified PEM file which contains the CERTIFICATE and PRIVATE
-   KEY information.
-   *Note:* if *-k key* is defined, you need to define *-c cafile* as well to
+   PEM file or PKCS11 URI for the certificate. The private key can be in
+   the PEM file, or use the same PKCS11 URI. If not, the private key is defined
+   by *-j keyfile*. +
+   Note: if *-k key* is defined, you need to define *-c certfile* as well to
    have the server support both PSK and PKI.
+
+*-j* keyfile::
+   PEM file or PKCS11 URI for the private key for the certificate in *-c
+   certfile* if the parameter is different from certfile in *-c certfile*.
 
 *-n* ::
    Disable the requirement for clients to have defined client certificates.
 
 *-C* cafile::
-  PEM file containing the CA Certificate that was used to sign the certfile
-  defined using *-c certfile*.
-  If defined, then the client will be given this CA Certificate during the TLS
-  set up. Furthermore, this will trigger the validation of the client
-  certificate. If certfile is self-signed (as defined by *-c certfile*), then
-  you need to have on the command line the same filename for both the certfile
-  and cafile (as in  *-c certfile -C certfile*) to trigger validation.
+  PEM file or PKCS11 URI for the CA certificate that was used to sign the
+  certfile. If defined, then the client will be given this CA certificate
+  during the TLS set up. Furthermore, this will trigger the validation of the
+  client certificate.  If certfile is self-signed (as defined by *-c
+  certfile*), then you need to have on the command line the same filename for
+  both the certfile and cafile (as in  *-c certfile -C certfile*) to trigger
+  validation.
+
+*-J* pkcs11_pin::
+   The user pin to unlock access to the PKCS11 token.
 
 *-R* root_cafile::
   PEM file containing the set of trusted root CAs that are to be used to
@@ -126,7 +139,7 @@ OPTIONS - PKI
 
 *-S* match_pki_sni_file::
    This option denotes a file that contains one or more lines of Subject Name
-   Identifier (SNI) to match for new Certificate File and new CA File (comma
+   Identifier (SNI) to match for new certificate File and new CA File (comma
    separated) to be used. E.g., entry per line +
    sni_to_match,new_cert_file,new_ca_file +
    A line that starts with # is treated as a comment. +

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -117,8 +117,8 @@ environment.
 [source, c]
 ----
 typedef struct coap_dtls_cpsk_t {
-  coap_dtls_cpsk_version_t version; /** Set to COAP_DTLS_CPSK_SETUP_VERSION
-                                   to support the version of the struct */
+  uint8_t version; /** Set to COAP_DTLS_CPSK_SETUP_VERSION
+                       to support the version of the struct */
 
   /* Options to enable different TLS functionality in libcoap */
   uint8_t reserved[7];             /* Reserved - must be set to 0 for
@@ -152,12 +152,7 @@ definition.
 *SECTION: PSK Client: coap_dtls_cpsk_t: Version*
 [source, c]
 ----
-typedef enum
-{
-  COAP_DTLS_CPSK_SETUP_VERSION_V1 = 1,
-  COAP_DTLS_CPSK_SETUP_VERSION =
-             COAP_DTLS_CPSK_SETUP_VERSION_V1, /**< Latest CPSK setup version */
-} coap_dtls_cpsk_version_t;
+#define COAP_DTLS_CPSK_SETUP_VERSION 1 /**< Latest CPSK setup version */
 ----
 
 *version* is set to COAP_DTLS_CPSK_SETUP_VERSION.  This will then allow
@@ -245,8 +240,8 @@ environment.
 [source, c]
 ----
 typedef struct coap_dtls_spsk_t {
-  coap_dtls_spsk_version_t version; /** Set to COAP_DTLS_SPSK_SETUP_VERSION
-                                   to support the version of the struct */
+  uint8_t version; /** Set to COAP_DTLS_SPSK_SETUP_VERSION
+                       to support the version of the struct */
 
   /* Options to enable different TLS functionality in libcoap */
   uint8_t reserved[7];             /* Reserved - must be set to 0 for
@@ -281,12 +276,7 @@ definition.
 *SECTION: PSK Server: coap_dtls_spsk_t: Version*
 [source, c]
 ----
-typedef enum
-{
-  COAP_DTLS_SPSK_SETUP_VERSION_V1 = 1,
-  COAP_DTLS_SPSK_SETUP_VERSION =
-       COAP_DTLS_SPSK_SETUP_VERSION_V1, /**< Latest SPSK setup version */
-} coap_dtls_spsk_version_t;
+#define COAP_DTLS_SPSK_SETUP_VERSION 1 /**< Latest SPSK setup version */
 ----
 
 *version* is set to COAP_DTLS_SPSK_SETUP_VERSION.  This will then allow
@@ -650,13 +640,15 @@ example, a different certificate should be provided.
 ----
 typedef enum coap_pki_key_t {
   COAP_PKI_KEY_PEM,     /* The PKI key type is PEM file */
-  COAP_PKI_KEY_ASN1,    /* The PKI key type is ASN.1 (DER) */
+  COAP_PKI_KEY_ASN1,    /* The PKI key type is ASN.1 (DER) buffer */
   COAP_PKI_KEY_PEM_BUF, /* The PKI key type is PEM buffer */
+  COAP_PKI_KEY_PKCS11,  /* The PKI key type is PKCS11 (DER) */
 } coap_pki_key_t;
 ----
 
 *key_type* defines the format that the certificates / keys are provided in.
-This can be COAP_PKI_KEY_PEM, COAP_PKI_KEY_PEM_BUF or COAP_PKI_KEY_ASN1.
+This can be COAP_PKI_KEY_PEM, COAP_PKI_KEY_PEM_BUF, COAP_PKI_KEY_ASN1 or
+COAP_PKI_KEY_PKCS11.
 
 *SECTION: PKI: coap_dtls_pki_t: PEM Key Definitions*
 [source, c]
@@ -772,6 +764,38 @@ of the private key.
 *key.asn1.private_key_type* is the encoding type of the DER encoded ASN.1
 definition of the private key.  This will be one of the COAP_ASN1_PKEY_*
 definitions.
+
+*SECTION: PKI: coap_dtls_pki_t: PKCS11 Key Definitions*
+[source, c]
+----
+typedef struct coap_pki_key_pkcs11_t {
+  const char *ca;            /* pkcs11: URI for Common CA Certificate */
+  const char *public_cert;   /* pkcs11: URI for Public Cert */
+  const char *private_key;   /* pkcs11: URI for Private Key */
+  const char *pin;           /* pin to access PKCS11.  If NULL, then
+                                pin-value= parameter must be set in
+                                pkcs11: URI as a query. */
+} coap_pki_key_pkcs11_t;
+----
+
+*key.pkcs11.ca* is a pkcs11: URI for the CA certificate or NULL.  This is for
+the CA (that has signed the public certificate) as this is passed from the
+server to the client when requesting the client's certificate. This certificate
+is also added into the valid root CAs list if not already present.
+An example URI is 'pkcs11:pkcs11:token=My%20Token;id=%aa%bb%cc%dd' which is
+for token 'My Token' and (hex) id of 'aabbccdd'.
+
+*key.pkcs11.public_cert* is a pkcs11: URI for the Public Certificate which
+was signed by *key.pkcs11.ca* or NULL.
+
+*key.pkcs11.private_key* is a pkcs11: URI for the Private Key for the
+public certificate defined by *key.pkcs11.public_cert* or NULL.
+
+*key.pkcs11.user_pin* is the user pin used to unlock the token or NULL.
+If NULL, the pin can be defined on the other pkcs11: URI entries by using
+pin-value=XXX as a query - e.g.
+'pkcs11:pkcs11:token=My%20Token;id=%aa%bb%cc%dd?pin-value=XXX' where XXX is
+the user pin.
 
 EXAMPLES
 --------

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -649,11 +649,17 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
       mbedtls_ssl_conf_ca_chain(&m_env->conf, cacert, NULL);
     }
     break;
+
+  case COAP_PKI_KEY_PKCS11:
+    coap_log(LOG_ERR,
+             "***setup_pki: (D)TLS: PKCS11 not currently supported\n");
+    return -1;
+
   default:
     coap_log(LOG_ERR,
              "***setup_pki: (D)TLS: Unknown key type %d\n",
              setup_data->pki_key.key_type);
-      return -1;
+    return -1;
   }
 
   if (m_context->root_ca_file) {
@@ -1786,6 +1792,9 @@ ssize_t coap_tls_read(coap_session_t *c_session UNUSED,
 
 void coap_dtls_startup(void)
 {
+}
+
+void coap_dtls_shutdown(void) {
 }
 
 static int keep_log_level = 0;

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -76,6 +76,9 @@ static int dtls_log_level = 0;
 void coap_dtls_startup(void) {
 }
 
+void coap_dtls_shutdown(void) {
+}
+
 void
 coap_dtls_set_log_level(int level) {
   dtls_log_level = level;

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -37,6 +37,9 @@ void coap_dtls_startup(void) {
   coap_ticks(&coap_tick_0);
 }
 
+void coap_dtls_shutdown(void) {
+}
+
 void
 coap_dtls_set_log_level(int level) {
   dtls_set_log_level(level);

--- a/src/net.c
+++ b/src/net.c
@@ -2678,6 +2678,7 @@ void coap_cleanup(void) {
 #if defined(HAVE_WINSOCK2_H)
   WSACleanup();
 #endif
+  coap_dtls_shutdown();
 }
 
 #if ! defined WITH_CONTIKI && ! defined WITH_LWIP && ! defined RIOT_VERSION


### PR DESCRIPTION
Add in a new PKI_KEY type for PKCS11 URI to get the PKI information from a
smart card or hsm device.

Currently only OpenSSL and GnuTLS are supported.

Makefile.am:

Do not expose coap_dtls_shutdown() function.

examples/client.c:
examples/coap-server.c:

Add in support for using pkcs11: URIs for defining the Certificates and
Private Keys.

include/coap2/coap_dtls.h:

Add in COAP_PKI_KEY_PKCS11 Key type.

man/coap-client.txt.in:
man/coap-server.txt.in:

Update documentation for supporting PKCS11.

man/coap_encryption.txt.in:

Add in documentation for COAP_PKI_KEY_PKCS11.
Correct some typos.

HOWTO.dual.gnutls (new):
HOWTO.dual.openssl (new):
HOWTO.pkcs11 (new):

HowTo information.

src/coap_gnutls.c:
src/coap_openssl.c:

Add in PKCS11 support.

src/coap_mbedtls.c:

PKCS11 not yet supported.
Add in no-op coap_dtls_shutdown() function.

src/coap_notls.c:
src/coap_tinydtls.c:

Add in no-op coap_dtls_shutdown() function.

src/net.c:

Invoke coap_dtls_shutdown() function in coap_cleanup().

NOTE: There are memory leaks after cleanly closing down.  These are not within
libcoap as far as can be determined.  These leaks are a work in progress.

Addresses PKCS11 question raised in the libcoap-developers mailing list.