### PR TITLE
RFC8768: Add in support for CoAP Option Hop Limit loop detection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -174,9 +174,11 @@ coap_dtls_session_update_mtu \
 coap_dtls_shutdown \
 coap_dtls_startup \
 coap_epoll_ctl_mod \
+coap_insert_option \
 coap_io_do_events \
 coap_mfree_endpoint \
 coap_packet_extract_pbuf \
+coap_pdu_check_resize \
 coap_pdu_from_pbuf \
 coap_session_mfree \
 coap_session_new_dtls_session \
@@ -199,6 +201,7 @@ coap_tls_new_client_session \
 coap_tls_new_server_session \
 coap_tls_read \
 coap_tls_write \
+coap_update_option \
 "
 
 # This helper is called by libcoap-$(LIBCOAP_API_VERSION).{map,sym} to see if

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ The following RFCs are supported
 * RFC8132: PATCH and FETCH Methods for the Constrained Application Protocol (CoAP)
 
 * RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets
+  [No WebSockets support]
+
+* RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option
 
 There is (D)TLS support for the following libraries
 

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -16,8 +16,9 @@ SYNOPSIS
 --------
 *coap-client* [*-a* addr] [*-b* [num,]size] [*-e* text] [*-f* file] [*-l* loss]
               [*-m* method] [*-o* file] [*-p* port] [*-r*] [*-s duration*]
-              [*-t* type] [*-v* num] [*-A* type] [*-B* seconds] [*-K* interval]
-              [*-N*] [*-O* num,text] [*-P* addr[:port]] [*-T* token] [*-U*]
+              [*-t* type] [*-v* num] [*-A* type] [*-B* seconds]
+              [*-H* hoplimit] [*-K* interval] [*-N*] [*-O* num,text]
+              [*-P* addr[:port]] [*-T* token] [*-U*]
               [[*-h* match_hint_file] [*-k* key] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [*-C* cafile] [*-J* pkcs11_pin]
               [*-R* root_cafile]] URI
@@ -108,6 +109,10 @@ OPTIONS - General
 
 *-B* seconds::
    Break operation after waiting given seconds (default is 90).
+
+*-H* hoplimit::
+   Set the Hop Limit count to hoplimit for proxies. Must have a value between
+   1 and 255 inclusive. Default is '16'.
 
 *-K* interval::
    Send a ping after interval seconds of inactivity.

--- a/man/coap.txt.in
+++ b/man/coap.txt.in
@@ -61,6 +61,8 @@ See
 
 "RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets"
 
+"RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option"
+
 for further information.
 
 BUGS

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -149,26 +149,54 @@ of the data of the option, and _data_ points to the content of the option.
 
 The following is the current list of options with their numeric value
 ----
-#define COAP_OPTION_IF_MATCH        1 /* opaque, 0-8 B */
-#define COAP_OPTION_URI_HOST        3 /* String, 1-255 B */
-#define COAP_OPTION_ETAG            4 /* opaque, 1-8 B */
-#define COAP_OPTION_IF_NONE_MATCH   5 /* empty,  0 B */
-#define COAP_OPTION_OBSERVE         6 /* empty/uint, 0 B/0-3 B */
-#define COAP_OPTION_URI_PORT        7 /* uint, 0-2 B */
-#define COAP_OPTION_LOCATION_PATH   8 /* String, 0-255 B */
-#define COAP_OPTION_URI_PATH       11 /* String, 0-255 B */
-#define COAP_OPTION_CONTENT_FORMAT 12 /* uint, 0-2 B */
-#define COAP_OPTION_MAXAGE         14 /* uint, 0-4 B, default 60 Seconds */
-#define COAP_OPTION_URI_QUERY      15 /* String, 1-255 B */
-#define COAP_OPTION_ACCEPT         17 /* uint, 0-2 B */
-#define COAP_OPTION_LOCATION_QUERY 20 /* String, 0-255 B */
-#define COAP_OPTION_BLOCK2         23 /* uint, 0-3 B */
-#define COAP_OPTION_BLOCK1         27 /* uint, 0-3 B */
-#define COAP_OPTION_SIZE2          28 /* uint, 0-4 B */
-#define COAP_OPTION_PROXY_URI      35 /* String, 1-1034 B */
-#define COAP_OPTION_PROXY_SCHEME   39 /* String, 1-255 B */
-#define COAP_OPTION_SIZE1          60 /* uint, 0-4 B */
-#define COAP_OPTION_NORESPONSE    258 /* uint, 0-1 B */
+/*
+ * The C, U, and N flags indicate the properties
+ * Critical, Unsafe, and NoCacheKey, respectively.
+ * If U is set, then N has no meaning as per
+ * https://tools.ietf.org/html/rfc7252#section-5.10
+ * and is set to a -.
+ * Separately, R is for the options that can be repeated
+ *
+ * The least significant byte of the option is set as followed
+ * as per https://tools.ietf.org/html/rfc7252#section-5.4.6
+ *
+ *   0   1   2   3   4   5   6   7
+ * --+---+---+---+---+---+---+---+
+ *           | NoCacheKey| U | C |
+ * --+---+---+---+---+---+---+---+
+ *
+ * https://tools.ietf.org/html/rfc8613#section-4 goes on to define E, I and U
+ * properties Encrypted and Integrity Protected, Integrity Protected Only and
+ * Unprotected respectively.  Integretity Protected Only is not currently used.
+ *
+ * An Option is tagged with CUNREIU with any of the letters replaced with _ if
+ * not set, or - for N if U is set (see above) for aiding understanding of the
+ * Option.
+ */
+
+#define COAP_OPTION_IF_MATCH        1 /* C__RE__, opaque,    0-8 B, RFC7252 */
+#define COAP_OPTION_URI_HOST        3 /* CU-___U, String,  1-255 B, RFC7252 */
+#define COAP_OPTION_ETAG            4 /* ___RE__, opaque,    1-8 B, RFC7252 */
+#define COAP_OPTION_IF_NONE_MATCH   5 /* C___E__, empty,       0 B, RFC7252 */
+#define COAP_OPTION_OBSERVE         6 /* _U-_E_U, empty/uint,  0 B/0-3 B, RFC7641 */
+#define COAP_OPTION_URI_PORT        7 /* CU-___U, uint,      0-2 B, RFC7252 */
+#define COAP_OPTION_LOCATION_PATH   8 /* ___RE__, String,  0-255 B, RFC7252 */
+#define COAP_OPTION_OSCORE          9 /* C_____U, *,       0-255 B, RFC8613 */
+#define COAP_OPTION_URI_PATH       11 /* CU-RE__, String,  0-255 B, RFC7252 */
+#define COAP_OPTION_CONTENT_FORMAT 12 /* ____E__, uint,      0-2 B, RFC7252 */
+/* COAP_OPTION_MAXAGE default 60 seconds if not set */
+#define COAP_OPTION_MAXAGE         14 /* _U-_E_U, uint,      0-4 B, RFC7252 */
+#define COAP_OPTION_URI_QUERY      15 /* CU-RE__, String,  1-255 B, RFC7252 */
+#define COAP_OPTION_HOP_LIMIT      16 /* ______U, uint,        1 B, RFC8768 */
+#define COAP_OPTION_ACCEPT         17 /* C___E__, uint,      0-2 B, RFC7252 */
+#define COAP_OPTION_LOCATION_QUERY 20 /* ___RE__, String,  0-255 B, RFC7252 */
+#define COAP_OPTION_BLOCK2         23 /* CU-_E_U, uint,      0-3 B, RFC7959 */
+#define COAP_OPTION_BLOCK1         27 /* CU-_E_U, uint,      0-3 B, RFC7959 */
+#define COAP_OPTION_SIZE2          28 /* __N_E_U, uint,      0-4 B, RFC7959 */
+#define COAP_OPTION_PROXY_URI      35 /* CU-___U, String, 1-1034 B, RFC7252 */
+#define COAP_OPTION_PROXY_SCHEME   39 /* CU-___U, String,  1-255 B, RFC7252 */
+#define COAP_OPTION_SIZE1          60 /* __N_E_U, uint,      0-4 B, RFC7252 */
+#define COAP_OPTION_NORESPONSE    258 /* _U-_E_U, uint,      0-1 B, RFC7967 */
 ----
 See FURTHER INFORMATION as to how to get the latest list.
 

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -316,14 +316,15 @@ msg_option_string(uint8_t code, uint16_t option_type) {
     { COAP_OPTION_CONTENT_FORMAT, "Content-Format" },
     { COAP_OPTION_MAXAGE, "Max-Age" },
     { COAP_OPTION_URI_QUERY, "Uri-Query" },
+    { COAP_OPTION_HOP_LIMIT, "Hop-Limit" },
     { COAP_OPTION_ACCEPT, "Accept" },
     { COAP_OPTION_LOCATION_QUERY, "Location-Query" },
     { COAP_OPTION_BLOCK2, "Block2" },
     { COAP_OPTION_BLOCK1, "Block1" },
+    { COAP_OPTION_SIZE2, "Size2" },
     { COAP_OPTION_PROXY_URI, "Proxy-Uri" },
     { COAP_OPTION_PROXY_SCHEME, "Proxy-Scheme" },
     { COAP_OPTION_SIZE1, "Size1" },
-    { COAP_OPTION_SIZE2, "Size2" },
     { COAP_OPTION_NORESPONSE, "No-Response" }
   };
 
@@ -571,6 +572,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
     case COAP_OPTION_OBSERVE:
     case COAP_OPTION_SIZE1:
     case COAP_OPTION_SIZE2:
+    case COAP_OPTION_HOP_LIMIT:
       /* show values as unsigned decimal value */
       buf_len = snprintf((char *)buf, sizeof(buf), "%u",
                          coap_decode_var_bytes(coap_opt_value(option),
@@ -584,6 +586,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
           opt_iter.type == COAP_OPTION_URI_HOST ||
           opt_iter.type == COAP_OPTION_LOCATION_PATH ||
           opt_iter.type == COAP_OPTION_LOCATION_QUERY ||
+          opt_iter.type == COAP_OPTION_PROXY_SCHEME ||
           opt_iter.type == COAP_OPTION_URI_QUERY) {
         encode = 0;
       } else {


### PR DESCRIPTION
All this is handled by libcoap with coap-client having the ability to define
an initial Hop Count value for testing. No other application support is
required.

Incoming requests are checked for the Hop Limit option - if found, the value
is decremented in the PDU before passing it up to the application. If it
decrements to 0, a 5.08 response is generated.

coap_add_option() checks if this is a Proxy option for a request. If so, and
Hop Limit option does not exist, then the Hop Limit option is inserted into
the PDU with the default value (16).

coap_send() checks if it is a 5.08 response and if so, prepends the diagnostic
data with the IP address of the transmitting interface. If the IP address
already exists, then the PDU is dropped as the return path for the 5.08 response
is looping.  An alternative method for return path looping check is also
used by initially setting, then testing and then decrementing the Hop Limit
value as response packets pass back through the proxies.  If a proxy does not
copy the Hop Limit options when returning the 5.08 response, then the IP address
duplication is used.

Makefile.am:

Hide the coap_insert_option(), coap_update_option and coap_pdu_check_resize()
function from applications.

README.md:

Add in RFC8768 is supported by libcoap.

examples/client.c:

Add in the -H hoplimit option.

include/coap2/pdu.h:

Add in the default Hop-Limit: option COAP_OPTION_HOP_LIMIT.
Re-organize the COAP_OPTION_ descriptions to include
the C, U, N, R, E, I and U flags.
Expose the internal coap_pdu_check_resize() function so src/net.c can use it.
Define the two new internal functions coap_insert_option() and
coap_update_option() and expose them so that the test suites can use them.

man/coap-client.txt.in:

Document the new -H hoplimit option.

man/coap.txt.in:

Include the new RFC8768.

man/coap_pdu_setup.txt.in:

Update documentation for the CoAP options.

src/coap_debug.c:

Add in support for printing out COAP_OPTION_HOP_LIMIT.

src/net.c:

Make sure that COAP_OPTION_HOP_LIMIT is not returned in an error response.
Decrement received Hop-limit in handle_request() and generate 5.08 response
if appropriate.
Update coap_send() to prepend IP in 5.08 response.
Support COAP_OPTION_HOP_LIMIT being used in the 5.08 response message.

src/pdu.c:

Report on CoAP options that are repeated, but not defined as repeatable.
Define new (5.08) Hop Limit Reached error response.

Add in new internal coap_insert_option() function. This now means that
callers of coap_add_option() no longer have to have the options in the
correct order.

Add in new internal coap_update_option() function that updates the value of
an option.

Make coap_pdu_check_resize() non-static.

tests/test_pdu.c:

Check that options are getting inserted in the correct order when using
coap_insert_option(), even though they are provided in a random order.

Test the coap_update_option() function.