### PR TITLE
Observe: Fix coap_free_context() assert when active observe

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -586,14 +586,15 @@ coap_free_context(coap_context_t *context) {
   if (!context)
     return;
 
+  /* Removing a resource may cause a CON observe to be sent */
+  coap_delete_all_resources(context);
+
   coap_delete_all(context->sendqueue);
 
 #ifdef WITH_LWIP
   context->sendqueue = NULL;
   coap_retransmittimer_restart(context);
 #endif
-
-  coap_delete_all_resources(context);
 
 #ifndef WITHOUT_ASYNC
   coap_delete_all_async(context);

--- a/src/resource.c
+++ b/src/resource.c
@@ -906,6 +906,9 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         assert(h);      /* we do not allow subscriptions if no
                          * GET/FETCH handler is defined */
         h(context, r, obs->session, NULL, &token, obs->query, response);
+        if (COAP_RESPONSE_CLASS(response->code) > 2) {
+          coap_delete_observer(r, obs->session, &token);
+        }
         break;
       case COAP_DELETING_RESOURCE:
       default:
@@ -913,9 +916,6 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         break;
       }
 
-      /* TODO: do not send response and remove observer when
-       *  COAP_RESPONSE_CLASS(response->hdr->code) > 2
-       */
       if (response->type == COAP_MESSAGE_CON ||
           (r->flags & COAP_RESOURCE_FLAGS_NOTIFY_NON_ALWAYS)) {
         obs->non_cnt = 0;


### PR DESCRIPTION
src/net.c:

Call coap_delete_all_resources() (which may send a CON observe bumping a
session ref count) before coap_delete_all() to remove any CON transmissions
that are still in flight in cop_free_context().

src/resource.c:

Delete observer if GET handler does not return a 2.xx code.