### PR TITLE
cmdline_read_user: Fix NULL terminating code

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -1306,7 +1306,7 @@ cmdline_read_user(char *arg, unsigned char **buf, size_t maxlen) {
   if (len) {
     *buf = (unsigned char *)arg;
     /* len is the size or less, so 0 terminate to maxlen */
-    buf[len] = '\000';
+    (*buf)[len] = '\000';
   }
   /* 0 length Identity is valid */
   return len;

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2222,7 +2222,7 @@ cmdline_read_user(char *arg, unsigned char **buf, size_t maxlen) {
   if (len) {
     *buf = (unsigned char *)arg;
     /* len is the size or less, so 0 terminate to maxlen */
-    buf[len] = '\000';
+    (*buf)[len] = '\000';
   }
   /* 0 length Identity is valid */
   return len;


### PR DESCRIPTION
Add indirection to pointer when NULL terminating the 'user' variable in
cmdline_read_user().

See #568