### PR TITLE
Observe: Support FETCH

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -941,9 +941,14 @@ set_blocksize(void) {
 
 static void
 cmdline_subscribe(char *arg) {
+  uint8_t buf[4];
+
   obs_seconds = atoi(arg);
-  coap_insert_optlist(&optlist, coap_new_optlist(COAP_OPTION_OBSERVE,
-                      COAP_OBSERVE_ESTABLISH, NULL));
+  coap_insert_optlist(&optlist,
+                      coap_new_optlist(COAP_OPTION_OBSERVE,
+                        coap_encode_var_safe(buf, sizeof(buf),
+                        COAP_OBSERVE_ESTABLISH), buf)
+                      );
 }
 
 static int

--- a/include/coap2/coap_subscribe_internal.h
+++ b/include/coap2/coap_subscribe_internal.h
@@ -50,9 +50,10 @@ struct coap_subscription_t {
   unsigned int dirty:1;    /**< set if the notification temporarily could not be
                             *   sent (in that case, the resource's partially
                             *   dirty flag is set too) */
-  unsigned int has_block2:1; /**< GET request had Block2 definition */
+  unsigned int has_block2:1; /**< request had Block2 definition */
+  uint8_t code;            /** request type code (GET/FETCH)*/
   uint16_t tid;             /**< transaction id, if any, in regular host byte order */
-  coap_block_t block2;     /**< GET request Block2 definition */
+  coap_block_t block2;     /**< request Block2 definition */
   size_t token_length;     /**< actual length of token */
   unsigned char token[8];  /**< token used for subscription */
   struct coap_string_t *query; /**< query string used for subscription, if any */

--- a/include/coap2/resource.h
+++ b/include/coap2/resource.h
@@ -423,6 +423,8 @@ coap_resource_t *coap_get_resource_from_uri_path(coap_context_t *context,
  *                        function returns NULL.
  * @param has_block2      If Option Block2 defined.
  * @param block2          Contents of Block2 if Block 2 defined.
+ * @param code            Request type code.
+ *
  * @return                A pointer to the added/updated subscription
  *                        information or @c NULL on error.
  */
@@ -431,7 +433,8 @@ coap_subscription_t *coap_add_observer(coap_resource_t *resource,
                                        const coap_binary_t *token,
                                        coap_string_t *query,
                                        int has_block2,
-                                       coap_block_t block2);
+                                       coap_block_t block2,
+                                       uint8_t code);
 
 /**
  * Returns a subscription object for given @p peer.

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -320,7 +320,9 @@ unsigned char *data, size_t length, int observe) {
     /* Indicate that we want to observe this resource */
     if (!coap_insert_optlist(&optlist_chain,
                              coap_new_optlist(COAP_OPTION_OBSERVE,
-                                         COAP_OBSERVE_ESTABLISH, NULL)))
+                               coap_encode_var_safe(buf, sizeof(buf),
+                               COAP_OBSERVE_ESTABLISH), buf)
+                             ))
       goto error;
   }
 

--- a/src/net.c
+++ b/src/net.c
@@ -2308,7 +2308,7 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
             if (coap_get_block(pdu, COAP_OPTION_BLOCK2, &block2)) {
               has_block2 = 1;
             }
-            subscription = coap_add_observer(resource, session, &token, query, has_block2, block2);
+            subscription = coap_add_observer(resource, session, &token, query, has_block2, block2, pdu->code);
             if (subscription) {
               /* Ownership of query is taken by subscription if not
                * NULL. In this case, we must not delete query here


### PR DESCRIPTION
Support observe for both GET and FETCH.

Correct coap-client programatic addition of observe establish option which
"happened" to work previously because COAP_OBSERVE_ESTABLISH was 0.