### PR TITLE
coap_endpoint_t: Update usage of struct coap_endpoint_t to coap_endpoint_t

### DIFF
--- a/include/coap2/block.h
+++ b/include/coap2/block.h
@@ -14,9 +14,6 @@
 #include "option.h"
 #include "pdu.h"
 
-struct coap_resource_t;
-struct coap_session_t;
-
 /**
  * @defgroup block Block Transfer
  * API functions for handling PDUs using CoAP BLOCK options

--- a/include/coap2/coap_debug.h
+++ b/include/coap2/coap_debug.h
@@ -191,8 +191,6 @@ void coap_show_tls_version(coap_log_t level);
  */
 char *coap_string_tls_version(char *buffer, size_t bufsize);
 
-struct coap_address_t;
-
 /**
  * Print the address into the defined buffer.
  *

--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -14,12 +14,6 @@
 #include "coap_time.h"
 #include "str.h"
 
-struct coap_str_const_t;
-struct coap_bin_const_t;
-struct coap_context_t;
-struct coap_session_t;
-struct coap_dtls_pki_t;
-
 /**
  * @defgroup dtls DTLS Support
  * API functions for interfacing with DTLS libraries.

--- a/include/coap2/coap_event.h
+++ b/include/coap2/coap_event.h
@@ -12,9 +12,6 @@
 
 #include "libcoap.h"
 
-struct coap_context_t;
-struct coap_session_t;
-
 /**
  * @defgroup events Event API
  * API functions for event delivery from lower-layer library functions.

--- a/include/coap2/coap_forward_decls.h
+++ b/include/coap2/coap_forward_decls.h
@@ -23,13 +23,17 @@
  */
 struct coap_cache_entry_t;
 struct coap_cache_key_t;
+struct coap_address_t;
+struct coap_bin_const_t;
 struct coap_context_t;
 struct coap_dtls_pki_t;
-struct coap_endpoint_t;
+struct coap_packet_t;
+struct coap_pdu_t;
 struct coap_queue_t;
+struct coap_resource_t;
 struct coap_session_t;
+struct coap_str_const_t;
 struct coap_string_t;
-struct coap_subscription_t;
 
 /*
  * typedef all the opaque structures that are defined in coap_*_internal.h
@@ -44,13 +48,15 @@ typedef struct coap_cache_key_t coap_cache_key_t;
 /* ************* coap_session_internal.h ***************** */
 
 /**
-* Abstraction of virtual endpoint that can be attached to coap_context_t.
-*/
+ * Abstraction of virtual endpoint that can be attached to coap_context_t.
+ */
 typedef struct coap_endpoint_t coap_endpoint_t;
 
 /* ************* coap_subscribe_internal.h ***************** */
 
-/** Subscriber information */
+/**
+ * Subscriber information
+ */
 typedef struct coap_subscription_t coap_subscription_t;
 
 #endif /* COAP_FORWARD_DECLS_H_ */

--- a/include/coap2/coap_io.h
+++ b/include/coap2/coap_io.h
@@ -43,11 +43,6 @@ typedef int coap_fd_t;
 #define COAP_INVALID_SOCKET (-1)
 #endif
 
-struct coap_packet_t;
-struct coap_session_t;
-struct coap_context_t;
-struct coap_pdu_t;
-
 typedef uint16_t coap_socket_flags_t;
 
 typedef struct coap_addr_tuple_t {
@@ -71,10 +66,11 @@ typedef struct coap_socket_t {
                                      Note: It must mot be wrapped with COAP_EPOLL_SUPPORT as
                                      coap_socket_t is seen in applications embedded in
                                      coap_session_t etc. */
-  struct coap_endpoint_t *endpoint; /* Used by the epoll logic for a listening endpoint.
-                                       Note: It must mot be wrapped with COAP_EPOLL_SUPPORT as
-                                       coap_socket_t is seen in applications embedded in
-                                       coap_session_t etc. */
+  coap_endpoint_t *endpoint; /* Used by the epoll logic for a listening
+                                endpoint.
+                                Note: It must mot be wrapped with
+                                COAP_EPOLL_SUPPORT as coap_socket_t is seen in
+                                applications embedded in coap_session_t etc. */
 } coap_socket_t;
 
 /**
@@ -94,8 +90,8 @@ typedef struct coap_socket_t {
 #define COAP_SOCKET_CAN_CONNECT  0x0800  /**< non blocking client socket can now connect without blocking */
 #define COAP_SOCKET_MULTICAST    0x1000  /**< socket is used for multicast communication */
 
-struct coap_endpoint_t *coap_malloc_endpoint( void );
-void coap_mfree_endpoint( struct coap_endpoint_t *ep );
+coap_endpoint_t *coap_malloc_endpoint( void );
+void coap_mfree_endpoint( coap_endpoint_t *ep );
 
 int
 coap_socket_connect_udp(coap_socket_t *sock,
@@ -200,7 +196,7 @@ struct pbuf *coap_packet_extract_pbuf(struct coap_packet_t *packet);
  */
 struct coap_packet_t {
   struct pbuf *pbuf;
-  const struct coap_endpoint_t *local_interface;
+  const coap_endpoint_t *local_interface;
   coap_addr_tuple_t addr_info; /**< local and remote addresses */
   int ifindex;                /**< the interface index */
 //  uint16_t srcport;

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -69,7 +69,7 @@ typedef struct coap_session_t {
   coap_addr_tuple_t addr_info;      /**< key: remote/local address info */
   int ifindex;                      /**< interface index */
   coap_socket_t sock;               /**< socket object for the session, if any */
-  struct coap_endpoint_t *endpoint; /**< session's endpoint */
+  coap_endpoint_t *endpoint;        /**< session's endpoint */
   struct coap_context_t *context;   /**< session's context */
   void *tls;                        /**< security parameters */
   uint16_t tx_mid;                  /**< the last message id that was used in this session */
@@ -311,7 +311,7 @@ coap_session_t *coap_new_client_session_pki(
 */
 coap_session_t *coap_new_server_session(
   struct coap_context_t *ctx,
-  struct coap_endpoint_t *ep
+  coap_endpoint_t *ep
 );
 
 /**

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -30,8 +30,6 @@
 #include "coap_prng.h"
 #include "coap_session.h"
 
-struct coap_queue_t;
-
 /**
  * Queue entry
  */
@@ -80,12 +78,6 @@ void coap_delete_all(coap_queue_t *queue);
  * @return New node entry, or @c NULL if failure.
  */
 coap_queue_t *coap_new_node(void);
-
-struct coap_resource_t;
-struct coap_context_t;
-#ifndef WITHOUT_ASYNC
-struct coap_async_state_t;
-#endif
 
 /**
  * Response handler that is used as callback in coap_context_t.

--- a/include/coap2/pdu.h
+++ b/include/coap2/pdu.h
@@ -17,8 +17,6 @@
 
 #include "uri.h"
 
-struct coap_session_t;
-
 #ifdef WITH_LWIP
 #include <lwip/pbuf.h>
 #endif

--- a/include/coap2/uri.h
+++ b/include/coap2/uri.h
@@ -13,7 +13,6 @@
 #include <stdint.h>
 
 #include "str.h"
-struct coap_pdu_t;
 
 /**
  * The scheme specifiers. Secure schemes have an odd numeric value,

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -72,14 +72,12 @@
 #endif /* IPV6_RECVPKTINFO */
 #endif /* !(WITH_CONTIKI || RIOT_VERSION) */
 
-void coap_free_endpoint(coap_endpoint_t *ep);
-
 #ifdef WITH_CONTIKI
 static int ep_initialized = 0;
 
-struct coap_endpoint_t *
+coap_endpoint_t *
   coap_malloc_endpoint() {
-  static struct coap_endpoint_t ep;
+  static coap_endpoint_t ep;
 
   if (ep_initialized) {
     return NULL;
@@ -90,7 +88,7 @@ struct coap_endpoint_t *
 }
 
 void
-coap_mfree_endpoint(struct coap_endpoint_t *ep) {
+coap_mfree_endpoint(coap_endpoint_t *ep) {
   ep_initialized = 0;
 }
 
@@ -140,13 +138,13 @@ void coap_socket_close(coap_socket_t *sock) {
 
 #else
 
-struct coap_endpoint_t *
+coap_endpoint_t *
   coap_malloc_endpoint(void) {
-  return (struct coap_endpoint_t *)coap_malloc_type(COAP_ENDPOINT, sizeof(struct coap_endpoint_t));
+  return (coap_endpoint_t *)coap_malloc_type(COAP_ENDPOINT, sizeof(coap_endpoint_t));
 }
 
 void
-coap_mfree_endpoint(struct coap_endpoint_t *ep) {
+coap_mfree_endpoint(coap_endpoint_t *ep) {
   coap_free_type(COAP_ENDPOINT, ep);
 }
 

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1070,7 +1070,7 @@ error:
 #ifndef WITH_LWIP
 coap_endpoint_t *
 coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, coap_proto_t proto) {
-  struct coap_endpoint_t *ep = NULL;
+  coap_endpoint_t *ep = NULL;
 
   assert(context);
   assert(listen_addr);
@@ -1106,7 +1106,7 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
     goto error;
   }
 
-  memset(ep, 0, sizeof(struct coap_endpoint_t));
+  memset(ep, 0, sizeof(coap_endpoint_t));
   ep->context = context;
   ep->proto = proto;
 

--- a/src/net.c
+++ b/src/net.c
@@ -99,8 +99,6 @@ coap_free_node(coap_queue_t *node) {
 }
 #endif /* !defined(WITH_LWIP) && !defined(WITH_CONTIKI) */
 
-void coap_free_endpoint(coap_endpoint_t *ep);
-
 #ifdef WITH_LWIP
 
 #include <lwip/memp.h>


### PR DESCRIPTION
Use 'coap_endpoint_t' instead of 'struct coap_endpoint_t' in library source
files where possible.

Remove unnecessary 'struct xxx_t;' forward declarations.

Remove unnecessary 'void coap_free_endpoint(coap_endpoint_t *ep);'