### PR TITLE
epoll: Stop spin between TCP connect and received data

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1696,6 +1696,9 @@ coap_io_do_epoll(coap_context_t *ctx, struct epoll_event *events, size_t nevents
             (events[j].events & (EPOLLOUT|EPOLLERR|EPOLLHUP|EPOLLRDHUP))) {
           sock->flags |= COAP_SOCKET_CAN_CONNECT;
           coap_connect_session(session->context, session, now);
+          if (!(sock->flags & COAP_SOCKET_WANT_WRITE)) {
+            coap_epoll_ctl_mod(sock, EPOLLIN, __func__);
+          }
         }
 
         if ((sock->flags & COAP_SOCKET_WANT_READ) &&


### PR DESCRIPTION
If a client TCP connection connects, EPOLLOUT remains enabled so epoll_wait()
always returns immediately causing a loop until there is other data traffic.

This fix is to enable EPOLLIN and disable EPOLLOUT if COAP_SOCKET_WANT_WRITE
is not set at point of connection successful.