### PR TITLE
CMakeLists.txt: Make library name libcoap-2 to match name in man pages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(
   LANGUAGES CXX C)
 
 set(LIBCOAP_API_VERSION 2)
-set(COAP_LIBRARY_NAME "coap")
+set(COAP_LIBRARY_NAME "coap-${LIBCOAP_API_VERSION}")
 
 add_library(${COAP_LIBRARY_NAME})
 


### PR DESCRIPTION
Change library name from coap to coap-2.