### PR TITLE
coap_opt_filter_t: Make it a proper structure

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -319,7 +319,7 @@ hnd_get_async(coap_context_t *ctx,
   if (async) {
     if (async->id != request->tid) {
       coap_opt_filter_t f;
-      coap_option_filter_clear(f);
+      coap_option_filter_clear(&f);
       response->code = COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE;
     }
     return;

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -341,10 +341,10 @@ hnd_get_query(coap_context_t *ctx UNUSED_PARAM,
                                        COAP_MEDIATYPE_TEXT_PLAIN),
                   buf);
 
-  coap_option_filter_clear(f);
-  coap_option_filter_set(f, COAP_OPTION_URI_QUERY);
+  coap_option_filter_clear(&f);
+  coap_option_filter_set(&f, COAP_OPTION_URI_QUERY);
 
-  coap_option_iterator_init(request, &opt_iter, f);
+  coap_option_iterator_init(request, &opt_iter, &f);
 
   len = 0;
   while ((len < sizeof(buf)) && (q = coap_option_next(&opt_iter))) {
@@ -379,17 +379,17 @@ hnd_get_separate(coap_context_t *ctx,
 
   if (async) {
     if (async->id != request->tid) {
-      coap_option_filter_clear(f);
+      coap_option_filter_clear(&f);
       response->code = COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE;
     }
     return;
   }
 
   /* search for option delay in query list */
-  coap_option_filter_clear(f);
-  coap_option_filter_set(f, COAP_OPTION_URI_QUERY);
+  coap_option_filter_clear(&f);
+  coap_option_filter_set(&f, COAP_OPTION_URI_QUERY);
 
-  coap_option_iterator_init(request, &opt_iter, f);
+  coap_option_iterator_init(request, &opt_iter, &f);
 
   while ((option = coap_option_next(&opt_iter))) {
     if (strncmp("delay=", (const char *)coap_opt_value(option), 6) == 0) {

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -282,7 +282,7 @@ coap_register_pong_handler(coap_context_t *context,
  */
 COAP_STATIC_INLINE void
 coap_register_option(coap_context_t *ctx, uint16_t type) {
-  coap_option_filter_set(ctx->known_options, type);
+  coap_option_filter_set(&ctx->known_options, type);
 }
 
 /**
@@ -456,7 +456,7 @@ void *coap_get_app_data(const coap_context_t *context);
  */
 coap_pdu_t *coap_new_error_response(coap_pdu_t *request,
                                     unsigned char code,
-                                    coap_opt_filter_t opts);
+                                    coap_opt_filter_t *opts);
 
 /**
  * Sends an error response with code @p code for request @p request to @p dst.
@@ -476,7 +476,7 @@ coap_pdu_t *coap_new_error_response(coap_pdu_t *request,
 coap_tid_t coap_send_error(coap_session_t *session,
                            coap_pdu_t *request,
                            unsigned char code,
-                           coap_opt_filter_t opts);
+                           coap_opt_filter_t *opts);
 
 /**
  * Helper function to create and send a message with @p type (usually ACK or

--- a/include/coap2/pdu.h
+++ b/include/coap2/pdu.h
@@ -477,7 +477,7 @@ coap_pdu_duplicate(const coap_pdu_t *old_pdu,
                    struct coap_session_t *session,
                    size_t token_length,
                    uint8_t *token,
-                   coap_opt_filter_t drop_options);
+                   coap_opt_filter_t *drop_options);
 
 /**
 * Interprets @p data to determine the number of bytes in the header.

--- a/src/block.c
+++ b/src/block.c
@@ -1071,11 +1071,11 @@ coap_handle_request_send_block(coap_session_t *session,
         /* Need to set up a copy of the pdu to send */
         coap_opt_filter_t drop_options;
 
-        memset(drop_options, 0, sizeof(coap_opt_filter_t));
+        memset(&drop_options, 0, sizeof(coap_opt_filter_t));
         if (block.num != 0)
-          coap_option_filter_set(drop_options, COAP_OPTION_OBSERVE);
+          coap_option_filter_set(&drop_options, COAP_OPTION_OBSERVE);
         out_pdu = coap_pdu_duplicate(&p->pdu, session, pdu->token_length,
-                                     pdu->token, drop_options);
+                                     pdu->token, &drop_options);
         if (!out_pdu) {
           response->code = COAP_RESPONSE_CODE(500);
           goto fail;

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -147,7 +147,7 @@ coap_pdu_duplicate(const coap_pdu_t *old_pdu,
                    coap_session_t *session,
                    size_t token_length,
                    uint8_t *token,
-                   coap_opt_filter_t drop_options) {
+                   coap_opt_filter_t *drop_options) {
   coap_pdu_t *pdu = coap_pdu_init(old_pdu->type,
                                   old_pdu->code,
                                   coap_new_message_id(session),

--- a/src/uri.c
+++ b/src/uri.c
@@ -559,9 +559,9 @@ coap_string_t *coap_get_query(const coap_pdu_t *request) {
   size_t length = 0;
   static const uint8_t hex[] = "0123456789ABCDEF";
 
-  coap_option_filter_clear(f);
-  coap_option_filter_set(f, COAP_OPTION_URI_QUERY);
-  coap_option_iterator_init(request, &opt_iter, f);
+  coap_option_filter_clear(&f);
+  coap_option_filter_set(&f, COAP_OPTION_URI_QUERY);
+  coap_option_iterator_init(request, &opt_iter, &f);
   while ((q = coap_option_next(&opt_iter))) {
     uint16_t seg_len = coap_opt_length(q), i;
     const uint8_t *seg= coap_opt_value(q);
@@ -580,7 +580,7 @@ coap_string_t *coap_get_query(const coap_pdu_t *request) {
     if (query) {
       query->length = length;
       unsigned char *s = query->s;
-      coap_option_iterator_init(request, &opt_iter, f);
+      coap_option_iterator_init(request, &opt_iter, &f);
       while ((q = coap_option_next(&opt_iter))) {
         if (s != query->s)
           *s++ = '&';
@@ -609,9 +609,9 @@ coap_string_t *coap_get_uri_path(const coap_pdu_t *request) {
   size_t length = 0;
   static const uint8_t hex[] = "0123456789ABCDEF";
 
-  coap_option_filter_clear(f);
-  coap_option_filter_set(f, COAP_OPTION_URI_PATH);
-  coap_option_iterator_init(request, &opt_iter, f);
+  coap_option_filter_clear(&f);
+  coap_option_filter_set(&f, COAP_OPTION_URI_PATH);
+  coap_option_iterator_init(request, &opt_iter, &f);
   while ((q = coap_option_next(&opt_iter))) {
     uint16_t seg_len = coap_opt_length(q), i;
     const uint8_t *seg= coap_opt_value(q);
@@ -634,7 +634,7 @@ coap_string_t *coap_get_uri_path(const coap_pdu_t *request) {
     uri_path->length = length;
     unsigned char *s = uri_path->s;
     int n = 0;
-    coap_option_iterator_init(request, &opt_iter, f);
+    coap_option_iterator_init(request, &opt_iter, &f);
     while ((q = coap_option_next(&opt_iter))) {
       if (n++) {
         *s++ = '/';

--- a/tests/test_error_response.c
+++ b/tests/test_error_response.c
@@ -38,8 +38,8 @@ t_error_response1(void) {
   pdu->tid = 0x1234;
 
   /* result = coap_add_token(pdu, 5, (unsigned char *)"token"); */
-  coap_option_filter_clear(opts);
-  response = coap_new_error_response(pdu, COAP_RESPONSE_CODE(400), opts);
+  coap_option_filter_clear(&opts);
+  response = coap_new_error_response(pdu, COAP_RESPONSE_CODE(400), &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);
 
@@ -68,8 +68,8 @@ t_error_response2(void) {
   coap_add_token(pdu, 5, (const uint8_t *)"token");
   coap_add_option(pdu, COAP_OPTION_URI_HOST, 4, (const uint8_t *)"time");
 
-  coap_option_filter_clear(opts);
-  response = coap_new_error_response(pdu, COAP_RESPONSE_CODE(404), opts);
+  coap_option_filter_clear(&opts);
+  response = coap_new_error_response(pdu, COAP_RESPONSE_CODE(404), &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);
 
@@ -100,9 +100,9 @@ t_error_response3(void) {
   /* unknown critical option 9 */
   coap_add_option(pdu, 9, 0, NULL);
 
-  coap_option_filter_clear(opts);
-  coap_option_filter_set(opts, 9);
-  response = coap_new_error_response(pdu, code, opts);
+  coap_option_filter_clear(&opts);
+  coap_option_filter_set(&opts, 9);
+  response = coap_new_error_response(pdu, code, &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);
 
@@ -139,9 +139,9 @@ t_error_response4(void) {
   /* unknown critical option 9 */
   coap_add_option(pdu, 9, sizeof(optval), optval);
 
-  coap_option_filter_clear(opts);
-  coap_option_filter_set(opts, 9);
-  response = coap_new_error_response(pdu, code, opts);
+  coap_option_filter_clear(&opts);
+  coap_option_filter_set(&opts, 9);
+  response = coap_new_error_response(pdu, code, &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);
 
@@ -180,9 +180,9 @@ t_error_response5(void) {
   /* unknown critical option 9 */
   coap_add_option(pdu, 9, sizeof(optval), optval);
 
-  coap_option_filter_clear(opts);
-  coap_option_filter_set(opts, 9);
-  response = coap_new_error_response(pdu, code, opts);
+  coap_option_filter_clear(&opts);
+  coap_option_filter_set(&opts, 9);
+  response = coap_new_error_response(pdu, code, &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);
 
@@ -221,9 +221,9 @@ t_error_response6(void) {
   /* unknown critical option 23 */
   coap_add_option(pdu, 23, sizeof(optval), optval);
 
-  coap_option_filter_clear(opts);
-  coap_option_filter_set(opts, 23);
-  response = coap_new_error_response(pdu, code, opts);
+  coap_option_filter_clear(&opts);
+  coap_option_filter_set(&opts, 23);
+  response = coap_new_error_response(pdu, code, &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);
 
@@ -263,9 +263,9 @@ t_error_response7(void) {
   /* unknown critical option 23 */
   coap_add_option(pdu, 23, sizeof(optval), optval);
 
-  coap_option_filter_clear(opts);
-  coap_option_filter_set(opts, 23);
-  response = coap_new_error_response(pdu, code, opts);
+  coap_option_filter_clear(&opts);
+  coap_option_filter_set(&opts, 23);
+  response = coap_new_error_response(pdu, code, &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);
 
@@ -303,10 +303,10 @@ t_error_response8(void) {
   /* known option 2000 */
   coap_add_option(pdu, 2000, 0, NULL);
 
-  coap_option_filter_clear(opts);
-  coap_option_filter_set(opts, 1001);
-  coap_option_filter_set(opts, 1014);
-  response = coap_new_error_response(pdu, code, opts);
+  coap_option_filter_clear(&opts);
+  coap_option_filter_set(&opts, 1001);
+  coap_option_filter_set(&opts, 1014);
+  response = coap_new_error_response(pdu, code, &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);
 

--- a/tests/test_options.c
+++ b/tests/test_options.c
@@ -650,9 +650,9 @@ t_iterate_option6(void) {
   coap_opt_t *option;
   coap_opt_filter_t filter;
 
-  coap_option_filter_clear(filter);
-  coap_option_filter_set(filter, 10);        /* option nr 10 only */
-  result = coap_option_iterator_init(&pdu, &oi, filter);
+  coap_option_filter_clear(&filter);
+  coap_option_filter_set(&filter, 10);        /* option nr 10 only */
+  result = coap_option_iterator_init(&pdu, &oi, &filter);
 
   CU_ASSERT_PTR_EQUAL(result, &oi);
   CU_ASSERT(oi.bad == 0);
@@ -696,10 +696,10 @@ t_iterate_option7(void) {
   coap_opt_filter_t filter;
 
   /* search options nr 8 and 22 */
-  coap_option_filter_clear(filter);
-  coap_option_filter_set(filter, 8);
-  coap_option_filter_set(filter, 22);
-  result = coap_option_iterator_init(&pdu, &oi, filter);
+  coap_option_filter_clear(&filter);
+  coap_option_filter_set(&filter, 8);
+  coap_option_filter_set(&filter, 22);
+  result = coap_option_iterator_init(&pdu, &oi, &filter);
 
   CU_ASSERT_PTR_EQUAL(result, &oi);
   CU_ASSERT(oi.bad == 0);
@@ -743,9 +743,9 @@ t_iterate_option8(void) {
   coap_opt_filter_t filter;
 
   /* search option nr 36 */
-  coap_option_filter_clear(filter);
-  coap_option_filter_set(filter, 36);
-  result = coap_option_iterator_init(&pdu, &oi, filter);
+  coap_option_filter_clear(&filter);
+  coap_option_filter_set(&filter, 36);
+  result = coap_option_iterator_init(&pdu, &oi, &filter);
 
   CU_ASSERT_PTR_EQUAL(result, &oi);
   CU_ASSERT(oi.bad == 0);
@@ -774,9 +774,9 @@ t_iterate_option9(void) {
   coap_opt_filter_t filter;
 
   /* search option nr 100 */
-  coap_option_filter_clear(filter);
-  coap_option_filter_set(filter, 100);
-  result = coap_option_iterator_init(&pdu, &oi, filter);
+  coap_option_filter_clear(&filter);
+  coap_option_filter_set(&filter, 100);
+  result = coap_option_iterator_init(&pdu, &oi, &filter);
 
   CU_ASSERT_PTR_EQUAL(result, &oi);
   CU_ASSERT(oi.bad == 0);
@@ -805,9 +805,9 @@ t_iterate_option10(void) {
   coap_opt_filter_t filter;
 
   /* search option nr 61 */
-  coap_option_filter_clear(filter);
-  coap_option_filter_set(filter, 61);
-  result = coap_option_iterator_init(&pdu, &oi, filter);
+  coap_option_filter_clear(&filter);
+  coap_option_filter_set(&filter, 61);
+  result = coap_option_iterator_init(&pdu, &oi, &filter);
 
   CU_ASSERT_PTR_EQUAL(result, &oi);
   CU_ASSERT(oi.bad == 0);
@@ -829,30 +829,30 @@ static void
 t_filter_option1(void) {
   coap_opt_filter_t filter;
 
-  coap_option_filter_clear(filter);
+  coap_option_filter_clear(&filter);
 
-  CU_ASSERT(coap_option_filter_set(filter, 0) == 1);
-  CU_ASSERT(coap_option_filter_set(filter, 37) == 1);
-  CU_ASSERT(coap_option_filter_set(filter, 37) == 1);
-  CU_ASSERT(coap_option_filter_set(filter, 43) == 1);
-  CU_ASSERT(coap_option_filter_set(filter, 290) == 1);
-  CU_ASSERT(coap_option_filter_set(filter, 65535) == 1);
+  CU_ASSERT(coap_option_filter_set(&filter, 0) == 1);
+  CU_ASSERT(coap_option_filter_set(&filter, 37) == 1);
+  CU_ASSERT(coap_option_filter_set(&filter, 37) == 1);
+  CU_ASSERT(coap_option_filter_set(&filter, 43) == 1);
+  CU_ASSERT(coap_option_filter_set(&filter, 290) == 1);
+  CU_ASSERT(coap_option_filter_set(&filter, 65535) == 1);
 
-  CU_ASSERT(coap_option_filter_get(filter, 0) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, 37) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, 43) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, 290) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, 65535) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 0) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 37) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 43) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 290) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 65535) == 1);
 
-  CU_ASSERT(coap_option_filter_unset(filter, 37) == 1);
+  CU_ASSERT(coap_option_filter_unset(&filter, 37) == 1);
 
-  CU_ASSERT(coap_option_filter_get(filter, 0) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, 43) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, 290) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, 65535) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 0) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 43) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 290) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 65535) == 1);
 
-  CU_ASSERT(coap_option_filter_get(filter, 37) == 0);
-  CU_ASSERT(coap_option_filter_get(filter, 89) == 0);
+  CU_ASSERT(coap_option_filter_get(&filter, 37) == 0);
+  CU_ASSERT(coap_option_filter_get(&filter, 89) == 0);
 }
 
 static void
@@ -860,18 +860,18 @@ t_filter_option2(void) {
   coap_opt_filter_t filter;
   int s;
 
-  coap_option_filter_clear(filter);
+  coap_option_filter_clear(&filter);
 
   /* fill all COAP_OPT_FILTER_SHORT slots */
   for (s = 0; s < COAP_OPT_FILTER_SHORT; s++) {
-    CU_ASSERT(coap_option_filter_set(filter, s));
+    CU_ASSERT(coap_option_filter_set(&filter, s));
   }
 
   /* adding a short option type must fail */
-  CU_ASSERT(coap_option_filter_set(filter, COAP_OPT_FILTER_SHORT) == 0);
+  CU_ASSERT(coap_option_filter_set(&filter, COAP_OPT_FILTER_SHORT) == 0);
 
   /* adding a long option type must succeed */
-  CU_ASSERT(coap_option_filter_set(filter, 256) == 1);
+  CU_ASSERT(coap_option_filter_set(&filter, 256) == 1);
 }
 
 static void
@@ -879,50 +879,50 @@ t_filter_option3(void) {
   coap_opt_filter_t filter;
   int l;
 
-  coap_option_filter_clear(filter);
+  coap_option_filter_clear(&filter);
 
   /* set COAP_OPT_FILTER_LONG long filters */
   for (l = 0; l < COAP_OPT_FILTER_LONG; l++) {
-    CU_ASSERT(coap_option_filter_set(filter, 256 + l) == 1);
+    CU_ASSERT(coap_option_filter_set(&filter, 256 + l) == 1);
   }
 
   /* the next must fail and must not be found */
-  CU_ASSERT(coap_option_filter_set(filter, 256 + COAP_OPT_FILTER_LONG) == 0);
-  CU_ASSERT(coap_option_filter_get(filter, 256 + COAP_OPT_FILTER_LONG) == 0);
+  CU_ASSERT(coap_option_filter_set(&filter, 256 + COAP_OPT_FILTER_LONG) == 0);
+  CU_ASSERT(coap_option_filter_get(&filter, 256 + COAP_OPT_FILTER_LONG) == 0);
 
   /* remove one item */
-  CU_ASSERT(coap_option_filter_unset(filter, 256) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, 256) == 0);
+  CU_ASSERT(coap_option_filter_unset(&filter, 256) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 256) == 0);
 
   /* now, storing a new filter must succeed */
-  CU_ASSERT(coap_option_filter_set(filter, 256 + COAP_OPT_FILTER_LONG) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, 256 + COAP_OPT_FILTER_LONG) == 1);
+  CU_ASSERT(coap_option_filter_set(&filter, 256 + COAP_OPT_FILTER_LONG) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 256 + COAP_OPT_FILTER_LONG) == 1);
 
   /* and all other items must be available as well */
   for (l = 0; l < COAP_OPT_FILTER_LONG; l++) {
-    CU_ASSERT(coap_option_filter_get(filter, 256 + l + 1) == 1);
+    CU_ASSERT(coap_option_filter_get(&filter, 256 + l + 1) == 1);
   }
 
   /* set COAP_OPT_FILTER_SHORT short filters */
   for (l = 0; l < COAP_OPT_FILTER_SHORT; l++) {
-    CU_ASSERT(coap_option_filter_set(filter, l) == 1);
+    CU_ASSERT(coap_option_filter_set(&filter, l) == 1);
   }
 
   /* the next must fail and must not be found */
-  CU_ASSERT(coap_option_filter_set(filter, COAP_OPT_FILTER_SHORT) == 0);
-  CU_ASSERT(coap_option_filter_get(filter, COAP_OPT_FILTER_SHORT) == 0);
+  CU_ASSERT(coap_option_filter_set(&filter, COAP_OPT_FILTER_SHORT) == 0);
+  CU_ASSERT(coap_option_filter_get(&filter, COAP_OPT_FILTER_SHORT) == 0);
 
   /* remove one item */
-  CU_ASSERT(coap_option_filter_unset(filter, 0) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, 0) == 0);
+  CU_ASSERT(coap_option_filter_unset(&filter, 0) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, 0) == 0);
 
   /* now, storing a new filter must succeed */
-  CU_ASSERT(coap_option_filter_set(filter, COAP_OPT_FILTER_SHORT) == 1);
-  CU_ASSERT(coap_option_filter_get(filter, COAP_OPT_FILTER_SHORT) == 1);
+  CU_ASSERT(coap_option_filter_set(&filter, COAP_OPT_FILTER_SHORT) == 1);
+  CU_ASSERT(coap_option_filter_get(&filter, COAP_OPT_FILTER_SHORT) == 1);
 
   /* and all other items must be available as well */
   for (l = 0; l < COAP_OPT_FILTER_SHORT; l++) {
-    CU_ASSERT(coap_option_filter_get(filter, l + 1) == 1);
+    CU_ASSERT(coap_option_filter_get(&filter, l + 1) == 1);
   }
 }
 


### PR DESCRIPTION
Update coap_opt_filter_t to be a structure rather than a 16bit array that is
aliased with the real structure format.

Update code to use pointers where appropriate.