### PR TITLE
coap_resource_t: Obfuscate coap_resource_t from applications.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST = \
   include/coap$(LIBCOAP_API_VERSION)/coap_asn1_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_block_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_cache_internal.h \
+  include/coap$(LIBCOAP_API_VERSION)/coap_resource_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_session_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_subscribe_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_tcp_internal.h \
@@ -157,7 +158,6 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_LDFLAGS =					\
 CTAGS_IGNORE=-I " \
 coap_delete_all \
 coap_delete_all_async \
-coap_delete_all_resources \
 coap_dtls_context_check_keys_enabled \
 coap_dtls_context_set_pki \
 coap_dtls_context_set_pki_root_cas \
@@ -191,12 +191,8 @@ coap_session_mfree \
 coap_session_new_dtls_session \
 coap_session_refresh_psk_hint \
 coap_session_refresh_psk_key \
-coap_socket_accept_tcp \
-coap_socket_bind_tcp \
 coap_socket_bind_udp \
 coap_socket_close \
-coap_socket_connect_tcp1 \
-coap_socket_connect_tcp2 \
 coap_socket_connect_udp \
 coap_socket_format_errno \
 coap_socket_read \

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -118,7 +118,7 @@ handle_sigint(int signum UNUSED_PARAM) {
 
 static void
 hnd_get_resource(coap_context_t  *ctx UNUSED_PARAM,
-                 struct coap_resource_t *resource,
+                 coap_resource_t *resource,
                  coap_session_t *session UNUSED_PARAM,
                  coap_pdu_t *request UNUSED_PARAM,
                  coap_binary_t *token UNUSED_PARAM,
@@ -126,8 +126,10 @@ hnd_get_resource(coap_context_t  *ctx UNUSED_PARAM,
                  coap_pdu_t *response) {
   rd_t *rd = NULL;
   unsigned char buf[3];
+  coap_str_const_t* uri_path = coap_resource_get_uri_path(resource);
 
-  HASH_FIND(hh, resources, resource->uri_path->s, resource->uri_path->length, rd);
+  if (uri_path)
+    HASH_FIND(hh, resources, uri_path->s, uri_path->length, rd);
 
   response->code = COAP_RESPONSE_CODE_CONTENT;
 
@@ -146,7 +148,7 @@ hnd_get_resource(coap_context_t  *ctx UNUSED_PARAM,
 
 static void
 hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
-                 struct coap_resource_t *resource UNUSED_PARAM,
+                 coap_resource_t *resource UNUSED_PARAM,
                  coap_session_t *session UNUSED_PARAM,
                  coap_pdu_t *request UNUSED_PARAM,
                  coap_binary_t *token UNUSED_PARAM,
@@ -225,15 +227,17 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
 
 static void
 hnd_delete_resource(coap_context_t  *ctx,
-                    struct coap_resource_t *resource,
+                    coap_resource_t *resource,
                     coap_session_t *session UNUSED_PARAM,
                     coap_pdu_t *request UNUSED_PARAM,
                     coap_binary_t *token UNUSED_PARAM,
                     coap_string_t *query UNUSED_PARAM,
                     coap_pdu_t *response) {
   rd_t *rd = NULL;
+  coap_str_const_t* uri_path = coap_resource_get_uri_path(resource);
 
-  HASH_FIND(hh, resources, resource->uri_path->s, resource->uri_path->length, rd);
+  if (uri_path)
+    HASH_FIND(hh, resources, uri_path->s, uri_path->length, rd);
   if (rd) {
     HASH_DELETE(hh, resources, rd);
     rd_delete(rd);
@@ -247,7 +251,7 @@ hnd_delete_resource(coap_context_t  *ctx,
 
 static void
 hnd_get_rd(coap_context_t  *ctx UNUSED_PARAM,
-           struct coap_resource_t *resource UNUSED_PARAM,
+           coap_resource_t *resource UNUSED_PARAM,
            coap_session_t *session UNUSED_PARAM,
            coap_pdu_t *request UNUSED_PARAM,
            coap_binary_t *token UNUSED_PARAM,
@@ -316,7 +320,7 @@ parse_param(const uint8_t *search,
 }
 
 static void
-add_source_address(struct coap_resource_t *resource,
+add_source_address(coap_resource_t *resource,
                    coap_address_t *peer) {
 #define BUFSIZE 64
   char *buf;
@@ -412,7 +416,7 @@ make_rd(coap_pdu_t *pdu) {
 
 static void
 hnd_post_rd(coap_context_t  *ctx,
-            struct coap_resource_t *resource UNUSED_PARAM,
+            coap_resource_t *resource UNUSED_PARAM,
             coap_session_t *session,
             coap_pdu_t *request,
             coap_binary_t *token UNUSED_PARAM,

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -69,7 +69,7 @@ static int quit = 0;
 static time_t clock_offset;
 static time_t my_clock_base = 0;
 
-struct coap_resource_t *time_resource = NULL;
+coap_resource_t *time_resource = NULL;
 
 static coap_binary_t *example_data_ptr = NULL;
 static int example_data_media_type = COAP_MEDIATYPE_TEXT_PLAIN;
@@ -177,7 +177,7 @@ handle_sigint(int signum UNUSED_PARAM) {
 
 static void
 hnd_get_index(coap_context_t *ctx UNUSED_PARAM,
-              struct coap_resource_t *resource,
+              coap_resource_t *resource,
               coap_session_t *session,
               coap_pdu_t *request,
               coap_binary_t *token,
@@ -193,7 +193,7 @@ hnd_get_index(coap_context_t *ctx UNUSED_PARAM,
 
 static void
 hnd_get_time(coap_context_t  *ctx UNUSED_PARAM,
-             struct coap_resource_t *resource,
+             coap_resource_t *resource,
              coap_session_t *session,
              coap_pdu_t *request,
              coap_binary_t *token,
@@ -242,7 +242,7 @@ hnd_get_time(coap_context_t  *ctx UNUSED_PARAM,
 
 static void
 hnd_put_time(coap_context_t *ctx UNUSED_PARAM,
-             struct coap_resource_t *resource,
+             coap_resource_t *resource,
              coap_session_t *session UNUSED_PARAM,
              coap_pdu_t *request,
              coap_binary_t *token UNUSED_PARAM,
@@ -292,7 +292,7 @@ hnd_put_time(coap_context_t *ctx UNUSED_PARAM,
 
 static void
 hnd_delete_time(coap_context_t *ctx UNUSED_PARAM,
-                struct coap_resource_t *resource UNUSED_PARAM,
+                coap_resource_t *resource UNUSED_PARAM,
                 coap_session_t *session UNUSED_PARAM,
                 coap_pdu_t *request UNUSED_PARAM,
                 coap_binary_t *token UNUSED_PARAM,
@@ -307,7 +307,7 @@ hnd_delete_time(coap_context_t *ctx UNUSED_PARAM,
 #ifndef WITHOUT_ASYNC
 static void
 hnd_get_async(coap_context_t *ctx,
-              struct coap_resource_t *resource UNUSED_PARAM,
+              coap_resource_t *resource UNUSED_PARAM,
               coap_session_t *session,
               coap_pdu_t *request,
               coap_binary_t *token UNUSED_PARAM,
@@ -945,7 +945,7 @@ release_proxy_body_data(coap_session_t *session UNUSED_PARAM,
 
 static void
 hnd_proxy_uri(coap_context_t *ctx UNUSED_PARAM,
-                struct coap_resource_t *resource UNUSED_PARAM,
+                coap_resource_t *resource UNUSED_PARAM,
                 coap_session_t *session,
                 coap_pdu_t *request,
                 coap_binary_t *token,

--- a/include/coap2/block.h
+++ b/include/coap2/block.h
@@ -178,7 +178,7 @@ coap_block_build_body(coap_binary_t *body_data, size_t length,
  *
  */
 void
-coap_add_data_blocked_response(struct coap_resource_t *resource,
+coap_add_data_blocked_response(coap_resource_t *resource,
                                struct coap_session_t *session,
                                coap_pdu_t *request,
                                coap_pdu_t *response,
@@ -297,7 +297,7 @@ int coap_add_data_large_request(struct coap_session_t *session,
  * @return @c 1 if addition is successful, else @c 0.
  */
 int
-coap_add_data_large_response(struct coap_resource_t *resource,
+coap_add_data_large_response(coap_resource_t *resource,
                              struct coap_session_t *session,
                              coap_pdu_t *request,
                              coap_pdu_t *response,

--- a/include/coap2/coap_block_internal.h
+++ b/include/coap2/coap_block_internal.h
@@ -62,7 +62,7 @@ typedef struct coap_l_block1_t {
  * (Responses)
  */
 typedef struct coap_l_block2_t {
-  struct coap_resource_t *resource; /**< associated resource */
+  coap_resource_t *resource; /**< associated resource */
   coap_string_t *query;  /**< Associated query for the resource */
   uint64_t etag;         /**< ETag value */
   coap_time_t maxage_expire; /**< When this entry expires */
@@ -135,7 +135,7 @@ struct coap_lg_srcv_t {
   uint32_t total_len;    /**< Length as indicated by SIZE1 option */
   coap_binary_t *body_data; /**< Used for re-assembling entire body */
   size_t amount_so_far;  /**< Amount of data seen so far */
-  struct coap_resource_t *resource; /**< associated resource */
+  coap_resource_t *resource; /**< associated resource */
   coap_str_const_t *uri_path; /** set to uri_path if unknown resource */
   coap_rblock_t rec_blocks; /** < list of received blocks */
   uint8_t last_token[8]; /**< last used token */
@@ -211,7 +211,7 @@ void coap_block_delete_lg_xmit(coap_session_t *session,
  */
 int coap_add_data_large_internal(struct coap_session_t *session,
                         coap_pdu_t *pdu,
-                        struct coap_resource_t *resource,
+                        coap_resource_t *resource,
                         const coap_string_t *query,
                         int maxage,
                         uint64_t etag,

--- a/include/coap2/coap_forward_decls.h
+++ b/include/coap2/coap_forward_decls.h
@@ -42,6 +42,7 @@ struct coap_string_t;
  *
  */
 typedef struct coap_pdu_t coap_pdu_t;
+typedef struct coap_context_t coap_context_t;
 
 /*
  * typedef all the opaque structures that are defined in coap_*_internal.h
@@ -49,7 +50,9 @@ typedef struct coap_pdu_t coap_pdu_t;
 
 /* ************* coap_cache_internal.h ***************** */
 
-/** Cache Entry information */
+/**
+ * Cache Entry information
+ */
 typedef struct coap_cache_entry_t coap_cache_entry_t;
 typedef struct coap_cache_key_t coap_cache_key_t;
 
@@ -60,7 +63,16 @@ typedef struct coap_cache_key_t coap_cache_key_t;
 */
 typedef struct coap_lg_xmit_t coap_lg_xmit_t;
 typedef struct coap_lg_crcv_t coap_lg_crcv_t;
+
 typedef struct coap_lg_srcv_t coap_lg_srcv_t;
+
+/* ************* coap_cache_internal.h ***************** */
+
+/**
+ * Resource information
+ */
+typedef struct coap_attr_t coap_attr_t;
+typedef struct coap_resource_t coap_resource_t;
 
 /* ************* coap_session_internal.h ***************** */
 

--- a/include/coap2/coap_internal.h
+++ b/include/coap2/coap_internal.h
@@ -50,6 +50,7 @@
 #include "coap_block_internal.h"
 #include "coap_cache_internal.h"
 #include "coap_session_internal.h"
+#include "coap_resource_internal.h"
 #include "coap_subscribe_internal.h"
 #include "coap_tcp_internal.h"
 

--- a/include/coap2/coap_resource_internal.h
+++ b/include/coap2/coap_resource_internal.h
@@ -1,0 +1,137 @@
+/*
+ * coap_resource_internal.h -- generic resource handling
+ *
+ * Copyright (C) 2010,2011,2014-2021 Olaf Bergmann <bergmann@tzi.org>
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_resource_internal.h
+ * @brief Generic resource internal handling
+ */
+
+#ifndef COAP_RESOURCE_INTERNAL_H_
+#define COAP_RESOURCE_INTERNAL_H_
+
+/**
+ * @defgroup coap_resource_internal Resources (Internal)
+ * Structures, Enums and Functions that are not exposed to applications
+ * @{
+ */
+
+/**
+* Abstraction of attribute associated with a resource.
+*/
+struct coap_attr_t {
+  struct coap_attr_t *next; /**< Pointer to next in chain or NULL */
+  coap_str_const_t *name;   /**< Name of the attribute */
+  coap_str_const_t *value;  /**< Value of the attribute (can be NULL) */
+  int flags;
+};
+
+/**
+* Abstraction of resource that can be attached to coap_context_t.
+* The key is uri_path.
+*/
+struct coap_resource_t {
+  unsigned int dirty:1;          /**< set to 1 if resource has changed */
+  unsigned int partiallydirty:1; /**< set to 1 if some subscribers have not yet
+                                  *   been notified of the last change */
+  unsigned int observable:1;     /**< can be observed */
+  unsigned int cacheable:1;      /**< can be cached */
+  unsigned int is_unknown:1;     /**< resource created for unknown handler */
+  unsigned int is_proxy_uri:1;   /**< resource created for proxy URI handler */
+
+  /**
+   * Used to store handlers for the seven coap methods @c GET, @c POST, @c PUT,
+   * @c DELETE, @c FETCH, @c PATCH and @c IPATCH.
+   * coap_dispatch() will pass incoming requests to handle_request() and then
+   * to the handler that corresponds to its request method or generate a 4.05
+   * response if no handler is available.
+   */
+  coap_method_handler_t handler[7];
+
+  UT_hash_handle hh;
+
+  coap_attr_t *link_attr; /**< attributes to be included with the link format */
+  coap_subscription_t *subscribers;  /**< list of observers for this resource */
+
+  /**
+   * Request URI Path for this resource. This field will point into static
+   * or allocated memory which must remain there for the duration of the
+   * resource.
+   */
+  coap_str_const_t *uri_path;  /**< the key used for hash lookup for this
+                                    resource */
+  int flags; /**< zero or more COAP_RESOURCE_FLAGS_* or'd together */
+
+  /**
+  * The next value for the Observe option. This field must be increased each
+  * time the resource changes. Only the lower 24 bits are sent.
+  */
+  unsigned int observe;
+
+  /**
+   * Pointer back to the context that 'owns' this resource.
+   */
+  coap_context_t *context;
+
+  /**
+   * Count of valid names this host is known by (proxy support)
+   */
+  size_t proxy_name_count;
+
+  /**
+   * Array valid names this host is known by (proxy support)
+   */
+  coap_str_const_t ** proxy_name_list;
+
+  /**
+   * This pointer is under user control. It can be used to store context for
+   * the coap handler.
+   */
+  void *user_data;
+
+};
+
+/**
+ * Deletes all resources from given @p context and frees their storage.
+ *
+ * @param context The CoAP context with the resources to be deleted.
+ */
+void coap_delete_all_resources(coap_context_t *context);
+
+#define RESOURCES_ADD(r, obj) \
+  HASH_ADD(hh, (r), uri_path->s[0], (obj)->uri_path->length, (obj))
+
+#define RESOURCES_DELETE(r, obj) \
+  HASH_DELETE(hh, (r), (obj))
+
+#define RESOURCES_ITER(r,tmp)  \
+  coap_resource_t *tmp, *rtmp; \
+  HASH_ITER(hh, (r), tmp, rtmp)
+
+#define RESOURCES_FIND(r, k, res) {                     \
+    HASH_FIND(hh, (r), (k)->s, (k)->length, (res)); \
+  }
+
+/**
+ * Deletes an attribute.
+ * Note: This is for internal use only, as it is not deleted from its chain.
+ *
+ * @param attr Pointer to a previously created attribute.
+ *
+ */
+void coap_delete_attr(coap_attr_t *attr);
+
+coap_print_status_t coap_print_wellknown(coap_context_t *,
+                                         unsigned char *,
+                                         size_t *, size_t,
+                                         coap_opt_t *);
+
+
+/** @} */
+
+#endif /* COAP_RESOURCE_INTERNAL_H_ */

--- a/include/coap2/coap_subscribe_internal.h
+++ b/include/coap2/coap_subscribe_internal.h
@@ -2,7 +2,7 @@
  * coap_subscribe_internal.h -- Structures, Enums & Functions that are not
  * exposed to application programming
  *
- * Copyright (C) 2010-2019 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2010-2021 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see README for terms
  * of use.
@@ -61,6 +61,101 @@ struct coap_subscription_t {
 };
 
 void coap_subscription_init(coap_subscription_t *);
+
+/**
+ * Handles a failed observe notify.
+ *
+ * @param context The context holding the resource.
+ * @param session The session that the observe notify failed on.
+ * @param token The token used when the observe notify failed.
+ */
+void
+coap_handle_failed_notify(coap_context_t *context,
+                          coap_session_t *session,
+                          const coap_binary_t *token);
+
+/**
+ * Checks all known resources to see if they are dirty and then notifies
+ * subscribed observers.
+ *
+ * @param context The context to check for dirty resources.
+ */
+void coap_check_notify(coap_context_t *context);
+
+/**
+ * Adds the specified peer as observer for @p resource. The subscription is
+ * identified by the given @p token. This function returns the registered
+ * subscription information if the @p observer has been added, or @c NULL on
+ * error.
+ *
+ * @param resource        The observed resource.
+ * @param session         The observer's session
+ * @param token           The token that identifies this subscription.
+ * @param query           The query string, if any. subscription will
+ *                        take ownership of the string unless this
+ *                        function returns NULL.
+ * @param has_block2      If Option Block2 defined.
+ * @param block2          Contents of Block2 if Block 2 defined.
+ * @param code            Request type code.
+ *
+ * @return                A pointer to the added/updated subscription
+ *                        information or @c NULL on error.
+ */
+coap_subscription_t *coap_add_observer(coap_resource_t *resource,
+                                       coap_session_t *session,
+                                       const coap_binary_t *token,
+                                       coap_string_t *query,
+                                       int has_block2,
+                                       coap_block_t block2,
+                                       uint8_t code);
+
+/**
+ * Returns a subscription object for given @p peer.
+ *
+ * @param resource The observed resource.
+ * @param session  The observer's session
+ * @param token    The token that identifies this subscription or @c NULL for
+ *                 any token.
+ * @return         A valid subscription if exists or @c NULL otherwise.
+ */
+coap_subscription_t *coap_find_observer(coap_resource_t *resource,
+                                        coap_session_t *session,
+                                        const coap_binary_t *token);
+
+/**
+ * Flags that data is ready to be sent to observers.
+ *
+ * @param context  The CoAP context to use.
+ * @param session  The observer's session
+ * @param token    The corresponding token that has been used for the
+ *                 subscription.
+ */
+void coap_touch_observer(coap_context_t *context,
+                         coap_session_t *session,
+                         const coap_binary_t *token);
+
+/**
+ * Removes any subscription for @p observer from @p resource and releases the
+ * allocated storage. The result is @c 1 if an observation relationship with @p
+ * observer and @p token existed, @c 0 otherwise.
+ *
+ * @param resource The observed resource.
+ * @param session  The observer's session.
+ * @param token    The token that identifies this subscription or @c NULL for
+ *                 any token.
+ * @return         @c 1 if the observer has been deleted, @c 0 otherwise.
+ */
+int coap_delete_observer(coap_resource_t *resource,
+                         coap_session_t *session,
+                         const coap_binary_t *token);
+
+/**
+ * Removes any subscription for @p session and releases the allocated storage.
+ *
+ * @param context  The CoAP context to use.
+ * @param session  The observer's session.
+ */
+void coap_delete_observers(coap_context_t *context, coap_session_t *session);
 
 /** @} */
 

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -1,7 +1,7 @@
 /*
  * net.h -- CoAP network interface
  *
- * Copyright (C) 2010-2015 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2010-2021 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see README for terms
  * of use.
@@ -29,6 +29,7 @@
 #include "pdu.h"
 #include "coap_prng.h"
 #include "coap_session.h"
+#include "resource.h"
 
 /**
  * Queue entry
@@ -138,14 +139,17 @@ typedef void (*coap_pong_handler_t)(struct coap_context_t *context,
 /**
  * The CoAP stack's global state is stored in a coap_context_t object.
  */
-typedef struct coap_context_t {
+struct coap_context_t {
   coap_opt_filter_t known_options;
-  struct coap_resource_t *resources; /**< hash table or list of known
-                                          resources */
-  struct coap_resource_t *unknown_resource; /**< can be used for handling
-                                                 unknown resources */
-  struct coap_resource_t *proxy_uri_resource; /**< can be used for handling
-                                                 proxy URI resources */
+  coap_resource_t *resources; /**< hash table or list of known
+                                   resources */
+  coap_resource_t *unknown_resource; /**< can be used for handling
+                                          unknown resources */
+  coap_resource_t *proxy_uri_resource; /**< can be used for handling
+                                            proxy URI resources */
+  coap_resource_release_userdata_handler_t release_userdata;
+                                        /**< function to  release user_data
+                                             when resource is deleted */
 
 #ifndef WITHOUT_ASYNC
   /**
@@ -214,7 +218,7 @@ typedef struct coap_context_t {
   int eptimerfd;                   /**< Internal FD for timeout */
   coap_tick_t next_timeout;        /**< When the next timeout is to occur */
 #endif /* COAP_EPOLL_SUPPORT */
-} coap_context_t;
+};
 
 /**
  * Registers a new message handler that is called whenever a response was

--- a/include/coap2/subscribe.h
+++ b/include/coap2/subscribe.h
@@ -2,7 +2,7 @@
  * subscribe.h -- subscription handling for CoAP
  *                see RFC7641
  *
- * Copyright (C) 2010-2012,2014-2015 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2010-2012,2014-2021 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see README for terms
  * of use.
@@ -23,16 +23,43 @@
  */
 
 /**
- * The value COAP_OBSERVE_ESTABLISH in a GET request indicates a new observe
- * relationship for (sender address, token) is requested.
+ * The value COAP_OBSERVE_ESTABLISH in a GET/FETCH request option
+ * COAP_OPTION_OBSERVE indicates a new observe relationship for (sender
+ * address, token) is requested.
  */
 #define COAP_OBSERVE_ESTABLISH 0
 
 /**
- * The value COAP_OBSERVE_CANCEL in a GET request indicates that the observe
- * relationship for (sender address, token) must be cancelled.
+ * The value COAP_OBSERVE_CANCEL in a GET/FETCH request option
+ * COAP_OPTION_OBSERVE indicates that the observe relationship for (sender
+ * address, token) must be cancelled.
  */
 #define COAP_OBSERVE_CANCEL 1
+
+/**
+ * Set whether a @p resource is observable.  If the resource is observable
+ * and the client has set the COAP_OPTION_OBSERVE in a request packet, then
+ * whenever the state of the resource changes (a call to
+ * coap_resource_trigger_observe()), an Observer response will get sent.
+ *
+ * @param resource The CoAP resource to use.
+ * @param mode     @c 1 if Observable is to be set, @c 0 otherwise.
+ *
+ */
+void coap_resource_set_get_observable(coap_resource_t *resource, int mode);
+
+/**
+ * Initiate the sending of an Observe packet for all observers of @p resource,
+ * optionally matching @p query if not NULL
+ *
+ * @param resource The CoAP resource to use.
+ * @param query    The Query to match against or NULL
+ *
+ * @return         @c 1 if the Observe has been triggered, @c 0 otherwise.
+ */
+int
+coap_resource_notify_observers(coap_resource_t *resource,
+                               const coap_string_t *query);
 
 /** @} */
 

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -17,6 +17,7 @@ global:
   coap_address_set_port;
   coap_add_token;
   coap_adjust_basetime;
+  coap_attr_get_value;
   coap_block_build_body;
   coap_cache_derive_key;
   coap_cache_get_app_data;
@@ -30,7 +31,6 @@ global:
   coap_cancel_observe;
   coap_cancel_session_messages;
   coap_can_exit;
-  coap_check_notify;
   coap_check_option;
   coap_cleanup;
   coap_clear_event_handler;
@@ -47,7 +47,6 @@ global:
   coap_debug_set_packet_loss;
   coap_decode_var_bytes;
   coap_decode_var_bytes8;
-  coap_delete_attr;
   coap_delete_binary;
   coap_delete_bin_const;
   coap_delete_cache_entry;
@@ -90,7 +89,6 @@ global:
   coap_get_uri_path;
   coap_handle_dgram;
   coap_handle_event;
-  coap_handle_failed_notify;
   coap_hash_impl;
   coap_insert_node;
   coap_insert_optlist;
@@ -157,7 +155,6 @@ global:
   coap_pop_next;
   coap_print_addr;
   coap_print_link;
-  coap_print_wellknown;
   coap_prng;
   coap_prng_init;
   coap_realloc_type;
@@ -167,10 +164,16 @@ global:
   coap_remove_async;
   coap_remove_from_queue;
   coap_resize_binary;
+  coap_resource_get_uri_path;
+  coap_resource_get_userdata;
   coap_resource_init;
   coap_resource_notify_observers;
   coap_resource_proxy_uri_init;
+  coap_resource_release_userdata_handler;
   coap_resource_set_dirty;
+  coap_resource_set_get_observable;
+  coap_resource_set_mode;
+  coap_resource_set_userdata;
   coap_resource_unknown_init;
   coap_response_phrase;
   coap_retransmit;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -15,6 +15,7 @@ coap_address_init
 coap_address_set_port
 coap_add_token
 coap_adjust_basetime
+coap_attr_get_value
 coap_block_build_body
 coap_cache_derive_key
 coap_cache_get_app_data
@@ -28,7 +29,6 @@ coap_cancel_all_messages
 coap_cancel_observe
 coap_cancel_session_messages
 coap_can_exit
-coap_check_notify
 coap_check_option
 coap_cleanup
 coap_clear_event_handler
@@ -45,7 +45,6 @@ coap_debug_send_packet
 coap_debug_set_packet_loss
 coap_decode_var_bytes
 coap_decode_var_bytes8
-coap_delete_attr
 coap_delete_binary
 coap_delete_bin_const
 coap_delete_cache_entry
@@ -88,7 +87,6 @@ coap_get_tls_library_version
 coap_get_uri_path
 coap_handle_dgram
 coap_handle_event
-coap_handle_failed_notify
 coap_hash_impl
 coap_insert_node
 coap_insert_optlist
@@ -155,7 +153,6 @@ coap_peek_next
 coap_pop_next
 coap_print_addr
 coap_print_link
-coap_print_wellknown
 coap_prng
 coap_prng_init
 coap_realloc_type
@@ -165,10 +162,16 @@ coap_register_handler
 coap_remove_async
 coap_remove_from_queue
 coap_resize_binary
+coap_resource_get_uri_path
+coap_resource_get_userdata
 coap_resource_init
 coap_resource_notify_observers
 coap_resource_proxy_uri_init
+coap_resource_release_userdata_handler
 coap_resource_set_dirty
+coap_resource_set_get_observable
+coap_resource_set_mode
+coap_resource_set_userdata
 coap_resource_unknown_init
 coap_response_phrase
 coap_retransmit

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,6 +1,6 @@
 # man/Makefile.am
 #
-# Copyright (C) 2018-2020 Jon Shallow <supjps-libcoap@jpshallow.com>
+# Copyright (C) 2018-2021 Jon Shallow <supjps-libcoap@jpshallow.com>
 #
 # This file is part of the CoAP C library libcoap. Please see README and
 # COPYING for terms of use.
@@ -93,6 +93,8 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_pdu_setup.3" > coap_split_path.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_split_query.3
 	@echo ".so man3/coap_resource.3" > coap_resource_get_userdata.3
+	@echo ".so man3/coap_resource.3" > coap_resource_release_userdata_handler.3
+	@echo ".so man3/coap_resource.3" > coap_resource_get_uri_path.3
 	@echo ".so man3/coap_session.3" > coap_session_get_app_data.3
 	@echo ".so man3/coap_session.3" > coap_session_set_app_data.3
 	@echo ".so man3/coap_session.3" > coap_tcp_is_supported.3

--- a/man/coap_attribute.txt.in
+++ b/man/coap_attribute.txt.in
@@ -25,6 +25,8 @@ SYNOPSIS
 *coap_attr_t *coap_find_attr(coap_resource_t *_resource_, coap_str_const_t
 *_name_);*
 
+*coap_str_const_t *coap_attr_get_value(coap_attr_t *_attribute_);*
+
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
 *-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*
 or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls* depending on your (D)TLS library
@@ -35,19 +37,24 @@ DESCRIPTION
 CoAP Resources on a CoAP Server need to be created, updated etc. The URI in
 the request packet defines the resource to work with, with possibly the Query
 referring to a sub-resource.
+
 When resources are configured on the CoAP server, the URI to match against
 is specified.
 Callback Handlers are then added to the resource to handle the different
 request methods.
-Adding Attributes allows textual information to be added to the resource
-which can then be reported back to any client doing a "GET .well-known/core"
-request.
 
-Attributes are automatically freed when a Resource is deleted.
+Adding Attributes allows textual information to be added to the resource
+which can then be reported back to any client doing a Resource Discovery using
+a "GET /.well-known/core" request with an optional query.
+See https://tools.ietf.org/html/rfc6690#section-5 for some examples of
+resource discovery usage.  Common attribute names are rt, if, sz, ct, obs, rel,
+anchor, rev, hreflang, media, title and type. href cannot be an attribute name.
+
+Attributes are automatically deleted when a Resource is deleted.
 
 The *coap_add_attr*() function
 registers a new attribute called _name_ for the _resource_.
-The value of the attribute is _value_.
+The value of the attribute is _value_ which can be NULL.
 
 _flags_ can be one or more of the following, which, if set, defines what is
 to be internally freed off when the attribute is deleted with
@@ -63,13 +70,20 @@ Free off _value_ when attribute is deleted with *coap_delete_resource*().
 The *coap_find_attr*() function returns the attribute with the _name_,
 if found, associated with _resource_.
 
+The *coap_attr_get_value*() function returns the _value_ associated with the
+specified _attribute_.
+
 RETURN VALUES
 -------------
-*coap_add_attr*() function return a pointer to
+*coap_add_attr*() function returns a pointer to
 the attribute that was created or NULL if there is a malloc failure.
 
 *coap_find_attr*() function returns a pointer to the first matching
 attribute or NULL if the _name_ was not found.
+
+*coap_attr_get_value*() function returns a pointer to the value held within
+the attribute. The pointer can be NULL if the _value_ id NULL, or NULL if
+_attribute_ does not exist.
 
 EXAMPLE
 -------
@@ -123,8 +137,13 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See RFC7252 `The Constrained Application Protocol (CoAP)' for further
-information.
+See
+
+"RFC7252: The Constrained Application Protocol (CoAP)"
+
+"RFC6690: Constrained RESTful Environments (CoRE) Link Format"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -13,10 +13,6 @@ NAME
 coap_observe,
 coap_resource_set_get_observable,
 coap_resource_notify_observers,
-coap_resource_get_uri_path,
-coap_find_observer,
-coap_delete_observer,
-coap_delete_observers,
 coap_cancel_observe
 - work with CoAP observe
 
@@ -29,17 +25,6 @@ int _mode_);*
 
 *int coap_resource_notify_observers(coap_resource_t *_resource_,
 const coap_string_t *_query_);*
-
-*coap_str_const_t *coap_resource_get_uri_path(coap_resource_t *_resource_);*
-
-*coap_subscription_t *coap_find_observer(coap_resource_t *_resource_,
-coap_session_t *_session_, const coap_binary_t *_token_);*
-
-*int coap_delete_observer(coap_resource_t *_resource_,
-coap_session_t *_session_, const coap_binary_t *_token_);*
-
-*void coap_delete_observers(coap_context_t *_context_,
-coap_session_t *_session_);*
 
 *int coap_cancel_observe(coap_session_t *_session_, coap_binary_t *_token_,
 uint8_t _message_type_);*
@@ -69,12 +54,8 @@ request with the COAP_OPTION_OBSERVE Option with a value of COAP_OBSERVE_CANCEL.
 If the request to "observe" had been sent using *coap_send_large*(), the
 "observe" can be cancelled using *coap_cancel_observe*() instead.
 
-Alternatively, the server can remove a subscription by calling
-*coap_delete_observer*() or *coap_delete_observers*(), but this does not
-notify the client that the subscription has been removed.
-
-The underlying library adds in and removes "subscribers" to the resource as
-appropriate in the server side logic.
+The underlying library adds in and removes "subscribers" to "observe" the
+resource as appropriate in the server side logic.
 
 Within the server application, it needs to determine that there is a change of
 state of the resource under observation, and then cause the CoAP library
@@ -128,19 +109,6 @@ The *coap_resource_notify_observers*() function needs to be called whenever the
 server application determines that there has been a change to the state of
 _resource_, possibly only matching a specific _query_ if _query_ is not NULL.
 
-The *coap_resource_get_uri_path*() function is used by the server to obtain
-the UriPath of the _resource_ definion.
-
-The *coap_find_observer*() function is used by the server to check whether the
-current GET/FETCH request as determined from _resource_, _session_ and _token_
-is currently being observed or not.
-
-The *coap_delete_observer*() function is used by the server to delete the
-specific observer associated with _resource_, _session_ and has _token_.
-
-The *coap_delete_observers*() function is used to by the server todelete all
-observers associated with the _session_ that is a part of the _context_.
-
 The *coap_cancel_observe*() function can be used by the client to cancel an
 observe request that is being tracked following the use of *coap_send_large*()
 (See *coap_block*(3)) to send the initial "observe" PDU. This will cause the
@@ -150,17 +118,10 @@ _message_type_ (use COAP_MESSAGE_NON or COAP_MESSAGE_CON).
 
 RETURN VALUES
 -------------
-The *coap_resource_get_uri_path*() function returns the uri_path or NULL if
-there was a failure.
-
-The *coap_find_observer*() function returns the subscription or NULL if there
-was a failure.
-
 The *coap_resource_set_get_observable*() function return 0 on failure, 1 on
 success.
 
-The *coap_delete_observer*() and *coap_cancel_observe*() functions return 0
-on failure, 1 on success.
+The *coap_cancel_observe*() function return 0 on failure, 1 on success.
 
 EXAMPLES
 --------

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -16,10 +16,11 @@ coap_resource_unknown_init,
 coap_resource_proxy_uri_init,
 coap_add_resource,
 coap_delete_resource,
-coap_delete_all_resources,
 coap_resource_set_mode,
 coap_resource_set_userdata,
-coap_resource_get_userdata
+coap_resource_get_userdata,
+coap_resource_release_userdata_handler,
+coap_resource_get_uri_path
 - Work with CoAP resources
 
 SYNOPSIS
@@ -41,13 +42,16 @@ coap_resource_t *_resource_);*
 *int coap_delete_resource(coap_context_t *_context_,
 coap_resource_t *_resource_);*
 
-*void coap_delete_all_resources(coap_context_t *_context_);*
-
 *void coap_resource_set_mode(coap_resource_t *_resource_, int _mode_);*
 
 *void coap_resource_set_userdata(coap_resource_t *_resource_, void *_data_);*
 
 *void *coap_resource_get_userdata(coap_resource_t *_resource_);*
+
+*void coap_resource_release_userdata_handler(coap_context_t *_context_,
+coap_resource_release_userdata_handler_t _callback_);*
+
+*coap_str_const_t *coap_resource_get_uri_path(coap_resource_t *_resource_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
 *-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*
@@ -140,9 +144,6 @@ The *coap_delete_resource*() function deletes a _resource_ identified by
 _resource_ from _context_. The storage allocated for that _resource_ is freed,
 along with any attrigutes associated with the _resource_.
 
-The *coap_delete_all_resources*() function deletes all resources from
-_context_ and frees their storage.
-
 The *coap_resource_set_mode*() changes the notification message type of
 _resource_ to the given _mode_ which must be one of
 COAP_RESOURCE_FLAGS_NOTIFY_NON, COAP_RESOURCE_FLAGS_NOTIFY_NON_ALWAYS or
@@ -158,6 +159,15 @@ The *coap_resource_get_userdata*() function obtains the user data pointer
 from the _resource_ that had previously been set up by
 *coap_resource_set_userdata*().
 
+The *coap_resource_release_userdata_handler*() function defines the _context_
+wide _callback_ handler to call to release the allocated user data that has
+been added to the resource using *coap_resource_set_userdata*() when the
+resource is deleted. _callback_ can be NULL (which is the default) if nothing
+needs to be freed off.
+
+The *coap_resource_get_uri_path*() function is used to obtain the UriPath of
+the _resource_ definion.
+
 RETURN VALUES
 -------------
 The *coap_resource_init*(), *coap_resource_unknown_init*() and
@@ -169,6 +179,9 @@ found), 1 on success.
 
 The *coap_resource_get_userdata*() function returns the value previously set
 by the *coap_resource_set_userdata*() function or NULL.
+
+The *coap_resource_get_uri_path*() function returns the uri_path or NULL if
+there was a failure.
 
 EXAMPLES
 --------

--- a/tests/test_wellknown.c
+++ b/tests/test_wellknown.c
@@ -1,6 +1,6 @@
 /* libcoap unit tests
  *
- * Copyright (C) 2013--2015 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2013--2021 Olaf Bergmann <bergmann@tzi.org>
  *
  * This file is part of the CoAP library libcoap. Please see
  * README for terms of use.
@@ -8,6 +8,7 @@
 
 #include "coap_config.h"
 #include "test_wellknown.h"
+#include "coap_internal.h"
 
 #include <coap.h>
 
@@ -90,7 +91,7 @@ t_wellknown2(void) {
   };
 
   r = coap_resource_init(coap_make_str_const("abcd"), 0);
-  r->observable = 1;
+  coap_resource_set_get_observable(r, 1);
   coap_add_attr(r, coap_make_str_const("if"), coap_make_str_const("\"one\""), 0);
 
   coap_add_resource(ctx, r);

--- a/win32/libcoap.vcxproj
+++ b/win32/libcoap.vcxproj
@@ -81,6 +81,7 @@
     <ClInclude Include="..\include\coap2\coap_io.h" />
     <ClInclude Include="..\include\coap2\coap_mutex.h" />
     <ClInclude Include="..\include\coap2\coap_prng.h" />
+    <ClInclude Include="..\include\coap2\coap_resource_internal.h" />
     <ClInclude Include="..\include\coap2\coap_session.h" />
     <ClInclude Include="..\include\coap2\coap_session_internal.h" />
     <ClInclude Include="..\include\coap2\coap_subscribe_internal.h" />

--- a/win32/libcoap.vcxproj.filters
+++ b/win32/libcoap.vcxproj.filters
@@ -146,6 +146,9 @@
     <ClInclude Include="..\include\coap2\coap_prng.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\coap2\coap_resource_internal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\include\coap2\coap_session.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
Create a new include/coap2/coap_resource_internal.h to hold all the information
not available to applications.

Makefile.am:

Include coap_resource_internal.h in EXTRA_DIST.
Remove functions no longer visible from CTAGS_IGNORE.

examples/coap-rd.c:
examples/contiki/server.c:
examples/etsi_iot_01.c:
tests/test_wellknown.c

Replace direct access to coap_resource_t variables with functions as
appropriate.

include/coap2/resource.h:
include/coap2/subscribe.h:
include/coap2/coap_resource_internal.h: (New)
include/coap2/coap_subscribe_internal.h:

Move coap_resource_t, coap_addr_t, non API #defines and non API functions from
resource.h into coap_resource_internal.h, coap_subscribe_internal.h and
subscribe.h.

Replace inline functions accessing coap_resource_t with actual function
definitions.

Add new functions coap_resource_release_userdata_handler() and
coap_attr_get_value().

include/coap2/block.h:

Use coap_resource_t typedef.

include/coap2/coap_forward_decls.h:

Include coap_resource_t and coap_addr_t typedefs.  Also typedef coap_context_t
to get rid of #include circular requirements.

include/coap2/coap_internal.h:
win32/libcoap.vcxproj:
win32/libcoap.vcxproj.filters:

Include coap_resource_internal.h.

include/coap2/net.h:

Remove "typedef struct coap_context_t" and do this in coap_forward_decls.h.

src/resource.c:

Update with the replaced inline functions. Add in the new functions
coap_resource_release_userdata_handler() and coap_attr_get_value().

libcoap-2.map:
libcoap-2.sym:

Update with new function visibility.

man/Makefile.am:
man/coap_attribute.txt.in:
man/coap_observe.txt.in:
man/coap_resource.txt.in:

Update with the new coap_resource_t and coap_attr_t usage.