### PR TITLE
[Oss-Fuzz] Improving pdu_parse_fuzzer

### DIFF
--- a/tests/oss-fuzz/pdu_parse_target.c
+++ b/tests/oss-fuzz/pdu_parse_target.c
@@ -6,7 +6,13 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     if (pdu) {
         coap_set_log_level(LOG_DEBUG);
         coap_pdu_parse(COAP_PROTO_UDP, data, size, pdu);
+        coap_string_t *query = coap_get_query(pdu);
+        coap_string_t *uri_path = coap_get_uri_path(pdu);
         coap_show_pdu(LOG_DEBUG, pdu);
+        coap_pdu_encode_header(pdu, COAP_PROTO_UDP);
+        
+        coap_delete_string(query);
+        coap_delete_string(uri_path);
         coap_delete_pdu(pdu);
     }
     return 0;


### PR DESCRIPTION
So i went through the code-base, and added a few helper/utility function calls to improve the coverage of the existing Fuzzer.
By doing so, the coverage goes up by 
Line coverage: 2.71% / 213 Lines
Function coverage: 4.54% / 15 functions
Region coverage: 2.36% / 167 new regions

Coverage report:
[https://imgur.com/a/GEnY81L](https://imgur.com/a/GEnY81L)

Let me know if there is any incorrect usage of the Api!
