### PR TITLE
Cygwin: Add in compiler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ doc/man_tmp/
 # the man/ folder
 man/docbook-xsl.css
 man/examples-code-check
+man/examples-code-check.exe
 man/examples-code-check.o
 man/Makefile
 man/Makefile.in
@@ -75,6 +76,7 @@ examples/coap-etsi_iot_01
 examples/coap-rd
 examples/coap-server
 examples/coap-tiny
+examples/*.exe
 
 # the include/ folder
 include/coap2/coap.h

--- a/configure.ac
+++ b/configure.ac
@@ -733,6 +733,12 @@ case $host in
     #AC_SUBST(OS_LINUX)
     ;;
 
+    *-cygwin*)
+    AC_MSG_RESULT([Cygwin])
+    ADDITIONAL_CFLAGS="-D_GNU_SOURCE -D_CYGWIN_ENV"
+    LDFLAGS="-no-undefined $LDFLAGS"
+    ;;
+
     *-solaris*)
     AC_MSG_RESULT([Solaris])
     # set _XOPEN_SOURCE and _XOPEN_SOURCE_EXTENDED to enable XPG4v2 (POSIX 2004)

--- a/examples/client.c
+++ b/examples/client.c
@@ -837,7 +837,7 @@ cmdline_content_type(char *arg, uint16_t key) {
   uint16_t value;
   uint8_t buf[2];
 
-  if (isdigit(*arg)) {
+  if (isdigit((int)arg[0])) {
     value = atoi(arg);
   } else {
     for (i=0;
@@ -1088,7 +1088,7 @@ hex2char(char c) {
 static size_t
 convert_hex_string(const char *src, uint8_t *dst) {
   uint8_t *p = dst;
-  while (isxdigit(src[0]) && isxdigit(src[1])) {
+  while (isxdigit((int)src[0]) && isxdigit((int)src[1])) {
     *p++ = (hex2char(src[0]) << 4) + hex2char(src[1]);
     src += 2;
   }
@@ -1638,7 +1638,7 @@ get_session(
     /* iterate through results until success */
     for ( rp = result; rp != NULL; rp = rp->ai_next ) {
       coap_address_t bind_addr;
-      if ( rp->ai_addrlen <= sizeof( bind_addr.addr ) ) {
+      if ( rp->ai_addrlen <= (socklen_t)sizeof( bind_addr.addr ) ) {
         coap_address_init( &bind_addr );
         bind_addr.size = (socklen_t)rp->ai_addrlen;
         memcpy( &bind_addr.addr, rp->ai_addr, rp->ai_addrlen );

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -721,7 +721,7 @@ get_context(const char *node, const char *port) {
     coap_address_t addr, addrs;
     coap_endpoint_t *ep_udp = NULL, *ep_dtls = NULL, *ep_tcp = NULL, *ep_tls = NULL;
 
-    if (rp->ai_addrlen <= sizeof(addr.addr)) {
+    if (rp->ai_addrlen <= (socklen_t)sizeof(addr.addr)) {
       coap_address_init(&addr);
       addr.size = (socklen_t)rp->ai_addrlen;
       memcpy(&addr.addr, rp->ai_addr, rp->ai_addrlen);

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2124,7 +2124,7 @@ get_context(const char *node, const char *port) {
     coap_address_t addr, addrs;
     coap_endpoint_t *ep_udp = NULL, *ep_dtls = NULL;
 
-    if (rp->ai_addrlen <= sizeof(addr.addr)) {
+    if (rp->ai_addrlen <= (socklen_t)sizeof(addr.addr)) {
       coap_address_init(&addr);
       addr.size = (socklen_t)rp->ai_addrlen;
       memcpy(&addr.addr, rp->ai_addr, rp->ai_addrlen);

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -616,7 +616,7 @@ get_context(const char *node, const char *port) {
   for (rp = result; rp != NULL; rp = rp->ai_next) {
     coap_address_t addr;
 
-    if (rp->ai_addrlen <= sizeof(addr.addr)) {
+    if (rp->ai_addrlen <= (socklen_t)sizeof(addr.addr)) {
       coap_address_init(&addr);
       addr.size = rp->ai_addrlen;
       memcpy(&addr.addr, rp->ai_addr, rp->ai_addrlen);

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -51,7 +51,7 @@ int main(int argc, char* argv[])
   DIR *pdir;
   struct dirent *pdir_ent;
   int exit_code = 0;
-  char buffer[512];
+  char buffer[1024];
 
   if (argc != 2) {
     fprintf(stderr, "usage: %s man_directory\n", argv[0]);
@@ -83,7 +83,7 @@ int main(int argc, char* argv[])
       char  keep_line[1024] = {0};
       FILE*  fpcode = NULL;
       FILE*  fpheader = NULL;
-      char  file_name[512];
+      char  file_name[300];
 
       fprintf(stderr, "Processing: %s\n", pdir_ent->d_name);
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -210,8 +210,8 @@ coap_socket_bind_udp(coap_socket_t *sock,
 
   if (bind(sock->fd, &listen_addr->addr.sa,
            listen_addr->addr.sa.sa_family == AF_INET ?
-            sizeof(struct sockaddr_in) :
-            listen_addr->size) == COAP_SOCKET_ERROR) {
+            (socklen_t)sizeof(struct sockaddr_in) :
+            (socklen_t)listen_addr->size) == COAP_SOCKET_ERROR) {
     coap_log(LOG_WARNING, "coap_socket_bind_udp: bind: %s\n",
              coap_socket_strerror());
     goto error;
@@ -300,8 +300,8 @@ coap_socket_connect_udp(coap_socket_t *sock,
 #endif /* RIOT_VERSION */
     if (bind(sock->fd, &local_if->addr.sa,
              local_if->addr.sa.sa_family == AF_INET ?
-              sizeof(struct sockaddr_in) :
-              local_if->size) == COAP_SOCKET_ERROR) {
+              (socklen_t)sizeof(struct sockaddr_in) :
+              (socklen_t)local_if->size) == COAP_SOCKET_ERROR) {
       coap_log(LOG_WARNING, "coap_socket_connect_udp: bind: %s\n",
                coap_socket_strerror());
       goto error;
@@ -538,6 +538,10 @@ static __declspec(thread) LPFN_WSARECVMSG lpWSARecvMsg = NULL;
 #define ipi_spec_dst ipi_addr
 #else
 #define iov_len_t size_t
+#endif
+
+#if defined(_CYGWIN_ENV)
+#define ipi_spec_dst ipi_addr
 #endif
 
 #ifndef RIOT_VERSION

--- a/src/coap_tcp.c
+++ b/src/coap_tcp.c
@@ -101,8 +101,8 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
                coap_socket_strerror());
     if (bind(sock->fd, &local_if->addr.sa,
              local_if->addr.sa.sa_family == AF_INET ?
-              sizeof(struct sockaddr_in) :
-              local_if->size) == COAP_SOCKET_ERROR) {
+              (socklen_t)sizeof(struct sockaddr_in) :
+              (socklen_t)local_if->size) == COAP_SOCKET_ERROR) {
       coap_log(LOG_WARNING, "coap_socket_connect_tcp1: bind: %s\n",
                coap_socket_strerror());
       goto error;
@@ -248,8 +248,8 @@ coap_socket_bind_tcp(coap_socket_t *sock,
 
   if (bind(sock->fd, &listen_addr->addr.sa,
            listen_addr->addr.sa.sa_family == AF_INET ?
-            sizeof(struct sockaddr_in) :
-            listen_addr->size) == COAP_SOCKET_ERROR) {
+            (socklen_t)sizeof(struct sockaddr_in) :
+            (socklen_t)listen_addr->size) == COAP_SOCKET_ERROR) {
     coap_log(LOG_ALERT, "coap_socket_bind_tcp: bind: %s\n",
              coap_socket_strerror());
     goto error;


### PR DESCRIPTION
See https://sourceforge.net/p/libcoap/mailman/message/37039434/

Works for

Computer: Windows 10 64 bit & CYGWIN_NT-10.0 x86_64
Cygwin: 3.1.5-1
OpenSSL: 1.1.1g
gcc:9.3.0

and gcc-10.2.0 + openssl1.1.1f

configure.ac:

Support cygwin build environment.  If so, set -D_CYGWIN_ENV in CFLAGS.

libtool: warning: undefined symbols not allowed in x86_64-pc-cygwin shared libraries; building static only
still to be fixed.

.gitignore:

Ignore *.exe filenames

src/coap_io.c:

define ipi_spec_dst as ipi_addr if _CYGWIN_ENV

examples/client.c:
examples/coap-rd.c:
examples/coap-server.c:
man/examples-code-check.c:
src/coap_io.c:
src/coap_tcp.c:

Fix compiler warnings.

sizeof(socklen_t) != sizeof(size_t) [-Wsign-compare]
isdigit() etc. complain about byte size array subscripts [-Wchar-subscripts]
snprintf size checks [-Wformat-truncation=]