### PR TITLE
Allow network interface to be specified when joining multicast group

### DIFF
--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -718,11 +718,16 @@ unsigned int coap_calc_timeout(coap_session_t *session, unsigned char r);
  *
  * @param ctx   The current context
  * @param groupname The name of the group that is to be joined for listening
+ * @param intf_index Index of network interface to join the group on
  *
  * @return       0 on success, -1 on error
  */
 int
-coap_join_mcast_group(coap_context_t *ctx, const char *groupname);
+coap_join_mcast_group_intf(coap_context_t *ctx, const char *groupname,
+                           unsigned int intf_index);
+
+#define coap_join_mcast_group(ctx, groupname) \
+	    (coap_join_mcast_group_intf(ctx, groupname, 0))
 
 /**
  * @defgroup app_io Application I/O Handling

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -96,7 +96,7 @@ global:
   coap_io_process;
   coap_io_process_with_fds;
   coap_is_mcast;
-  coap_join_mcast_group;
+  coap_join_mcast_group_intf;
   coap_log_impl;
   coap_make_str_const;
   coap_malloc_endpoint;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -94,7 +94,7 @@ coap_io_prepare_io
 coap_io_process
 coap_io_process_with_fds
 coap_is_mcast
-coap_join_mcast_group
+coap_join_mcast_group_intf
 coap_log_impl
 coap_make_str_const
 coap_malloc_endpoint

--- a/src/net.c
+++ b/src/net.c
@@ -2939,34 +2939,38 @@ void coap_cleanup(void) {
 
 #if ! defined WITH_CONTIKI && ! defined WITH_LWIP && ! defined RIOT_VERSION
 int
-coap_join_mcast_group(coap_context_t *ctx, const char *group_name) {
+coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
+  unsigned int intf_index) {
   struct ipv6_mreq mreq;
   struct addrinfo   *reslocal = NULL, *resmulti = NULL, hints, *ainfo;
   int result = -1;
   coap_endpoint_t *endpoint;
   int mgroup_setup = 0;
 
-  /* we have to resolve the link-local interface to get the interface id */
-  memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_INET6;
-  hints.ai_socktype = SOCK_DGRAM;
+  if (!intf_index) {
+    /* we have to resolve the link-local interface to get the interface id */
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET6;
+    hints.ai_socktype = SOCK_DGRAM;
 
-  result = getaddrinfo("::", NULL, &hints, &reslocal);
-  if (result != 0) {
-    coap_log(LOG_ERR,
-             "coap_join_mcast_group: cannot resolve link-local interface: %s\n",
-             gai_strerror(result));
-    goto finish;
-  }
+    result = getaddrinfo("::", NULL, &hints, &reslocal);
+    if (result != 0) {
+      coap_log(LOG_ERR,
+              "coap_join_mcast_group: cannot resolve link-local interface: %s\n",
+              gai_strerror(result));
+      goto finish;
+    }
 
-  /* get the first suitable interface identifier */
-  for (ainfo = reslocal; ainfo != NULL; ainfo = ainfo->ai_next) {
-    if (ainfo->ai_family == AF_INET6) {
-      mreq.ipv6mr_interface =
-                ((struct sockaddr_in6 *)ainfo->ai_addr)->sin6_scope_id;
-      break;
+    /* get the first suitable interface identifier */
+    for (ainfo = reslocal; ainfo != NULL; ainfo = ainfo->ai_next) {
+      if (ainfo->ai_family == AF_INET6) {
+        intf_index = ((struct sockaddr_in6 *)ainfo->ai_addr)->sin6_scope_id;
+        break;
+      }
     }
   }
+
+  mreq.ipv6mr_interface = intf_index;
 
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = AF_INET6;
@@ -3017,9 +3021,11 @@ coap_join_mcast_group(coap_context_t *ctx, const char *group_name) {
 }
 #else /* defined WITH_CONTIKI || defined WITH_LWIP */
 int
-coap_join_mcast_group(coap_context_t *ctx, const char *group_name) {
+coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
+  unsigned int intf_index) {
   (void)ctx;
   (void)group_name;
+  (void)intf_index;
   return -1;
 }
 #endif /* defined WITH_CONTIKI || defined WITH_LWIP */


### PR DESCRIPTION
This change renames `coap_join_mcast_group()` to `coap_join_mcast_group_intf()`
and adds an extra `unsigned int intf_index` parameter to specify the network
interface, which is passed to `setsockopt()`. If it is zero, then it falls back
to resolving `::` as before.

A `coap_join_mcast_group` macro is defined to maintain backwards API
compatibility.