### PR TITLE
doxygen: Tidy up comments and add in missing modules

### DIFF
--- a/include/coap2/coap_asn1_internal.h
+++ b/include/coap2/coap_asn1_internal.h
@@ -18,7 +18,8 @@
 
 /**
  * @defgroup asn1 ASN.1 Support (Internal)
- * API functions for CoAP ASN.1
+ * CoAP ASN.1 Structures, Enums and Functions that are not exposed to
+ * applications
  * @{
  */
 
@@ -33,6 +34,8 @@ typedef enum {
 /**
  * Callback to validate the asn1 tag and data.
  *
+ * Internal function.
+ *
  * @param data  The start of the tag and data
  * @param size  The size of the tag and data
  *
@@ -43,6 +46,8 @@ typedef int (*asn1_validate)(const uint8_t *data, size_t size);
 /**
  * Get the asn1 length from the current @p ptr.
  *
+ * Internal function.
+ *
  * @param ptr  The current asn.1 object length pointer
  *
  * @return The length of the asn.1 object. @p ptr is udated to past the length.
@@ -51,6 +56,8 @@ size_t asn1_len(const uint8_t **ptr);
 
 /**
  * Get the asn1 tag from the current @p ptr.
+ *
+ * Internal function.
  *
  * @param ptr  The current asn.1 object tag pointer
  * @param constructed  1 if current tag is constructed
@@ -62,6 +69,8 @@ coap_asn1_tag_t asn1_tag_c(const uint8_t **ptr, int *constructed, int *class);
 
 /**
  * Get the asn1 tag and data from the current @p ptr.
+ *
+ * Internal function.
  *
  * @param ltag The tag to look for
  * @param ptr  The current asn.1 object pointer

--- a/include/coap2/coap_cache.h
+++ b/include/coap2/coap_cache.h
@@ -17,6 +17,12 @@
 #include "coap_forward_decls.h"
 
 /**
+ * @defgroup cache Cache Support
+ * API functions for CoAP Caching
+ * @{
+ */
+
+/**
  * Callback to free off the app data when the cache-entry is
  * being deleted / freed off.
  *
@@ -186,5 +192,7 @@ void coap_cache_set_app_data(coap_cache_entry_t *cache_entry, void *data,
  * @return The data pointer previously stored or @c NULL if no data stored.
  */
 void *coap_cache_get_app_data(const coap_cache_entry_t *cache_entry);
+
+/** @} */
 
 #endif  /* COAP_CACHE_H */

--- a/include/coap2/coap_cache_internal.h
+++ b/include/coap2/coap_cache_internal.h
@@ -18,8 +18,9 @@
 #include "coap_io.h"
 
 /**
- * @defgroup cache Cache Support (Internal)
- * API functions for CoAP Caching
+ * @defgroup cache_internal Cache Support (Internal)
+ * CoAP Cache Structures, Enums and Functions that are not exposed to
+ * applications
  * @{
  */
 

--- a/include/coap2/coap_dtls.h
+++ b/include/coap2/coap_dtls.h
@@ -459,7 +459,7 @@ typedef struct coap_dtls_spsk_t {
 
 /**
  * @defgroup dtls_internal DTLS Support (Internal)
- * Internal API functions for interfacing with DTLS libraries.
+ * Internal API functions for interfacing with DTLS library wrappers.
  * @{
  */
 

--- a/include/coap2/coap_event.h
+++ b/include/coap2/coap_event.h
@@ -70,6 +70,8 @@ typedef int (*coap_event_handler_t)(struct coap_context_t *,
 void coap_register_event_handler(struct coap_context_t *context,
                             coap_event_handler_t hnd);
 
+/** @} */
+
 /**
  * Registers the function @p hnd as callback for events from the given
  * CoAP context @p context. Any event handler that has previously been
@@ -93,7 +95,5 @@ void coap_set_event_handler(struct coap_context_t *context,
  */
 COAP_DEPRECATED
 void coap_clear_event_handler(struct coap_context_t *context);
-
-/** @} */
 
 #endif /* COAP_EVENT_H */

--- a/include/coap2/coap_session_internal.h
+++ b/include/coap2/coap_session_internal.h
@@ -18,13 +18,14 @@
 
 /**
  * @defgroup session_internal Sessions (Internal)
- * Structures, Enums and Functions that are not exposed to applications
+ * CoAP Session Structures, Enums and Functions that are not exposed to
+ * applications
  * @{
  */
 
 /**
 * Abstraction of virtual endpoint that can be attached to coap_context_t. The
-* tuple (handle, addr) must uniquely identify this endpoint.
+* keys (port, bind_addr) must uniquely identify this endpoint.
 */
 struct coap_endpoint_t {
   struct coap_endpoint_t *next;

--- a/include/coap2/coap_subscribe_internal.h
+++ b/include/coap2/coap_subscribe_internal.h
@@ -17,8 +17,9 @@
 #define COAP_SUBSCRIBE_INTERNAL_H_
 
 /**
- * @defgroup subscribe_internal Subscribe (Internal)
- * Structures, Enums and Functions that are not exposed to applications
+ * @defgroup subscribe_internal Observe Subscription (Internal)
+ * CoAP Observe Subscription Structures, Enums and Functions that are not
+ * exposed to applications
  * @{
  */
 

--- a/include/coap2/coap_tcp_internal.h
+++ b/include/coap2/coap_tcp_internal.h
@@ -19,7 +19,8 @@
 
 /**
  * @defgroup tcp TCP Support (Internal)
- * API functions for interfacing with the system TCP stack.
+ * CoAP TCP Structures, Enums and Functions that are not exposed to
+ * applications
  * @{
  */
 

--- a/include/coap2/encode.h
+++ b/include/coap2/encode.h
@@ -46,6 +46,12 @@ extern int coap_flsll(long long i);
 #define COAP_PSEUDOFP_ENCODE_8_4_UP(v,ls,s) (v < HIBIT ? v : (ls = coap_fls(v) - Nn, (s = (((v + ((1<<ENCODE_HEADER_SIZE<<ls)-1)) >> ls) & MMASK)), s == 0 ? HIBIT + ls + 1 : s + ls))
 
 /**
+ * @defgroup encode Encode / Decode API
+ * API functions for endoding/decoding CoAP options.
+ * @{
+ */
+
+/**
  * Decodes multiple-length byte sequences. @p buf points to an input byte
  * sequence of length @p length. Returns the up to 4 byte decoded value.
  *
@@ -98,6 +104,8 @@ unsigned int coap_encode_var_safe(uint8_t *buf,
 unsigned int coap_encode_var_safe8(uint8_t *buf,
                                   size_t length,
                                   uint64_t value);
+
+/** @} */
 
 /**
  * @deprecated Use coap_encode_var_safe() instead.

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -732,9 +732,6 @@ coap_join_mcast_group(coap_context_t *ctx, const char *groupname);
 
 #define COAP_IO_WAIT    0
 #define COAP_IO_NO_WAIT ((uint32_t)-1)
-/* Old definitions which may be hanging around in old code - be helpful! */
-#define COAP_RUN_NONBLOCK COAP_RUN_NONBLOCK_deprecated_use_COAP_IO_NO_WAIT
-#define COAP_RUN_BLOCK COAP_RUN_BLOCK_deprecated_use_COAP_IO_WAIT
 
 /**
  * The main I/O processing function.  All pending network I/O is completed,
@@ -765,31 +762,6 @@ coap_join_mcast_group(coap_context_t *ctx, const char *groupname);
  *         an error
  */
 int coap_io_process(coap_context_t *ctx, uint32_t timeout_ms);
-
-/**
- * @deprecated Use coap_io_process() instead.
- *
- * This function just calls coap_io_process().
- *
- * @param ctx The CoAP context
- * @param timeout_ms Minimum number of milliseconds to wait for new packets
- *                   before returning after doing any processing.
- *                   If COAP_IO_WAIT, the call will block until the next
- *                   internal action (e.g. packet retransmit) if any, or block
- *                   until the next packet is received whichever is the sooner
- *                   and do the necessary processing.
- *                   If COAP_IO_NO_WAIT, the function will return immediately
- *                   after processing without waiting for any new input
- *                   packets to arrive.
- *
- * @return Number of milliseconds spent in function or @c -1 if there was
- *         an error
- */
-COAP_STATIC_INLINE COAP_DEPRECATED int
-coap_run_once(coap_context_t *ctx, uint32_t timeout_ms)
-{
-  return coap_io_process(ctx, timeout_ms);
-}
 
 #ifndef RIOT_VERSION
 /**
@@ -823,6 +795,14 @@ int coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
                         int nfds, fd_set *readfds, fd_set *writefds,
                         fd_set *exceptfds);
 #endif /* !RIOT_VERSION */
+
+/**@}*/
+
+/**
+ * @defgroup app_io_internal Application I/O Handling (Internal)
+ * Internal API functions for Application Input / Output
+ * @{
+ */
 
 /**
 * Iterates through all the coap_socket_t structures embedded in endpoints or
@@ -866,34 +846,6 @@ coap_io_prepare_io(coap_context_t *ctx,
 );
 
 /**
-* @deprecated Use coap_io_prepare_io() instead.
-*
-* This function just calls coap_io_prepare_io().
-*
-* Internal function.
-*
-* @param ctx The CoAP context
-* @param sockets Array of socket descriptors, filled on output
-* @param max_sockets Size of socket array.
-* @param num_sockets Pointer to the number of valid entries in the socket
-*                    arrays on output.
-* @param now Current time.
-*
-* @return timeout Maxmimum number of milliseconds that can be used by a
-*                 select() to wait for network events or 0 if wait should be
-*                 forever.
-*/
-COAP_STATIC_INLINE COAP_DEPRECATED unsigned int
-coap_write(coap_context_t *ctx,
-  coap_socket_t *sockets[],
-  unsigned int max_sockets,
-  unsigned int *num_sockets,
-  coap_tick_t now
-) {
-  return coap_io_prepare_io(ctx, sockets, max_sockets, num_sockets, now);
-}
-
-/**
  * Processes any outstanding read, write, accept or connect I/O as indicated
  * in the coap_socket_t structures (COAP_SOCKET_CAN_xxx set) embedded in
  * endpoints or sessions associated with @p ctx.
@@ -907,22 +859,6 @@ coap_write(coap_context_t *ctx,
  * @param now Current time
  */
 void coap_io_do_io(coap_context_t *ctx, coap_tick_t now);
-
-/**
- * @deprecated Use coap_io_do_io() instead.
- *
- * This function just calls coap_io_do_io().
- *
- * Internal function.
- *
- * @param ctx The CoAP context
- * @param now Current time
- */
-COAP_STATIC_INLINE COAP_DEPRECATED void
-coap_read(coap_context_t *ctx, coap_tick_t now
-) {
-  coap_io_do_io(ctx, now);
-}
 
 /**
  * Any now timed out delayed packet is transmitted, along with any packets
@@ -965,5 +901,78 @@ void coap_io_do_epoll(coap_context_t *ctx, struct epoll_event* events,
                       size_t nevents);
 
 /**@}*/
+
+/**
+ * @deprecated Use coap_io_process() instead.
+ *
+ * This function just calls coap_io_process().
+ *
+ * @param ctx The CoAP context
+ * @param timeout_ms Minimum number of milliseconds to wait for new packets
+ *                   before returning after doing any processing.
+ *                   If COAP_IO_WAIT, the call will block until the next
+ *                   internal action (e.g. packet retransmit) if any, or block
+ *                   until the next packet is received whichever is the sooner
+ *                   and do the necessary processing.
+ *                   If COAP_IO_NO_WAIT, the function will return immediately
+ *                   after processing without waiting for any new input
+ *                   packets to arrive.
+ *
+ * @return Number of milliseconds spent in function or @c -1 if there was
+ *         an error
+ */
+COAP_STATIC_INLINE COAP_DEPRECATED int
+coap_run_once(coap_context_t *ctx, uint32_t timeout_ms)
+{
+  return coap_io_process(ctx, timeout_ms);
+}
+
+/**
+* @deprecated Use coap_io_prepare_io() instead.
+*
+* This function just calls coap_io_prepare_io().
+*
+* Internal function.
+*
+* @param ctx The CoAP context
+* @param sockets Array of socket descriptors, filled on output
+* @param max_sockets Size of socket array.
+* @param num_sockets Pointer to the number of valid entries in the socket
+*                    arrays on output.
+* @param now Current time.
+*
+* @return timeout Maxmimum number of milliseconds that can be used by a
+*                 select() to wait for network events or 0 if wait should be
+*                 forever.
+*/
+COAP_STATIC_INLINE COAP_DEPRECATED unsigned int
+coap_write(coap_context_t *ctx,
+  coap_socket_t *sockets[],
+  unsigned int max_sockets,
+  unsigned int *num_sockets,
+  coap_tick_t now
+) {
+  return coap_io_prepare_io(ctx, sockets, max_sockets, num_sockets, now);
+}
+
+/**
+ * @deprecated Use coap_io_do_io() instead.
+ *
+ * This function just calls coap_io_do_io().
+ *
+ * Internal function.
+ *
+ * @param ctx The CoAP context
+ * @param now Current time
+ */
+COAP_STATIC_INLINE COAP_DEPRECATED void
+coap_read(coap_context_t *ctx, coap_tick_t now
+) {
+  coap_io_do_io(ctx, now);
+}
+
+/* Old definitions which may be hanging around in old code - be helpful! */
+#define COAP_RUN_NONBLOCK COAP_RUN_NONBLOCK_deprecated_use_COAP_IO_NO_WAIT
+#define COAP_RUN_BLOCK COAP_RUN_BLOCK_deprecated_use_COAP_IO_WAIT
 
 #endif /* COAP_NET_H_ */

--- a/include/coap2/option.h
+++ b/include/coap2/option.h
@@ -168,57 +168,6 @@ int coap_option_filter_unset(coap_opt_filter_t filter, uint16_t type);
 int coap_option_filter_get(coap_opt_filter_t filter, uint16_t type);
 
 /**
- * Sets the corresponding bit for @p type in @p filter. This function returns @c
- * 1 if bit was set or @c -1 on error (i.e. when the given type does not fit in
- * the filter).
- *
- * @deprecated Use coap_option_filter_set() instead.
- *
- * @param filter The filter object to change.
- * @param type   The type for which the bit should be set.
- *
- * @return       @c 1 if bit was set, @c -1 otherwise.
- */
-COAP_STATIC_INLINE COAP_DEPRECATED int
-coap_option_setb(coap_opt_filter_t filter, uint16_t type) {
-  return coap_option_filter_set(filter, type) ? 1 : -1;
-}
-
-/**
- * Clears the corresponding bit for @p type in @p filter. This function returns
- * @c 1 if bit was cleared or @c -1 on error (i.e. when the given type does not
- * fit in the filter).
- *
- * @deprecated Use coap_option_filter_unset() instead.
- *
- * @param filter The filter object to change.
- * @param type   The type for which the bit should be cleared.
- *
- * @return       @c 1 if bit was set, @c -1 otherwise.
- */
-COAP_STATIC_INLINE COAP_DEPRECATED int
-coap_option_clrb(coap_opt_filter_t filter, uint16_t type) {
-  return coap_option_filter_unset(filter, type) ? 1 : -1;
-}
-
-/**
- * Gets the corresponding bit for @p type in @p filter. This function returns @c
- * 1 if the bit is set @c 0 if not, or @c -1 on error (i.e. when the given type
- * does not fit in the filter).
- *
- * @deprecated Use coap_option_filter_get() instead.
- *
- * @param filter The filter object to read bit from.
- * @param type   The type for which the bit should be read.
- *
- * @return       @c 1 if bit was set, @c 0 if not, @c -1 on error.
- */
-COAP_STATIC_INLINE COAP_DEPRECATED int
-coap_option_getb(coap_opt_filter_t filter, uint16_t type) {
-  return coap_option_filter_get(filter, type);
-}
-
-/**
  * Iterator to run through PDU options. This object must be
  * initialized with coap_option_iterator_init(). Call
  * coap_option_next() to walk through the list of options until
@@ -375,8 +324,6 @@ uint32_t coap_opt_length(const coap_opt_t *opt);
  */
 const uint8_t *coap_opt_value(const coap_opt_t *opt);
 
-/** @} */
-
 /**
  * Representation of chained list of CoAP options to install.
  *
@@ -445,5 +392,58 @@ int coap_insert_optlist(coap_optlist_t **optlist_chain,
  * @param optlist_chain The optlist chain to remove all the entries from
  */
 void coap_delete_optlist(coap_optlist_t *optlist_chain);
+
+/** @} */
+
+/**
+ * Sets the corresponding bit for @p type in @p filter. This function returns @c
+ * 1 if bit was set or @c -1 on error (i.e. when the given type does not fit in
+ * the filter).
+ *
+ * @deprecated Use coap_option_filter_set() instead.
+ *
+ * @param filter The filter object to change.
+ * @param type   The type for which the bit should be set.
+ *
+ * @return       @c 1 if bit was set, @c -1 otherwise.
+ */
+COAP_STATIC_INLINE COAP_DEPRECATED int
+coap_option_setb(coap_opt_filter_t filter, uint16_t type) {
+  return coap_option_filter_set(filter, type) ? 1 : -1;
+}
+
+/**
+ * Clears the corresponding bit for @p type in @p filter. This function returns
+ * @c 1 if bit was cleared or @c -1 on error (i.e. when the given type does not
+ * fit in the filter).
+ *
+ * @deprecated Use coap_option_filter_unset() instead.
+ *
+ * @param filter The filter object to change.
+ * @param type   The type for which the bit should be cleared.
+ *
+ * @return       @c 1 if bit was set, @c -1 otherwise.
+ */
+COAP_STATIC_INLINE COAP_DEPRECATED int
+coap_option_clrb(coap_opt_filter_t filter, uint16_t type) {
+  return coap_option_filter_unset(filter, type) ? 1 : -1;
+}
+
+/**
+ * Gets the corresponding bit for @p type in @p filter. This function returns @c
+ * 1 if the bit is set @c 0 if not, or @c -1 on error (i.e. when the given type
+ * does not fit in the filter).
+ *
+ * @deprecated Use coap_option_filter_get() instead.
+ *
+ * @param filter The filter object to read bit from.
+ * @param type   The type for which the bit should be read.
+ *
+ * @return       @c 1 if bit was set, @c 0 if not, @c -1 on error.
+ */
+COAP_STATIC_INLINE COAP_DEPRECATED int
+coap_option_getb(coap_opt_filter_t filter, uint16_t type) {
+  return coap_option_filter_get(filter, type);
+}
 
 #endif /* COAP_OPTION_H_ */

--- a/include/coap2/str.h
+++ b/include/coap2/str.h
@@ -25,7 +25,7 @@
  */
 
 /**
- * Coap string data definition
+ * CoAP string data definition
  */
 typedef struct coap_string_t {
   size_t length;    /**< length of string */
@@ -33,7 +33,7 @@ typedef struct coap_string_t {
 } coap_string_t;
 
 /**
- * Coap string data definition with const data
+ * CoAP string data definition with const data
  */
 typedef struct coap_str_const_t {
   size_t length;    /**< length of string */
@@ -43,7 +43,7 @@ typedef struct coap_str_const_t {
 #define COAP_SET_STR(st,l,v) { (st)->length = (l), (st)->s = (v); }
 
 /**
- * Coap binary data definition
+ * CoAP binary data definition
  */
 typedef struct coap_binary_t {
   size_t length;    /**< length of binary data */
@@ -51,7 +51,7 @@ typedef struct coap_binary_t {
 } coap_binary_t;
 
 /**
- * Coap binary data definition with const data
+ * CoAP binary data definition with const data
  */
 typedef struct coap_bin_const_t {
   size_t length;    /**< length of binary data */

--- a/man/coap_cache.txt.in
+++ b/man/coap_cache.txt.in
@@ -21,7 +21,7 @@ coap_cache_get_by_pdu,
 coap_cache_get_pdu,
 coap_cache_set_app_data,
 coap_cache_get_app_data
-- cache functions
+- Work with CoAP cache functions
 
 SYNOPSIS
 --------

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -17,7 +17,7 @@ coap_register_nack_handler,
 coap_register_ping_handler,
 coap_register_pong_handler,
 coap_register_event_handler
-- work with CoAP handlers
+- Work with CoAP handlers
 
 SYNOPSIS
 --------

--- a/man/coap_keepalive.txt.in
+++ b/man/coap_keepalive.txt.in
@@ -12,7 +12,7 @@ NAME
 ----
 coap_keepalive,
 coap_context_set_keepalive
-- work with CoAP keepalive
+- Work with CoAP keepalive
 
 SYNOPSIS
 --------

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -17,7 +17,7 @@ coap_resource_get_uri_path,
 coap_find_observer,
 coap_delete_observer,
 coap_delete_observers
-- work with CoAP observe
+- Work with CoAP observe
 
 SYNOPSIS
 --------

--- a/man/coap_string.txt.in
+++ b/man/coap_string.txt.in
@@ -23,7 +23,7 @@ coap_delete_bin_const,
 coap_make_str_const,
 coap_string_equal,
 coap_binary_equal
-- string functions
+- Work with CoAP string functions
 
 SYNOPSIS
 --------


### PR DESCRIPTION
Make documentation more consistent across doxygen output.

Add in caching module.
Add in encoding/decoding module.
Add in application i/o internal module.

Move deprecated items out of respective modules.