### PR TITLE
Update interface index with received packet's index when getting session

### DIFF
--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -41,7 +41,10 @@ IPv6 address references, angle brackets are required (c.f. EXAMPLES).
 OPTIONS - General
 -----------------
 *-a* addr::
-   The local address of the interface that has to be used.
+   The local address of the interface that has to be used. +
+   Note: Do not use this option if the interface is likely to be transient -
+   i.e. it is a tunnel interface that may come and go, as this is likely to
+   cause "No such device" errors on transmission.
 
 *-b* [num,]size::
    The block size to be used in GET/PUT/POST requests (value must be a

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -507,6 +507,7 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
 
   SESSIONS_FIND(endpoint->sessions, packet->addr_info, session);
   if (session) {
+    session->ifindex = packet->ifindex;
     session->last_rx_tx = now;
     return session;
   }


### PR DESCRIPTION
When a session is created with `coap_make_session`, libcoap assigns an interface index based on the packet's interface index, and this is never updated if the interface disappears and is recreated, for example if the interface is a tunnel (VPN, etc).

The proposed fix updates the interface index in the session each time a `coap_endpoint_get_session` is called.

Fixes #559; with thanks to @mrdeep1.

