### PR TITLE
Observe: Remove WITHOUT_OBSERVE conditional statements in the library.

### DIFF
--- a/include/coap2/async.h
+++ b/include/coap2/async.h
@@ -23,10 +23,9 @@
  * @defgroup coap_async Asynchronous Messaging
  * @{
  * Structure for managing asynchronous state of CoAP resources. A
- * coap_resource_t object holds a list of coap_async_state_t objects that can be
+ * coap_context_t object holds a list of coap_async_state_t objects that can be
  * used to generate a separate response in case a result of an operation cannot
- * be delivered in time, or the resource has been explicitly subscribed to with
- * the option @c observe.
+ * be delivered in time.
  */
 typedef struct coap_async_state_t {
   unsigned char flags;  /**< holds the flags to control behaviour */
@@ -55,7 +54,6 @@ typedef struct coap_async_state_t {
  */
 #define COAP_ASYNC_CONFIRM   0x01  /**< send confirmable response */
 #define COAP_ASYNC_SEPARATE  0x02  /**< send separate response */
-#define COAP_ASYNC_OBSERVED  0x04  /**< the resource is being observed */
 
 /** release application data on destruction */
 #define COAP_ASYNC_RELEASE_DATA  0x08

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -425,9 +425,7 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
 
   coap_log(LOG_DEBUG, "***%s: session disconnected (reason %d)\n",
            coap_session_str(session), reason);
-#ifndef WITHOUT_OBSERVE
   coap_delete_observers( session->context, session );
-#endif
 
   if ( session->tls) {
     if (session->proto == COAP_PROTO_DTLS)

--- a/src/net.c
+++ b/src/net.c
@@ -550,9 +550,7 @@ coap_new_context(
   process_start(&coap_retransmit_process, (char *)c);
 
   PROCESS_CONTEXT_BEGIN(&coap_retransmit_process);
-#ifndef WITHOUT_OBSERVE
   etimer_set(&c->notify_timer, COAP_RESOURCE_CHECK_TIME * COAP_TICKS_PER_SECOND);
-#endif /* WITHOUT_OBSERVE */
   /* the retransmit timer must be initialized to some large value */
   etimer_set(&the_coap_context.retransmit_timer, 0xFFFF);
   PROCESS_CONTEXT_END(&coap_retransmit_process);
@@ -1238,7 +1236,6 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
            coap_session_str(node->session), node->id, node->retransmit_cnt);
 #endif
 
-#ifndef WITHOUT_OBSERVE
   /* Check if subscriptions exist that should be canceled after
      COAP_MAX_NOTIFY_FAILURES */
   if (node->pdu->code >= 64) {
@@ -1249,7 +1246,6 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
 
     coap_handle_failed_notify(context, node->session, &token);
   }
-#endif /* WITHOUT_OBSERVE */
   if (node->session->con_active) {
     node->session->con_active--;
     if (node->session->state == COAP_SESSION_STATE_ESTABLISHED) {
@@ -2198,7 +2194,6 @@ error:
  */
 static int
 coap_cancel(coap_context_t *context, const coap_queue_t *sent) {
-#ifndef WITHOUT_OBSERVE
   coap_binary_t token = { 0, NULL };
   int num_cancelled = 0;    /* the number of observers cancelled */
 
@@ -2214,9 +2209,6 @@ coap_cancel(coap_context_t *context, const coap_queue_t *sent) {
   }
 
   return num_cancelled;
-#else /* WITOUT_OBSERVE */
-  return 0;
-#endif /* WITOUT_OBSERVE */
 }
 
 /**
@@ -3054,12 +3046,10 @@ PROCESS_THREAD(coap_retransmit_process, ev, data) {
         etimer_set(&the_coap_context.retransmit_timer,
           nextpdu ? nextpdu->t - now : 0xFFFF);
       }
-#ifndef WITHOUT_OBSERVE
       if (etimer_expired(&the_coap_context.notify_timer)) {
         coap_check_notify(&the_coap_context);
         etimer_reset(&the_coap_context.notify_timer);
       }
-#endif /* WITHOUT_OBSERVE */
     }
   }
 

--- a/src/resource.c
+++ b/src/resource.c
@@ -670,7 +670,6 @@ coap_register_handler(coap_resource_t *resource,
   resource->handler[method-1] = handler;
 }
 
-#ifndef WITHOUT_OBSERVE
 coap_subscription_t *
 coap_find_observer(coap_resource_t *resource, coap_session_t *session,
                      const coap_binary_t *token) {
@@ -1067,4 +1066,3 @@ coap_handle_failed_notify(coap_context_t *context,
         coap_remove_failed_observers(context, r, session, token);
   }
 }
-#endif /* WITHOUT_NOTIFY */


### PR DESCRIPTION
As RFC7641 is now fully supported, these code segments should always be
compiled in and WITHOUT_OBSERVE wrappers are no longer required.

src/coap_session.c:
src/net.c:
src/resource.c:

Remove WITHOUT_OBSERVE wrappers.

include/coap2/async.h:

Correct definition for coap_async_state_t and remove references for
supporting observing as this is no longer supported.