### PR TITLE
Allow network interface name to be specified when joining multicast group

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -664,7 +664,7 @@ fi
 AC_CHECK_HEADERS([assert.h arpa/inet.h limits.h netdb.h netinet/in.h \
                   pthread.h \
                   stdlib.h string.h strings.h sys/socket.h sys/time.h \
-                  time.h unistd.h sys/unistd.h syslog.h sys/ioctl.h])
+                  time.h unistd.h sys/unistd.h syslog.h sys/ioctl.h net/if.h])
 
 # For epoll, need two headers (sys/epoll.h sys/timerfd.h), but set up one #define
 AC_CHECK_HEADER([sys/epoll.h])

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -840,7 +840,7 @@ main(int argc, char **argv) {
     return -1;
 
   if (group)
-    coap_join_mcast_group(ctx, group);
+    coap_join_mcast_group_intf(ctx, group, NULL);
 
   init_resources(ctx);
 

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2543,7 +2543,7 @@ main(int argc, char **argv) {
              sizeof(cache_ignore_options)/sizeof(cache_ignore_options[0]));
   /* join multicast group if requested at command line */
   if (group)
-    coap_join_mcast_group(ctx, group);
+    coap_join_mcast_group_intf(ctx, group, NULL);
 
   coap_fd = coap_context_get_coap_fd(ctx);
   if (coap_fd != -1) {

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -716,13 +716,18 @@ unsigned int coap_calc_timeout(coap_session_t *session, unsigned char r);
 /**
  * Function interface for joining a multicast group for listening
  *
- * @param ctx   The current context
+ * @param ctx       The current context
  * @param groupname The name of the group that is to be joined for listening
+ * @param ifname    Network interface to join the group on
  *
  * @return       0 on success, -1 on error
  */
 int
-coap_join_mcast_group(coap_context_t *ctx, const char *groupname);
+coap_join_mcast_group_intf(coap_context_t *ctx, const char *groupname,
+                           const char *ifname);
+
+#define coap_join_mcast_group(ctx, groupname) \
+	    (coap_join_mcast_group_intf(ctx, groupname, NULL))
 
 /**
  * @defgroup app_io Application I/O Handling

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -96,7 +96,7 @@ global:
   coap_io_process;
   coap_io_process_with_fds;
   coap_is_mcast;
-  coap_join_mcast_group;
+  coap_join_mcast_group_intf;
   coap_log_impl;
   coap_make_str_const;
   coap_malloc_endpoint;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -94,7 +94,7 @@ coap_io_prepare_io
 coap_io_process
 coap_io_process_with_fds
 coap_is_mcast
-coap_join_mcast_group
+coap_join_mcast_group_intf
 coap_log_impl
 coap_make_str_const
 coap_malloc_endpoint

--- a/src/address.c
+++ b/src/address.c
@@ -86,7 +86,9 @@ int coap_is_mcast(const coap_address_t *a) {
  case AF_INET:
    return IN_MULTICAST(ntohl(a->addr.sin.sin_addr.s_addr));
  case  AF_INET6:
-   return IN6_IS_ADDR_MULTICAST(&a->addr.sin6.sin6_addr);
+   return IN6_IS_ADDR_MULTICAST(&a->addr.sin6.sin6_addr) ||
+       (IN6_IS_ADDR_V4MAPPED(&a->addr.sin6.sin6_addr) &&
+           IN_MULTICAST(ntohl(a->addr.sin6.sin6_addr.s6_addr[12])));
  default:  /* fall through and signal error */
    ;
   }

--- a/src/net.c
+++ b/src/net.c
@@ -27,11 +27,17 @@
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
+#ifdef HAVE_SYS_IOCTL_H
+#include <sys/ioctl.h>
+#endif
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
+#endif
+#ifdef HAVE_NET_IF_H
+#include <net/if.h>
 #endif
 #ifdef COAP_EPOLL_SUPPORT
 #include <sys/epoll.h>
@@ -2939,37 +2945,70 @@ void coap_cleanup(void) {
 
 #if ! defined WITH_CONTIKI && ! defined WITH_LWIP && ! defined RIOT_VERSION
 int
-coap_join_mcast_group(coap_context_t *ctx, const char *group_name) {
-  struct ipv6_mreq mreq;
+coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
+  const char *ifname) {
+  struct ip_mreq mreq4;
+  struct ipv6_mreq mreq6;
   struct addrinfo   *reslocal = NULL, *resmulti = NULL, hints, *ainfo;
+  struct ifreq ifr;
   int result = -1;
   coap_endpoint_t *endpoint;
   int mgroup_setup = 0;
 
-  /* we have to resolve the link-local interface to get the interface id */
-  memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_INET6;
-  hints.ai_socktype = SOCK_DGRAM;
+  mreq6.ipv6mr_interface = -1U;
+  mreq4.imr_interface.s_addr = INADDR_BROADCAST;
 
-  result = getaddrinfo("::", NULL, &hints, &reslocal);
-  if (result != 0) {
-    coap_log(LOG_ERR,
-             "coap_join_mcast_group: cannot resolve link-local interface: %s\n",
-             gai_strerror(result));
-    goto finish;
-  }
+  if (!ifname) {
+    /* no interface specified */
+    /* we have to resolve the link-local interface to get the interface id */
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET6;
+    hints.ai_socktype = SOCK_DGRAM;
 
-  /* get the first suitable interface identifier */
-  for (ainfo = reslocal; ainfo != NULL; ainfo = ainfo->ai_next) {
-    if (ainfo->ai_family == AF_INET6) {
-      mreq.ipv6mr_interface =
+    result = getaddrinfo("::", NULL, &hints, &reslocal);
+    if (result != 0) {
+      coap_log(LOG_WARNING, "coap_join_mcast_group_intf: "
+               "cannot resolve link-local interface: %s\n",
+               gai_strerror(result));
+    }
+    else {
+      /* get the first suitable interface identifier */
+      for (ainfo = reslocal; ainfo != NULL; ainfo = ainfo->ai_next) {
+        if (ainfo->ai_family == AF_INET6) {
+            mreq6.ipv6mr_interface =
                 ((struct sockaddr_in6 *)ainfo->ai_addr)->sin6_scope_id;
-      break;
+          break;
+        }
+      }
+    }
+
+    mreq4.imr_interface.s_addr = INADDR_ANY;
+  }
+  else {
+    /* interface specified */
+    /* get interface index for IPv6 and address for IPv4 */
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
+
+    result = ioctl(ctx->endpoint->sock.fd, SIOCGIFINDEX, &ifr);
+    if (result != 0) {
+      coap_log(LOG_WARNING, "coap_join_mcast_group_intf: "
+               "cannot get interface index for '%s': %d\n", ifname, result);
+    }
+    else {
+      mreq6.ipv6mr_interface = ifr.ifr_ifindex;
+    }
+
+    result = ioctl(ctx->endpoint->sock.fd, SIOCGIFADDR, &ifr);
+    if (result != 0) {
+      coap_log(LOG_WARNING, "coap_join_mcast_group_intf: "
+               "cannot get IPv4 address for '%s': %d\n", ifname, result);
+    }
+    else {
+      mreq4.imr_interface = ((struct sockaddr_in*)&ifr.ifr_addr)->sin_addr;
     }
   }
 
   memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_INET6;
   hints.ai_socktype = SOCK_DGRAM;
 
   /* resolve the multicast group address */
@@ -2983,25 +3022,37 @@ coap_join_mcast_group(coap_context_t *ctx, const char *group_name) {
   }
 
   for (ainfo = resmulti; ainfo != NULL; ainfo = ainfo->ai_next) {
-    if (ainfo->ai_family == AF_INET6) {
-      mreq.ipv6mr_multiaddr =
-                ((struct sockaddr_in6 *)ainfo->ai_addr)->sin6_addr;
-      break;
-    }
-  }
+    LL_FOREACH(ctx->endpoint, endpoint) {
+      if (endpoint->proto == COAP_PROTO_UDP ||
+          endpoint->proto == COAP_PROTO_DTLS) {
+        if (ainfo->ai_family == AF_INET6) {
+          if (mreq6.ipv6mr_interface == -1U)
+            continue;
+          mreq6.ipv6mr_multiaddr =
+                    ((struct sockaddr_in6 *)ainfo->ai_addr)->sin6_addr;
+          result = setsockopt(endpoint->sock.fd, IPPROTO_IPV6, IPV6_JOIN_GROUP,
+                              (char *)&mreq6, sizeof(mreq6));
+        }
+        else if (ainfo->ai_family == AF_INET) {
+          if (mreq4.imr_interface.s_addr == INADDR_BROADCAST)
+            continue;
+          mreq4.imr_multiaddr.s_addr =
+              ((struct sockaddr_in *)ainfo->ai_addr)->sin_addr.s_addr;
+          result = setsockopt(endpoint->sock.fd, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+                              (char *)&mreq4, sizeof(mreq4));
+        }
+        else {
+          continue;
+        }
 
-  LL_FOREACH(ctx->endpoint, endpoint) {
-    if (endpoint->proto == COAP_PROTO_UDP ||
-        endpoint->proto == COAP_PROTO_DTLS) {
-      result = setsockopt(endpoint->sock.fd, IPPROTO_IPV6, IPV6_JOIN_GROUP,
-                          (char *)&mreq, sizeof(mreq));
-      if (result == COAP_SOCKET_ERROR) {
-        coap_log(LOG_ERR,
-                 "coap_join_mcast_group: setsockopt: %s: '%s'\n",
-                 coap_socket_strerror(), group_name);
-      }
-      else {
-        mgroup_setup = 1;
+        if (result == COAP_SOCKET_ERROR) {
+          coap_log(LOG_ERR,
+                   "coap_join_mcast_group: setsockopt: %s: '%s'\n",
+                   coap_socket_strerror(), group_name);
+        }
+        else {
+          mgroup_setup = 1;
+        }
       }
     }
   }
@@ -3017,9 +3068,11 @@ coap_join_mcast_group(coap_context_t *ctx, const char *group_name) {
 }
 #else /* defined WITH_CONTIKI || defined WITH_LWIP */
 int
-coap_join_mcast_group(coap_context_t *ctx, const char *group_name) {
+coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
+  const char *ifname) {
   (void)ctx;
   (void)group_name;
+  (void)ifname;
   return -1;
 }
 #endif /* defined WITH_CONTIKI || defined WITH_LWIP */


### PR DESCRIPTION
This change renames `coap_join_mcast_group` to `coap_join_mcast_group_intf`
and adds an extra `const char *ifname` parameter to specify the interface
name.

A `coap_join_mcast_group` macro is defined to maintain backwards API
compatibility.

`coap_is_mcast` has been modified to recognize IPv6-mapped IPv4 multicast
addresses. Without this `coap_network_send` treats these addresses as
unicast which makes `semdmsg` fail with EINVAL.

fixes #570 
fixes #566 