### PR TITLE
Update libcoap.{map|sym} files

### DIFF
--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -391,7 +391,7 @@ hnd_get_separate(coap_context_t *ctx,
 
   while ((option = coap_option_next(&opt_iter))) {
     if (strncmp("delay=", (const char *)coap_opt_value(option), 6) == 0) {
-      int i;
+      unsigned int i;
       unsigned long d = 0;
 
       for (i = 6; i < coap_opt_length(option); ++i)

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -88,7 +88,6 @@ global:
   coap_handle_failed_notify;
   coap_hash_impl;
   coap_insert_node;
-  coap_insert_option;
   coap_insert_optlist;
   coap_io_do_epoll;
   coap_io_do_io;
@@ -123,7 +122,6 @@ global:
   coap_new_string;
   coap_new_uri;
   coap_opt_block_num;
-  coap_opt_delta;
   coap_opt_encode;
   coap_opt_encode_size;
   coap_option_check_critical;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -86,7 +86,6 @@ coap_handle_event
 coap_handle_failed_notify
 coap_hash_impl
 coap_insert_node
-coap_insert_option
 coap_insert_optlist
 coap_io_do_epoll
 coap_io_do_io
@@ -121,7 +120,6 @@ coap_new_str_const
 coap_new_string
 coap_new_uri
 coap_opt_block_num
-coap_opt_delta
 coap_opt_encode
 coap_opt_encode_size
 coap_option_check_critical


### PR DESCRIPTION
Missed from commit 605f990e.

Also fixes a compiler warning now that coap_opt_length() returns uin32_t.