### PR TITLE
Windows: Fix compiler warnings

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -37,6 +37,7 @@ static char* strndup(const char* s1, size_t n)
 };
 #include <io.h>
 #define access _access
+#define fileno _fileno
 #else
 #include <unistd.h>
 #include <sys/select.h>
@@ -1470,7 +1471,7 @@ main(int argc, char **argv) {
       if (result >= 0) {
         coap_ticks(&end);
         /* Track the overall time spent in select() and coap_io_process() */
-        result = end - begin;
+        result = (int)(end - begin);
       }
     }
     else {

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1227,7 +1227,7 @@ setup_pki_ssl(SSL *ssl,
     if (setup_data->pki_key.key.pem_buf.public_cert &&
         setup_data->pki_key.key.pem_buf.public_cert_len) {
       BIO *bp = BIO_new_mem_buf(setup_data->pki_key.key.pem_buf.public_cert,
-                           setup_data->pki_key.key.pem_buf.public_cert_len);
+                         (int)setup_data->pki_key.key.pem_buf.public_cert_len);
       X509 *cert = bp ? PEM_read_bio_X509(bp, NULL, 0, NULL) : NULL;
 
       if (!cert || !SSL_use_certificate(ssl, cert)) {
@@ -1250,7 +1250,7 @@ setup_pki_ssl(SSL *ssl,
     if (setup_data->pki_key.key.pem_buf.private_key &&
         setup_data->pki_key.key.pem_buf.private_key_len) {
       BIO *bp = BIO_new_mem_buf(setup_data->pki_key.key.pem_buf.private_key,
-                           setup_data->pki_key.key.pem_buf.private_key_len);
+                        (int)setup_data->pki_key.key.pem_buf.private_key_len);
       EVP_PKEY *pkey = bp ? PEM_read_bio_PrivateKey(bp, NULL, 0, NULL) : NULL;
 
       if (!pkey || !SSL_use_PrivateKey(ssl, pkey)) {
@@ -1273,7 +1273,7 @@ setup_pki_ssl(SSL *ssl,
     if (setup_data->pki_key.key.pem_buf.ca_cert &&
         setup_data->pki_key.key.pem_buf.ca_cert_len) {
       BIO *bp = BIO_new_mem_buf(setup_data->pki_key.key.pem_buf.ca_cert,
-                           setup_data->pki_key.key.pem_buf.ca_cert_len);
+                        (int)setup_data->pki_key.key.pem_buf.ca_cert_len);
       SSL_CTX *ctx = SSL_get_SSL_CTX(ssl);
       X509 *x;
       X509_STORE *st = SSL_CTX_get_cert_store(ctx);


### PR DESCRIPTION
Fix size_t to int warnings by explicit casting.
Fix usage of fileno.