### PR TITLE
Mbed TLS: Update MbedTLS and mbedTLS to Mbed TLS to reflect brand name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -77,9 +77,9 @@ that are licensed under the terms of the Eclipse Distribution License 1.0
 (http://www.eclipse.org/org/documents/edl-v10.php).
 
 ========================================================================
-MbedTLS
+Mbed TLS
 
-When compiled with MbedTLS support, this software includes components
+When compiled with Mbed TLS support, this software includes components
 that are licensed under the terms of the Apache 2.0 license
 (http://www.apache.org/licenses/LICENSE-2.0).
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ There is (D)TLS support for the following libraries
 
 * GnuTLS (Minimum version 3.3.0) [PKI, PSK, RPK(3.6.6+) and PKCS11]
 
-* MbedTLS (Minimum version 2.7.10) [PKI and PSK] [Currently only DTLS]
+* Mbed TLS (Minimum version 2.7.10) [PKI and PSK] [Currently only DTLS]
 
 * TinyDTLS [PSK and RPK] [DTLS Only]
 

--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -55,7 +55,7 @@ typedef enum coap_tls_library_t {
   COAP_TLS_LIBRARY_TINYDTLS,  /**< Using TinyDTLS library */
   COAP_TLS_LIBRARY_OPENSSL,   /**< Using OpenSSL library */
   COAP_TLS_LIBRARY_GNUTLS,    /**< Using GnuTLS library */
-  COAP_TLS_LIBRARY_MBEDTLS,   /**< Using MbedTLS library */
+  COAP_TLS_LIBRARY_MBEDTLS,   /**< Using Mbed TLS library */
 } coap_tls_library_t;
 
 /**

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -36,7 +36,7 @@ DESCRIPTION
 This man page focuses on setting up CoAP to use encryption.
 
 When the libcoap library was built, it will have been compiled using a
-specific underlying TLS implementation type (e.g. OpenSSL, GnuTLS, MbedTLS,
+specific underlying TLS implementation type (e.g. OpenSSL, GnuTLS, Mbed TLS,
 TinyDTLS or noTLS).
 When the libcoap library is linked into an application, it is possible
 that the application needs to dynamically determine whether DTLS or TLS is
@@ -49,7 +49,7 @@ version is 1.1.0.
 *NOTE:* If GnuTLS is being used, then the minimum GnuTLS library version is
 3.3.0.
 
-*NOTE:* If MbedTLS is being used, then the minimum MbedTLS library version is
+*NOTE:* If Mbed TLS is being used, then the minimum Mbed TLS library version is
 2.7.10.
 
 *NOTE:* If GnuTLS is going to interoperate with TinyDTLS, then a minimum
@@ -58,7 +58,7 @@ by TinyDTLS as TinyDTLS currently only supports CCM.
 
 *NOTE:* For Raw Public Key support, GnuTLS library version must be 3.6.6 or
 later. TinyDTLS only supports TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, curve
-secp256r1 and hash SHA-256.  There currently is no OpenSSL or MbedTLS RPK support
+secp256r1 and hash SHA-256.  There currently is no OpenSSL or Mbed TLS RPK support
 (respective library limitations).
 
 Network traffic can be un-encrypted or encrypted with libcoap if there is an

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -40,7 +40,7 @@ type.
 DESCRIPTION
 -----------
 When the libcoap library was built, it will have been compiled using a
-specific TLS implementation type (e.g. OpenSSL, GnuTLS, MbedTLS, TinyDTLS or
+specific TLS implementation type (e.g. OpenSSL, GnuTLS, Mbed TLS, TinyDTLS or
 noTLS).
 When the libcoap library is linked into an application, it is possible that
 the application needs to dynamically determine whether DTLS or TLS is
@@ -94,7 +94,7 @@ typedef enum coap_tls_library_t {
   COAP_TLS_LIBRARY_TINYDTLS,  /* Using TinyDTLS library */
   COAP_TLS_LIBRARY_OPENSSL,   /* Using OpenSSL library */
   COAP_TLS_LIBRARY_GNUTLS,    /* Using GnuTLS library */
-  COAP_TLS_LIBRARY_MBEDTLS,   /* Using MbedTLS library */
+  COAP_TLS_LIBRARY_MBEDTLS,   /* Using Mbed TLS library */
 } coap_tls_library_t;
 
 typedef struct coap_tls_version_t {

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -784,7 +784,7 @@ char *coap_string_tls_version(char *buffer, size_t bufsize)
              (unsigned long)(tls_version->built_version & 0xff));
     break;
   case COAP_TLS_LIBRARY_MBEDTLS:
-    snprintf(buffer, bufsize, "TLS Library: MbedTLS - runtime %lu.%lu.%lu, "
+    snprintf(buffer, bufsize, "TLS Library: Mbed TLS - runtime %lu.%lu.%lu, "
              "libcoap built for %lu.%lu.%lu",
              (unsigned long)(tls_version->version >> 24),
              (unsigned long)((tls_version->version >> 16) & 0xff),

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -1,7 +1,7 @@
 /*
-* coap_mbedtls.c -- mbedTLS Datagram Transport Layer Support for libcoap
+* coap_mbedtls.c -- Mbed TLS Datagram Transport Layer Support for libcoap
 *
-* Copyright (C) 2019-2020 Jon Shallow <supjps-libcoap@jpshallow.com>
+* Copyright (C) 2019-2021 Jon Shallow <supjps-libcoap@jpshallow.com>
 *               2019 Jitin George <jitin@espressif.com>
 *
 * This file is part of the CoAP library libcoap. Please see README for terms
@@ -81,7 +81,7 @@ typedef struct coap_ssl_t {
 } coap_ssl_t;
 
 /*
- * This structure encapsulates the mbedTLS session object.
+ * This structure encapsulates the Mbed TLS session object.
  * It handles both TLS and DTLS.
  * c_session->tls points to this.
  */
@@ -430,7 +430,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
 
   if (setup_data->is_rpk_not_cert) {
     coap_log(LOG_ERR,
-          "RPK Support not available in MbedTLS\n");
+          "RPK Support not available in Mbed TLS\n");
     return -1;
   }
   switch (setup_data->pki_key.key_type) {
@@ -1036,7 +1036,7 @@ static int setup_client_ssl_session(coap_session_t *c_session,
       mbedtls_ssl_set_hostname(&m_env->ssl,
                                c_session->cpsk_setup_data.client_sni);
     }
-    /* Identity Hint currently not supported in MbedTLS so code removed */
+    /* Identity Hint currently not supported in Mbed TLS so code removed */
 
     set_ciphersuites(&m_env->conf, COAP_ENC_PSK);
 #endif /* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
@@ -1119,7 +1119,7 @@ static int do_mbedtls_handshake(coap_session_t *c_session,
   switch (ret) {
   case 0:
     m_env->established = 1;
-    coap_log(LOG_DEBUG, "*  %s: MbedTLS established\n",
+    coap_log(LOG_DEBUG, "*  %s: Mbed TLS established\n",
                                             coap_session_str(c_session));
     ret = 1;
     break;
@@ -1253,8 +1253,8 @@ int coap_dtls_is_supported(void) {
   return 1;
 #else /* !MBEDTLS_SSL_PROTO_DTLS */
   coap_log(LOG_EMERG,
-        "libcoap not compiled for DTLS with MbedTLS"
-        " - update MbedTLS to include DTLS\n");
+        "libcoap not compiled for DTLS with Mbed TLS"
+        " - update Mbed TLS to include DTLS\n");
   return 0;
 #endif /* !MBEDTLS_SSL_PROTO_DTLS */
 }
@@ -1289,8 +1289,8 @@ coap_dtls_context_set_spsk(coap_context_t *c_context,
 
 #if !defined(MBEDTLS_SSL_SRV_C)
   coap_log(LOG_EMERG, "coap_context_set_spsk:"
-           " libcoap not compiled for Server Mode for MbedTLS"
-           " - update MbedTLS to include Server Mode\n");
+           " libcoap not compiled for Server Mode for Mbed TLS"
+           " - update Mbed TLS to include Server Mode\n");
   return 0;
 #endif /* !MBEDTLS_SSL_SRV_C */
   if (!m_context || !setup_data)
@@ -1310,8 +1310,8 @@ coap_dtls_context_set_cpsk(coap_context_t *c_context,
 ) {
 #if !defined(MBEDTLS_SSL_CLI_C)
   coap_log(LOG_EMERG, "coap_context_set_spsk:"
-           " libcoap not compiled for Client Mode for MbedTLS"
-           " - update MbedTLS to include Client Mode\n");
+           " libcoap not compiled for Client Mode for Mbed TLS"
+           " - update Mbed TLS to include Client Mode\n");
   return 0;
 #endif /* !MBEDTLS_SSL_CLI_C */
   coap_mbedtls_context_t *m_context =
@@ -1322,7 +1322,7 @@ coap_dtls_context_set_cpsk(coap_context_t *c_context,
 
   if (setup_data->validate_ih_call_back) {
     coap_log(LOG_WARNING,
-        "CoAP Client with MbedTLS does not support Identity Hint selection\n");
+        "CoAP Client with Mbed TLS does not support Identity Hint selection\n");
   }
   m_context->psk_pki_enabled |= IS_PSK;
   return 1;
@@ -1418,8 +1418,8 @@ void *coap_dtls_new_client_session(coap_session_t *c_session)
 #if !defined(MBEDTLS_SSL_CLI_C)
   (void)c_session;
   coap_log(LOG_EMERG, "coap_dtls_new_client_session:"
-           " libcoap not compiled for Client Mode for MbedTLS"
-           " - update MbedTLS to include Client Mode\n");
+           " libcoap not compiled for Client Mode for Mbed TLS"
+           " - update Mbed TLS to include Client Mode\n");
   return NULL;
 #else /* MBEDTLS_SSL_CLI_C */
   coap_mbedtls_env_t *m_env = coap_dtls_new_mbedtls_env(c_session,
@@ -1724,8 +1724,8 @@ int coap_dtls_hello(coap_session_t *c_session,
   (void)data;
   (void)data_len;
   coap_log(LOG_EMERG, "coap_dtls_hello:"
-           " libcoap not compiled for DTLS or Server Mode for MbedTLS"
-           " - update MbedTLS to include DTLS and Server Mode\n");
+           " libcoap not compiled for DTLS or Server Mode for Mbed TLS"
+           " - update Mbed TLS to include DTLS and Server Mode\n");
   return -1;
 #else /* MBEDTLS_SSL_PROTO_DTLS && MBEDTLS_SSL_SRV_C */
   coap_mbedtls_env_t *m_env = (coap_mbedtls_env_t *)c_session->tls;
@@ -1841,7 +1841,7 @@ void coap_dtls_set_log_level(int level)
 #if !defined(ESPIDF_VERSION)
   int use_level;
   /*
-   * MbedTLS debug levels filter
+   * Mbed TLS debug levels filter
    *  0 No debug
    *  1 Error
    *  2 State change


### PR DESCRIPTION
LICENSE:
README.md:
include/coap2/coap_dtls.h:
man/coap_encryption.txt.in:
man/coap_tls_library.txt.in:
src/coap_debug.c:
src/coap_mbedtls.c:

Replace MbedTLS and mbedTLS with "Mbed TLS".