### PR TITLE
TCP_DISABLE: reduce more of the dead code when --disable-tcp is in used

### DIFF
--- a/include/coap2/coap_tcp_internal.h
+++ b/include/coap2/coap_tcp_internal.h
@@ -23,6 +23,8 @@
  * @{
  */
 
+#if !COAP_DISABLE_TCP
+
 /**
  * Create a new TCP socket and initiate the connection
  *
@@ -98,6 +100,8 @@ coap_socket_accept_tcp(coap_socket_t *server,
                        coap_socket_t *new_client,
                        coap_address_t *local_addr,
                        coap_address_t *remote_addr);
+
+#endif /* !COAP_DISABLE_TCP */
 
 /** @} */
 


### PR DESCRIPTION
src/coap_session.c:
src/net.c:

Wrap more code with #if !COAP_DISABLE_TCP

See #330.