### PR TITLE
net.c: Delay sending ACK until after response_handler() is called

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1541,7 +1541,7 @@ proxy_event_handler(coap_context_t *ctx UNUSED_PARAM,
   return 0;
 }
 
-static void
+static coap_response_t
 proxy_message_handler(struct coap_context_t *ctx UNUSED_PARAM,
                 coap_session_t *session,
                 coap_pdu_t *sent UNUSED_PARAM,
@@ -1572,7 +1572,7 @@ proxy_message_handler(struct coap_context_t *ctx UNUSED_PARAM,
   }
   if (i == proxy_list_count) {
     coap_log(LOG_DEBUG, "Unknown proxy ongoing session response received\n");
-    return;
+    return COAP_RESPONSE_OK;
   }
 
   coap_log(LOG_DEBUG, "** process upstream incoming %d.%02d response:\n",
@@ -1590,10 +1590,10 @@ proxy_message_handler(struct coap_context_t *ctx UNUSED_PARAM,
     size, data, offset, total);
     if (!proxy_entry->body_data) {
       coap_log(LOG_DEBUG, "body build memory error\n");
-      return;
+      return COAP_RESPONSE_OK;
     }
     if (offset + size != total)
-      return;
+      return COAP_RESPONSE_OK;
     data = proxy_entry->body_data->s;
     size = proxy_entry->body_data->length;
   }
@@ -1606,7 +1606,7 @@ proxy_message_handler(struct coap_context_t *ctx UNUSED_PARAM,
                       coap_session_max_pdu_size(incoming));
   if (!pdu) {
     coap_log(LOG_DEBUG, "Failed to create ongoing proxy response PDU\n");
-    return;
+    return COAP_RESPONSE_OK;
   }
 
   if (!coap_add_token(pdu, received->token_length, received->token)) {
@@ -1659,7 +1659,7 @@ proxy_message_handler(struct coap_context_t *ctx UNUSED_PARAM,
     coap_show_pdu(LOG_INFO, pdu);
 
   coap_send_large(incoming, pdu);
-  return;
+  return COAP_RESPONSE_OK;
 }
 
 static void

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -79,6 +79,11 @@ void coap_delete_all(coap_queue_t *queue);
  */
 coap_queue_t *coap_new_node(void);
 
+typedef enum coap_response_t {
+  COAP_RESPONSE_FAIL, /**< Response not liked - send CoAP RST packet */
+  COAP_RESPONSE_OK    /**< Response is fine */
+} coap_response_t;
+
 /**
  * Response handler that is used as callback in coap_context_t.
  *
@@ -87,12 +92,15 @@ coap_queue_t *coap_new_node(void);
  * @param sent The PDU that was transmitted.
  * @param received The PDU that was received.
  * @param id CoAP transaction ID.
+
+ * @return @c COAP_RESPONSE_OK if successful, else @c COAP_RESPONSE_FAIL which
+ *         triggers sending a RST packet.
  */
-typedef void (*coap_response_handler_t)(struct coap_context_t *context,
-                                        coap_session_t *session,
-                                        coap_pdu_t *sent,
-                                        coap_pdu_t *received,
-                                        const coap_tid_t id);
+typedef coap_response_t (*coap_response_handler_t)(struct coap_context_t *context,
+                                                   coap_session_t *session,
+                                                   coap_pdu_t *sent,
+                                                   coap_pdu_t *received,
+                                                   const coap_tid_t id);
 
 /**
  * Negative Acknowedge handler that is used as callback in coap_context_t.

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -87,17 +87,26 @@ de-registered.
 The handler function prototype is defined as:
 [source, c]
 ----
-typedef void (*coap_response_handler_t)(coap_context_t *context,
-                                        coap_session_t *session,
-                                        coap_pdu_t *sent,
-                                        coap_pdu_t *received,
-                                        const coap_tid_t id);
+typedef enum coap_response_t {
+  COAP_RESPONSE_FAIL, /* Response not liked - send CoAP RST packet */
+  COAP_RESPONSE_OK    /* Response is fine */
+} coap_response_t;
+
+typedef coap_response_t (*coap_response_handler_t)(coap_context_t *context,
+                                                   coap_session_t *session,
+                                                   coap_pdu_t *sent,
+                                                   coap_pdu_t *received,
+                                                   const coap_tid_t id);
 ----
 
 *NOTE:* _sent_ will only be non NULL when the request PDU is Confirmable and
 this is an ACK or RST response to the request.  In general, matching of
-Requests and Responses whould be done generating unique Tokens for each Request
+Requests and Responses whould be done by generating unique Tokens for each Request
 and then matching up based on the Token in _received_ Response.
+
+*NOTE:* If the returned value is COAP_RESPONSE_FAIL, then a CoAP RST packet will get
+sent to the server by libcoap.  The returned value of COAP_RESPONSE_OK indicates
+that all is OK.
 
 The *coap_register_nack_handler*() function defines a request's negative
 response _handler_ for traffic associated with the _context_.
@@ -258,25 +267,28 @@ static int check_token(coap_pdu_t *received) {
   return 1;
 }
 
-static void
+static coap_response_t
 response_handler(coap_context_t *ctx, coap_session_t *session,
 coap_pdu_t *sent, coap_pdu_t *received, const coap_tid_t id) {
   /* Remove (void) definition if variable is used */
   (void)ctx;
+  (void)session;
   (void)id;
 
   /* check if this is a response to our original request */
   if (!check_token(received)) {
     /* drop if this was just some message, or send RST in case of notification */
     if (!sent && (received->type == COAP_MESSAGE_CON ||
-                  received->type == COAP_MESSAGE_NON))
-      coap_send_rst(session, received);
-    return;
+                  received->type == COAP_MESSAGE_NON)) {
+      /* Cause a CoAP RST to be sent */
+      return COAP_RESPONSE_FAIL;
+    }
+    return COAP_RESPONSE_OK;
   }
 
   if (received->type == COAP_MESSAGE_RST) {
     coap_log(LOG_INFO, "got RST\n");
-    return;
+    return COAP_RESPONSE_OK;
   }
 
   /* Output the received data, if any */
@@ -284,7 +296,7 @@ coap_pdu_t *sent, coap_pdu_t *received, const coap_tid_t id) {
     /* Additional code to deal with the response */
 
   }
-  return;
+  return COAP_RESPONSE_OK;
 
 }
 ----

--- a/src/net.c
+++ b/src/net.c
@@ -2747,8 +2747,6 @@ static void
 handle_response(coap_context_t *context, coap_session_t *session,
   coap_pdu_t *sent, coap_pdu_t *rcvd) {
 
-  coap_send_ack(session, rcvd);
-
   /* In a lossy context, the ACK of a separate response may have
    * been lost, so we need to stop retransmitting requests with the
    * same token.
@@ -2772,7 +2770,14 @@ handle_response(coap_context_t *context, coap_session_t *session,
 
   /* Call application-specific response handler when available. */
   if (context->response_handler) {
-    context->response_handler(context, session, sent, rcvd, rcvd->tid);
+    if (context->response_handler(context, session, sent, rcvd,
+                                  rcvd->tid) == COAP_RESPONSE_FAIL)
+      coap_send_rst(session, rcvd);
+    else
+      coap_send_ack(session, rcvd);
+  }
+  else {
+    coap_send_ack(session, rcvd);
   }
 }
 


### PR DESCRIPTION

In handle_response() the ACK is sent before calling ctx->response_handler() so
if the response_handler() wants to send RST the server ignores it as the ACK
has already been received.

By updating coap_response_handler_t to return a value, this can be used to
send the ACK (return of COAP_RESPONSE_OK) or a RST (return of COAP_RESPONSE_FAIL) 
after ctx->response_handler() is called.

include/coap2/net.h:
man/coap_handler.txt.in:

Create a new enum coap_response_t for use as the return value for 
coap_response_handler_t.
Update coap_response_handler_t and associated documentation.

src/net.c:

Send CoAP ACK or RST depending on return value of ctx->response_handler().

examples/client.c:

Update message_handler() to use the new coap_response_handler_t return values
(coap_response_t).

In part addresses #542