### PR TITLE
Proxy: Update Proxy support for Proxy-Uri: CoAP option

### DIFF
--- a/TODO
+++ b/TODO
@@ -11,8 +11,6 @@ Classification of issues:
 =================
 * CRITICAL ISSUES
 =================
--> Proxy functionality
- -> A coap-server should be able to act as proxy server
 
 ================
 * SERIOUS ISSUES

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -152,6 +152,8 @@ typedef struct coap_context_t {
                                           resources */
   struct coap_resource_t *unknown_resource; /**< can be used for handling
                                                  unknown resources */
+  struct coap_resource_t *proxy_uri_resource; /**< can be used for handling
+                                                 proxy URI resources */
 
 #ifndef WITHOUT_ASYNC
   /**

--- a/include/coap2/resource.h
+++ b/include/coap2/resource.h
@@ -89,6 +89,7 @@ typedef struct coap_resource_t {
   unsigned int observable:1;     /**< can be observed */
   unsigned int cacheable:1;      /**< can be cached */
   unsigned int is_unknown:1;     /**< resource created for unknown handler */
+  unsigned int is_proxy_uri:1;   /**< resource created for proxy URI handler */
 
   /**
    * Used to store handlers for the seven coap methods @c GET, @c POST, @c PUT,
@@ -122,6 +123,16 @@ typedef struct coap_resource_t {
    * Pointer back to the context that 'owns' this resource.
    */
   coap_context_t *context;
+
+  /**
+   * Count of valid names this host is known by (proxy support)
+   */
+  size_t proxy_name_count;
+
+  /**
+   * Array valid names this host is known by (proxy support)
+   */
+  coap_str_const_t ** proxy_name_list;
 
   /**
    * This pointer is under user control. It can be used to store context for
@@ -193,6 +204,24 @@ coap_resource_t *coap_resource_init(coap_str_const_t *uri_path,
  * @return       A pointer to the new object or @c NULL on error.
  */
 coap_resource_t *coap_resource_unknown_init(coap_method_handler_t put_handler);
+
+/**
+ * Creates a new resource object for handling proxy URIs.
+ * This function returns the new coap_resource_t object.
+ *
+ * Note: There can only be one proxy resource handler per context - attaching
+ *       a new one overrides the previous definition.
+ *
+ * @param handler The PUT/POST/GET etc. handler that handles all request types.
+ * @param host_name_count The number of provided host_name_list entries. A
+ *                        minimum of 1 must be provided.
+ * @param host_name_list Array of depth host_name_count names that this proxy
+ *                       is known by.
+ *
+ * @return         A pointer to the new object or @c NULL on error.
+ */
+coap_resource_t *coap_resource_proxy_uri_init(coap_method_handler_t handler,
+                      size_t host_name_count, const char *host_name_list[]);
 
 /**
  * Sets the notification message type of resource @p resource to given

--- a/include/coap2/uri.h
+++ b/include/coap2/uri.h
@@ -19,19 +19,22 @@ struct coap_pdu_t;
  * The scheme specifiers. Secure schemes have an odd numeric value,
  * others are even.
  */
-enum coap_uri_scheme_t {
-  COAP_URI_SCHEME_COAP=0,
-  COAP_URI_SCHEME_COAPS=1,
-  COAP_URI_SCHEME_COAP_TCP=2,
-  COAP_URI_SCHEME_COAPS_TCP=3
-};
+typedef enum coap_uri_scheme_t {
+  COAP_URI_SCHEME_COAP = 0,
+  COAP_URI_SCHEME_COAPS,     /* 1 */
+  COAP_URI_SCHEME_COAP_TCP,  /* 2 */
+  COAP_URI_SCHEME_COAPS_TCP, /* 3 */
+  COAP_URI_SCHEME_HTTP,      /* 4 Proxy-Uri only */
+  COAP_URI_SCHEME_HTTPS      /* 5 Proxy-Uri only */
+} coap_uri_scheme_t;
 
 /** This mask can be used to check if a parsed URI scheme is secure. */
 #define COAP_URI_SCHEME_SECURE_MASK 0x01
 
 /**
  * Representation of parsed URI. Components may be filled from a string with
- * coap_split_uri() and can be used as input for option-creation functions.
+ * coap_split_uri() or coap_split_proxy_uri() and can be used as input for
+ * option-creation functions.
  */
 typedef struct {
   coap_str_const_t host;  /**< host part of the URI */
@@ -79,16 +82,35 @@ coap_uri_t *coap_clone_uri(const coap_uri_t *uri);
  * Parses a given string into URI components. The identified syntactic
  * components are stored in the result parameter @p uri. Optional URI
  * components that are not specified will be set to { 0, 0 }, except for the
- * port which is set to @c COAP_DEFAULT_PORT. This function returns @p 0 if
- * parsing succeeded, a value less than zero otherwise.
+ * port which is set to the default port for the protocol. This function
+ * returns @p 0 if parsing succeeded, a value less than zero otherwise.
  *
  * @param str_var The string to split up.
  * @param len     The actual length of @p str_var
  * @param uri     The coap_uri_t object to store the result.
+ *
  * @return        @c 0 on success, or < 0 on error.
  *
  */
 int coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri);
+
+/**
+ * Parses a given string into URI components. The identified syntactic
+ * components are stored in the result parameter @p uri. Optional URI
+ * components that are not specified will be set to { 0, 0 }, except for the
+ * port which is set to default port for the protocol. This function returns
+ * @p 0 if parsing succeeded, a value less than zero otherwise.
+ * Note: This function enforces that the given string is in Proxy-Uri format
+ *       as well as supports different schema such as http.
+ *
+ * @param str_var The string to split up.
+ * @param len     The actual length of @p str_var
+ * @param uri     The coap_uri_t object to store the result.
+ *
+ * @return        @c 0 on success, or < 0 on error.
+ *
+ */
+int coap_split_proxy_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri);
 
 /**
  * Splits the given URI path into segments. Each segment is preceded

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -163,6 +163,7 @@ global:
   coap_resize_binary;
   coap_resource_init;
   coap_resource_notify_observers;
+  coap_resource_proxy_uri_init;
   coap_resource_set_dirty;
   coap_resource_unknown_init;
   coap_response_phrase;
@@ -204,6 +205,7 @@ global:
   coap_show_tls_version;
   coap_socket_strerror;
   coap_split_path;
+  coap_split_proxy_uri;
   coap_split_query;
   coap_split_uri;
   coap_startup;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -161,6 +161,7 @@ coap_remove_from_queue
 coap_resize_binary
 coap_resource_init
 coap_resource_notify_observers
+coap_resource_proxy_uri_init
 coap_resource_set_dirty
 coap_resource_unknown_init
 coap_response_phrase
@@ -202,6 +203,7 @@ coap_show_pdu
 coap_show_tls_version
 coap_socket_strerror
 coap_split_path
+coap_split_proxy_uri
 coap_split_query
 coap_split_uri
 coap_startup

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -87,6 +87,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_pdu_setup.3" > coap_encode_var_safe8.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_split_path.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_split_query.3
+	@echo ".so man3/coap_resource.3" > coap_resource_get_userdata.3
 	@echo ".so man3/coap_session.3" > coap_session_get_app_data.3
 	@echo ".so man3/coap_session.3" > coap_session_set_app_data.3
 	@echo ".so man3/coap_session.3" > coap_tcp_is_supported.3

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -18,7 +18,7 @@ SYNOPSIS
               [*-m* method] [*-o* file] [*-p* port] [*-r*] [*-s duration*]
               [*-t* type] [*-v* num] [*-A* type] [*-B* seconds]
               [*-H* hoplimit] [*-K* interval] [*-N*] [*-O* num,text]
-              [*-P* addr[:port]] [*-T* token] [*-U*]
+              [*-P* scheme://addr[:port]] [*-T* token] [*-U*]
               [[*-h* match_hint_file] [*-k* key] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [*-C* cafile] [*-J* pkcs11_pin]
               [*-M* rpk_file] [*-R* root_cafile]] URI
@@ -129,9 +129,10 @@ OPTIONS - General
    Add option 'num' with contents of 'text' to the request. If the text begins
    with 0x, then the hex text is converted to binary data.
 
-*-P* addr[:port]::
-   Address (and port) for proxy to use (automatically adds Proxy-Uri option
-   to request).
+*-P* scheme://addr[:port]::
+   Scheme, address and optional port to define how to connect to a CoAP proxy
+   (automatically adds Proxy-Uri option to request) to forward the request to.
+   Scheme is one of coap, coaps, coap+tcp and coaps+tcp.
 
 *-T* token::
    Include the 'token' to the request.

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -15,9 +15,9 @@ coap-server - CoAP Server based on libcoap
 SYNOPSIS
 --------
 *coap-server* [*-d* max] [*-g* group] [*-l* loss] [*-p* port] [*-v* num]
-              [*-A* address] [*-N*]
+              [*-A* address] [*-N*] [*-P* scheme://addr[:port],name1[,name2..]]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
-              [*-s* match_psk_sni_file]]
+              [*-s* match_psk_sni_file] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
               [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* root_cafile]
               [*-S* match_pki_sni_file]]
@@ -64,6 +64,16 @@ OPTIONS - General
    fifth response will still be sent as a confirmable response
    (RFC 7641 requirement).
 
+*-P* scheme://address[:port],name1[,name2[,name3..]] ::
+   Scheme, address, optional port of how to connect to the next proxy server
+   and one or more names (comma separated) that this proxy server is known by.
+   If the hostname of the incoming proxy request matches one of these names,
+   then this server is considered to be the final endpoint. If
+   scheme://address[:port] is not defined before the leading , (comma) of the
+   first name, then the ongoing connection will be a direct connection.
+   Scheme is one of coap, coaps, coap+tcp and coaps+tcp.
+
+
 OPTIONS - PSK
 -------------
 (If supported by underlying (D)TLS library)
@@ -96,6 +106,9 @@ OPTIONS - PSK
    A line that starts with # is treated as a comment. +
    Note: -k still needs to be defined for the default case +
    Note: the new Pre-Shared Key will get updated if there is also a -i match
+
+*-u* user ::
+   User identity for pre-shared key mode (only used if option P is set).
 
 OPTIONS - PKI
 -------------

--- a/man/coap_cache.txt.in
+++ b/man/coap_cache.txt.in
@@ -232,7 +232,7 @@ hnd_put_example_data(coap_context_t *ctx,
     if (!cache_entry && block1.num == 0) {
       /*
        * Set idle_timeout parameter to COAP_MAX_TRANSMIT_WAIT if you want
-       * early removal on transmission failure. -1 means only delete when
+       * early removal on transmission failure. 0 means only delete when
        * the session is deleted as session_based is set here.
        */
       cache_entry = coap_new_cache_entry(session, request,

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -13,6 +13,7 @@ NAME
 coap_resource,
 coap_resource_init,
 coap_resource_unknown_init,
+coap_resource_proxy_uri_init,
 coap_add_resource,
 coap_delete_resource,
 coap_delete_all_resources,
@@ -30,6 +31,9 @@ int _flags_);*
 
 *coap_resource_t *coap_resource_unknown_init(coap_method_handler_t
 _put_handler_);*
+
+*coap_resource_t *coap_resource_proxy_uri_init(coap_method_handler_t
+_proxy_handler_, size_t _host_name_count_, const char *_host_name_list_[]);*
 
 *void coap_add_resource(coap_context_t *_context_,
 coap_resource_t *_resource_);*
@@ -108,10 +112,19 @@ Free off the coap_str_const_t for _uri_path_ when the _resource_ is deleted.
 *NOTE:* _uri_path_, if not 7 bit readable ASCII, binary bytes must be hex
 encoded according to the rules defined in RFC3968 Section 2.1.
 
-The *coap_resource_unknown_init*() returns a newly created _resource_ of
-type _coap_resource_t_ *. _put_handler_ is automatically added to the
+The *coap_resource_unknown_init*() function returns a newly created _resource_
+of type _coap_resource_t_ *. _put_handler_ is automatically added to the
 _resource_ to handle PUT requests to resources that are unknown. Additional
 handlers can be added to this resource if required.
+
+The *coap_resource_proxy_uri_init*() function returns a newly created
+_resource_ of type _coap_resource_t_ *. _proxy_handler_ is automatically added
+to the _resource_ to handle PUT/POST/GET etc. requests that use the Proxy-Uri:
+option.  There is no need to add explicit request type handlers. One or more
+names by which the proxy is known by (IP address, DNS name etc.) must be
+supplied in the array defined by _host_name_list_[] which has a count of
+_host_name_count_.  This is used to check whether the current endpoint is
+the proxy target address.
 
 The *coap_add_resource*() function registers the given _resource_ with the
 _context_. The _resource_ must have been created by *coap_resource_init*(),
@@ -147,8 +160,9 @@ from the _resource_ that had previously been set up by
 
 RETURN VALUES
 -------------
-The *coap_resource_init*() and *coap_resource_unknown_init*() functions
-return a newly created resource or NULL if there is a malloc failure.
+The *coap_resource_init*(), *coap_resource_unknown_init*() and
+*coap_resource_proxy_uri_init*() functions return a newly created resource
+or NULL if there is a malloc failure.
 
 The *coap_delete_resource*() function return 0 on failure (_resource_ not
 found), 1 on success.

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -1921,13 +1921,15 @@ coap_dtls_free_gnutls_env(coap_gnutls_context_t *g_context,
     gnutls_deinit(g_env->g_session);
     g_env->g_session = NULL;
     if (g_context->psk_pki_enabled & IS_PSK) {
-      if (g_context->psk_pki_enabled & IS_CLIENT) {
+      if ((g_context->psk_pki_enabled & IS_CLIENT) &&
+          g_env->psk_cl_credentials != NULL) {
         gnutls_psk_free_client_credentials(g_env->psk_cl_credentials);
         g_env->psk_cl_credentials = NULL;
       }
       else {
         /* YUK - A memory leak in 3.3.0 (fixed by 3.3.26) of hint */
-        gnutls_psk_free_server_credentials(g_env->psk_sv_credentials);
+        if (g_env->psk_sv_credentials != NULL)
+          gnutls_psk_free_server_credentials(g_env->psk_sv_credentials);
         g_env->psk_sv_credentials = NULL;
       }
     }

--- a/src/uri.c
+++ b/src/uri.c
@@ -39,10 +39,20 @@ strnchr(const uint8_t *s, size_t len, unsigned char c) {
 #define ISEQUAL_CI(a,b) \
   ((a) == (b) || (islower(b) && ((a) == ((b) - 0x20))))
 
-int
-coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
+typedef enum coap_uri_check_t {
+  COAP_URI_CHECK_URI,
+  COAP_URI_CHECK_PROXY
+} coap_uri_check_t;
+
+static int
+coap_split_uri_sub(const uint8_t *str_var,
+                   size_t len,
+                   coap_uri_t *uri,
+                   coap_uri_check_t check_proxy) {
   const uint8_t *p, *q;
   int res = 0;
+  int is_http_proxy_scheme = 0;
+  size_t keep_len = len;
 
   if (!str_var || !uri)
     return -1;
@@ -53,6 +63,8 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
   /* search for scheme */
   p = str_var;
   if (*p == '/') {
+    if (check_proxy == COAP_URI_CHECK_PROXY)
+      return -1;
     q = p;
     goto path;
   }
@@ -60,6 +72,34 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
   q = (const uint8_t *)COAP_DEFAULT_SCHEME;
   while (len && *q && ISEQUAL_CI(*p, *q)) {
     ++p; ++q; --len;
+  }
+  if (*q && check_proxy == COAP_URI_CHECK_PROXY) {
+    /* Scheme could be something other than coap */
+    len = keep_len;
+    p = str_var;
+    q = (const uint8_t *)"http";
+    while (len && *q && ISEQUAL_CI(*p, *q)) {
+      ++p; ++q; --len;
+    }
+    if (*q == 0) {
+      if (len && ISEQUAL_CI(*p, 's')) {
+        /* https:// */
+        ++p; --len;
+        uri->scheme = COAP_URI_SCHEME_HTTPS;
+        uri->port = 443;
+      }
+      else {
+        /* http:// */
+        uri->scheme = COAP_URI_SCHEME_HTTP;
+        uri->port = 80;
+      }
+    }
+    else {
+      /* Unknown scheme */
+      res = -1;
+      goto error;
+    }
+    is_http_proxy_scheme = 1;
   }
 
   /* If q does not point to the string end marker '\0', the schema
@@ -69,23 +109,25 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
     goto error;
   }
 
-  /* There might be an additional 's', indicating the secure version: */
-  if (len && (*p == 's')) {
-    ++p; --len;
-    uri->scheme = COAP_URI_SCHEME_COAPS;
-    uri->port = COAPS_DEFAULT_PORT;
-  } else {
-    uri->scheme = COAP_URI_SCHEME_COAP;
-  }
+  if (is_http_proxy_scheme == 0) {
+    /* There might be an additional 's', indicating the secure version: */
+    if (len && (*p == 's')) {
+      ++p; --len;
+      uri->scheme = COAP_URI_SCHEME_COAPS;
+      uri->port = COAPS_DEFAULT_PORT;
+    } else {
+      uri->scheme = COAP_URI_SCHEME_COAP;
+    }
 
-  /* There might be and addition "+tcp", indicating reliable transport: */
-  if (len>=4 && p[0] == '+' && p[1] == 't' && p[2] == 'c' && p[3] == 'p' ) {
-    p += 4;
-    len -= 4;
-    if (uri->scheme == COAP_URI_SCHEME_COAPS)
-      uri->scheme = COAP_URI_SCHEME_COAPS_TCP;
-    else
-      uri->scheme = COAP_URI_SCHEME_COAP_TCP;
+    /* There might be an addition "+tcp", indicating reliable transport: */
+    if (len>=4 && p[0] == '+' && p[1] == 't' && p[2] == 'c' && p[3] == 'p' ) {
+      p += 4;
+      len -= 4;
+      if (uri->scheme == COAP_URI_SCHEME_COAPS)
+        uri->scheme = COAP_URI_SCHEME_COAPS_TCP;
+      else
+        uri->scheme = COAP_URI_SCHEME_COAP_TCP;
+    }
   }
   q = (const uint8_t *)"://";
   while (len && *q && *p == *q) {
@@ -186,6 +228,16 @@ coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
 
   error:
   return res;
+}
+
+int
+coap_split_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
+  return coap_split_uri_sub(str_var, len, uri, COAP_URI_CHECK_URI);
+}
+
+int
+coap_split_proxy_uri(const uint8_t *str_var, size_t len, coap_uri_t *uri) {
+  return coap_split_uri_sub(str_var, len, uri, COAP_URI_CHECK_PROXY);
 }
 
 /**


### PR DESCRIPTION
Add code to better support the Proxy-Uri: and Proxy-Scheme: CoAP Options.

examples/client.c:

Make sure that the Proxy-Uri: option is added (if set) when clearing down an
observation (fixes #112).
Check that Proxy-Uri: option has a maximum data length of 1034 bytes.
Handle user defined Proxy-Scheme: option correctly.
Update -P option to include scheme to be used when connecting to the proxy.

examples/coap-server.c:

Add in hnd_proxy_uri() handler function. This has support for a direct or ongoing
proxy connection for the coap* protocols. The ongoing connection is set up as a
different CoAP session and is assocated with the incoming session for relaying
requests / responses.

Internal functions taken from client.c are used where appropriate.

Proxy support code has a SERVER_CAN_PROXY wrapper, so footprint can easily be
reduced if required.

New -P and -u options added to support ongoing connections.

include/coap2/net.h:

Add in tracking the proxy uri handler into coap_context_t.

include/coap2/resource.h:

Track whether a resource definition is for Proxy-Uri:/Proxy-Scheme:.
Define the coap_resource_proxy_uri_init() function for handling the Proxy-Uri:
option or Proxy-Scheme: option in an incoming request.

include/coap2/uri.h:

Add in COAP_URI_SCHEME_HTTP and COAP_URI_SCHEME_HTTPS as valid Proxy-Uri:
schemes.
Define the coap_split_proxy_uri() function (similar to coap_split_uri() but
supports the proxy extras.  Both now use a common sub function internally.

libcoap-2.map:
libcoap-2.sym:

Expose the new coap_resource_proxy_uri_init() and coap_split_proxy_uri()
functions.

man/Makefile.am:

Handle coap_resource_get_userdata(3) now being over the 10 definition limit
in man/coap_resource.txt.in.

man/coap-client.txt.in:

Update documentation for the -P option.

man/coap-server.txt.in:

Document the new -P proxy option.
Document the new -u user option.

man/coap_resource.txt.in:

Include documentation for coap_resource_proxy_uri_init().

src/coap_debug.c:

Output the Proxy-Scheme: Option as text.

src/net.c:

Sanity check and handle COAP_OPTION_PROXY_URI and COAP_OPTION_PROXY_SCHEME
in handle_request().

src/resource.c:

Add in coap_resource_proxy_uri_init() function.
Handle the addition of a proxy uri handler in coap_add_resource().

src/uri.c:

Rename coap_split_uri() to coap_split_uri_sub() and add in extra proxy
handling support based on input parameters.

Create new coap_split_uri() and coap_split_proxy_uri() which call
coap_split_uri_sub() appropriately.

[Code abstracted from #476 to separate 2 PRs]