### PR TITLE
coap_add_option: Fix code rebase logging level issue

### DIFF
--- a/src/pdu.c
+++ b/src/pdu.c
@@ -383,7 +383,7 @@ coap_add_option(coap_pdu_t *pdu, uint16_t type, size_t len,
   }
 
   if (type < pdu->max_opt) {
-    coap_log(LOG_WARNING,
+    coap_log(LOG_DEBUG,
              "coap_add_option: options are not in correct order\n");
     return coap_insert_option(pdu, type, len, data);
   }


### PR DESCRIPTION
PR #476 added in coap_insert_option() which could be called by
coap_add_option() with with a coap_log() message set to LOG_DEBUG.

When PR #539 was merged in, this upped the logging level to LOG_WARNING which
now causes test/testdriver to report unecessary messages.

Logging level reverted to LOG_DEBUG.