### PR TITLE
RPK RFC7250: Add in support

### DIFF
--- a/HOWTO.pkcs11
+++ b/HOWTO.pkcs11
@@ -74,7 +74,7 @@ pkcs11-tool --module=/usr/local/lib/softhsm/libsofthsm2.so --list-objects \
   --pin 1234 --token-label "token-0"
 
 #
-# Run coap-server using PKCS11
+# Run coap-server using PKCS11 (-C option may need to be -C cert.der)
 #
 coap-server -C 'pkcs11:token=token-0;id=%cc%00?pin-value=1234' \
   -c 'pkcs11:token=token-0;id=%aa%01?pin-value=1234' \
@@ -91,7 +91,7 @@ coap-server -C 'pkcs11:token=token-0;object=ca-cert' \
   -j 'pkcs11:token=token-0;object=server-key' -J 1234 -v9 -n
 
 #
-# Run coap-client using PKCS11
+# Run coap-client using PKCS11 (-C option may need to be -C cert.der)
 #
 coap-client -C 'pkcs11:token=token-0;id=%cc%00?pin-value=1234' \
   -c 'pkcs11:token=token-0;id=%bb%01?pin-value=1234' \
@@ -107,3 +107,9 @@ coap-client -C 'pkcs11:token=token-0;object=ca-cert' \
   -c 'pkcs11:token=token-0;object=client-cert' \
   -j 'pkcs11:token=token-0;object=client-key' -J 1234 -v9 coaps://[::1]
 
+#
+# Client and Server using RPK (GnuTLS only)
+#
+coap-server -M 'pkcs11:token=token-0;object=server-key' -J 1234 -v9 -n
+# and
+coap-client -M 'pkcs11:token=token-0;object=client-key' -J 1234 -v9 coaps://[::1]

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,7 @@ EXTRA_DIST = \
   examples/getopt.c \
   include/coap$(LIBCOAP_API_VERSION)/coap_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_riot.h \
+  include/coap$(LIBCOAP_API_VERSION)/coap_asn1_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_cache_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_session_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_subscribe_internal.h \
@@ -76,6 +77,7 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_SOURCES = \
   src/address.c \
   src/async.c \
   src/block.c \
+  src/coap_asn1.c \
   src/coap_cache.c \
   src/coap_debug.c \
   src/coap_event.c \

--- a/README.md
+++ b/README.md
@@ -54,15 +54,13 @@ The following RFCs are supported
 
 There is (D)TLS support for the following libraries
 
-* OpenSSL (Minimum version 1.1.0)
+* OpenSSL (Minimum version 1.1.0) [PKI, PSK and PKCS11]
 
-* GnuTLS (Minimum version 3.3.0)
+* GnuTLS (Minimum version 3.3.0) [PKI, PSK, RPK(3.6.6+) and PKCS11]
 
-* MbedTLS (Minimum version 2.7.10)
-  [Currently only DTLS]
+* MbedTLS (Minimum version 2.7.10) [PKI and PSK] [Currently only DTLS]
 
-* TinyDTLS
-  [DTLS Only]
+* TinyDTLS [PSK and RPK] [DTLS Only]
 
 The examples directory contain a CoAP client, CoAP Resource Directory server
 and a CoAP server to demonstrate the use of this library.

--- a/examples/client.c
+++ b/examples/client.c
@@ -82,6 +82,7 @@ static char *pkcs11_pin = NULL; /* PKCS11 pin to unlock access to token */
 static char *ca_file = NULL;   /* CA for cert_file - for cert checking in PEM,
                                   DER or PKCS11 URI */
 static char *root_ca_file = NULL; /* List of trusted Root CAs in PEM */
+static int is_rpk_not_cert = 0; /* Cert is RPK if set */
 
 typedef struct ih_def_t {
   char* hint_match;
@@ -648,7 +649,7 @@ usage( const char *program, const char *version) {
      "\t\t[-O num,text] [-P addr[:port]] [-T token] [-U]\n"
      "\t\t[[-h match_hint_file] [-k key] [-u user]]\n"
      "\t\t[[-c certfile] [-j keyfile] [-C cafile] [-J pkcs11_pin]\n"
-     "\t\t[-R root_cafile] [-S match_pki_sni_file]] URI\n"
+     "\t\t[-M raw_pk] [-R root_cafile] [-S match_pki_sni_file]] URI\n"
      "\tURI can be an absolute URI or a URI prefixed with scheme and host\n\n"
      "General Options\n"
      "\t-a addr\t\tThe local interface address to use\n"
@@ -722,6 +723,9 @@ usage( const char *program, const char *version) {
      "\t       \t\tthe certfile and cafile (as in '-c certfile -C certfile')\n"
      "\t       \t\tto trigger validation\n"
      "\t-J pkcs11_pin\tThe user pin to unlock access to the PKCS11 token\n"
+     "\t-M rpk_file\tRaw Public Key (RPK) PEM file or PKCS11 URI that contains\n"
+     "\t       \t\tboth PUBLIC KEY and PRIVATE KEY or just EC PRIVATE KEY.\n"
+     "\t       \t\t(GnuTLS and TinyDTLS support only) '-C cafile' not required\n"
      "\t-R root_cafile\tPEM file containing the set of trusted root CAs that\n"
      "\t       \t\tare to be used to validate the server certificate.\n"
      "\t       \t\tThe '-C cafile' does not have to be in this list and is\n"
@@ -1379,7 +1383,7 @@ setup_pki(coap_context_t *ctx) {
      * coap_context_set_pki_root_cas(), but this is used to define what
      * checking actually takes place.
      */
-    dtls_pki.verify_peer_cert        = 1;
+    dtls_pki.verify_peer_cert        = !is_rpk_not_cert;
     dtls_pki.require_peer_cert       = 1;
     dtls_pki.allow_self_signed       = 1;
     dtls_pki.allow_expired_certs     = 1;
@@ -1393,10 +1397,11 @@ setup_pki(coap_context_t *ctx) {
     dtls_pki.validate_sni_call_back  = NULL;
     dtls_pki.sni_call_back_arg       = NULL;
   }
-  if (uri.host.length)
+  if (uri.host.length && memcmp(uri.host.s, "::1", 3) != 0)
     memcpy(client_sni, uri.host.s, min(uri.host.length, sizeof(client_sni)-1));
   else
     memcpy(client_sni, "localhost", 9);
+  dtls_pki.is_rpk_not_cert = is_rpk_not_cert;
   dtls_pki.client_sni = client_sni;
   if ((key_file && strncasecmp (key_file, "pkcs11:", 7) == 0) ||
       (cert_file && strncasecmp (cert_file, "pkcs11:", 7) == 0) ||
@@ -1563,7 +1568,7 @@ main(int argc, char **argv) {
   struct sigaction sa;
 #endif
 
-  while ((opt = getopt(argc, argv, "a:b:c:e:f:h:j:k:l:m:o:p:rs:t:u:v:A:B:C:J:K:H:NO:P:R:T:U")) != -1) {
+  while ((opt = getopt(argc, argv, "a:b:c:e:f:h:j:k:l:m:o:p:rs:t:u:v:A:B:C:J:K:H:M:NO:P:R:T:U")) != -1) {
     switch (opt) {
     case 'a':
       strncpy(node_str, optarg, NI_MAXHOST - 1);
@@ -1631,6 +1636,10 @@ main(int argc, char **argv) {
       break;
     case 't':
       cmdline_content_type(optarg, COAP_OPTION_CONTENT_TYPE);
+      break;
+    case 'M':
+      cert_file = optarg;
+      is_rpk_not_cert = 1;
       break;
     case 'O':
       cmdline_option(optarg);

--- a/examples/client.c
+++ b/examples/client.c
@@ -83,6 +83,10 @@ static char *ca_file = NULL;   /* CA for cert_file - for cert checking in PEM,
                                   DER or PKCS11 URI */
 static char *root_ca_file = NULL; /* List of trusted Root CAs in PEM */
 static int is_rpk_not_cert = 0; /* Cert is RPK if set */
+static uint8_t *cert_mem = NULL; /* certificate and private key in PEM_BUF */
+static uint8_t *ca_mem = NULL;   /* CA for cert checking in PEM_BUF */
+static size_t cert_mem_len = 0;
+static size_t ca_mem_len = 0;
 
 typedef struct ih_def_t {
   char* hint_match;
@@ -1308,6 +1312,37 @@ static int cmdline_read_hint_check(const char *arg) {
   return valid_ihs.count > 0;
 }
 
+static uint8_t *read_file_mem(const char* filename, size_t *length) {
+  FILE *f;
+  uint8_t *buf;
+  struct stat statbuf;
+
+  *length = 0;
+  if (!filename || !(f = fopen(filename, "r")))
+    return NULL;
+
+  if (fstat(fileno(f), &statbuf) == -1) {
+    fclose(f);
+    return NULL;
+  }
+
+  buf = coap_malloc(statbuf.st_size+1);
+  if (!buf) {
+    fclose(f);
+    return NULL;
+  }
+
+  if (fread(buf, 1, statbuf.st_size, f) != (size_t)statbuf.st_size) {
+    fclose(f);
+    coap_free(buf);
+    return NULL;
+  }
+  buf[statbuf.st_size] = '\000';
+  *length = (size_t)(statbuf.st_size + 1);
+  fclose(f);
+  return buf;
+}
+
 static int
 verify_cn_callback(const char *cn,
                    const uint8_t *asn1_public_cert UNUSED_PARAM,
@@ -1397,10 +1432,12 @@ setup_pki(coap_context_t *ctx) {
     dtls_pki.validate_sni_call_back  = NULL;
     dtls_pki.sni_call_back_arg       = NULL;
   }
-  if (uri.host.length && memcmp(uri.host.s, "::1", 3) != 0)
+  if ((uri.host.length == 3 && memcmp(uri.host.s, "::1", 3) != 0) ||
+      (uri.host.length == 9 && memcmp(uri.host.s, "127.0.0.1", 9) != 0))
     memcpy(client_sni, uri.host.s, min(uri.host.length, sizeof(client_sni)-1));
   else
     memcpy(client_sni, "localhost", 9);
+
   dtls_pki.is_rpk_not_cert = is_rpk_not_cert;
   dtls_pki.client_sni = client_sni;
   if ((key_file && strncasecmp (key_file, "pkcs11:", 7) == 0) ||
@@ -1413,11 +1450,23 @@ setup_pki(coap_context_t *ctx) {
     dtls_pki.pki_key.key.pkcs11.ca = ca_file;
     dtls_pki.pki_key.key.pkcs11.user_pin = pkcs11_pin;
   }
-  else {
+  else if (!is_rpk_not_cert) {
     dtls_pki.pki_key.key_type = COAP_PKI_KEY_PEM;
     dtls_pki.pki_key.key.pem.public_cert = cert_file;
     dtls_pki.pki_key.key.pem.private_key = key_file ? key_file : cert_file;
     dtls_pki.pki_key.key.pem.ca_file = ca_file;
+  }
+  else {
+    /* Map file into memory */
+    ca_mem = read_file_mem(ca_file, &ca_mem_len);
+    cert_mem = read_file_mem(cert_file, &cert_mem_len);
+    dtls_pki.pki_key.key_type = COAP_PKI_KEY_PEM_BUF;
+    dtls_pki.pki_key.key.pem_buf.ca_cert = ca_mem;
+    dtls_pki.pki_key.key.pem_buf.public_cert = cert_mem;
+    dtls_pki.pki_key.key.pem_buf.private_key = cert_mem;
+    dtls_pki.pki_key.key.pem_buf.ca_cert_len = ca_mem_len;
+    dtls_pki.pki_key.key.pem_buf.public_cert_len = cert_mem_len;
+    dtls_pki.pki_key.key.pem_buf.private_key_len = cert_mem_len;
   }
   return &dtls_pki;
 }
@@ -1859,6 +1908,10 @@ main(int argc, char **argv) {
 
  finish:
 
+  if (ca_mem)
+    coap_free(ca_mem);
+  if (cert_mem)
+    coap_free(cert_mem);
   for (i = 0; i < valid_ihs.count; i++) {
     free(valid_ihs.ih_list[i].hint_match);
     coap_delete_bin_const(valid_ihs.ih_list[i].new_identity);

--- a/include/coap2/coap_asn1_internal.h
+++ b/include/coap2/coap_asn1_internal.h
@@ -1,0 +1,78 @@
+/*
+ * coap_asn1_internal.h -- ASN.1 functions for libcoap
+ *
+ * Copyright (C) 2020 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_asn1_internal.h
+ * @brief COAP ASN.1 internal information
+ */
+
+#ifndef COAP_ASN1_INTERNAL_H_
+#define COAP_ASN1_INTERNAL_H_
+
+
+/**
+ * @defgroup asn1 ASN.1 Support (Internal)
+ * API functions for CoAP ASN.1
+ * @{
+ */
+
+typedef enum {
+  COAP_ASN1_NONE = 0,
+  COAP_ASN1_INTEGER = 2,
+  COAP_ASN1_BITSTRING = 3,
+  COAP_ASN1_OCTETSTRING = 4,
+  COAP_ASN1_IDENTIFIER = 6,
+} coap_asn1_tag_t;
+
+/**
+ * Callback to validate the asn1 tag and data.
+ *
+ * @param data  The start of the tag and data
+ * @param size  The size of the tag and data
+ *
+ * @return @c 1 if pass, else @c 0 if fail
+ */
+typedef int (*asn1_validate)(const uint8_t *data, size_t size);
+
+/**
+ * Get the asn1 length from the current @p ptr.
+ *
+ * @param ptr  The current asn.1 object length pointer
+ *
+ * @return The length of the asn.1 object. @p ptr is udated to past the length.
+ */
+size_t asn1_len(const uint8_t **ptr);
+
+/**
+ * Get the asn1 tag from the current @p ptr.
+ *
+ * @param ptr  The current asn.1 object tag pointer
+ * @param constructed  1 if current tag is constructed
+ * @param class  The current class of the tag
+ *
+ * @return The tag value.@p ptr is udated to pass the tag.
+ */
+coap_asn1_tag_t asn1_tag_c(const uint8_t **ptr, int *constructed, int *class);
+
+/**
+ * Get the asn1 tag and data from the current @p ptr.
+ *
+ * @param ltag The tag to look for
+ * @param ptr  The current asn.1 object pointer
+ * @param tlen The remaining size oof the asn.1 data
+ * @param validate Call validate to verify tag data or @c NULL
+ *
+ * @return The asn.1 tag and data or @c NULL if not found
+ */
+coap_binary_t *get_asn1_tag(coap_asn1_tag_t ltag, const uint8_t *ptr,
+                            size_t tlen, asn1_validate validate);
+
+/** @} */
+
+#endif /* COAP_ASN1_INTERNAL_H_ */

--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -105,7 +105,7 @@ typedef int (*coap_dtls_security_setup_t)(void* tls_session,
  * but the application needs to check that the CN is allowed.
  * CN is the SubjectAltName in the cert, if not present, then the leftmost
  * Common Name (CN) component of the subject name.
- * NOTE: If using RPK, then the Public Key does not contain a CN, but the 
+ * NOTE: If using RPK, then the Public Key does not contain a CN, but the
  * content of COAP_DTLS_RPK_CERT_CN is presented for the @p cn parameter.
  *
  * @param cn  The determined CN from the certificate
@@ -164,11 +164,8 @@ typedef enum coap_pki_key_t {
  */
 typedef struct coap_pki_key_pem_t {
   const char *ca_file;       /**< File location of Common CA in PEM format */
-  const char *public_cert;   /**< File location of Public Cert, or Public
-                                  Key if RPK, in PEM format */
-  const char *private_key;   /**< File location of Private Key in PEM format.
-                                  If RPK and 'EC PRIVATE KEY' this can be used
-                                  for both the public_cert and private_key */
+  const char *public_cert;   /**< File location of Public Cert */
+  const char *private_key;   /**< File location of Private Key in PEM format */
 } coap_pki_key_pem_t;
 
 /**
@@ -183,7 +180,9 @@ typedef struct coap_pki_key_pem_t {
 typedef struct coap_pki_key_pem_buf_t {
   const uint8_t *ca_cert;     /**< PEM buffer Common CA Cert */
   const uint8_t *public_cert; /**< PEM buffer Public Cert, or Public Key if RPK */
-  const uint8_t *private_key; /**< PEM buffer Private Key */
+  const uint8_t *private_key; /**< PEM buffer Private Key
+                                  If RPK and 'EC PRIVATE KEY' this can be used
+                                  for both the public_cert and private_key */
   size_t ca_cert_len;         /**< PEM buffer CA Cert length */
   size_t public_cert_len;     /**< PEM buffer Public Cert length */
   size_t private_key_len;     /**< PEM buffer Private Key length */
@@ -263,9 +262,11 @@ typedef struct coap_dtls_pki_t {
   uint8_t check_cert_revocation;   /**< 1 if revocation checks wanted */
   uint8_t allow_no_crl;            /**< 1 ignore if CRL not there */
   uint8_t allow_expired_crl;       /**< 1 if expired crl is allowed */
-  uint8_t allow_bad_md_hash;       /**< 1 if unsupported MD hashes are allowed */
-  uint8_t allow_short_rsa_length;  /**< 1 if small RSA keysizes are allowed */
-  uint8_t is_rpk_not_cert;         /**< 1 is RPK instead of Public Certificate */
+  uint8_t allow_bad_md_hash;      /**< 1 if unsupported MD hashes are allowed */
+  uint8_t allow_short_rsa_length; /**< 1 if small RSA keysizes are allowed */
+  uint8_t is_rpk_not_cert;        /**< 1 is RPK instead of Public Certificate.
+                                   *     If set, PKI key format type cannot be
+                                   *     COAP_PKI_KEY_PEM */
   uint8_t reserved[3];             /**< Reserved - must be set to 0 for
                                         future compatibility */
                                    /* Size of 3 chosen to align to next

--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -40,6 +40,8 @@ struct coap_dtls_pki_t;
 
 #define COAP_DTLS_RETRANSMIT_COAP_TICKS (COAP_DTLS_RETRANSMIT_MS * COAP_TICKS_PER_SECOND / 1000)
 
+#define COAP_DTLS_RPK_CERT_CN "RPK"
+
 /**
  * Check whether DTLS is available.
  *
@@ -103,6 +105,8 @@ typedef int (*coap_dtls_security_setup_t)(void* tls_session,
  * but the application needs to check that the CN is allowed.
  * CN is the SubjectAltName in the cert, if not present, then the leftmost
  * Common Name (CN) component of the subject name.
+ * NOTE: If using RPK, then the Public Key does not contain a CN, but the 
+ * content of COAP_DTLS_RPK_CERT_CN is presented for the @p cn parameter.
  *
  * @param cn  The determined CN from the certificate
  * @param asn1_public_cert  The ASN.1 DER encoded X.509 certificate
@@ -160,8 +164,11 @@ typedef enum coap_pki_key_t {
  */
 typedef struct coap_pki_key_pem_t {
   const char *ca_file;       /**< File location of Common CA in PEM format */
-  const char *public_cert;   /**< File location of Public Cert in PEM format */
-  const char *private_key;   /**< File location of Private Key in PEM format */
+  const char *public_cert;   /**< File location of Public Cert, or Public
+                                  Key if RPK, in PEM format */
+  const char *private_key;   /**< File location of Private Key in PEM format.
+                                  If RPK and 'EC PRIVATE KEY' this can be used
+                                  for both the public_cert and private_key */
 } coap_pki_key_pem_t;
 
 /**
@@ -175,7 +182,7 @@ typedef struct coap_pki_key_pem_t {
  */
 typedef struct coap_pki_key_pem_buf_t {
   const uint8_t *ca_cert;     /**< PEM buffer Common CA Cert */
-  const uint8_t *public_cert; /**< PEM buffer Public Cert */
+  const uint8_t *public_cert; /**< PEM buffer Public Cert, or Public Key if RPK */
   const uint8_t *private_key; /**< PEM buffer Private Key */
   size_t ca_cert_len;         /**< PEM buffer CA Cert length */
   size_t public_cert_len;     /**< PEM buffer Public Cert length */
@@ -187,7 +194,7 @@ typedef struct coap_pki_key_pem_buf_t {
  */
 typedef struct coap_pki_key_asn1_t {
   const uint8_t *ca_cert;     /**< ASN1 (DER) Common CA Cert */
-  const uint8_t *public_cert; /**< ASN1 (DER) Public Cert */
+  const uint8_t *public_cert; /**< ASN1 (DER) Public Cert, or Public Key if RPK */
   const uint8_t *private_key; /**< ASN1 (DER) Private Key */
   size_t ca_cert_len;         /**< ASN1 CA Cert length */
   size_t public_cert_len;     /**< ASN1 Public Cert length */
@@ -258,9 +265,10 @@ typedef struct coap_dtls_pki_t {
   uint8_t allow_expired_crl;       /**< 1 if expired crl is allowed */
   uint8_t allow_bad_md_hash;       /**< 1 if unsupported MD hashes are allowed */
   uint8_t allow_short_rsa_length;  /**< 1 if small RSA keysizes are allowed */
-  uint8_t reserved[4];             /**< Reserved - must be set to 0 for
+  uint8_t is_rpk_not_cert;         /**< 1 is RPK instead of Public Certificate */
+  uint8_t reserved[3];             /**< Reserved - must be set to 0 for
                                         future compatibility */
-                                   /* Size of 4 chosen to align to next
+                                   /* Size of 3 chosen to align to next
                                     * parameter, so if newly defined option
                                     * it can use one of the reserverd slot so
                                     * no need to change

--- a/include/coap2/coap_internal.h
+++ b/include/coap2/coap_internal.h
@@ -46,6 +46,7 @@
 #include "coap_mutex.h"
 
 /* Specifically defined internal .h files */
+#include "coap_asn1_internal.h"
 #include "coap_cache_internal.h"
 #include "coap_session_internal.h"
 #include "coap_subscribe_internal.h"

--- a/include/coap2/str.h
+++ b/include/coap2/str.h
@@ -147,7 +147,9 @@ coap_bin_const_t *coap_new_bin_const(const uint8_t *data, size_t size);
  */
 void coap_delete_bin_const(coap_bin_const_t *binary);
 
+#ifndef COAP_MAX_STR_CONST_FUNC
 #define COAP_MAX_STR_CONST_FUNC 2
+#endif /* COAP_MAX_STR_CONST_FUNC */
 
 /**
  * Take the specified byte array (text) and create a coap_str_const_t *

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -21,7 +21,7 @@ SYNOPSIS
               [*-P* addr[:port]] [*-T* token] [*-U*]
               [[*-h* match_hint_file] [*-k* key] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [*-C* cafile] [*-J* pkcs11_pin]
-              [*-R* root_cafile]] URI
+              [*-M* rpk_file] [*-R* root_cafile]] URI
 
 DESCRIPTION
 -----------
@@ -183,6 +183,11 @@ definitions have to be in DER, not PEM, format.  Otherwise all of
 
 *-J* pkcs11_pin::
   The user pin to unlock access to the PKCS11 token.
+
+*-M* rpk_file::
+  Raw Public Key (RPK) PEM file that contains both PUBLIC KEY and PRIVATE KEY
+  or just EC PRIVATE KEY.
+  (GnuTLS and TinyDTLS support only) '-C cafile' not required.
 
 *-R* root_cafile::
   PEM file containing the set of trusted root CAs that are to be used to

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -19,7 +19,8 @@ SYNOPSIS
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
               [*-s* match_psk_sni_file]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
-              [*-J* pkcs11_pin] [*-R* root_cafile] [*-S* match_pki_sni_file]]
+              [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* root_cafile]
+              [*-S* match_pki_sni_file]]
 
 DESCRIPTION
 -----------
@@ -130,6 +131,11 @@ definitions have to be in DER, not PEM, format.  Otherwise all of
 
 *-J* pkcs11_pin::
    The user pin to unlock access to the PKCS11 token.
+
+*-M*::
+  Raw Public Key (RPK) PEM file that contains both PUBLIC KEY and PRIVATE KEY
+  or just EC PRIVATE KEY.
+  (GnuTLS and TinyDTLS support only) '-C cafile' not required.
 
 *-R* root_cafile::
   PEM file containing the set of trusted root CAs that are to be used to

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -304,6 +304,7 @@ setup_server_context_pki (const char *public_cert_file,
   dtls_pki.allow_expired_crl       = 1;
   dtls_pki.allow_bad_md_hash       = 0;
   dtls_pki.allow_short_rsa_length  = 0;
+  dtls_pki.is_rpk_not_cert         = 0; /* Set to 1 if RPK */
   dtls_pki.validate_cn_call_back   = verify_cn_callback;
   dtls_pki.cn_call_back_arg        = valid_cn_list;
   dtls_pki.validate_sni_call_back  = verify_pki_sni_callback;

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -427,7 +427,9 @@ typedef struct coap_dtls_pki_t {
   uint8_t allow_expired_crl;        /* 1 if expired crl is allowed */
   uint8_t allow_bad_md_hash;        /* 1 if unsupported MD hashes are allowed */
   uint8_t allow_short_rsa_length;   /* 1 if small RSA keysizes are allowed */
-  uint8_t is_rpk_not_cert;          /* 1 if RPK instead of Public Certificate */
+  uint8_t is_rpk_not_cert;          /* 1 is RPK instead of Public Certificate.
+                                     *   If set, PKI key format type cannot be
+                                     *   COAP_PKI_KEY_PEM */
   uint8_t reserved[3];              /* Reserved - must be set to 0 for
                                        future compatibility */
 
@@ -522,6 +524,7 @@ definition to be valid, else 0.
 *allow_short_rsa_length* Set to 1 if small RSA keysizes are allowed, else 0.
 
 *is_rpk_not_cert* Set to 1 if the Certificate is actually a Raw Public Key.
+If set, PKI key format type cannot be COAP_PKI_KEY_PEM.
 
 *SECTION: PKI/RPK: coap_dtls_pki_t: Reserved*
 
@@ -539,7 +542,7 @@ these reserved definitions.
  * but the application needs to check that the CN is allowed.
  * CN is the SubjectAltName in the cert, if not present, then the leftmost
  * Common Name (CN) component of the subject name.
- * NOTE: If using RPK, then the Public Key does not contain a CN, but the 
+ * NOTE: If using RPK, then the Public Key does not contain a CN, but the
  * content of COAP_DTLS_RPK_CERT_CN is presented for the @p cn parameter.
  *
  * @param cn  The determined CN from the certificate
@@ -579,7 +582,8 @@ typedef struct coap_dtls_key_t {
   union {
     coap_pki_key_pem_t pem;         /* for PEM file keys */
     coap_pki_key_pem_buf_t pem_buf; /* for PEM memory keys */
-    coap_pki_key_asn1_t asn1;       /* for ASN.1 (DER) file keys */
+    coap_pki_key_asn1_t asn1;       /* for ASN.1 (DER) memory keys */
+    coap_pki_key_pkcs11_t pkcs11;   /* for PKCS11 keys */
   } key;
 } coap_dtls_key_t;
 
@@ -662,16 +666,13 @@ typedef enum coap_pki_key_t {
 This can be COAP_PKI_KEY_PEM, COAP_PKI_KEY_PEM_BUF, COAP_PKI_KEY_ASN1 or
 COAP_PKI_KEY_PKCS11.
 
-*SECTION: PKI/RPK: coap_dtls_pki_t: PEM Key Definitions*
+*SECTION: PKI: coap_dtls_pki_t: PEM Key Definitions*
 [source, c]
 ----
 typedef struct coap_pki_key_pem_t {
   const char *ca_file;       /* File location of Common CA in PEM format */
-  const char *public_cert;   /* File location of Public Cert, or Public
-                                Key if RPK, in PEM format */
-  const char *private_key;   /* File location of Private Key in PEM format.
-                                If RPK and 'EC PRIVATE KEY' this can be used
-                                for both the public_cert and private_key */
+  const char *public_cert;   /* File location of Public Cert */
+  const char *private_key;   /* File location of Private Key in PEM format */
 } coap_pki_key_pem_t;
 ----
 
@@ -681,8 +682,8 @@ public certificate) as this is passed from the server to the client when
 requesting the client's certificate. This certificate is also added into
 the valid root CAs list if not already present.
 
-*key.pem.public_cert* points to the public certificate (or public key if RPK)
-location on disk which will be in PEM format.
+*key.pem.public_cert* points to the public certificate location on disk which
+will be in PEM format.
 
 *key.pem.private_key* points to the private key location on disk which
 will be in PEM format.  This file cannot be password protected.
@@ -694,6 +695,8 @@ typedef struct coap_pki_key_pem_buf_t {
   const uint8_t *ca_cert;     /* PEM buffer Common CA Cert */
   const uint8_t *public_cert; /* PEM buffer Public Cert, or Public Key if RPK */
   const uint8_t *private_key; /* PEM buffer Private Key */
+                                 If RPK and 'EC PRIVATE KEY' this can be used
+                                 for both the public_cert and private_key */
   size_t ca_cert_len;         /* PEM buffer CA Cert length */
   size_t public_cert_len;     /* PEM buffer Public Cert length */
   size_t private_key_len;     /* PEM buffer Private Key length */
@@ -714,7 +717,8 @@ RPK) location in memory which will be in PEM format.
 *key.pem_buf.public_cert_len* is the length of the public certificate.
 
 *key.pem_buf.private_key* points to the private key location in memory which
-will be in PEM format.  This data cannot be password protected.
+will be in PEM format.  This data cannot be password protected. If RPK and
+'EC PRIVATE KEY' this can be used for both the public_cert and private_key.
 
 *key.pem_buf.private_key* is the length of the private key.
 

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -56,14 +56,19 @@ version is 1.1.0.
 revision of GnuTLS 3.5.5 which supports CCM algorithms is required
 by TinyDTLS as TinyDTLS currently only supports CCM.
 
+*NOTE:* For Raw Public Key support, GnuTLS library version must be 3.6.6 or
+later. TinyDTLS only supports TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, curve
+secp256r1 and hash SHA-256.  There currently is no OpenSSL or MbedTLS RPK support
+(respective library limitations).
+
 Network traffic can be un-encrypted or encrypted with libcoap if there is an
 underlying TLS library.
 
 If TLS is going to be used for encrypting the network traffic, then the TLS
-information for Pre-Shared Keys (PSK) or Public Key Infrastructure (PKI) needs
-to be configured before any network traffic starts to flow. For Servers, this
-has to be done before the Endpoint is created, for Clients, this is done
-during the Client Session set up.
+information for Pre-Shared Keys (PSK), Public Key Infrastructure (PKI) or
+Raw Public Key (RPK) needs to be configured before any network traffic starts
+to flow. For Servers, this has to be done before the Endpoint is created,
+for Clients, this is done during the Client Session set up.
 
 For Servers, all the encryption information is held internally by the TLS
 Context level and the CoAP Context level as the Server is listening for new
@@ -383,12 +388,12 @@ typedef struct coap_dtls_spsk_info_t {
 
 *key* defines the Pre-Shared Key to use
 
-PKI CLIENT AND SERVER INFORMATION
----------------------------------
+PKI/RPK CLIENT AND SERVER INFORMATION
+-------------------------------------
 
-For PKI setup, if the libcoap PKI configuration options do not handle a specific
-requirement as defined by the available options, then an application defined
-Callback can called to do the additional specific checks.
+For PKI or RPK setup, if the libcoap PKI/RPK configuration options do not
+handle a specific requirement as defined by the available options, then an
+application defined Callback can called to do the additional specific checks.
 
 The information passed to this Application Callback will be the
 TLS session (as well the configuration information), but the structures
@@ -396,15 +401,15 @@ containing this information will be different as they will be based on the
 underlying TLS library type. coap_get_tls_library_version() is provided to help
 here.
 
-Libcoap will add in the defined Certificate, Private Key and CA Certificate
-into the TLS environment.  The CA Certificate is also added in to the list of
-valid CAs for Certificate checking.
+Libcoap will add in the defined Certificate (or Public Key), Private Key and
+CA Certificate into the TLS environment.  The CA Certificate is also added
+in to the list of valid CAs for Certificate checking.
 
 The internal Callbacks (and optionally the Application Callback) will then
 check the required information as defined in the coap_dtls_pki_t described
 below.
 
-*SECTION: PKI: coap_dtls_pki_t*
+*SECTION: PKI/RPK: coap_dtls_pki_t*
 [source, c]
 ----
 typedef struct coap_dtls_pki_t {
@@ -422,7 +427,8 @@ typedef struct coap_dtls_pki_t {
   uint8_t allow_expired_crl;        /* 1 if expired crl is allowed */
   uint8_t allow_bad_md_hash;        /* 1 if unsupported MD hashes are allowed */
   uint8_t allow_short_rsa_length;   /* 1 if small RSA keysizes are allowed */
-  uint8_t reserved[4];              /* Reserved - must be set to 0 for
+  uint8_t is_rpk_not_cert;          /* 1 if RPK instead of Public Certificate */
+  uint8_t reserved[3];              /* Reserved - must be set to 0 for
                                        future compatibility */
 
   /** CN check callback function
@@ -459,14 +465,14 @@ More detailed explanation of the coap_dtls_pki_t structure follows.
 
 *WARNING*: For all the parameter definitions that are pointers to other
 locations, these locations must remain valid during the lifetime of all the
-underlying TLS sessions that are, or will get created based on this PKI
+underlying TLS sessions that are, or will get created based on this PKI/RPK
 definition.
 
 The first parameter in each subsection enables/disables the functionality, the
 remaining parameter(s) control what happens when the functionality is
 enabled.
 
-*SECTION: PKI: coap_dtls_pki_t: Version*
+*SECTION: PKI/RPK: coap_dtls_pki_t: Version*
 [source, c]
 ----
 #define COAP_DTLS_PKI_SETUP_VERSION 1
@@ -475,13 +481,13 @@ enabled.
 *version* is set to COAP_DTLS_PKI_SETUP_VERSION.  This will then allow support
 for different versions of the coap_dtls_pki_t structure in the future.
 
-*SECTION: PKI: coap_dtls_pki_t: Peer Certificate Checking*
+*SECTION: PKI/RPK: coap_dtls_pki_t: Peer Certificate Checking*
 
 *verify_peer_cert* Set to 1 to check that the peer's certificate is valid if
 provided, else 0.
 
 *require_peer_cert* Set to 1 to enforce that the peer provides a certificate,
-else 0.  If the Server, this initates a request for the peer certificate.
+else 0.  If the Server, this initiates a request for the peer certificate.
 
 *allow_self_signed* Set to 1 to allow the peer (or any certificate in the
 certificate chain) to be a self-signed certificate, else 0.
@@ -489,7 +495,7 @@ certificate chain) to be a self-signed certificate, else 0.
 *allow_expired_certs* Set to 1 to allow certificates that have either expired,
 or are not yet valid to be allowed, else 0.
 
-*SECTION: PKI: coap_dtls_pki_t: Certificate Chain Validation*
+*SECTION: PKI/RPK: coap_dtls_pki_t: Certificate Chain Validation*
 
 *cert_chain_validation* Set to 1 to check that the certificate chain is valid,
 else 0.
@@ -498,7 +504,7 @@ else 0.
 is the number of intermediate CAs in the chain. If set to 0, then there can be
 no intermediate CA in the chain.
 
-*SECTION: PKI: coap_dtls_pki_t: Certificate Revocation*
+*SECTION: PKI/RPK: coap_dtls_pki_t: Certificate Revocation*
 
 *check_cert_revocation* Set to 1 to check whether any certificate in the chain
 has been revoked, else 0.
@@ -509,26 +515,32 @@ else 0.
 *allow_expired_crl* Set to 1 to allow an certificate that has an expired CRL
 definition to be valid, else 0.
 
-*SECTION: PKI: coap_dtls_pki_t: Other*
+*SECTION: PKI/RPK: coap_dtls_pki_t: Other*
 
 *allow_bad_md_hash* Set to 1 if unsupported MD hashes are allowed, else 0.
 
 *allow_short_rsa_length* Set to 1 if small RSA keysizes are allowed, else 0.
 
-*SECTION: PKI: coap_dtls_pki_t: Reserved*
+*is_rpk_not_cert* Set to 1 if the Certificate is actually a Raw Public Key.
+
+*SECTION: PKI/RPK: coap_dtls_pki_t: Reserved*
 
 *reserved* All must be set to 0.  Future functionality updates will make use of
 these reserved definitions.
 
-*SECTION: PKI: coap_dtls_pki_t: Common Name (CN) Callback*
+*SECTION: PKI/RPK: coap_dtls_pki_t: Common Name (CN) Callback*
 [source, c]
 ----
+#define COAP_DTLS_RPK_CERT_CN "RPK"
+
 /**
  * CN Validation callback that can be set up by coap_context_set_pki().
  * Invoked when libcoap has done the validation checks at the TLS level,
  * but the application needs to check that the CN is allowed.
  * CN is the SubjectAltName in the cert, if not present, then the leftmost
- * Common Name (CN) component of the subject name
+ * Common Name (CN) component of the subject name.
+ * NOTE: If using RPK, then the Public Key does not contain a CN, but the 
+ * content of COAP_DTLS_RPK_CERT_CN is presented for the @p cn parameter.
  *
  * @param cn  The determined CN from the certificate
  * @param asn1_public_cert  The ASN.1 encoded (DER) X.509 certificate
@@ -559,7 +571,7 @@ The Callback returns 1 on success, 0 if the TLS connection is to be aborted.
 in to the validate_cn_call_back() function and can be used by that function.
 An example would be a set of CNs that are allowed.
 
-*SECTION: PKI: coap_dtls_pki_t: Subject Name Identifier (SNI) Callback*
+*SECTION: PKI/RPK: coap_dtls_pki_t: Subject Name Identifier (SNI) Callback*
 [source, c]
 ----
 typedef struct coap_dtls_key_t {
@@ -602,7 +614,7 @@ in to the validate_sni_call_back() function and can be used by that function.
 An example would be a set of SNIs that are allowed with their matching
 certificate sets.
 
-*SECTION: PKI: coap_dtls_pki_t: Application Additional Setup Callback*
+*SECTION: PKI/RPK: coap_dtls_pki_t: Application Additional Setup Callback*
 [source, c]
 ----
 /**
@@ -627,7 +639,7 @@ function that will do additional checking/changes/updates after libcoap has
 done all of the configured TLS setup checking, or NULL to do no additional
 checking.
 
-*SECTION: PKI: coap_dtls_pki_t: Subject Name Indicator (SNI) Definition*
+*SECTION: PKI/RPK: coap_dtls_pki_t: Subject Name Indicator (SNI) Definition*
 
 *client_sni* points to the SNI name that will be added in as a TLS extension,
 or set NULL.  This typically is the DNS name of the server that the client is
@@ -635,7 +647,7 @@ trying to contact.  This is only used by a client application and the server
 is then able to decide, based on the name in the SNI extension, whether, for
 example, a different certificate should be provided.
 
-*SECTION: PKI: coap_dtls_pki_t: Key Type Definition*
+*SECTION: PKI/RPK: coap_dtls_pki_t: Key Type Definition*
 [source, c]
 ----
 typedef enum coap_pki_key_t {
@@ -650,13 +662,16 @@ typedef enum coap_pki_key_t {
 This can be COAP_PKI_KEY_PEM, COAP_PKI_KEY_PEM_BUF, COAP_PKI_KEY_ASN1 or
 COAP_PKI_KEY_PKCS11.
 
-*SECTION: PKI: coap_dtls_pki_t: PEM Key Definitions*
+*SECTION: PKI/RPK: coap_dtls_pki_t: PEM Key Definitions*
 [source, c]
 ----
 typedef struct coap_pki_key_pem_t {
   const char *ca_file;       /* File location of Common CA in PEM format */
-  const char *public_cert;   /* File location of Public Cert in PEM format */
-  const char *private_key;   /* File location of Private Key in PEM format */
+  const char *public_cert;   /* File location of Public Cert, or Public
+                                Key if RPK, in PEM format */
+  const char *private_key;   /* File location of Private Key in PEM format.
+                                If RPK and 'EC PRIVATE KEY' this can be used
+                                for both the public_cert and private_key */
 } coap_pki_key_pem_t;
 ----
 
@@ -666,18 +681,18 @@ public certificate) as this is passed from the server to the client when
 requesting the client's certificate. This certificate is also added into
 the valid root CAs list if not already present.
 
-*key.pem.public_cert* points to the public certificate location on disk
-which will be in PEM format.
+*key.pem.public_cert* points to the public certificate (or public key if RPK)
+location on disk which will be in PEM format.
 
 *key.pem.private_key* points to the private key location on disk which
 will be in PEM format.  This file cannot be password protected.
 
-*SECTION: PKI: coap_dtls_pki_t: PEM Memory Key Definitions*
+*SECTION: PKI/RPK: coap_dtls_pki_t: PEM Memory Key Definitions*
 [source, c]
 ----
 typedef struct coap_pki_key_pem_buf_t {
   const uint8_t *ca_cert;     /* PEM buffer Common CA Cert */
-  const uint8_t *public_cert; /* PEM buffer Public Cert */
+  const uint8_t *public_cert; /* PEM buffer Public Cert, or Public Key if RPK */
   const uint8_t *private_key; /* PEM buffer Private Key */
   size_t ca_cert_len;         /* PEM buffer CA Cert length */
   size_t public_cert_len;     /* PEM buffer Public Cert length */
@@ -693,8 +708,8 @@ the valid root CAs list if not already present.
 
 *key.pem_buf.ca_cert_len* is the length of the CA.
 
-*key.pem_buf.public_cert* points to the public certificate location in memory
-which will be in PEM format.
+*key.pem_buf.public_cert* points to the public certificate (or public key if
+RPK) location in memory which will be in PEM format.
 
 *key.pem_buf.public_cert_len* is the length of the public certificate.
 
@@ -708,12 +723,12 @@ performance reasons (to save a potential buffer copy) and the length include
 this NULL terminator. It is not a requirement to have the NULL terminator
 though and the length must then reflect the actual data size.
 
-*SECTION: PKI: coap_dtls_pki_t: ASN1 Key Definitions*
+*SECTION: PKI/RPK: coap_dtls_pki_t: ASN1 Key Definitions*
 [source, c]
 ----
 typedef struct coap_pki_key_asn1_t {
   const uint8_t *ca_cert;     /* ASN1 Common CA Certificate */
-  const uint8_t *public_cert; /* ASN1 Public Certificate */
+  const uint8_t *public_cert; /* ASN1 (DER) Public Cert, or Public Key if RPK */
   const uint8_t *private_key; /* ASN1 Private Key */
   int ca_cert_len;            /* ASN1 CA Certificate length */
   int public_cert_len;        /* ASN1 Public Certificate length */
@@ -747,7 +762,7 @@ when requesting the client's certificate. This certificate is also added into
 the valid root CAs list if not already present.
 
 *key.asn1.public_cert* points to a DER encoded ASN.1 definition of the
-public certificate.
+public certificate (or public key if RPK).
 
 *key.asn1.private_key* points to DER encoded ASN.1 definition of the
 private key.
@@ -810,11 +825,13 @@ typedef struct valid_cns_t {
 } valid_cns_t;
 
 /**
- * CN Validation callback that is set up by coap_context_set_pki().
+ * CN Validation callback that can be set up by coap_context_set_pki().
  * Invoked when libcoap has done the validation checks at the TLS level,
  * but the application needs to check that the CN is allowed.
  * CN is the SubjectAltName in the cert, if not present, then the leftmost
- * Common Name (CN) component of the subject name
+ * Common Name (CN) component of the subject name.
+ * NOTE: If using RPK, then the Public Key does not contain a CN, but "RPK"
+ * is presented for the cn parameter.
  *
  * @param cn  The determined CN from the certificate
  * @param asn1_public_cert  The ASN.1 encoded (DER) X.509 certificate
@@ -930,6 +947,7 @@ setup_server_context_pki (const char *public_cert_file,
   dtls_pki.allow_expired_crl       = 1;
   dtls_pki.allow_bad_md_hash       = 0;
   dtls_pki.allow_short_rsa_length  = 0;
+  dtls_pki.is_rpk_not_cert         = 0; /* Set to 1 if RPK */
   dtls_pki.validate_cn_call_back   = verify_cn_callback;
   dtls_pki.cn_call_back_arg        = valid_cn_list;
   dtls_pki.validate_sni_call_back  = verify_pki_sni_callback;

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -300,6 +300,7 @@ setup_client_session_pki (struct in_addr ip_address,
   dtls_pki.allow_expired_crl       = 1;
   dtls_pki.allow_bad_md_hash       = 0;
   dtls_pki.allow_short_rsa_length  = 0;
+  dtls_pki.is_rpk_not_cert         = 0; /* Set to 1 if RPK */
   dtls_pki.validate_cn_call_back   = verify_cn_callback;
   dtls_pki.cn_call_back_arg        = NULL;
   dtls_pki.validate_sni_call_back  = NULL;

--- a/src/coap_asn1.c
+++ b/src/coap_asn1.c
@@ -1,0 +1,100 @@
+/* coap_asn1.c -- ASN.1 handling functions
+*
+* Copyright (C) 2020 Jon Shallow <supjps-libcoap@jpshallow.com>
+*
+* This file is part of the CoAP library libcoap. Please see
+* README for terms of use.
+*/
+
+#include "coap_internal.h"
+
+size_t
+asn1_len(const uint8_t **ptr)
+{
+  size_t len = 0;
+
+  if ((**ptr) & 0x80) {
+    size_t octets = (**ptr) & 0x7f;
+    (*ptr)++;
+    while (octets) {
+      len = (len << 8) + (**ptr);
+      (*ptr)++;
+      octets--;
+    }
+  }
+  else {
+    len = (**ptr) & 0x7f;
+    (*ptr)++;
+  }
+  return len;
+}
+
+coap_asn1_tag_t
+asn1_tag_c(const uint8_t **ptr, int *constructed, int *class)
+{
+  coap_asn1_tag_t tag = 0;
+  uint8_t byte;
+
+  byte = (**ptr);
+  *constructed = (byte & 0x20) ? 1 : 0;
+  *class = byte >> 6;
+  tag = byte & 0x1F;
+  (*ptr)++;
+  if (tag < 0x1F)
+    return tag;
+
+  /* Tag can be one byte or more based on B8 */
+  byte = (**ptr);
+  while (byte & 0x80) {
+    tag = (tag << 7) + (byte & 0x7F);
+    (*ptr)++;
+    byte = (**ptr);
+  }
+  /* Do the final one */
+  tag = (tag << 7) + (byte & 0x7F);
+  (*ptr)++;
+  return tag;
+}
+
+/* caller must free off returned coap_binary_t* */
+coap_binary_t *
+get_asn1_tag(coap_asn1_tag_t ltag, const uint8_t *ptr, size_t tlen,
+             asn1_validate validate)
+{
+  int constructed;
+  int class;
+  const uint8_t *acp = ptr;
+  uint8_t tag = asn1_tag_c(&acp, &constructed, &class);
+  size_t len = asn1_len(&acp);
+  coap_binary_t *tag_data;
+
+  while (tlen > 0 && len <= tlen) {
+    if (class == 2 && constructed == 1) {
+      /* Skip over element description */
+      tag = asn1_tag_c(&acp, &constructed, &class);
+      len = asn1_len(&acp);
+    }
+    if (tag == ltag) {
+      if (!validate || validate(acp, len)) {
+        tag_data = coap_new_binary(len);
+        if (tag_data == NULL)
+          return NULL;
+        tag_data->length = len;
+        memcpy(tag_data->s, acp, len);
+        return tag_data;
+      }
+    }
+    if (tag == 0x10 && constructed == 1) {
+      /* SEQUENCE or SEQUENCE OF */
+      tag_data = get_asn1_tag(ltag, acp, len, validate);
+      if (tag_data)
+        return tag_data;
+    }
+    acp += len;
+    tlen -= len;
+    tag = asn1_tag_c(&acp, &constructed, &class);
+    len = asn1_len(&acp);
+  }
+  return NULL;
+}
+

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -1,7 +1,8 @@
 /*
  * coap_tinydtls.c -- Datagram Transport Layer Support for libcoap with tinydtls
  *
- * Copyright (C) 2016 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2016-2020 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2020 Jon Shallow <supjps-libcoap@jpshallow.com>
  *
  * This file is part of the CoAP library libcoap. Please see README for terms
  * of use.
@@ -22,6 +23,22 @@
 #include <tinydtls.h>
 #include <dtls.h>
 #include <dtls_debug.h>
+
+typedef struct coap_tiny_context_t {
+  struct dtls_context_t *dtls_context;
+  coap_context_t *coap_context;
+#ifdef DTLS_ECC
+  coap_dtls_pki_t setup_data;
+  coap_binary_t *priv_key;
+  coap_binary_t *pub_key;
+#endif /* DTLS_ECC */
+} coap_tiny_context_t;
+
+#ifdef __GNUC__
+#define UNUSED __attribute__((unused))
+#else /* __GNUC__ */
+#define UNUSED
+#endif /* __GNUC__ */
 
 static dtls_tick_t dtls_tick_0 = 0;
 static coap_tick_t coap_tick_0 = 0;
@@ -90,10 +107,13 @@ static void put_session_addr(const coap_address_t *a, session_t *s) {
 static int
 dtls_send_to_peer(struct dtls_context_t *dtls_context,
   session_t *dtls_session, uint8 *data, size_t len) {
-  coap_context_t *coap_context = (coap_context_t *)dtls_get_app_data(dtls_context);
+  coap_tiny_context_t *t_context =
+                  (coap_tiny_context_t *)dtls_get_app_data(dtls_context);
+  coap_context_t *coap_context = t_context ? t_context->coap_context : NULL;
   coap_session_t *coap_session;
   coap_address_t remote_addr;
 
+  assert(coap_context);
   get_session_addr(dtls_session, &remote_addr);
   coap_session = coap_session_get_by_peer(coap_context, &remote_addr, dtls_session->ifindex);
   if (!coap_session) {
@@ -106,10 +126,13 @@ dtls_send_to_peer(struct dtls_context_t *dtls_context,
 static int
 dtls_application_data(struct dtls_context_t *dtls_context,
   session_t *dtls_session, uint8 *data, size_t len) {
-  coap_context_t *coap_context = (coap_context_t *)dtls_get_app_data(dtls_context);
+  coap_tiny_context_t *t_context =
+                  (coap_tiny_context_t *)dtls_get_app_data(dtls_context);
+  coap_context_t *coap_context = t_context ? t_context->coap_context : NULL;
   coap_session_t *coap_session;
   coap_address_t remote_addr;
 
+  assert(coap_context);
   get_session_addr(dtls_session, &remote_addr);
   coap_session = coap_session_get_by_peer(coap_context, &remote_addr, dtls_session->ifindex);
   if (!coap_session) {
@@ -168,7 +191,9 @@ get_psk_info(struct dtls_context_t *dtls_context,
   const uint8_t *id, size_t id_len,
   unsigned char *result, size_t result_length) {
 
-  coap_context_t *coap_context;
+  coap_tiny_context_t *t_context =
+                  (coap_tiny_context_t *)dtls_get_app_data(dtls_context);
+  coap_context_t *coap_context = t_context ? t_context->coap_context : NULL;
   coap_session_t *coap_session;
   int fatal_error = DTLS_ALERT_INTERNAL_ERROR;
   size_t identity_length;
@@ -179,7 +204,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
   coap_dtls_spsk_t *setup_sdata;
   coap_bin_const_t temp;
 
-  coap_context = (coap_context_t *)dtls_get_app_data(dtls_context);
+  assert(coap_context);
   get_session_addr(dtls_session, &remote_addr);
   coap_session = coap_session_get_by_peer(coap_context, &remote_addr, dtls_session->ifindex);
   if (!coap_session) {
@@ -304,12 +329,101 @@ error:
   return dtls_alert_fatal_create(fatal_error);
 }
 
-static dtls_handler_t cb = {
+#ifdef DTLS_ECC
+static int
+get_ecdsa_key(struct dtls_context_t *dtls_context,
+              const session_t *dtls_session UNUSED,
+              const dtls_ecdsa_key_t **result) {
+  static dtls_ecdsa_key_t ecdsa_key;
+  coap_tiny_context_t *t_context =
+                  (coap_tiny_context_t *)dtls_get_app_data(dtls_context);
+
+  ecdsa_key.curve = DTLS_ECDH_CURVE_SECP256R1;
+  ecdsa_key.priv_key = t_context->priv_key->s;
+  ecdsa_key.pub_key_x = t_context->pub_key->s;
+  ecdsa_key.pub_key_y = &t_context->pub_key->s[DTLS_EC_KEY_SIZE];
+
+  *result = &ecdsa_key;
+  return 0;
+}
+
+/* first part of Raw public key, the is the start of the Subject Public Key */
+static const unsigned char cert_asn1_header[] = {
+  0x30, 0x59, /* SEQUENCE, length 89 bytes */
+    0x30, 0x13, /* SEQUENCE, length 19 bytes */
+      0x06, 0x07, /* OBJECT IDENTIFIER ecPublicKey (1 2 840 10045 2 1) */
+        0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01,
+      0x06, 0x08, /* OBJECT IDENTIFIER prime256v1 (1 2 840 10045 3 1 7) */
+        0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07,
+      0x03, 0x42, 0x00, /* BIT STRING, length 66 bytes, 0 bits unused */
+         0x04 /* uncompressed, followed by the r and s values of the public key */
+};
+#define DTLS_CE_LENGTH (3 + 27 + key_size + key_size)
+#define DTLS_EC_SUBJECTPUBLICKEY_SIZE (2 * key_size + sizeof(cert_asn1_header))
+
+static int
+verify_ecdsa_key(struct dtls_context_t *dtls_context UNUSED,
+                 const session_t *dtls_session UNUSED,
+                 const uint8_t *other_pub_x,
+                 const uint8_t *other_pub_y,
+                 size_t key_size) {
+  coap_tiny_context_t *t_context =
+                  (coap_tiny_context_t *)dtls_get_app_data(dtls_context);
+  if (t_context && t_context->setup_data.validate_cn_call_back) {
+    /* Need to build asn.1 certificate - code taken from tinydtls */
+    uint8 *p;
+    uint8 buf[DTLS_CE_LENGTH];
+    coap_session_t *c_session;
+    coap_address_t remote_addr;
+
+    /* Certificate
+     *
+     * Start message construction at beginning of buffer. */
+    p = buf;
+
+    /* length of this certificate */
+    dtls_int_to_uint24(p, DTLS_EC_SUBJECTPUBLICKEY_SIZE);
+    p += sizeof(uint24);
+
+    memcpy(p, &cert_asn1_header, sizeof(cert_asn1_header));
+    p += sizeof(cert_asn1_header);
+
+    memcpy(p, other_pub_x, key_size);
+    p += key_size;
+
+    memcpy(p, other_pub_y, key_size);
+    p += key_size;
+
+    assert(p <= (buf + sizeof(buf)));
+
+    get_session_addr(dtls_session, &remote_addr);
+    c_session = coap_session_get_by_peer(t_context->coap_context,
+                                         &remote_addr, dtls_session->ifindex);
+    if (!c_session)
+      return -3;
+    if (!t_context->setup_data.validate_cn_call_back(COAP_DTLS_RPK_CERT_CN,
+        buf, p-buf, c_session, 0, 1, t_context->setup_data.cn_call_back_arg)) {
+      return -1;
+    }
+  }
+  return 0;
+}
+static dtls_handler_t ec_cb = {
+  .write = dtls_send_to_peer,
+  .read = dtls_application_data,
+  .event = dtls_event,
+  .get_psk_info = NULL,
+  .get_ecdsa_key = get_ecdsa_key,
+  .verify_ecdsa_key = verify_ecdsa_key
+};
+#endif /* DTLS_ECC */
+
+static dtls_handler_t psk_cb = {
   .write = dtls_send_to_peer,
   .read = dtls_application_data,
   .event = dtls_event,
   .get_psk_info = get_psk_info,
-#ifdef WITH_ECC
+#ifdef DTLS_ECC
   .get_ecdsa_key = NULL,
   .verify_ecdsa_key = NULL
 #endif
@@ -317,21 +431,40 @@ static dtls_handler_t cb = {
 
 void *
 coap_dtls_new_context(struct coap_context_t *coap_context) {
-  struct dtls_context_t *dtls_context = dtls_new_context(coap_context);
+  coap_tiny_context_t *t_context = coap_malloc(sizeof(coap_tiny_context_t));
+  struct dtls_context_t *dtls_context = t_context ? dtls_new_context(t_context) : NULL;
   if (!dtls_context)
     goto error;
-  dtls_set_handler(dtls_context, &cb);
-  return dtls_context;
+  memset(t_context, 0, sizeof(coap_tiny_context_t));
+  t_context->coap_context = coap_context;
+  t_context->dtls_context = dtls_context;
+  dtls_set_handler(dtls_context, &psk_cb);
+  return t_context;
 error:
-  coap_dtls_free_context(dtls_context);
+  if (t_context)
+    coap_free(t_context);
+  if (dtls_context)
+    coap_dtls_free_context(dtls_context);
   return NULL;
 }
 
 void
 coap_dtls_free_context(void *handle) {
   if (handle) {
-    struct dtls_context_t *dtls_context = (struct dtls_context_t *)handle;
-    dtls_free_context(dtls_context);
+    coap_tiny_context_t *t_context = (coap_tiny_context_t *)handle;
+#ifdef DTLS_ECC
+    if (t_context->priv_key) {
+      coap_delete_binary(t_context->priv_key);
+      t_context->priv_key = NULL;
+    }
+    if (t_context->pub_key) {
+      coap_delete_binary(t_context->pub_key);
+      t_context->pub_key = NULL;
+    }
+#endif /* DTLS_ECC */
+    if (t_context->dtls_context)
+      dtls_free_context(t_context->dtls_context);
+    coap_free(t_context);
   }
 }
 
@@ -357,22 +490,22 @@ void *coap_dtls_new_server_session(coap_session_t *session) {
 
 void *coap_dtls_new_client_session(coap_session_t *session) {
   dtls_peer_t *peer;
-  session_t *dtls_session = coap_dtls_new_session(session);
+  coap_tiny_context_t *t_context = (coap_tiny_context_t *)session->context->dtls_context;
+  dtls_context_t *dtls_context = t_context ? t_context->dtls_context : NULL;
+  session_t *dtls_session = dtls_context ? coap_dtls_new_session(session) : NULL;
+
   if (!dtls_session)
     return NULL;
   peer =
-    dtls_get_peer((struct dtls_context_t *)session->context->dtls_context,
-      dtls_session);
+    dtls_get_peer(dtls_context, dtls_session);
 
   if (!peer) {
     /* The peer connection does not yet exist. */
     /* dtls_connect() returns a value greater than zero if a new
     * connection attempt is made, 0 for session reuse. */
-    if (dtls_connect((struct dtls_context_t *)session->context->dtls_context,
-      dtls_session) >= 0) {
+    if (dtls_connect(dtls_context, dtls_session) >= 0) {
       peer =
-        dtls_get_peer((struct dtls_context_t *)session->context->dtls_context,
-          dtls_session);
+        dtls_get_peer(dtls_context, dtls_session);
     }
   }
 
@@ -392,16 +525,18 @@ coap_dtls_session_update_mtu(coap_session_t *session) {
 
 void
 coap_dtls_free_session(coap_session_t *coap_session) {
-  struct dtls_context_t *ctx;
-  if (coap_session->context == NULL)
+  coap_tiny_context_t *t_context =
+                 (coap_tiny_context_t *)coap_session->context->dtls_context;
+  dtls_context_t *dtls_context = t_context ? t_context->dtls_context : NULL;
+
+  if (dtls_context == NULL)
     return;
-  ctx = (struct dtls_context_t *)coap_session->context->dtls_context;
-  if (coap_session->tls && ctx) {
-    dtls_peer_t *peer = dtls_get_peer(ctx, (session_t *)coap_session->tls);
+  if (coap_session->tls && dtls_context) {
+    dtls_peer_t *peer = dtls_get_peer(dtls_context, (session_t *)coap_session->tls);
     if ( peer )
-      dtls_reset_peer(ctx, peer);
+      dtls_reset_peer(dtls_context, peer);
     else
-      dtls_close(ctx, (session_t *)coap_session->tls);
+      dtls_close(dtls_context, (session_t *)coap_session->tls);
     coap_log(LOG_DEBUG, "***removed session %p\n", coap_session->tls);
     coap_free_type(COAP_DTLS_SESSION, coap_session->tls);
     coap_session->tls = NULL;
@@ -416,13 +551,16 @@ coap_dtls_send(coap_session_t *session,
 ) {
   int res;
   uint8_t *data_rw;
+  coap_tiny_context_t *t_context = (coap_tiny_context_t *)session->context->dtls_context;
+  dtls_context_t *dtls_context = t_context ? t_context->dtls_context : NULL;
 
+  assert(dtls_context);
   coap_log(LOG_DEBUG, "call dtls_write\n");
 
   coap_event_dtls = -1;
   /* Need to do this to not get a compiler warning about const parameters */
   memcpy (&data_rw, &data, sizeof(data_rw));
-  res = dtls_write((struct dtls_context_t *)session->context->dtls_context,
+  res = dtls_write(dtls_context,
     (session_t *)session->tls, data_rw, data_len);
 
   if (res < 0)
@@ -445,9 +583,12 @@ int coap_dtls_is_context_timeout(void) {
   return 1;
 }
 
-coap_tick_t coap_dtls_get_context_timeout(void *dtls_context) {
+coap_tick_t coap_dtls_get_context_timeout(void *tiny_context) {
   clock_time_t next = 0;
-  dtls_check_retransmit((struct dtls_context_t *)dtls_context, &next);
+  coap_tiny_context_t *t_context = (coap_tiny_context_t *)tiny_context;
+  dtls_context_t *dtls_context = t_context ? t_context->dtls_context : NULL;
+  if (tiny_context)
+    dtls_check_retransmit(dtls_context, &next);
   if (next > 0)
     return ((coap_tick_t)(next - dtls_tick_0)) * COAP_TICKS_PER_SECOND / DTLS_TICKS_PER_SECOND + coap_tick_0;
   return 0;
@@ -472,13 +613,14 @@ coap_dtls_receive(coap_session_t *session,
   session_t *dtls_session = (session_t *)session->tls;
   int err;
   uint8_t *data_rw;
+  coap_tiny_context_t *t_context = (coap_tiny_context_t *)session->context->dtls_context;
+  dtls_context_t *dtls_context = t_context ? t_context->dtls_context : NULL;
 
+  assert(dtls_context);
   coap_event_dtls = -1;
   /* Need to do this to not get a compiler warning about const parameters */
   memcpy (&data_rw, &data, sizeof(data_rw));
-  err = dtls_handle_message(
-    (struct dtls_context_t *)session->context->dtls_context,
-    dtls_session, data_rw, (int)data_len);
+  err = dtls_handle_message(dtls_context, dtls_session, data_rw, (int)data_len);
 
   if (err){
     coap_event_dtls = COAP_EVENT_DTLS_ERROR;
@@ -503,10 +645,11 @@ coap_dtls_hello(coap_session_t *session,
   size_t data_len
 ) {
   session_t dtls_session;
-  struct dtls_context_t *dtls_context =
-    (struct dtls_context_t *)session->context->dtls_context;
+  coap_tiny_context_t *t_context = (coap_tiny_context_t *)session->context->dtls_context;
+  dtls_context_t *dtls_context = t_context ? t_context->dtls_context : NULL;
   uint8_t *data_rw;
 
+  assert(dtls_context);
   dtls_session_init(&dtls_session);
   put_session_addr(&session->addr_info.remote, &dtls_session);
   dtls_session.ifindex = session->ifindex;
@@ -527,12 +670,6 @@ unsigned int coap_dtls_get_overhead(coap_session_t *session) {
   (void)session;
   return 13 + 8 + 8;
 }
-
-#ifdef __GNUC__
-#define UNUSED __attribute__((unused))
-#else /* __GNUC__ */
-#define UNUSED
-#endif /* __GNUC__ */
 
 int coap_tls_is_supported(void) {
   return 0;
@@ -562,11 +699,640 @@ coap_get_tls_library_version(void) {
   return &version;
 }
 
+#ifdef DTLS_ECC
+static const uint8_t b64_6[256] =
+  {
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+/*                                             +               / */
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
+/* 0   1   2   3   4   5   6   7   8   9               =         */
+  52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
+/*     A   B   C   D   E   F   G   H   I   J   K   L   M   N   O */
+  64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+/* P   Q   R   S   T   U   V   W   X   Y   Z                     */
+  15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
+/*     a   b   c   d   e   f   g   h   i   j   k   l   m   n   o */
+  64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+/* p   q   r   s   t   u   v   w   x   y   z                     */
+  41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64,
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+  64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64
+  };
+
+/* caller must free off returned coap_binary_t* */
+static coap_binary_t *
+pem_base64_decode (const uint8_t *data, size_t size)
+{
+  uint8_t *tbuf = coap_malloc(size);
+  size_t nbytesdecoded;
+  size_t i;
+  coap_binary_t *decoded;
+  uint8_t *ptr;
+  uint8_t *out;
+  size_t nb64bytes = 0;
+
+  for (i = 0; i < size; i++) {
+    switch (data[i]) {
+    case ' ':
+    case '\r':
+    case '\n':
+    case '\t':
+      break;
+    default:
+      if (b64_6[data[i]] == 64)
+        goto end;
+      tbuf[nb64bytes++] = data[i];
+      break;
+    }
+  }
+
+end:
+  nbytesdecoded = ((nb64bytes + 3) / 4) * 3;
+  decoded = coap_new_binary(nbytesdecoded + 1);
+  if (!decoded)
+    return NULL;
+
+  out = decoded->s;
+  ptr = tbuf;
+
+  while (nb64bytes > 4) {
+    *(out++) = b64_6[ptr[0]] << 2 | b64_6[ptr[1]] >> 4;
+    *(out++) = b64_6[ptr[1]] << 4 | b64_6[ptr[2]] >> 2;
+    *(out++) = b64_6[ptr[2]] << 6 | b64_6[ptr[3]];
+    ptr += 4;
+    nb64bytes -= 4;
+  }
+
+  /* Note: (nb64bytes == 1) is an error */
+  if (nb64bytes > 1) {
+    *(out++) = b64_6[ptr[0]] << 2 | b64_6[ptr[1]] >> 4;
+  }
+  if (nb64bytes > 2) {
+    *(out++) = b64_6[ptr[1]] << 4 | b64_6[ptr[2]] >> 2;
+  }
+  if (nb64bytes > 3) {
+    *(out++) = b64_6[ptr[2]] << 6 | b64_6[ptr[3]];
+  }
+
+  decoded->length = nbytesdecoded - ((4 - nb64bytes) & 3);
+  coap_free(tbuf);
+  return decoded;
+}
+
+static size_t
+asn1_len(const uint8_t **ptr)
+{
+  size_t len = 0;
+
+  if ((**ptr) & 0x80) {
+    size_t octets = (**ptr) & 0x7f;
+    (*ptr)++;
+    while (octets) {
+      len = (len << 8) + (**ptr);
+      (*ptr)++;
+      octets--;
+    }
+  }
+  else {
+    len = (**ptr) & 0x7f;
+    (*ptr)++;
+  }
+  return len;
+}
+
+static size_t
+asn1_tag_c(const uint8_t **ptr, int *constructed, int *class)
+{
+  size_t tag = 0;
+  uint8_t byte;
+
+  byte = (**ptr);
+  *constructed = (byte & 0x20) ? 1 : 0;
+  *class = byte >> 6;
+  tag = byte & 0x1F;
+  (*ptr)++;
+  if (tag < 0x1F)
+    return tag;
+
+  /* Tag can be one byte or more based on B8 */
+  byte = (**ptr);
+  while (byte & 0x80) {
+    tag = (tag << 7) + (byte & 0x7F);
+    (*ptr)++;
+    byte = (**ptr);
+  }
+  /* Do the final one */
+  tag = (tag << 7) + (byte & 0x7F);
+  (*ptr)++;
+  return tag;
+}
+
+typedef coap_binary_t * (*asn1_callback)(const uint8_t *data, size_t size);
+
+static coap_binary_t *
+asn1_callback_privkey(const uint8_t *data, size_t size)
+{
+  coap_binary_t *priv_key;
+
+  /* Check if we have the private key (with optional leading 0x00) */
+  /* skip leading 0x00 */
+  if (size - 1 == DTLS_EC_KEY_SIZE && *data == '\000') {
+        --size;
+        ++data;
+  }
+
+  /* Check if we have the private key */
+  if (size != DTLS_EC_KEY_SIZE)
+    return NULL;
+
+  priv_key = coap_new_binary(DTLS_EC_KEY_SIZE);
+  if (!priv_key)
+    return NULL;
+
+  memcpy(priv_key->s, data, DTLS_EC_KEY_SIZE);
+  return priv_key;
+}
+
+static coap_binary_t *
+asn1_callback_pubkey(const uint8_t *data, size_t size)
+{
+  coap_binary_t *pub_key;
+
+  /* We have the public key
+     (with a leading 0x00 (no unused bits) 0x04 (not compressed() */
+  if (size - 2 != 2 * DTLS_EC_KEY_SIZE)
+    return NULL;
+
+  pub_key = coap_new_binary(size-2);
+  if (!pub_key)
+    return NULL;
+
+  memcpy(pub_key->s, data+2, size-2);
+  return pub_key;
+}
+
+static coap_binary_t *
+asn1_callback_curve(const uint8_t *data, size_t size)
+{
+  coap_binary_t *curve_key;
+  static uint8_t prime256v1_oid[] =
+         /* OID 1.2.840.10045.3.1.7 */
+         { 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07 };
+
+  /* Check that we have the correct EC (only one supported) */
+  if (size != sizeof(prime256v1_oid) ||
+      memcmp(data, prime256v1_oid, size) != 0)
+    return NULL;
+
+  curve_key = coap_new_binary(0);
+  return curve_key;
+}
+
+static coap_binary_t *
+asn1_callback_pkcs8_version(const uint8_t *data, size_t size)
+{
+  coap_binary_t *version_key;
+
+  /* Check that we have the version */
+  if (size != 1 || *data != 0)
+    return NULL;
+
+  version_key = coap_new_binary(0);
+  return version_key;
+}
+
+static coap_binary_t *
+asn1_callback_ec_identifier(const uint8_t *data, size_t size)
+{
+  coap_binary_t *id_key;
+  static uint8_t ec_public_key_oid[] =
+         /* OID 1.2.840.10045.2.1 */
+         { 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01 };
+
+  /* Check that we have the correct ecPublicKey */
+  if (size != sizeof(ec_public_key_oid) ||
+      memcmp(data, ec_public_key_oid, size) != 0)
+    return NULL;
+
+  id_key = coap_new_binary(0);
+  return id_key;
+}
+
+static coap_binary_t *
+asn1_callback_ec_key(const uint8_t *data, size_t size)
+{
+  coap_binary_t *ec_key;
+
+  if (size == 0)
+    return NULL;
+
+  ec_key = coap_new_binary(size);
+  if (!ec_key)
+    return NULL;
+
+  memcpy(ec_key->s, data, size);
+  return ec_key;
+}
+
+/* caller must free off returned coap_binary_t* */
+static coap_binary_t *
+asn1_abstract_tag(const uint8_t *ptr, size_t tlen, uint8_t ltag, asn1_callback callback)
+{
+  int constructed;
+  int class;
+  const uint8_t *acp = ptr;
+  uint8_t tag = asn1_tag_c(&acp, &constructed, &class);
+  size_t len = asn1_len(&acp);
+  coap_binary_t *tag_data;
+
+  while (tlen > 0 && len <= tlen) {
+    if (class == 2 && constructed == 1) {
+      /* Skip over element description */
+      tag = asn1_tag_c(&acp, &constructed, &class);
+      len = asn1_len(&acp);
+    }
+    if (tag == ltag) {
+      tag_data = callback(acp, len);
+      if (tag_data)
+        return tag_data;
+    }
+    if (tag == 0x10 && constructed == 1) {
+      /* SEQUENCE or SEQUENCE OF */
+      tag_data = asn1_abstract_tag(acp, len, ltag, callback);
+      if (tag_data)
+        return tag_data;
+    }
+    acp += len;
+    tlen -= len;
+    tag = asn1_tag_c(&acp, &constructed, &class);
+    len = asn1_len(&acp);
+  }
+  return NULL;
+}
+
+static int
+asn1_derive_keys(coap_tiny_context_t *t_context,
+                 const uint8_t *priv_data, size_t priv_len,
+                 const uint8_t *pub_data, size_t pub_len,
+                 int is_pkcs8)
+{
+  coap_binary_t *test;
+
+  t_context->priv_key = asn1_abstract_tag(priv_data, priv_len,
+                                              0x04, asn1_callback_privkey);
+  if (!t_context->priv_key) {
+    coap_log(LOG_INFO, "EC Private Key (RPK) invalid\n");
+    return 0;
+  }
+
+  if (!is_pkcs8) {
+    /* pkcs8 abstraction tested for valid eliptic curve */
+    test = asn1_abstract_tag(priv_data, priv_len,
+                                    0x06, asn1_callback_curve);
+    if (!test) {
+      coap_log(LOG_INFO, "EC Private Key (RPK) invalid elliptic curve\n");
+      coap_delete_binary(t_context->priv_key);
+      t_context->priv_key = NULL;
+      return 0;
+    }
+    coap_delete_binary(test);
+  }
+
+  t_context->pub_key = asn1_abstract_tag(pub_data, pub_len,
+                                              0x03, asn1_callback_pubkey);
+  if (!t_context->pub_key) {
+    coap_log(LOG_INFO, "EC Public Key (RPK) invalid\n");
+    coap_delete_binary(t_context->priv_key);
+    t_context->priv_key = NULL;
+    return 0;
+  }
+  dtls_set_handler(t_context->dtls_context, &ec_cb);
+  return 1;
+}
+
+static coap_binary_t *
+ec_abstract_pkcs8_asn1(const uint8_t *asn1_ptr, size_t asn1_length)
+{
+  coap_binary_t *test;
+
+  test = asn1_abstract_tag(asn1_ptr, asn1_length,
+                               0x02, asn1_callback_pkcs8_version);
+  if (!test)
+    return 0;
+
+  coap_delete_binary(test);
+
+  test = asn1_abstract_tag(asn1_ptr, asn1_length,
+                               0x06, asn1_callback_ec_identifier);
+  if (!test)
+    return 0;
+  coap_delete_binary(test);
+
+  test = asn1_abstract_tag(asn1_ptr, asn1_length,
+                               0x06, asn1_callback_curve);
+  if (!test) {
+    coap_log(LOG_INFO, "EC Private Key (RPK) invalid elliptic curve\n");
+    return 0;
+  }
+  coap_delete_binary(test);
+
+  test = asn1_abstract_tag(asn1_ptr, asn1_length,
+                               0x04, asn1_callback_ec_key);
+  return test;
+}
+
+static coap_binary_t *
+pem_decode_mem_asn1(const char *begstr, const uint8_t *str)
+{
+  char *bcp = str ? strstr((const char*)str, begstr) : NULL;
+  char *tcp = bcp ? strstr(bcp, "-----END ") : NULL;
+
+  if (bcp && tcp) {
+    bcp += strlen(begstr);
+    return pem_base64_decode ((const uint8_t *)bcp, tcp - bcp);
+  }
+  return NULL;
+}
+
+#include <stdio.h>
+#include <sys/stat.h>
+
+static uint8_t *read_file_mem(const char* file, size_t *length) {
+  FILE *f = fopen(file, "r");
+  uint8_t *buf;
+  struct stat statbuf;
+
+  *length = 0;
+  if (!f)
+    return NULL;
+
+  if (fstat(fileno(f), &statbuf) == -1) {
+    fclose(f);
+    return NULL;
+  }
+
+  buf = coap_malloc(statbuf.st_size+1);
+  if (!buf)
+    return NULL;
+
+  if (fread(buf, 1, statbuf.st_size, f) != (size_t)statbuf.st_size) {
+    fclose(f);
+    free(buf);
+    return NULL;
+  }
+  buf[statbuf.st_size] = '\000';
+  *length = (size_t)(statbuf.st_size + 1);
+  fclose(f);
+  return buf;
+}
+
+static coap_binary_t *
+pem_decode_file_asn1(const char *begstr, const char *file)
+{
+  size_t length;
+  uint8_t *str = read_file_mem(file, &length);
+  char *bcp;
+  char *tcp;
+  coap_binary_t *decoded = NULL;
+
+  if (!str) {
+    return NULL;
+  }
+
+  bcp = strstr((const char*)str, begstr);
+  tcp = bcp ? strstr(bcp, "-----END ") : NULL;
+  if (bcp && tcp) {
+    bcp += strlen(begstr);
+    decoded = pem_base64_decode ((const uint8_t *)bcp, tcp - bcp);
+  }
+  coap_free(str);
+  return decoded;
+}
+#endif /* DTLS_ECC */
+
 int
-coap_dtls_context_set_pki(coap_context_t *ctx UNUSED,
-  coap_dtls_pki_t* setup_data UNUSED,
+coap_dtls_context_set_pki(coap_context_t *ctx,
+  coap_dtls_pki_t* setup_data,
   coap_dtls_role_t role UNUSED
 ) {
+#ifdef DTLS_ECC
+  coap_tiny_context_t *t_context;
+  coap_binary_t *asn1_priv;
+  coap_binary_t *asn1_pub;
+  coap_binary_t *asn1_temp;
+  int is_pkcs8 = 0;
+
+  if (!setup_data)
+    return 0;
+  if (setup_data->version != COAP_DTLS_PKI_SETUP_VERSION)
+    return 0;
+  if (!setup_data->is_rpk_not_cert) {
+    coap_log(LOG_WARNING, "Only RPK, not full PKI is supported\n");
+    return 0;
+  }
+  if (!ctx)
+    return 0;
+  t_context = (coap_tiny_context_t *)ctx->dtls_context;
+  if (!t_context)
+    return 0;
+  if (t_context->priv_key) {
+    coap_delete_binary(t_context->priv_key);
+    t_context->priv_key = NULL;
+  }
+  if (t_context->pub_key) {
+    coap_delete_binary(t_context->pub_key);
+    t_context->pub_key = NULL;
+  }
+  t_context->setup_data = *setup_data;
+
+  /* All should be RPK only now */
+  switch (setup_data->pki_key.key_type) {
+  case COAP_PKI_KEY_PEM:
+    if (setup_data->pki_key.key.pem.private_key &&
+        setup_data->pki_key.key.pem.private_key[0]) {
+      /* Need to read in the PEM information and convert to binary */
+      asn1_priv = pem_decode_file_asn1("-----BEGIN EC PRIVATE KEY-----",
+                                 setup_data->pki_key.key.pem.private_key);
+      if (!asn1_priv) {
+        asn1_priv = pem_decode_file_asn1("-----BEGIN PRIVATE KEY-----",
+                                 setup_data->pki_key.key.pem.private_key);
+        if (!asn1_priv) {
+          coap_log(LOG_INFO, "Private Key (RPK) invalid\n");
+          return 0;
+        }
+        asn1_temp = ec_abstract_pkcs8_asn1(asn1_priv->s, asn1_priv->length);
+        if (!asn1_temp) {
+          coap_log(LOG_INFO, "PKCS#8 Private Key (RPK) invalid\n");
+          coap_delete_binary(asn1_priv);
+          return 0;
+        }
+        coap_delete_binary(asn1_priv);
+        asn1_priv = asn1_temp;
+        is_pkcs8 = 1;
+      }
+      /* See if public key has been explicitly provided */
+      asn1_pub = pem_decode_file_asn1( "-----BEGIN PUBLIC KEY-----",
+                                 setup_data->pki_key.key.pem.public_cert);
+      if (!asn1_pub) {
+        /* Else use public key embedded into EC Private key */
+        asn1_pub = pem_decode_file_asn1("-----BEGIN EC PRIVATE KEY-----",
+                                 setup_data->pki_key.key.pem.private_key);
+        if (!asn1_pub) {
+          asn1_pub = pem_decode_file_asn1("-----BEGIN PRIVATE KEY-----",
+                                 setup_data->pki_key.key.pem.private_key);
+          if (!asn1_pub) {
+            coap_log(LOG_INFO, "Public Key (RPK) invalid\n");
+            coap_delete_binary(asn1_priv);
+            return 0;
+          }
+          asn1_temp = ec_abstract_pkcs8_asn1(asn1_pub->s, asn1_pub->length);
+          if (!asn1_temp) {
+            coap_log(LOG_INFO, "PKCS#8 Private Key (RPK) invalid\n");
+            coap_delete_binary(asn1_priv);
+            coap_delete_binary(asn1_pub);
+            return 0;
+          }
+          coap_delete_binary(asn1_pub);
+          asn1_pub = asn1_temp;
+          is_pkcs8 = 1;
+        }
+      }
+
+      if (!asn1_derive_keys(t_context, asn1_priv->s, asn1_priv->length,
+                            asn1_pub->s, asn1_pub->length, is_pkcs8)) {
+        coap_log(LOG_INFO, "Unable to derive Public/Private Keys\n");
+        coap_delete_binary(asn1_priv);
+        coap_delete_binary(asn1_pub);
+        return 0;
+      }
+      coap_delete_binary(asn1_priv);
+      coap_delete_binary(asn1_pub);
+      return 1;
+    }
+    break;
+  case COAP_PKI_KEY_PEM_BUF:
+    if (setup_data->pki_key.key.pem_buf.public_cert &&
+        setup_data->pki_key.key.pem_buf.public_cert[0] &&
+        setup_data->pki_key.key.pem_buf.private_key &&
+        setup_data->pki_key.key.pem_buf.private_key[0]) {
+      /* Need to take PEM memory information and convert to binary */
+      asn1_priv = pem_decode_mem_asn1("-----BEGIN EC PRIVATE KEY-----",
+                                 setup_data->pki_key.key.pem_buf.private_key);
+      if (!asn1_priv) {
+        asn1_priv = pem_decode_mem_asn1("-----BEGIN PRIVATE KEY-----",
+                                 setup_data->pki_key.key.pem_buf.private_key);
+        if (!asn1_priv) {
+          coap_log(LOG_INFO, "Private Key (RPK) invalid\n");
+          return 0;
+        }
+        asn1_temp = ec_abstract_pkcs8_asn1(asn1_priv->s, asn1_priv->length);
+        if (!asn1_temp) {
+          coap_log(LOG_INFO, "PKCS#8 Private Key (RPK) invalid\n");
+          coap_delete_binary(asn1_priv);
+          return 0;
+        }
+        coap_delete_binary(asn1_priv);
+        asn1_priv = asn1_temp;
+        is_pkcs8 = 1;
+      }
+      asn1_pub = pem_decode_mem_asn1(
+                                "-----BEGIN PUBLIC KEY-----",
+                                 setup_data->pki_key.key.pem_buf.public_cert);
+      if (!asn1_pub) {
+        asn1_pub = pem_decode_mem_asn1("-----BEGIN EC PRIVATE KEY-----",
+                                 setup_data->pki_key.key.pem_buf.private_key);
+        if (!asn1_pub) {
+          asn1_pub = pem_decode_mem_asn1("-----BEGIN PRIVATE KEY-----",
+                                 setup_data->pki_key.key.pem_buf.private_key);
+          if (!asn1_pub) {
+            coap_log(LOG_INFO, "Public Key (RPK) invalid\n");
+            coap_delete_binary(asn1_priv);
+            return 0;
+          }
+          asn1_temp = ec_abstract_pkcs8_asn1(asn1_pub->s, asn1_pub->length);
+          if (!asn1_temp) {
+            coap_log(LOG_INFO, "PKCS#8 Private Key (RPK) invalid\n");
+            coap_delete_binary(asn1_priv);
+            coap_delete_binary(asn1_pub);
+            return 0;
+          }
+          coap_delete_binary(asn1_pub);
+          asn1_pub = asn1_temp;
+          is_pkcs8 = 1;
+        }
+      }
+      if (!asn1_derive_keys(t_context, asn1_priv->s, asn1_priv->length,
+                            asn1_pub->s, asn1_pub->length, is_pkcs8)) {
+        coap_log(LOG_INFO, "Unable to derive Public/Private Keys\n");
+        coap_delete_binary(asn1_priv);
+        coap_delete_binary(asn1_pub);
+        return 0;
+      }
+      coap_delete_binary(asn1_priv);
+      coap_delete_binary(asn1_pub);
+      return 1;
+    }
+    break;
+  case COAP_PKI_KEY_ASN1:
+    if (setup_data->pki_key.key.asn1.private_key &&
+        setup_data->pki_key.key.asn1.private_key_len &&
+         setup_data->pki_key.key.asn1.private_key_type == COAP_ASN1_PKEY_EC) {
+      const uint8_t* private_key = setup_data->pki_key.key.asn1.private_key;
+      size_t private_key_len = setup_data->pki_key.key.asn1.private_key_len;
+
+      /* Check to see whether this is in pkcs8 format or not */
+      asn1_temp = ec_abstract_pkcs8_asn1(
+                       setup_data->pki_key.key.asn1.private_key,
+                       setup_data->pki_key.key.asn1.private_key_len);
+      if (asn1_temp) {
+        private_key = asn1_temp->s;
+        private_key_len = asn1_temp->length;
+        is_pkcs8 = 1;
+      }
+      /* Need to take ASN1 memory information and convert to binary */
+      if (setup_data->pki_key.key.asn1.public_cert &&
+          setup_data->pki_key.key.asn1.public_cert_len) {
+        if (!asn1_derive_keys(t_context,
+                              private_key,
+                              private_key_len,
+                              setup_data->pki_key.key.asn1.public_cert,
+                              setup_data->pki_key.key.asn1.public_cert_len,
+                              is_pkcs8)) {
+          coap_log(LOG_INFO, "Unable to derive Public/Private Keys\n");
+          if (asn1_temp) coap_delete_binary(asn1_temp);
+          return 0;
+        }
+      }
+      else {
+        if (!asn1_derive_keys(t_context,
+                              private_key,
+                              private_key_len,
+                              private_key,
+                              private_key_len,
+                              is_pkcs8)) {
+          coap_log(LOG_INFO, "Unable to derive Public/Private Keys\n");
+          if (asn1_temp) coap_delete_binary(asn1_temp);
+          return 0;
+        }
+      }
+      return 1;
+    }
+    break;
+  case COAP_PKI_KEY_PKCS11:
+  default:
+    break;
+  }
+#else /* ! DTLS_ECC */
+  (void)ctx;
+  (void)setup_data;
+#endif /* ! DTLS_ECC */
   return 0;
 }
 
@@ -579,7 +1345,7 @@ coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx UNUSED,
 }
 
 int
-coap_dtls_context_set_cpsk(coap_context_t *c_context UNUSED,
+coap_dtls_context_set_cpsk(coap_context_t *coap_context UNUSED,
   coap_dtls_cpsk_t *setup_data
 ) {
   if (!setup_data)
@@ -589,7 +1355,7 @@ coap_dtls_context_set_cpsk(coap_context_t *c_context UNUSED,
 }
 
 int
-coap_dtls_context_set_spsk(coap_context_t *c_context UNUSED,
+coap_dtls_context_set_spsk(coap_context_t *coap_context UNUSED,
   coap_dtls_spsk_t *setup_data
 ) {
   if (!setup_data)


### PR DESCRIPTION
This supersedes #128
Issue raised in #500 
~~Needs TinyDTLS PR https://github.com/eclipse/tinydtls/pull/32 for TinyDTLS to interoperate with GnuTLS.~~

Currently OpenSSL and MBedTLS do not support RFC7250. See
https://en.wikipedia.org/wiki/Comparison_of_TLS_implementations#Extensions
last column.

GnuTLS >= 3.6.6 required.

~~TinyDTLS update required.~~

New option is_rpk_not_cert added to PKI setup structure which is enabled
in coap-client and coap-server by the -M option and the use of a PUBLIC KEY
instead of a CERTIFICATE in the cert file.

man/coap-client.txt.in:
man/coap-server.txt.in:

Document -M option.

man/coap_encryption.txt.in:
man/coap-server.txt.in:
man/coap_context.txt.in:

Add in documentation for RPK.

examples/client.c:
examples/coap-server.c:

Add in support for is_rpk_not_cert and -M option.

include/coap2/coap_dtls.h:

Add in is_rpk_not_cert option.

include/coap2/str.h:
src/str.c:
libcoap-2.map:
libcoap-2.sym:

Add in coap_new_binary() and coap_delete_binary() functions.

src/coap_openssl.c:

Report RPK is not supported if invoked.
Check that all received data is used up for error recovery.

src/coap_mbedtls.c:

Report RPK is not supported if invoked.
Handle more MbedTLS generated errors.
Check that all received data is used up for error recovery.

src/coap_gnutls.c:

Add in support for RPK.
Add in sending Hello Verify if not cookie match in Client Hello
Check that all received data is used up for error recovery.

src/coap_tinydtls.c:

Add in support for RPK.