### PR TITLE
link to git.eclipse.org submodule broken 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ext/tinydtls"]
 	path = ext/tinydtls
-	url = https://git.eclipse.org/r/tinydtls/org.eclipse.tinydtls
+	url = https://github.com/eclipse/tinydtls.git
     ignore = dirty


### PR DESCRIPTION
Please update dtls submodule to 
https://github.com/eclipse/tinydtls

Breaks platform.io / espressif esp-idf 4.0 toolchain installation
(which still doesn't work, because they point at a specific commit, but the maintainers should update to point at the release-v4.2.0 once the submodule link is corrected)



