### PR TITLE
man pages: Tidy up

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -62,53 +62,38 @@ man7_MANS = $(MAN7)
 	$(A2X) --doctype manpage --format manpage $<
 	$(A2X) --doctype manpage --format xhtml $<
 
-# Man pages built byt a2x based on the NAMES section of the .txt file
+# Man pages built by a2x based on the NAMES section of the .txt file.
+# Note - this list includes all the defined entries, but a2x only builds the first 10.
 A2X_EXTRA_PAGES = @DOLLAR_SIGN@(shell for fil in $(TXT3) ; do sed -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $${fil} | \
 	sed -ne '/coap_/{ s/ *, */\n/g; p }' | sed -ne 's/^\(coap_[a-zA-Z_0-9]\+\).*$$/\1.3/p' ; done)
-
-# Extra man pages that need to be installed due to limit of 10
-# names built by a2x
-#
-# These files are created in install-man
-#
-EXTRA_PAGES = \
-	coap_context_set_pki_root_cas.3 \
-	coap_add_data_blocked_response.3 \
-	coap_encode_var_bytes.3 \
-	coap_split_path.3 \
-	coap_split_query.3 \
-	coap_session_get_app_data.3 \
-	coap_session_set_app_data.3 \
-	coap_is_tcp_supported.3 \
-	coap_endpoint_str.3 \
-	coap_session_str.3
 
 # a2x builds alternative .3 files up to a limit of 10 names from the
 # NAME section, so that 'man' works against the alternative different
 # function names.
 #
 # However, if there are more alternative names, they need to be defined
-# as per below as well as in EXTRA_PAGES above.
+# as per below
 #
 # Then all the alternative names as well as the extras defined below need
 # to be cleaned up in a 'make unistall'.
 install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_set_pki_root_cas.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_add_data_blocked_response.3
-	@echo ".so man3/coap_pdu_setup.3" > coap_encode_var_bytes.3
+	@echo ".so man3/coap_pdu_setup.3" > coap_encode_var_safe.3
+	@echo ".so man3/coap_pdu_setup.3" > coap_encode_var_safe8.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_split_path.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_split_query.3
 	@echo ".so man3/coap_session.3" > coap_session_get_app_data.3
 	@echo ".so man3/coap_session.3" > coap_session_set_app_data.3
-	@echo ".so man3/coap_session.3" > coap_is_tcp_supported.3
+	@echo ".so man3/coap_session.3" > coap_tcp_is_supported.3
 	@echo ".so man3/coap_logging.3" > coap_endpoint_str.3
 	@echo ".so man3/coap_logging.3" > coap_session_str.3
-	$(INSTALL_DATA) $(EXTRA_PAGES) $(A2X_EXTRA_PAGES) "$(DESTDIR)$(man3dir)"
+	$(INSTALL_DATA) $(A2X_EXTRA_PAGES) "$(DESTDIR)$(man3dir)"
 
 # As well as removing the base 'man' pages, remove other .3 files built by
 # a2x, as well as build by install-man specials.
 uninstall-man: uninstall-man3 uninstall-man5 uninstall-man7
-	-(cd $(DESTDIR)$(man3dir) ; rm -f $(EXTRA_PAGES) $(A2X_EXTRA_PAGES) )
+	-(cd $(DESTDIR)$(man3dir) ; rm -f $(A2X_EXTRA_PAGES) )
 
 endif # BUILD_MANPAGES
 

--- a/man/coap_attribute.txt.in
+++ b/man/coap_attribute.txt.in
@@ -10,7 +10,9 @@ coap_attribute(3)
 
 NAME
 ----
-coap_attribute, coap_add_attr, coap_find_attr
+coap_attribute,
+coap_add_attr,
+coap_find_attr
 - Work with CoAP attributes
 
 SYNOPSIS
@@ -127,7 +129,8 @@ information.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -10,9 +10,15 @@ coap_context(3)
 
 NAME
 ----
-coap_context, coap_new_context, coap_free_context,
-coap_context_set_pki, coap_context_set_psk2, coap_new_endpoint,
-coap_free_endpoint, coap_endpoint_set_default_mtu
+coap_context,
+coap_new_context,
+coap_free_context,
+coap_context_set_pki,
+coap_context_set_pki_root_cas,
+coap_context_set_psk2,
+coap_new_endpoint,
+coap_free_endpoint,
+coap_endpoint_set_default_mtu
 - Work with CoAP contexts
 
 SYNOPSIS
@@ -542,7 +548,8 @@ information.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -10,7 +10,10 @@ coap_encryption(3)
 
 NAME
 ----
-coap_encryption, coap_dtls_cpsk_t, coap_dtls_spsk_t, coap_dtls_pki_t
+coap_encryption,
+coap_dtls_cpsk_t,
+coap_dtls_spsk_t,
+coap_dtls_pki_t
 - Work with CoAP TLS/DTLS
 
 SYNOPSIS
@@ -1152,7 +1155,8 @@ information.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -10,9 +10,13 @@ coap_handler(3)
 
 NAME
 ----
-coap_handler, coap_register_handler, coap_register_response_handler,
-coap_register_nack_handler, coap_register_ping_handler,
-coap_register_pong_handler, coap_register_event_handler
+coap_handler,
+coap_register_handler,
+coap_register_response_handler,
+coap_register_nack_handler,
+coap_register_ping_handler,
+coap_register_pong_handler,
+coap_register_event_handler
 - work with CoAP handlers
 
 SYNOPSIS
@@ -301,7 +305,8 @@ information.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -10,8 +10,14 @@ coap_io(3)
 
 NAME
 ----
-coap_io, coap_io_process, coap_io_process_with_fds, coap_context_get_coap_fd,
-coap_io_prepare_io, coap_io_do_io, coap_io_prepare_epoll, coap_io_do_epoll
+coap_io,
+coap_io_process,
+coap_io_process_with_fds,
+coap_context_get_coap_fd,
+coap_io_prepare_io,
+coap_io_do_io,
+coap_io_prepare_epoll,
+coap_io_do_epoll
 - Work with CoAP I/O to do the packet send and receives
 
 SYNOPSIS
@@ -417,7 +423,8 @@ information.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_keepalive.txt.in
+++ b/man/coap_keepalive.txt.in
@@ -10,7 +10,9 @@ coap_keepalive(3)
 
 NAME
 ----
-coap_keepalive, coap_context_set_keepalive - work with CoAP keepalive
+coap_keepalive,
+coap_context_set_keepalive
+- work with CoAP keepalive
 
 SYNOPSIS
 --------
@@ -66,7 +68,8 @@ FURTHER INFORMATION
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -10,9 +10,17 @@ coap_logging(3)
 
 NAME
 ----
-coap_logging, coap_log, coap_get_log_level, coap_set_log_level,
-coap_set_log_handler, coap_package_name, coap_package_version,
-coap_set_show_pdu_output, coap_show_pdu
+coap_logging,
+coap_log,
+coap_get_log_level,
+coap_set_log_level,
+coap_set_log_handler,
+coap_package_name,
+coap_package_version,
+coap_set_show_pdu_output,
+coap_show_pdu,
+coap_endpoint_str,
+coap_session_str
 - Work with CoAP logging
 
 SYNOPSIS
@@ -160,7 +168,8 @@ information.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -10,9 +10,14 @@ coap_observe(3)
 
 NAME
 ----
-coap_observe, coap_resource_set_get_observable, coap_resource_notify_observers,
-coap_resource_get_uri_path, coap_find_observer, coap_delete_observer,
-coap_delete_observers - work with CoAP observe
+coap_observe,
+coap_resource_set_get_observable,
+coap_resource_notify_observers,
+coap_resource_get_uri_path,
+coap_find_observer,
+coap_delete_observer,
+coap_delete_observers
+- work with CoAP observe
 
 SYNOPSIS
 --------
@@ -404,7 +409,8 @@ FURTHER INFORMATION
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -10,9 +10,21 @@ coap_pdu_setup(3)
 
 NAME
 ----
-coap_pdu_setup, coap_pdu_init, coap_add_token, coap_new_optlist,
-coap_insert_optlist, coap_delete_optlist, coap_add_optlist_pdu,
-coap_add_option, coap_add_data - Work with CoAP PDUs
+coap_pdu_setup,
+coap_pdu_init,
+coap_add_token,
+coap_new_optlist,
+coap_insert_optlist,
+coap_delete_optlist,
+coap_add_optlist_pdu,
+coap_add_option,
+coap_add_data,
+coap_add_data_blocked_response,
+coap_encode_var_safe,
+coap_encode_var_safe8,
+coap_split_path,
+coap_split_query
+- Work with CoAP PDUs
 
 SYNOPSIS
 --------
@@ -47,11 +59,14 @@ size_t _length_, const uint8_t *_data_);*
 *unsigned int coap_encode_var_safe(uint8_t *_buffer_, size_t _size_,
 unsigned int _value_);*
 
+*unsigned int coap_encode_var_safe8(uint8_t *_buffer_, size_t _size_,
+uint64_t _value_);*
+
 *int coap_split_path(const uint8_t *_path_, size_t _length_, uint8_t *_buffer_,
 size_t *_buflen_);*
 
-*int coap_split_query(const uint8_t *_query_, size_t _length_, uint8_t *_buffer_,
-size_t *_buflen_);*
+*int coap_split_query(const uint8_t *_query_, size_t _length_,
+uint8_t *_buffer_, size_t *_buflen_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
 *-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*
@@ -200,6 +215,10 @@ The *coap_encode_var_safe*() function encodes _value_ into _buffer_ which has
 a size of _size_ in bytes.  Normally, the _buffer_ size should be at least
 the sizeof(int) bytes unless you definitely know less space is required.
 
+The *coap_encode_var_safe8*() function encodes 8 byte _value_ into _buffer_
+which has a size of _size_ in bytes.  Normally, the _buffer_ size should be at
+least 8 bytes unless you definitely know less space is required.
+
 The *coap_split_path*() function splits up _path_ of length _length_ and
 places the result in _buffer_ which has a size of _buflen_.  _buflen_ needs
 to be preset with the size of _buffer_ before the function call, and then
@@ -226,6 +245,9 @@ The *coap_add_optlist*() function returns either the length of the option
 or 0 on failure.
 
 The *coap_encode_var_safe*() function returns either the length of bytes
+encoded or 0 on failure.
+
+The *coap_encode_var_safe8*() function returns either the length of bytes
 encoded or 0 on failure.
 
 EXAMPLES
@@ -407,7 +429,8 @@ for the current set of defined CoAP Options.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_recovery.txt.in
+++ b/man/coap_recovery.txt.in
@@ -10,9 +10,13 @@ coap_recovery(3)
 
 NAME
 ----
-coap_recovery, coap_session_set_max_retransmit, coap_session_set_ack_timeout,
-coap_session_set_ack_random_factor, coap_session_get_max_transmit,
-coap_session_get_ack_timeout, coap_session_get_ack_random_factor,
+coap_recovery,
+coap_session_set_max_retransmit,
+coap_session_set_ack_timeout,
+coap_session_set_ack_random_factor,
+coap_session_get_max_transmit,
+coap_session_get_ack_timeout,
+coap_session_get_ack_random_factor,
 coap_debug_set_packet_loss
 - Work with CoAP packet transmissions
 
@@ -159,7 +163,8 @@ information.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -10,10 +10,16 @@ coap_resource(3)
 
 NAME
 ----
-coap_resource, coap_resource_init, coap_resource_unknown_init,
-coap_add_resource, coap_delete_resource, coap_delete_all_resources,
-coap_resource_set_mode, coap_resource_set_userdata,
-coap_resource_get_userdata - Work with CoAP resources
+coap_resource,
+coap_resource_init,
+coap_resource_unknown_init,
+coap_add_resource,
+coap_delete_resource,
+coap_delete_all_resources,
+coap_resource_set_mode,
+coap_resource_set_userdata,
+coap_resource_get_userdata
+- Work with CoAP resources
 
 SYNOPSIS
 --------
@@ -456,7 +462,8 @@ information.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -17,7 +17,10 @@ coap_new_client_session_pki,
 coap_session_reference,
 coap_session_release,
 coap_session_set_mtu,
-coap_session_max_pdu_size
+coap_session_max_pdu_size,
+coap_session_set_app_data,
+coap_session_get_app_data,
+coap_tcp_is_supported
 - Work with CoAP sessions
 
 SYNOPSIS
@@ -430,7 +433,8 @@ setup_client_session_dtls (struct in_addr ip_address) {
 
 SEE ALSO
 --------
-*coap_context*(3), *coap_resource*(3), *coap_encryption*(3) and *coap_tls_library*(3)
+*coap_context*(3), *coap_resource*(3), *coap_encryption*(3) and
+*coap_tls_library*(3)
 
 FURTHER INFORMATION
 -------------------
@@ -440,7 +444,8 @@ information.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -10,8 +10,12 @@ coap_tls_library(3)
 
 NAME
 ----
-coap_tls_library, coap_dtls_is_supported, coap_tls_is_supported,
-coap_get_tls_library_version, coap_string_tls_version, coap_show_tls_version
+coap_tls_library,
+coap_dtls_is_supported,
+coap_tls_is_supported,
+coap_get_tls_library_version,
+coap_string_tls_version,
+coap_show_tls_version
 - Work with CoAP TLS libraries
 
 SYNOPSIS
@@ -24,7 +28,7 @@ SYNOPSIS
 
 *coap_tls_version_t *coap_get_tls_library_version(void);*
 
-*char *coap_string_tls_version(char *_buffer_, size_t _bufsize_);
+*char *coap_string_tls_version(char *_buffer_, size_t _bufsize_);*
 
 *void coap_show_tls_version(coap_log_t _level_);*
 
@@ -86,17 +90,17 @@ for this information to be output using coap_log().
 [source, c]
 ----
 typedef enum coap_tls_library_t {
-  COAP_TLS_LIBRARY_NOTLS = 0, /**< No DTLS library */
-  COAP_TLS_LIBRARY_TINYDTLS,  /**< Using TinyDTLS library */
-  COAP_TLS_LIBRARY_OPENSSL,   /**< Using OpenSSL library */
-  COAP_TLS_LIBRARY_GNUTLS,    /**< Using GnuTLS library */
-  COAP_TLS_LIBRARY_MBEDTLS,   /**< Using MbedTLS library */
+  COAP_TLS_LIBRARY_NOTLS = 0, /* No DTLS library */
+  COAP_TLS_LIBRARY_TINYDTLS,  /* Using TinyDTLS library */
+  COAP_TLS_LIBRARY_OPENSSL,   /* Using OpenSSL library */
+  COAP_TLS_LIBRARY_GNUTLS,    /* Using GnuTLS library */
+  COAP_TLS_LIBRARY_MBEDTLS,   /* Using MbedTLS library */
 } coap_tls_library_t;
 
 typedef struct coap_tls_version_t {
-  uint64_t version; /* (D)TLS runtime Library Version */
-  coap_tls_library_t type; /**< Library type. One of COAP_TLS_LIBRARY_* */
-  uint64_t built_version; /* (D)TLS Built against Library Version */
+  uint64_t version;        /* (D)TLS runtime Library Version */
+  coap_tls_library_t type; /* Library type. One of COAP_TLS_LIBRARY_* */
+  uint64_t built_version;  /* (D)TLS Built against Library Version */
 }
 ----
 
@@ -122,7 +126,8 @@ information.
 BUGS
 ----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------


### PR DESCRIPTION
man/coap_attribute.txt.in:
man/coap_context.txt.in:
man/coap_encryption.txt.in:
man/coap_handler.txt.in:
man/coap_io.txt.in:
man/coap_keepalive.txt.in:
man/coap_logging.txt.in:
man/coap_observe.txt.in:
man/coap_pdu_setup.txt.in:
man/coap_recovery.txt.in:
man/coap_resource.txt.in:
man/coap_session.txt.in:
man/coap_tls_library.txt.in:

Make sure the full list is defined in the NAME section
[Gives a2x warnings that there are more than 10 entries, but this is OK]

Update where BUGS can be reported to.

man/Makefile.am:

Remove EXTRA_PAGES as all the names are now defined under NAMES