### PR TITLE
Options: Sanity check CoAP options in the PDU

### DIFF
--- a/include/coap2/pdu.h
+++ b/include/coap2/pdu.h
@@ -256,12 +256,6 @@ typedef int coap_tid_t;
 
 #define COAP_PDU_DELAYED -3
 
-#define COAP_OPT_LONG 0x0F      /* OC == 0b1111 indicates that the option list
-                                 * in a CoAP message is limited by 0b11110000
-                                 * marker */
-
-#define COAP_OPT_END 0xF0       /* end marker */
-
 #define COAP_PAYLOAD_START 0xFF /* payload marker */
 
 /**
@@ -299,7 +293,7 @@ typedef struct coap_pdu_t {
   uint8_t hdr_size;         /**< actual size used for protocol-specific header */
   uint8_t token_length;     /**< length of Token */
   uint16_t tid;             /**< transaction id, if any, in regular host byte order */
-  uint16_t max_delta;       /**< highest option number */
+  uint16_t max_opt;         /**< highest option number in PDU */
   size_t alloc_size;        /**< allocated storage for token, options and payload */
   size_t used_size;         /**< used bytes of storage for token, options and payload */
   size_t max_size;          /**< maximum size for token, options and payload, or zero for variable size pdu */

--- a/src/option.c
+++ b/src/option.c
@@ -531,9 +531,7 @@ coap_option_filter_unset(coap_opt_filter_t filter, uint16_t type) {
 
 int
 coap_option_filter_get(coap_opt_filter_t filter, uint16_t type) {
-  /* Ugly cast to make the const go away (FILTER_GET wont change filter
-   * but as _set and _unset do, the function does not take a const). */
-  return coap_option_filter_op((uint16_t *)filter, type, FILTER_GET);
+  return coap_option_filter_op(filter, type, FILTER_GET);
 }
 
 coap_optlist_t *

--- a/tests/test_pdu.c
+++ b/tests/test_pdu.c
@@ -382,7 +382,7 @@ t_encode_pdu4(void) {
        18, (const uint8_t *)"fancyproxy.coap.me");
 
   CU_ASSERT(result == 20);
-  CU_ASSERT(pdu->max_delta == 3);
+  CU_ASSERT(pdu->max_opt == 3);
   CU_ASSERT(pdu->used_size == 20);
   CU_ASSERT_PTR_NULL(pdu->data);
 
@@ -390,21 +390,21 @@ t_encode_pdu4(void) {
                            4, (const uint8_t *)"path");
 
   CU_ASSERT(result == 5);
-  CU_ASSERT(pdu->max_delta == 11);
+  CU_ASSERT(pdu->max_opt == 11);
   CU_ASSERT(pdu->used_size == 25);
   CU_ASSERT_PTR_NULL(pdu->data);
 
   result = coap_add_option(pdu, COAP_OPTION_URI_PATH, 0, NULL);
 
   CU_ASSERT(result == 1);
-  CU_ASSERT(pdu->max_delta == 11);
+  CU_ASSERT(pdu->max_opt == 11);
   CU_ASSERT(pdu->used_size == 26);
   CU_ASSERT_PTR_NULL(pdu->data);
 
   result = coap_add_option(pdu, 8000, 8, (const uint8_t *)"fancyopt");
 
   CU_ASSERT(result == 11);
-  CU_ASSERT(pdu->max_delta == 8000);
+  CU_ASSERT(pdu->max_opt == 8000);
   CU_ASSERT(pdu->used_size == 37);
   CU_ASSERT_PTR_NULL(pdu->data);
 
@@ -437,7 +437,7 @@ t_encode_pdu5(void) {
                            8, (const uint8_t *)"ABCDEFGH");
 
   CU_ASSERT(result == 9);
-  CU_ASSERT(pdu->max_delta == 1);
+  CU_ASSERT(pdu->max_opt == 1);
   CU_ASSERT(pdu->used_size == 17);
   CU_ASSERT_PTR_NULL(pdu->data);
 
@@ -445,7 +445,7 @@ t_encode_pdu5(void) {
                            1, (const uint8_t *)"\x12");
 
   CU_ASSERT(result == 3);
-  CU_ASSERT(pdu->max_delta == 17);
+  CU_ASSERT(pdu->max_opt == 17);
   CU_ASSERT(pdu->used_size == 20);
   CU_ASSERT_PTR_NULL(pdu->data);
 
@@ -547,14 +547,14 @@ t_encode_pdu9(void) {
   result = coap_add_option(pdu, COAP_OPTION_ETAG, 8, (const uint8_t *)"someetag");
 
   CU_ASSERT(result == 9);
-  CU_ASSERT(pdu->max_delta == 4);
+  CU_ASSERT(pdu->max_opt == 4);
   CU_ASSERT(pdu->used_size == 9);
   CU_ASSERT_PTR_NULL(pdu->data);
 
   result = coap_add_option(pdu, COAP_OPTION_IF_NONE_MATCH, 0, NULL);
 
   CU_ASSERT(result == 1);
-  CU_ASSERT(pdu->max_delta == 5);
+  CU_ASSERT(pdu->max_opt == 5);
   CU_ASSERT(pdu->used_size == 10);
   CU_ASSERT_PTR_NULL(pdu->data);
 
@@ -562,7 +562,7 @@ t_encode_pdu9(void) {
                            17, (const uint8_t *)"someratherlonguri");
 
   CU_ASSERT(result == 20);
-  CU_ASSERT(pdu->max_delta == 35);
+  CU_ASSERT(pdu->max_opt == 35);
   CU_ASSERT(pdu->used_size == 30);
   CU_ASSERT_PTR_NULL(pdu->data);
 
@@ -633,7 +633,7 @@ t_encode_pdu10(void) {
                            (const uint8_t *)"coap://example.com/12345/%3Fxyz/3048234234/23402348234/239084234-23/%AB%30%af/+123/hfksdh/23480-234-98235/1204/243546345345243/0198sdn3-a-3///aff0934/97u2141/0002/3932423532/56234023/----/=1234=/098141-9564643/21970-----/82364923472wererewr0-921-39123-34/");
 
   CU_ASSERT(result == 257);
-  CU_ASSERT(pdu->max_delta == 8);
+  CU_ASSERT(pdu->max_opt == 8);
   CU_ASSERT(pdu->used_size == 259);
   CU_ASSERT_PTR_NULL(pdu->data);
 
@@ -641,7 +641,7 @@ t_encode_pdu10(void) {
                            (const uint8_t *)"//492403--098/");
 
   CU_ASSERT(result == 16);
-  CU_ASSERT(pdu->max_delta == 8);
+  CU_ASSERT(pdu->max_opt == 8);
   CU_ASSERT(pdu->used_size == 275);
   CU_ASSERT_PTR_NULL(pdu->data);
 
@@ -649,7 +649,7 @@ t_encode_pdu10(void) {
                            1, (const uint8_t *)"*");
 
   CU_ASSERT(result == 2);
-  CU_ASSERT(pdu->max_delta == 20);
+  CU_ASSERT(pdu->max_opt == 20);
   CU_ASSERT(pdu->used_size == 277);
   CU_ASSERT_PTR_NULL(pdu->data);
 


### PR DESCRIPTION
include/coap2/pdu.h:
src/pdu.c:
tests/test_pdu.c:

Change parameter max_delta to max_opt to better reflect actual usage.

include/coap2/pdu.h:
src/pdu.c:

Remove unneeded COAP_OPT_LONG and COAP_OPT_END definitions.

Remove unused function coap_add_option_later().

src/pdu.c:

Update coap_pdu_parse_opt() to sanity check the valid lengths of all the
known options.

src/coap_io_lwip.c:
src/net.c:

Send back a RST for UDP/DTLS if malformed PDU.

src/option.c:

Clean up coap_option_filter_get() documentation.