### PR TITLE
CMakeLists.txt: Put BUILD_SHARED_LIBS option before add_library()

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -45,16 +45,21 @@ General Building with cmake for linux/windows/macos/android (not for LwIP or Con
  cmake -E remove_directory build
  cmake -E make_directory build
  cd build
- cmake .. -DENABLE_EXAMPLES=ON
+ cmake .. -DENABLE_TESTS=ON
  cmake --build .
  [sudo] cmake --build . -- install
+ cd ..
+
  Note: to see possible options (TLS lib, doc, tests, examples etc.):
- cmake -LH .
- Note: For windows, this is supported by Visual Studio Code with CMake extension
- Note: You should use cmake version >=3.10.
+ cmake -LH build
 
- Note: you can use cmake's find package after installation: find_package(libcoap REQUIRED), and target_link_libraries(myTarget PRIVATE libcoap::coap)
+ Note: For Windows, this is supported by Visual Studio Code with CMake extension
+ Note: You must use cmake version >=3.10.
 
+ Note: you can use cmake's find package after installation: find_package(libcoap-2 REQUIRED),
+ and target_link_libraries(myTarget PRIVATE libcoap::coap-2)
+
+ Note: Shared Library support is not currently available for Windows.
 
 General Building with autoconf (not for LwIP or Contiki - see below)
 ================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ project(
 set(LIBCOAP_API_VERSION 2)
 set(COAP_LIBRARY_NAME "coap-${LIBCOAP_API_VERSION}")
 
+option(
+  BUILD_SHARED_LIBS
+  "Build shared libs"
+  OFF)
+
 add_library(${COAP_LIBRARY_NAME})
 
 #
@@ -66,10 +71,6 @@ option(
   ENABLE_DOCS
   "build also doxygen documentation"
   ON)
-option(
-  BUILD_SHARED_LIBS
-  "Build shared libs"
-  OFF)
 
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 11)


### PR DESCRIPTION
To build shared libraries, either the BUILD_SHARED_LIBS=ON option can be
defined globally for building, otherwise defining BUILD_SHARED_LIBS as an
OPTION in CMakeLists.txt works providing the OPTION is defined before the
add_library() call.

This fix is to move the OPTION BUILD_SHARED_LIBS to before the
add_library() call.

NOTE: Shared Library support is not currently available for Windows as the
appropriate functions are not currently exported.

BUILDING:

Document the Windows limitation and tidy up a bit.