### PR TITLE
Allow network interface to be specified when joining multicast group

### DIFF
--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -721,11 +721,16 @@ unsigned int coap_calc_timeout(coap_session_t *session, unsigned char r);
  *
  * @param ctx   The current context
  * @param groupname The name of the group that is to be joined for listening
+ * @param intf_index Index of network interface to join the group on
  *
  * @return       0 on success, -1 on error
  */
 int
-coap_join_mcast_group(coap_context_t *ctx, const char *groupname);
+coap_join_mcast_group_intf(coap_context_t *ctx, const char *groupname,
+                           unsigned int intf_index);
+
+#define coap_join_mcast_group(ctx, groupname) \
+	    (coap_join_mcast_group_intf(ctx, groupname, 0))
 
 /**
  * @defgroup app_io Application I/O Handling

--- a/src/net.c
+++ b/src/net.c
@@ -2933,9 +2933,11 @@ coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
 }
 #else /* defined WITH_CONTIKI || defined WITH_LWIP */
 int
-coap_join_mcast_group(coap_context_t *ctx, const char *group_name) {
+coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
+  unsigned int intf_index) {
   (void)ctx;
   (void)group_name;
+  (void)intf_index;
   return -1;
 }
 #endif /* defined WITH_CONTIKI || defined WITH_LWIP */


### PR DESCRIPTION
This change renames `coap_join_mcast_group()` to `coap_join_mcast_group_netif()`
and adds an extra `unsigned int intf_index` parameter to specify the network
interface, which is passed to `setsockopt()`. If it is zero, then it falls back
to resolving `::` as before.

A `coap_join_mcast_group` macro is defined to maintain backwards API
compatibility.