### PR TITLE
LwIP: Check memory allocation sizes for COAP_OPTLIST and COAP_STRING

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -543,6 +543,14 @@ coap_new_optlist(uint16_t number,
 ) {
   coap_optlist_t *node;
 
+#ifdef WITH_LWIP
+  if (length > MEMP_LEN_COAPOPTLIST) {
+    coap_log(LOG_CRIT,
+             "coap_new_optlist: size too large (%zu > MEMP_LEN_COAPOPTLIST)\n",
+             length);
+    return NULL;
+  }
+#endif /* WITH_LWIP */
   node = coap_malloc_type(COAP_OPTLIST, sizeof(coap_optlist_t) + length);
 
   if (node) {

--- a/src/str.c
+++ b/src/str.c
@@ -11,8 +11,18 @@
 #include <stdio.h>
 
 coap_string_t *coap_new_string(size_t size) {
-  coap_string_t *s =
-            (coap_string_t *)coap_malloc_type(COAP_STRING, sizeof(coap_string_t) + size + 1);
+  coap_string_t *s;
+#ifdef WITH_LWIP
+  if (size >= MEMP_LEN_COAPSTRING) {
+    coap_log(LOG_CRIT,
+             "coap_new_string: size too large (%zu +1 > MEMP_LEN_COAPSTRING)\n",
+             size);
+    return NULL;
+  }
+#endif /* WITH_LWIP */
+  assert(size+1 != 0);
+  s = (coap_string_t *)coap_malloc_type(COAP_STRING,
+                                        sizeof(coap_string_t) + size + 1);
   if ( !s ) {
     coap_log(LOG_CRIT, "coap_new_string: malloc: failed\n");
     return NULL;


### PR DESCRIPTION
These are fixed memory sizes, but applications can ask for a bigger size
which will lead to memory corruption.

src/option.c:
src/str.c:

Check the requesting size to verify that it is within limits.  Contiki
properly checks the sizes.  Return NULL if too large with a logged varning.