### PR TITLE
WIP: Code-Fragments for coap_cache

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST = \
   include/coap$(LIBCOAP_API_VERSION)/coap_subscribe_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_tcp_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/utlist.h \
+  src/murmur3.h \
   tests/test_error_response.h \
   tests/test_encode.h \
   tests/test_options.h \
@@ -73,6 +74,7 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_SOURCES = \
   src/address.c \
   src/async.c \
   src/block.c \
+  src/coap_cache.c \
   src/coap_debug.c \
   src/coap_event.c \
   src/coap_hashkey.c \
@@ -87,6 +89,7 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_SOURCES = \
   src/coap_tinydtls.c \
   src/encode.c \
   src/mem.c \
+  src/murmur3.c \
   src/net.c \
   src/option.c \
   src/pdu.c \
@@ -112,6 +115,7 @@ libcoap_include_HEADERS = \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/bits.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/block.h \
   $(top_builddir)/include/coap$(LIBCOAP_API_VERSION)/coap.h \
+  $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_cache.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_debug.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_dtls.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_event.h \

--- a/include/coap2/coap.h.in
+++ b/include/coap2/coap.h.in
@@ -37,6 +37,7 @@ extern "C" {
 #include "async.h"
 #include "bits.h"
 #include "block.h"
+#include "coap_cache.h"
 #include "coap_dtls.h"
 #include "coap_event.h"
 #include "coap_io.h"

--- a/include/coap2/coap_cache.h
+++ b/include/coap2/coap_cache.h
@@ -1,0 +1,89 @@
+/* coap_cache.h -- Caching of CoAP requests
+*
+* Copyright (C) 2020 Olaf Bergmann <bergmann@tzi.org>
+*
+* This file is part of the CoAP library libcoap. Please see
+* README for terms of use.
+*/
+
+/**
+ * @file coap_cache.h
+ * @brief Provides a simple request storage for CoAP requests
+ */
+
+#ifndef COAP_CACHE_H_
+#define COAP_CACHE_H_
+
+#include <limits.h>
+
+#include "coap_forward_decls.h"
+
+typedef enum {
+              COAP_CACHE_INVALID=-1,
+              COAP_CACHE_MAXKEY=INT_MAX
+} coap_cache_key_t;
+
+/**
+ * Calculates a cache key for the given CoAP PDU. See
+ * https://tools.ietf.org/html/rfc7252#section-5.6
+ * for an explanation of CoAP cache keys.
+ *
+ * @param pdu The CoAP PDU for which a cache key is to be
+ *            calculated.
+ *
+ * @return The calculcated cache key.
+ */
+coap_cache_key_t coap_cache_key(const coap_pdu_t *pdu);
+
+/**
+ * Marks a request for permanent storage. The request may be retrieved
+ * through its cache-key.
+ *
+ * @param ctx     The context to use.
+ * @param request The request to be stored.
+ *
+ * @return The cache key that corresponds to the newly stored
+ *         request or @c COAP_CACHE_INVALID if the request could
+ *         not be stored.
+ */
+coap_cache_key_t coap_cache_mark_request(coap_context_t *ctx,
+                                         const coap_pdu_t *request);
+
+/**
+ * Clears a mark from a request.
+ *
+ * @param ctx        The context to use.
+ * @param cache_key  The cache key for the request which can be
+ *                   unmarked.
+ */
+void coap_cache_unmark_request(coap_context_t *ctx,
+                               coap_cache_key_t cache_key);
+
+/**
+ * Searches for a cache entry identified by @p cache_key. This
+ * function returns the corresponding cache entry or @c NULL
+ * if not found.
+ *
+ * @param ctx        The context to use.
+ * @param cache_key  The cache key to look up.
+ *
+ * @return The cache entry for @p cache_key or @c NULL if not found.
+ */
+struct coap_cache_entry_t *coap_cache_lookup_key(coap_context_t *ctx,
+                                                 coap_cache_key_t cache_key);
+
+/**
+ * Searches for a cache entry corresponding to @p request. This
+ * function returns the corresponding cache entry or @c NULL if not
+ * found.
+ *
+ * @param ctx        The context to use.
+ * @param request    The CoAP request to search for.
+ *
+ * @return The cache entry for @p request or @c NULL if not found.
+ */
+struct coap_cache_entry_t *coap_cache_lookup_request(coap_context_t *ctx,
+                                                     const coap_pdu_t *request);
+
+
+#endif  /* COAP_CACHE_H */

--- a/include/coap2/coap_forward_decls.h
+++ b/include/coap2/coap_forward_decls.h
@@ -28,6 +28,7 @@ struct coap_queue_t;
 struct coap_session_t;
 struct coap_string_t;
 struct coap_subscription_t;
+struct coap_cache_entry_t;
 
 /*
  * typedef all the structures that are defined in coap_*_internal.h

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -206,6 +206,7 @@ typedef struct coap_context_t {
   unsigned int ping_timeout;           /**< Minimum inactivity time before sending a ping message. 0 means disabled. */
   unsigned int csm_timeout;           /**< Timeout for waiting for a CSM from the remote side. 0 means disabled. */
 
+  struct coap_cache_entry_t *cache; /**< CoAP message cache */
   void *app;                       /**< application-specific data */
 #ifdef COAP_EPOLL_SUPPORT
   int epfd;                        /**< External FD for epoll */

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -1,0 +1,110 @@
+/* coap_cache.c -- Caching of CoAP requests
+*
+* Copyright (C) 2020 Olaf Bergmann <bergmann@tzi.org>
+*
+* This file is part of the CoAP library libcoap. Please see
+* README for terms of use.
+*/
+
+#include "coap_internal.h"
+
+#include "murmur3.h"
+
+/* Determines if the given option_type denotes an option type that can
+ * be used as CacheKey. Options that can be cache keys are not Unsafe
+ * and not marked explicitly as NoCacheKey. */
+static int
+is_cache_key(uint16_t option_type) {
+  const uint16_t unsafe = 0x02;
+  const uint16_t no_cache_key = 0x04;
+
+  return (option_type & (unsafe | no_cache_key)) == 0;
+}
+
+coap_cache_key_t
+coap_cache_key(const coap_pdu_t *pdu) {
+  coap_opt_t *option;
+  coap_opt_iterator_t opt_iter;
+  murmur3_context_t mctx;
+
+  if (!coap_option_iterator_init(pdu, &opt_iter, COAP_OPT_ALL)) {
+    return COAP_CACHE_INVALID;
+  }
+
+  murmur3_32_init(&mctx);
+
+  while ((option = coap_option_next(&opt_iter))) {
+    if (is_cache_key(opt_iter.type)) {
+      murmur3_32_update(&mctx, option, coap_opt_size(option));
+    }
+  }
+
+  /* The body of a FETCH payload is part of the cache key,
+   * see https://tools.ietf.org/html/rfc8132#section-2 */
+  if (pdu->code == COAP_REQUEST_FETCH) {
+    size_t len;
+    uint8_t *data;
+    if (coap_get_data(pdu, &len, &data)) {
+      murmur3_32_update(&mctx, option, coap_opt_size(option));
+    }
+  }
+
+  return murmur3_32_finalize(&mctx);
+}
+
+typedef struct coap_cache_entry_t {
+  UT_hash_handle hh;
+  const coap_pdu_t *pdu;
+  coap_cache_key_t cache_key;
+} coap_cache_entry_t;
+
+/**
+ * Marks a request for permanent storage. The request may be retrieved
+ * through its cache-key.
+ *
+ * @param ctx     The context to use.
+ * @param request The request to be stored.
+ *
+ * @return The cache key that corresponds to the newly stored
+ *         request or @c COAP_CACHE_INVALID if the request could
+ *         not be stored.
+ */
+coap_cache_key_t
+coap_cache_mark_request(coap_context_t *ctx, const coap_pdu_t *request) {
+  coap_cache_entry_t *entry = coap_malloc(sizeof(coap_cache_entry_t));
+  if (!entry) {
+    return COAP_CACHE_INVALID;
+  }
+
+  entry->pdu = request;
+  entry->cache_key = coap_cache_key(request);
+  HASH_ADD(hh, ctx->cache, cache_key, sizeof(coap_cache_key_t), entry);
+  return entry->cache_key;
+}
+
+coap_cache_entry_t *
+coap_cache_lookup_key(coap_context_t *ctx, coap_cache_key_t key) {
+  coap_cache_entry_t *entry = NULL;
+  if (key != COAP_CACHE_INVALID) {
+    HASH_FIND(hh, ctx->cache, &key, sizeof(coap_cache_key_t), entry);
+  }
+  return entry;
+}
+
+coap_cache_entry_t *
+coap_cache_lookup_request(coap_context_t *ctx, const coap_pdu_t *request) {
+  return coap_cache_lookup_key(ctx, coap_cache_key(request));
+}
+
+/**
+ * Clears a mark from a request.
+ *
+ * @param ctx        The context to use.
+ * @param cache_key  The cache key for the request which can be
+ *                   unmarked.
+ */
+void
+coap_cache_unmark_request(coap_context_t *ctx, coap_cache_key_t cache_key) {
+  (void)ctx;
+  (void)cache_key;
+}


### PR DESCRIPTION
This PR addresses #470 by providing functions to select CacheKey options from CoAP messages. It uses a [murmur3 implementation](https://github.com/obgm/murmur3) for hash key calculations. As described in #470, this should be replaced by a cryptographically secure hash function. The idea is to provide wrapper functions `coap_crypto_sha256()` to the crypto functions of the underlying TLS library or fall back to `coap_hash()` if not built with TLS support. Example configuration for this etc. can be found [here](https://gitlab.informatik.uni-bremen.de/DCAF/dcaf/-/tree/master/) (see `src/dcaf_crypto*` and `include/dcaf/dcaf_crypto.h`).