### PR TITLE
message id: Report everywhere the hex value for consistency

### DIFF
--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -208,7 +208,7 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
   response = coap_pdu_init(type, code, request->hdr->id, size);
 
   if (!response) {
-    coap_log(LOG_DEBUG, "cannot create response for message %d\n",
+    coap_log(LOG_DEBUG, "cannot create response for mid=0x%x\n",
              request->hdr->id);
     return;
   }
@@ -217,7 +217,7 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
     coap_add_token(response, request->hdr->token_length, request->hdr->token);
 
   if (coap_send(ctx, peer, response) == COAP_INVALID_TID) {
-    coap_log(LOG_DEBUG, "hnd_get_rd: cannot send response for message %d\n",
+    coap_log(LOG_DEBUG, "hnd_get_rd: cannot send response for mid=0x%x\n",
     request->hdr->id);
   }
 #endif

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -454,7 +454,7 @@ check_async(coap_context_t *ctx,
   coap_add_data(response, 4, (const uint8_t *)"done");
 
   if (coap_send(async->session, response) == COAP_INVALID_TID) {
-    coap_log(LOG_DEBUG, "check_async: cannot send response for message %d\n",
+    coap_log(LOG_DEBUG, "check_async: cannot send response for mid=0x%x\n",
           response->tid);
   }
   coap_remove_async(ctx, async->session, async->id, &tmp);

--- a/src/async.c
+++ b/src/async.c
@@ -38,7 +38,7 @@ coap_register_async(coap_context_t *context, coap_session_t *session,
     /* We must return NULL here as the caller must know that he is
      * responsible for releasing @p data. */
     coap_log(LOG_DEBUG,
-         "asynchronous state for transaction %d already registered\n", id);
+         "asynchronous state for mid=0x%x already registered\n", id);
     return NULL;
   }
 

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -289,7 +289,7 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
     /* Check that the same tid is not getting re-used in violation of RFC7252 */
     LL_FOREACH(session->delayqueue, q) {
       if (q->id == pdu->tid) {
-        coap_log(LOG_ERR, "**  %s: tid=%d: already in-use - dropped\n", coap_session_str(session), pdu->tid);
+        coap_log(LOG_ERR, "**  %s: mid=0x%x: already in-use - dropped\n", coap_session_str(session), pdu->tid);
         return COAP_INVALID_TID;
       }
     }
@@ -306,7 +306,7 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
     }
   }
   LL_APPEND(session->delayqueue, node);
-  coap_log(LOG_DEBUG, "** %s: tid=%d: delayed\n",
+  coap_log(LOG_DEBUG, "** %s: mid=0x%x: delayed\n",
            coap_session_str(session), node->id);
   return COAP_PDU_DELAYED;
 }
@@ -391,7 +391,7 @@ void coap_session_connected(coap_session_t *session) {
     session->delayqueue = q->next;
     q->next = NULL;
 
-    coap_log(LOG_DEBUG, "** %s: tid=%d: transmitted after delay\n",
+    coap_log(LOG_DEBUG, "** %s: mid=0x%x: transmitted after delay\n",
              coap_session_str(session), (int)q->pdu->tid);
     bytes_written = coap_session_send_pdu(session, q->pdu);
     if (q->pdu->type == COAP_MESSAGE_CON && COAP_PROTO_NOT_RELIABLE(session->proto)) {
@@ -456,7 +456,7 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
     coap_queue_t *q = session->delayqueue;
     session->delayqueue = q->next;
     q->next = NULL;
-    coap_log(LOG_DEBUG, "** %s: tid=%d: not transmitted after disconnect\n",
+    coap_log(LOG_DEBUG, "** %s: mid=0x%x: not transmitted after disconnect\n",
              coap_session_str(session), q->id);
     if (q->pdu->type==COAP_MESSAGE_CON
       && COAP_PROTO_NOT_RELIABLE(session->proto)


### PR DESCRIPTION
coap_show_pdu() reports the Message ID (mid) as a hex value prefixes by i:.
Elsewhere it is reported as an integer or unsigned making those entries
difficult to match up with the reported PDU.

examples/coap-rd.c:
examples/etsi_iot_01.c:
src/async.c:
src/coap_session.c:
src/net.c:

Replace tid=%d, message %d and transaction %d with mid=0x%x for clarity.