### PR TITLE
testdriver: Add in support for access to libcoap internal functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -560,7 +560,7 @@ AC_SUBST([DOLLAR_SIGN],[$])
 # __tests__
 AC_ARG_ENABLE([tests],
               [AS_HELP_STRING([--enable-tests],
-                              [Enable building the binary testsuite [default=no]])],
+                              [Enable building the binary testsuite. Requires --enable-static  [default=no]])],
               [build_tests="$enableval"],
               [build_tests="no"])
 
@@ -573,6 +573,10 @@ if test "x$build_tests" = "xyes"; then
                        AC_MSG_WARN([==> You want to build the testing binary but the pkg-config file cunit.pc could not be found or installed CUnit version is too old!])
                        AC_MSG_ERROR([==> Install the package(s) that contains the development files for CUnit or disable the testing binary using '--disable-tests'.])
                       ])
+    if test "x$enable_static" = "xno"; then
+        enable_static=yes
+        AC_MSG_WARN([--enable-tests requires --enable-static which is now enabled.])
+    fi
 fi
 AM_CONDITIONAL(HAVE_CUNIT, [test "x$CUNIT_LIBS" != "x"])
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,7 +26,9 @@ testdriver_SOURCES = \
  test_wellknown.c \
  test_tls.c
 
-testdriver_LDADD = $(CUNIT_LIBS) $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+# The .a file is uses instead of .la so that testdriver can always access the
+# internal functions that are not globaly exposed in a .so file.
+testdriver_LDADD = $(CUNIT_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).a ${DTLS_LIBS}
 
 # If there is a API change to something $(LIBCOAP_API_VERSION) > 1 there is
 # nothing to adopt here. No needed to implement something here because the test


### PR DESCRIPTION
libtool marks functions included in the Makefile.am CTAGS_IGNORE list as
nm type 't' in .so library files so that they are not globally visible.
This means that tests/testdriver is unable to access these functions.

However, when building .a files, these functions remain as nm type 'T', so
are globally available.

This change causes tests/testdriver to always be be built with the .a
library file.

configure.ac:

Always enable --enable-static if --enable-tests is set.
Include this --enable-static requirement in the help information.

tests.Makefile.am

Change the default library type to always be .a and re-order parameters.