### PR TITLE
Fix some compile error in windows visual studio

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -17,6 +17,7 @@
 #include <sys/stat.h>
 #ifdef _WIN32
 #define strcasecmp _stricmp
+#define strncasecmp _strnicmp
 #include "getopt.c"
 #if !defined(S_ISDIR)
 #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -19,6 +19,7 @@
 #include <signal.h>
 #ifdef _WIN32
 #define strcasecmp _stricmp
+#define strncasecmp _strnicmp
 #include "getopt.c"
 #if !defined(S_ISDIR)
 #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)

--- a/include/coap2/coap_prng.h
+++ b/include/coap2/coap_prng.h
@@ -65,33 +65,6 @@ lwip_prng_impl(unsigned char *buf, size_t len) {
 #define coap_prng(Buf,Length) lwip_prng_impl((Buf), (Length))
 #define coap_prng_init(Value)
 
-#elif defined(_WIN32)
-
-errno_t __cdecl rand_s( _Out_ unsigned int* _RandomValue );
-/**
- * Fills \p buf with \p len random bytes. This is the default implementation for
- * coap_prng(). You might want to change coap_prng_impl() to use a better
- * PRNG on your specific platform.
- */
-COAP_STATIC_INLINE int
-coap_prng_impl( unsigned char *buf, size_t len ) {
-        while ( len != 0 ) {
-                uint32_t r = 0;
-                size_t i;
-                if ( rand_s( &r ) != 0 )
-                        return 0;
-                for ( i = 0; i < len && i < 4; i++ ) {
-                        *buf++ = (uint8_t)r;
-                        r >>= 8;
-                }
-                len -= i;
-        }
-        return 1;
-}
-
-#define coap_prng(Buf,Length) coap_prng_impl((Buf), (Length))
-#define coap_prng_init(Value)
-
 #else
 
 /**

--- a/include/coap2/pdu.h
+++ b/include/coap2/pdu.h
@@ -508,16 +508,6 @@ size_t coap_add_option(coap_pdu_t *pdu,
                        size_t len,
                        const uint8_t *data);
 
-/**
- * Adds option of given type to pdu that is passed as first parameter, but does
- * not write a value. It works like coap_add_option with respect to calling
- * sequence (i.e. after token and before data). This function returns a memory
- * address to which the option data has to be written before the PDU can be
- * sent, or @c NULL on error.
- */
-uint8_t *coap_add_option_later(coap_pdu_t *pdu,
-                               uint16_t type,
-                               size_t len);
 
 
 /**

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -7,7 +7,6 @@ global:
   coap_add_data_blocked_response;
   coap_add_observer;
   coap_add_option;
-  coap_add_option_later;
   coap_add_optlist_pdu;
   coap_add_resource;
   coap_address_equals;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -5,7 +5,6 @@ coap_add_data_after
 coap_add_data_blocked_response
 coap_add_observer
 coap_add_option
-coap_add_option_later
 coap_add_optlist_pdu
 coap_add_resource
 coap_address_equals

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -79,6 +79,7 @@
 
 #ifdef _WIN32
 #define strcasecmp _stricmp
+#define strncasecmp _strnicmp
 #endif
 
 /* RFC6091/RFC7250 */

--- a/src/coap_prng.c
+++ b/src/coap_prng.c
@@ -15,19 +15,48 @@
 #include <stdlib.h>
 #endif /* !HAVE_GETRANDOM */
 
+#if defined(_WIN32)
+
+errno_t __cdecl rand_s( _Out_ unsigned int* _RandomValue );
+/**
+ * Fills \p buf with \p len random bytes. This is the default implementation for
+ * coap_prng(). You might want to change coap_prng_impl() to use a better
+ * PRNG on your specific platform.
+ */
+COAP_STATIC_INLINE int
+coap_prng_impl( unsigned char *buf, size_t len ) {
+        while ( len != 0 ) {
+                uint32_t r = 0;
+                size_t i;
+                if ( rand_s( &r ) != 0 )
+                        return 0;
+                for ( i = 0; i < len && i < 4; i++ ) {
+                        *buf++ = (uint8_t)r;
+                        r >>= 8;
+                }
+                len -= i;
+        }
+        return 1;
+}
+
+#endif
+
 static int
 coap_prng_default(void *buf, size_t len) {
 #ifdef HAVE_GETRANDOM
   return getrandom(buf, len, 0);
 #else /* !HAVE_GETRANDOM */
-  unsigned char *dst = (unsigned char *)buf;
-  while (len--)
-    *dst++ = rand() & 0xFF;
-  return 1;
+  return coap_prng_impl(buf,len);
 #endif /* !HAVE_GETRANDOM */
 }
 
 static coap_rand_func_t rand_func = coap_prng_default;
+
+#if defined(WITH_CONTIKI)
+
+#elif defined(WITH_LWIP) && defined(LWIP_RAND)
+
+#else
 
 void
 coap_set_prng(coap_rand_func_t rng) {
@@ -54,3 +83,5 @@ coap_prng(void *buf, size_t len) {
   rand_func(buf, len);
   return 1;
 }
+
+#endif

--- a/win32/libcoap.vcxproj
+++ b/win32/libcoap.vcxproj
@@ -47,6 +47,7 @@
     <ClCompile Include="..\src\coap_mbedtls.c" />
     <ClCompile Include="..\src\coap_notls.c" />
     <ClCompile Include="..\src\coap_openssl.c" />
+    <ClCompile Include="..\src\coap_prng.c" />
     <ClCompile Include="..\src\coap_session.c" />
     <ClCompile Include="..\src\coap_time.c" />
     <ClCompile Include="..\src\coap_tcp.c" />


### PR DESCRIPTION
1. Since coap_add_option_later() has been removed, so remove coap_add_option_later in lib-coap-2.(map,sym) and pdu.h
2. [PRNG] need include coap_prng.c into visual studio project too, since new
functions for generating pseudo numbers replace the old macro-based
approach.
3. [PRNG] need define coap_prng() coap_prng_init() coap_set_prng() for
windows too since these function are exported in lib-coap-2.(map,sym)