### PR TITLE
PKI: Make (D)TLS operation consistent across all TLS libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -388,7 +388,7 @@ if test "x$build_dtls" = "xyes"; then
     # mbed TLS [does not have mbedtls.pc pkg-config file]
     AC_CHECK_LIB(mbedtls, mbedtls_ssl_handshake,
                  [have_mbedtls="yes"; MbedTLS_CFLAGS="" ; MbedTLS_LIBS="-lmbedtls -lmbedcrypto -lmbedx509"],
-                 [have_mbedtls="no"])
+                 [have_mbedtls="no"], -lmbedx509 -lmbedcrypto)
 
     # TinyDTLS ?
     # TBD ?

--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -248,8 +248,10 @@ typedef struct coap_dtls_pki_t {
 
   /* Options to enable different TLS functionality in libcoap */
   uint8_t verify_peer_cert;        /**< 1 if peer cert is to be verified */
-  uint8_t require_peer_cert;       /**< 1 if peer cert is required */
-  uint8_t allow_self_signed;       /**< 1 if self signed certs are allowed */
+  uint8_t check_common_ca;         /**< 1 if peer cert is to be signed by
+                                    * the same CA as the local cert */
+  uint8_t allow_self_signed;       /**< 1 if self-signed certs are allowed.
+                                    *     Ignored if check_common_ca set */
   uint8_t allow_expired_certs;     /**< 1 if expired certs are allowed */
   uint8_t cert_chain_validation;   /**< 1 if to check cert_chain_verify_depth */
   uint8_t cert_chain_verify_depth; /**< recommended depth is 3 */
@@ -536,8 +538,8 @@ coap_dtls_context_set_cpsk(struct coap_context_t *coap_context,
 
 int
 coap_dtls_context_set_pki(struct coap_context_t *coap_context,
-                          coap_dtls_pki_t *setup_data,
-                          coap_dtls_role_t role);
+                          const coap_dtls_pki_t *setup_data,
+                          const coap_dtls_role_t role);
 
 /**
  * Set the dtls context's default Root CA information for a client or server.

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -339,7 +339,7 @@ int coap_context_set_psk2(coap_context_t *context,
  */
 int
 coap_context_set_pki(coap_context_t *context,
-                     coap_dtls_pki_t *setup_data);
+                     const coap_dtls_pki_t *setup_data);
 
 /**
  * Set the context's default Root CA information for a client or server.

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -20,8 +20,8 @@ SYNOPSIS
               [*-H* hoplimit] [*-K* interval] [*-N*] [*-O* num,text]
               [*-P* scheme://addr[:port]] [*-T* token] [*-U*]
               [[*-h* match_hint_file] [*-k* key] [*-u* user]]
-              [[*-c* certfile] [*-j* keyfile] [*-C* cafile] [*-J* pkcs11_pin]
-              [*-M* rpk_file] [*-R* root_cafile]] URI
+              [[*-c* certfile] [*-j* keyfile] [-n] [*-C* cafile]
+              [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* trust_casfile]] URI
 
 DESCRIPTION
 -----------
@@ -148,19 +148,20 @@ OPTIONS - PSK
 (If supported by underlying (D)TLS library)
 
 *-h* match_hint_file::
-   This option denotes a file that contains one or more lines of Identity
-   Hints to match for new user and new pre-shared key (PSK) (comma separated)
-   to be used.
-   E.g., entry per line +
-   hint_to_match,new_user,new_key +
+   This is a file that contains one or more lines of received Identity Hints
+   to match to use different user identity and associated pre-shared key (PSK)
+   (comma separated) instead of the *-k key* and *-u user* options. E.g., per
+   line +
+   hint_to_match,use_user,with_key +
    A line that starts with # is treated as a comment. +
-   Note: *-k key* and *-u user* still need to be defined for the default case.
+   Note: *-k key* and *-u user* still need to be defined for the default case in
+   case there is no match.
 
 *-k* key::
-   Pre-shared key for the specified user (*-u* option also required).
+   Pre-shared key for the specified user identity (*-u* option also required).
 
 *-u* user::
-   User identity for pre-shared key mode (*-k* option also required).
+   User identity to send for pre-shared key mode (*-k* option also required).
 
 OPTIONS - PKI
 -------------
@@ -172,35 +173,41 @@ definitions have to be in DER, not PEM, format.  Otherwise all of
 *certfile*, *keyfile* or *cafile* are in PEM format.
 
 *-c* certfile::
-   PEM file or PKCS11 URI for the certificate. The private key can be in the
-   PEM file, or use the same PKCS11 URI. If not, the private key is defined
+   PEM file or PKCS11 URI for the certificate. The private key can also be in
+   the PEM file, or has the same PKCS11 URI. If not, the private key is defined
    by *-j keyfile*.
 
 *-j* keyfile::
    PEM file or PKCS11 URI for the private key for the certificate in *-c
    certfile* if the parameter is different from certfile in *-c certfile*.
 
+*-n* ::
+  Disable remote peer certificate checking.
+
 *-C* cafile::
-  PEM file or PKCS11 URI for the CA certificate that was used to sign the
-  certfile defined using *-c certfile*.
-  This will trigger the validation of the server certificate.
-  If certfile is self-signed (as defined by *-c certfile*), then you need to
-  have on the command line the same filename for both the certfile and cafile
-  (as in *-c certfile -C certfile*) to trigger validation.
+PEM file or PKCS11 URI for the CA certificate that was used to sign the server
+  certfile. Ideally the client certificate should be signed by the same CA so
+  that mutual authentication can take place. The contents of cafile are added
+  to the trusted store of root CAs. Using the *-C* or *-R* options will trigger
+  the validation of the server certificate unless overridden by the *-n* option.
 
 *-J* pkcs11_pin::
   The user pin to unlock access to the PKCS11 token.
 
 *-M* rpk_file::
-  Raw Public Key (RPK) PEM file that contains both PUBLIC KEY and PRIVATE KEY
-  or just EC PRIVATE KEY.
-  (GnuTLS and TinyDTLS support only) '-C cafile' not required.
+  Raw Public Key (RPK) PEM file or PKCS11 URI that contains both PUBLIC KEY
+  and PRIVATE KEY or just EC PRIVATE KEY. (GnuTLS and TinyDTLS(PEM) support
+  only).  *-C cafile* or *-R trust_casfile* are not required.
 
-*-R* root_cafile::
+*-R* trust_casfile::
   PEM file containing the set of trusted root CAs that are to be used to
-  validate the server certificate.  The *-C cafile* does not have to be in
-  this list and is "trusted" for the verification.
-  Alternatively, this can point to a directory containing a set of CA PEM files.
+  validate the server certificate. Alternatively, this can point to a
+  directory containing a set of CA PEM files. The *-C cafile* CA does not have
+  to be in this list and is trusted for the validation. Using
+  *-R trust_casfile* disables common CA mutual authentication which can only
+  be done by using *-C cafile*. Using the *-C* or *-R* options will will
+  trigger the validation of the server certificate unless overridden by the
+  *-n* option.
 
 EXAMPLES
 --------

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -16,7 +16,7 @@ SYNOPSIS
 --------
 *coap-rd* [*-g* group] [*-p* port] [*-v* num] [*-A* address]
           [[*-h* hint] [*-k* key]]
-          [[*-c* certfile] [*-n*] [*-C* cafile] [*-R* root_cafile]]
+          [[*-c* certfile] [*-n*] [*-C* cafile] [*-R* trusted_casfile]]
 
 DESCRIPTION
 -----------
@@ -47,8 +47,7 @@ OPTIONS - PSK
 (If supported by underlying (D)TLS library)
 
 *-h* hint::
-   Identity hint to use for inbound connections. The default is 'CoAP'.
-   This cannot be empty if defined.
+   Identity Hint to send. Default is *CoAP*. Zero length is no hint.
 
 *-k* key::
    Pre-shared key to use for inbound connections. This cannot be empty if
@@ -63,26 +62,32 @@ OPTIONS - PKI
 *-c* certfile::
    Use the specified PEM file which contains the CERTIFICATE and PRIVATE
    KEY information.
-   *Note:* if *-k key* is defined, you need to define *-c cafile* as well to
+   Note: if *-k key* is defined, you need to define *-c certfile* as well to
    have the server support both PSK and PKI.
 
 *-n* ::
-   Disable the requirement for clients to have defined client certificates.
+  Disable remote peer certificate checking. This gives clients the ability to
+  use PKI, but without any defined certificates.
 
 *-C* cafile::
-  PEM file containing the CA Certificate that was used to sign the certfile
-  defined using *-c certfile*.
-  If defined, then the client will be given this CA Certificate during the TLS
-  set up. Furthermore, this will trigger the validation of the client
-  certificate. If certfile is self-signed (as defined by *-c certfile*), then
-  you need to have on the command line the same filename for both the certfile
-  and cafile (as in  *-c certfile -C certfile*) to trigger validation.
+  PEM file that contains a list of one or more CAs that are to
+  be passed to the client for the client to determine what client certificate
+  to use.  Normally, this list of CAs would be the root CA and and any
+  intermediate CAs. Ideally the server certificate should be signed by the
+  same CA so that mutual authentication can take place. The contents of
+  *cafile* are added to the trusted store of root CAs.  Using the *-C* or *-R*
+  options will will trigger the validation of the client certificate unless
+  overridden by the *-n* option.
 
-*-R* root_cafile::
+*-R* trust_casfile::
   PEM file containing the set of trusted root CAs that are to be used to
-  validate the server certificate.  The *-C cafile* does not have to be in
-  this list and is "trusted" for the verification.
-  Alternatively, this can point to a directory containing a set of CA PEM files.
+  validate the client certificate. Alternatively, this can point to a
+  directory containing a set of CA PEM files. The *-C cafile* CA does not have
+  to be in this list and is trusted for the validation. Using
+  *-R trust_casfile* disables common CA mutual authentication which can only
+  be done by using *-C cafile*. Using the *-C* or *-R* options will will
+  trigger the validation of the server certificate unless overridden by the
+  *-n* option.
 
 EXAMPLES
 --------

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -19,7 +19,7 @@ SYNOPSIS
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
               [*-s* match_psk_sni_file] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
-              [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* root_cafile]
+              [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* trust_casfile]
               [*-S* match_pki_sni_file]]
 
 DESCRIPTION
@@ -79,17 +79,17 @@ OPTIONS - PSK
 (If supported by underlying (D)TLS library)
 
 *-h* hint::
-   Identity hint to use for inbound connections. The default is 'CoAP'.
-   This cannot be empty if defined.
+   Identity Hint to send. Default is *CoAP*. Zero length is no hint.
 
 *-i* match_identiity_file::
-   This option denotes a file that contains one or more lines of client Hints
-   and (user) Identities to match for a new Pre-Shared key (PSK)
-   (comma separated) to be used.
-   E.g., entry per line +
-   hint_to_match,identity_to_match,new_key +
+   This is a file that contains one or more lines of Identity Hints and (user)
+   Identities to match for a different new Pre-Shared Key (PSK) (comma
+   separated) to be used. E.g., per line +
+   hint_to_match,identity_to_match,use_key +
    A line that starts with # is treated as a comment. +
-   Note: -k still needs to be defined for the default case +
+   Note: *-k* still needs to be defined for the default case. +
+   Note: A match using the *-s* option may mean that the current Identity Hint
+   is different to that defined by *-h*.
 
 *-k* key::
    Pre-shared key to use for inbound connections. This cannot be empty if
@@ -98,17 +98,18 @@ OPTIONS - PSK
    have the server support both PSK and PKI.
 
 *-s* match_psk_sni_file::
-   This option denotes a file that contains one or more lines of Subject Name
-   Identifier (SNI) to match for new Identity Hint and new Pre-Shared Key
-   (PSK) (comma separated) to be used.
-   E.g., entry per line +
-   sni_to_match,new_hint,new_key +
-   A line that starts with # is treated as a comment. +
-   Note: -k still needs to be defined for the default case +
-   Note: the new Pre-Shared Key will get updated if there is also a -i match
+   This is a file that contains one or more lines of received Subject Name
+   Identifier (SNI) to match to use a different Identity Hint and associated
+   Pre-Shared Key (PSK) (comma separated) instead of the *-h hint* and
+   *-k key* options. E.g., per line +
+   sni_to_match,use_hint,with_key +
+   Note: *-k key* still needs to be defined for the default case if there is
+   not a match. +
+   Note: The associated Pre-Shared Key will get updated if there is also a *-i*
+   match. The update checking order is *-s* followed by *-i*.
 
 *-u* user ::
-   User identity for pre-shared key mode (only used if option P is set).
+   User identity for pre-shared key mode (only used if option *-P* is set).
 
 OPTIONS - PKI
 -------------
@@ -120,41 +121,47 @@ definitions have to be in DER, not PEM, format.  Otherwise all of
 *certfile*, *keyfile* or *cafile* are in PEM format.
 
 *-c* certfile::
-   PEM file or PKCS11 URI for the certificate. The private key can be in
-   the PEM file, or use the same PKCS11 URI. If not, the private key is defined
-   by *-j keyfile*. +
-   Note: if *-k key* is defined, you need to define *-c certfile* as well to
-   have the server support both PSK and PKI.
+  PEM file or PKCS11 URI for the certificate. The private key can also be in
+  the PEM file, or has the same PKCS11 URI. If not, the private key is defined
+  by *-j keyfile*. +
+  Note: if *-k key* is defined, you need to define *-c certfile* as well to
+  have the server support both PSK and PKI.
 
 *-j* keyfile::
-   PEM file or PKCS11 URI for the private key for the certificate in *-c
-   certfile* if the parameter is different from certfile in *-c certfile*.
+  PEM file or PKCS11 URI for the private key for the certificate in *-c
+  certfile* if the parameter is different from certfile in *-c certfile*.
 
 *-n* ::
-   Disable the requirement for clients to have defined client certificates.
+  Disable remote peer certificate checking. This gives clients the ability to
+  use PKI, but without any defined certificates.
 
 *-C* cafile::
-  PEM file or PKCS11 URI for the CA certificate that was used to sign the
-  certfile. If defined, then the client will be given this CA certificate
-  during the TLS set up. Furthermore, this will trigger the validation of the
-  client certificate.  If certfile is self-signed (as defined by *-c
-  certfile*), then you need to have on the command line the same filename for
-  both the certfile and cafile (as in  *-c certfile -C certfile*) to trigger
-  validation.
+  PEM file or PKCS11 URI that contains a list of one or more CAs that are to
+  be passed to the client for the client to determine what client certificate
+  to use.  Normally, this list of CAs would be the root CA and and any
+  intermediate CAs. Ideally the server certificate should be signed by the
+  same CA so that mutual authentication can take place. The contents of
+  *cafile* are added to the trusted store of root CAs.  Using the *-C* or *-R*
+  options will will trigger the validation of the client certificate unless
+  overridden by the *-n* option.
 
 *-J* pkcs11_pin::
    The user pin to unlock access to the PKCS11 token.
 
 *-M*::
-  Raw Public Key (RPK) PEM file that contains both PUBLIC KEY and PRIVATE KEY
-  or just EC PRIVATE KEY.
-  (GnuTLS and TinyDTLS support only) '-C cafile' not required.
+  Raw Public Key (RPK) PEM file or PKCS11 URI that contains both PUBLIC KEY
+  and PRIVATE KEY or just EC PRIVATE KEY. (GnuTLS and TinyDTLS(PEM) support
+  only).  *-C cafile* or *-R trust_casfile* are not required.
 
-*-R* root_cafile::
+*-R* trust_casfile::
   PEM file containing the set of trusted root CAs that are to be used to
-  validate the server certificate.  The *-C cafile* does not have to be in
-  this list and is "trusted" for the verification.
-  Alternatively, this can point to a directory containing a set of CA PEM files.
+  validate the client certificate. Alternatively, this can point to a
+  directory containing a set of CA PEM files. The *-C cafile* CA does not have
+  to be in this list and is trusted for the validation. Using
+  *-R trust_casfile* disables common CA mutual authentication which can only
+  be done by using *-C cafile*. Using the *-C* or *-R* options will will
+  trigger the validation of the server certificate unless overridden by the
+  *-n* option.
 
 *-S* match_pki_sni_file::
    This option denotes a file that contains one or more lines of Subject Name

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -30,7 +30,7 @@ SYNOPSIS
 *void coap_free_context(coap_context_t *_context_);*
 
 *int coap_context_set_pki(coap_context_t *_context_,
-coap_dtls_pki_t *_setup_data_);*
+const coap_dtls_pki_t *_setup_data_);*
 
 *int coap_context_set_pki_root_cas(coap_context_t *_context_,
 const char *_ca_file_, const char *_ca_dir_);*
@@ -124,7 +124,12 @@ root CAs to be used instead of the default set of root CAs provided as a part
 of the TLS library.  _ca_file_ points to a PEM encoded file containing the
 list of CAs.  _ca_file can be NULL.  _ca_dir_ points to a directory
 containing a set of PEM encoded files containing rootCAs.  _ca_dir_ can be
-NULL. One or both of _ca_file_ and _ca_dir_ must be set.
+NULL. One or both of _ca_file_ and _ca_dir_ must be set. +
+*NOTE:* Some TLS libraries send the full list of CAs added by this function
+during the (D)TLS session setup handshakes. To stop this, either provide a
+single CA using the _ca_file_ definition in _pki_key_ in _setup_data_ variable
+when calling *coap_context_set_pki*(), or set _check_common_ca to 0 in
+_setup_data_ variable. See *coap_encryption*(3).
 
 The *coap_context_set_psk2*() function is used to configure the TLS context
 using the _setup_data_ variables as defined in the
@@ -294,7 +299,7 @@ setup_server_context_pki (const char *public_cert_file,
   /* see coap_encryption(3) */
   dtls_pki.version                 = COAP_DTLS_PKI_SETUP_VERSION;
   dtls_pki.verify_peer_cert        = 1;
-  dtls_pki.require_peer_cert       = 1;
+  dtls_pki.check_common_ca         = 1;
   dtls_pki.allow_self_signed       = 1;
   dtls_pki.allow_expired_certs     = 1;
   dtls_pki.cert_chain_validation   = 1;

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -417,8 +417,11 @@ typedef struct coap_dtls_pki_t {
 
   /* Options to enable different TLS functionality in libcoap */
   uint8_t verify_peer_cert;         /* 1 if peer cert is to be verified */
-  uint8_t require_peer_cert;        /* 1 if peer cert is required */
-  uint8_t allow_self_signed;        /* 1 if self signed certs are allowed */
+  uint8_t check_common_ca;          /* 1 if peer cert is to be signed by
+                                     * the same CA as the local cert */
+  uint8_t allow_self_signed;        /* 1 if self-signed certs are allowed */
+  uint8_t allow_self_signed;        /* 1 if self-signed certs are allowed.
+                                     * Ignored if check_common_ca set */
   uint8_t allow_expired_certs;      /* 1 if expired certs are allowed */
   uint8_t cert_chain_validation;    /* 1 if to check cert_chain_verify_depth */
   uint8_t cert_chain_verify_depth;  /* recommended depth is 3 */
@@ -486,13 +489,20 @@ for different versions of the coap_dtls_pki_t structure in the future.
 *SECTION: PKI/RPK: coap_dtls_pki_t: Peer Certificate Checking*
 
 *verify_peer_cert* Set to 1 to check that the peer's certificate is valid if
-provided, else 0.
+provided, else 0. If not set, check_common_ca, allow_self_signed,
+allow_expired_certs, cert_chain_validation, cert_chain_verify_depth,
+check_cert_revocation, allow_no_crl, allow_expired_crl, allow_bad_md_hash
+and allow_short_rsa_length settings are all ignored.
 
-*require_peer_cert* Set to 1 to enforce that the peer provides a certificate,
-else 0.  If the Server, this initiates a request for the peer certificate.
+*check_common_ca* Set to 1 to check that the CA that signed the peer's
+certificate is the same CA that signed the local certificate
+else 0.  If set to 1 and *verify_peer_cert* is set to 1, then for the server, a
+list of valid CAs are sent to client.  For the client, the logic will check
+that both the client and server certificates are signed by the same CA.
 
 *allow_self_signed* Set to 1 to allow the peer (or any certificate in the
-certificate chain) to be a self-signed certificate, else 0.
+certificate chain) to be a self-signed certificate, else 0. If
+*check_common_ca* is set, then a self-signed certificate will not be allowed.
 
 *allow_expired_certs* Set to 1 to allow certificates that have either expired,
 or are not yet valid to be allowed, else 0.
@@ -524,7 +534,11 @@ definition to be valid, else 0.
 *allow_short_rsa_length* Set to 1 if small RSA keysizes are allowed, else 0.
 
 *is_rpk_not_cert* Set to 1 if the Certificate is actually a Raw Public Key.
-If set, PKI key format type cannot be COAP_PKI_KEY_PEM.
+If set, PKI key format type cannot be COAP_PKI_KEY_PEM.  If set,
+check_common_ca, allow_self_signed, allow_expired_certs,
+cert_chain_validation, cert_chain_verify_depth, check_cert_revocation,
+allow_no_crl, allow_expired_crl, allow_bad_md_hash and
+allow_short_rsa_length settings are all ignored.
 
 *SECTION: PKI/RPK: coap_dtls_pki_t: Reserved*
 
@@ -941,7 +955,7 @@ setup_server_context_pki (const char *public_cert_file,
 
   dtls_pki.version                 = COAP_DTLS_PKI_SETUP_VERSION;
   dtls_pki.verify_peer_cert        = 1;
-  dtls_pki.require_peer_cert       = 1;
+  dtls_pki.check_common_ca         = 1;
   dtls_pki.allow_self_signed       = 1;
   dtls_pki.allow_expired_certs     = 1;
   dtls_pki.cert_chain_validation   = 1;

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -290,7 +290,7 @@ setup_client_session_pki (struct in_addr ip_address,
   /* See coap_encryption(3) */
   dtls_pki.version                 = COAP_DTLS_PKI_SETUP_VERSION;
   dtls_pki.verify_peer_cert        = 1;
-  dtls_pki.require_peer_cert       = 1;
+  dtls_pki.check_common_ca         = 1;
   dtls_pki.allow_self_signed       = 1;
   dtls_pki.allow_expired_certs     = 1;
   dtls_pki.cert_chain_validation   = 1;

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -430,8 +430,14 @@ coap_socket_write(coap_socket_t *sock, const uint8_t *data, size_t data_len) {
 #endif /* COAP_EPOLL_SUPPORT */
       return 0;
     }
-    coap_log(LOG_WARNING, "coap_socket_write: send: %s\n",
-             coap_socket_strerror());
+    if (errno == EPIPE || errno == ECONNRESET) {
+      coap_log(LOG_INFO, "coap_socket_write: send: %s\n",
+               coap_socket_strerror());
+    }
+    else {
+      coap_log(LOG_WARNING, "coap_socket_write: send: %s\n",
+               coap_socket_strerror());
+    }
     return -1;
   }
   if (r < (ssize_t)data_len) {

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -37,8 +37,8 @@ coap_get_tls_library_version(void) {
 
 int
 coap_dtls_context_set_pki(coap_context_t *ctx UNUSED,
-                          coap_dtls_pki_t* setup_data UNUSED,
-                          coap_dtls_role_t role UNUSED
+                          const coap_dtls_pki_t* setup_data UNUSED,
+                          const coap_dtls_role_t role UNUSED
 ) {
   return 0;
 }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -966,8 +966,8 @@ pem_decode_mem_asn1(const char *begstr, const uint8_t *str)
 
 int
 coap_dtls_context_set_pki(coap_context_t *ctx,
-  coap_dtls_pki_t* setup_data,
-  coap_dtls_role_t role UNUSED
+                          const coap_dtls_pki_t* setup_data,
+                          const coap_dtls_role_t role UNUSED
 ) {
 #ifdef DTLS_ECC
   coap_tiny_context_t *t_context;
@@ -1130,6 +1130,7 @@ coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx UNUSED,
   const char *ca_file UNUSED,
   const char *ca_path UNUSED
 ) {
+  coap_log(LOG_WARNING, "Root CAs PKI not supported\n");
   return 0;
 }
 

--- a/src/net.c
+++ b/src/net.c
@@ -412,7 +412,7 @@ int coap_context_set_psk2(coap_context_t *ctx,
 }
 
 int coap_context_set_pki(coap_context_t *ctx,
-  coap_dtls_pki_t* setup_data
+  const coap_dtls_pki_t* setup_data
 ) {
   if (!setup_data)
     return 0;
@@ -1508,7 +1508,7 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
           session->read_header[0] = *p++;
           bytes_read -= 1;
           if (!coap_pdu_parse_header_size(session->proto,
-            session->read_header)) {
+                                          session->read_header)) {
             bytes_read = -1;
             break;
           }


### PR DESCRIPTION
The use of the verify_peer_cert and require_peer_cert variables in the
coap_dtls_pki_t structure was giving inconsistent results across all the
TLS libraries.  This primarily was down to the large numbers of options
available to control the TLS handshakes in OpenSSL compared to the limited
control available to mbedTLS port which followed later. require_peer_cert is
not easy to control in mbedTLS as it is an implicit configuration based on how
other, not always related, items were configured.

require_peer_cert was used by the server to control whether the client could
use anonymous certificates or not.  This is now controlled by verify_peer_cert.

require_peer_cert variable has been replaced with check_common_ca, so that
the OpenSSL functionality can continue, but enable GnuTLS / mbedTLS to
produce the same results.  This allows peers to mutually authenticate (because
the peer certs are signed by the same common CA) or not which was in effect
controlled by verify_peer_cert previously.

If check_common_ca is set, then allow_self_signed is ignored.

If is_rpk_not_cert is set, then all certificate validation is ignored.

In the examples, use of the -R option unsets check_common_ca, so disables
mutual authentication support by having a common CA.  This was needed as
mbedTLS and GnuTLS only have a single trust store for CAs.

configure.ac:

Increase the number of mbed libraries to use when checking for mbedTLS.

examples/client.c:
examples/coap-rd.c:
examples/coap-server.c:

Add in -n (unset verify_peer_cert) option. In the case of coap-server and
coap-rd, make -n refer to verify_peer_cert.
Add in TLS library capabilites in usage().

Update usage() documentation as appropriate, with some changes to fit
everything into a 80 column output.

include/coap2/coap_dtls.h:
include/coap2/net.h:

Update with variable changes, and make the coap_dtls_pki_t parameter const for
the *_context_set_pki() functions.

man/coap-client.txt.in:
man/coap-rd.txt.in:
man/coap-server.txt.in:

Update documentation to reflect the examples option usage.

man/coap_context.txt.in:
man/coap_encryption.txt.in:
man/coap_session.txt.in:

Update with the new variable name and document as appropriate.

src/coap_gnutls.c
src/coap_mbedtls.c
src/coap_notls.c
src/coap_openssl.c
coap_tinydtls.c

Update to make variable usage consistent. Update logging from LOG_WARNING to
LOG_INFO where there is an override of a PKI check failure by one of the
coap_dtls_pki_t variables.

Timing window closed for TLS where the peer does not like a certificate, sends
fatal alert and closes connection.  local then fails on writing the next
handshake - but now also reads in alert and reports on it.

src/coap_io.c:

Update logging from LOG_WARNING to LOG_INFO for EPIPE or ECONNRESET errors in
coap_socket_write().

src/net.c:

Handle the const coap_dtls_pki_t parameter in coap_context_set_pki() function.

This replaces #557