### PR TITLE
workflow: Add in distribution and CMake checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,28 +29,81 @@ jobs:
           submodules: recursive
       - name: setup
         run: |
-          sudo apt-get update && sudo apt-get install -y libcunit1-dev libmbedtls-dev libgnutls28-dev libtool libtool-bin exuberant-ctags valgrind graphviz doxygen libxml2-utils xsltproc docbook-xml docbook-xsl asciidoc
+          sudo apt-get update && sudo apt-get install -y libcunit1-dev libmbedtls-dev libgnutls28-dev libtool libtool-bin exuberant-ctags valgrind
           ./autogen.sh
       - name: configure no-TLS
         if: matrix.TLS == 'no'
         run: |
           mkdir build-${{matrix.TLS}}-${{matrix.CC}}
           cd build-${{matrix.TLS}}-${{matrix.CC}}
-          $GITHUB_WORKSPACE/configure --enable-examples --enable-tests --disable-dtls CC=${{matrix.CC}}
+          $GITHUB_WORKSPACE/configure --disable-documentation --enable-examples --enable-tests --disable-dtls CC=${{matrix.CC}}
       - name: configure TLS
         if: matrix.TLS != 'no'
         run: |
           mkdir build-${{matrix.TLS}}-${{matrix.CC}}
           cd build-${{matrix.TLS}}-${{matrix.CC}}
-          "$GITHUB_WORKSPACE/configure" --enable-examples --enable-tests --with-${{matrix.TLS}} CC=${{matrix.CC}}
+          "$GITHUB_WORKSPACE/configure" --disable-documentation --enable-examples --enable-tests --with-${{matrix.TLS}} CC=${{matrix.CC}}
       - name: compile
         run: |
           cd build-${{matrix.TLS}}-${{matrix.CC}}
-          make EXTRA_CFLAGS=-Werror
+          make EXTRA_CFLAGS=-Werror && make check EXTRA_CFLAGS=-Werror
       - name: test
         run: |
           cd build-${{matrix.TLS}}-${{matrix.CC}}
           libtool --mode=execute valgrind --track-origins=yes --leak-check=yes --show-reachable=yes --error-exitcode=123 --quiet --suppressions=$GITHUB_WORKSPACE/tests/valgrind_suppression tests/testdriver
+  tinydtls-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: setup
+        run: |
+          sudo apt-get update && sudo apt-get install -y libcunit1-dev libtool libtool-bin exuberant-ctags valgrind
+          ./autogen.sh
+      - name: configure
+        run: |
+          $GITHUB_WORKSPACE/configure --disable-documentation --enable-examples --enable-tests --with-tinydtls
+      - name: compile
+        run: |
+          make EXTRA_CFLAGS=-Werror && make check EXTRA_CFLAGS=-Werror
+      - name: test
+        run: |
+          LD_LIBRARY_PATH=ext/tinydtls libtool --mode=execute valgrind --track-origins=yes --leak-check=yes --show-reachable=yes --error-exitcode=123 --quiet --suppressions=$GITHUB_WORKSPACE/tests/valgrind_suppression tests/testdriver
+  cmake-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: setup
+        run: |
+          sudo apt-get update && sudo apt-get install -y libcunit1-dev libgnutls28-dev
+          cmake -E make_directory $GITHUB_WORKSPACE}/build
+      - name: configure
+        run: |
+          cd $GITHUB_WORKSPACE}/build
+          cmake $GITHUB_WORKSPACE -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -DENABLE_DTLS=ON -DDTLS_BACKEND=gnutls
+      - name: build
+        run: |
+          cd $GITHUB_WORKSPACE}/build
+          cmake --build .
+  other-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        OS: ["contiki", "lwip"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup
+        run: |
+          ./autogen.sh
+      - name: configure
+        run: |
+          $GITHUB_WORKSPACE/configure --disable-documentation --disable-examples --disable-tests --disable-dtls
+      - name: compile
+        run: |
+          make -C examples/${{matrix.OS}}
   additional-tests:
     runs-on: ubuntu-latest
     steps:
@@ -79,7 +132,36 @@ jobs:
           ./autogen.sh
       - name: configure
         run: ./configure --disable-tests --enable-documentation
-      - name: manual page examples check
+      - name: manuals check
         run: |
           make -C man
+      - name: manual page examples check
+        run: |
           man/examples-code-check man
+      - name: doxygen check
+        run: |
+          make -C doc
+  distribution:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: setup
+        run: |
+          sudo apt-get update && sudo apt-get install -y libcunit1-dev libtool libtool-bin exuberant-ctags graphviz doxygen libxml2-utils xsltproc docbook-xml docbook-xsl asciidoc
+          ./autogen.sh
+      - name: configure
+        run: |
+          mkdir build-dist
+          cd build-dist
+          $GITHUB_WORKSPACE/configure --enable-silent-rules --enable-documentation --enable-examples --disable-dtls
+      - name: build distribution
+        run: |
+          cd build-dist
+          make dist
+      - name: check distribution build
+        run: |
+          cd build-dist
+          $GITHUB_WORKSPACE/scripts/github_dist.sh
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # libcoap: A C implementation of the Constrained Application Protocol (RFC 7252)
 
-[![Build Status: master](https://github.com/obgm/libcoap/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/obgm/libcoap/actions)
-[![Build Status: develop](https://github.com/obgm/libcoap/actions/workflows/main.yml/badge.svg?branch=develop)](https://github.com/obgm/libcoap/actions)
+[![Build Status: master](https://github.com/obgm/libcoap/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/obgm/libcoap/actions?query=branch:master)
+[![Build Status: develop](https://github.com/obgm/libcoap/actions/workflows/main.yml/badge.svg?branch=develop)](https://github.com/obgm/libcoap/actions?query=branch:develop)
 [![Static Analysis](https://scan.coverity.com/projects/10970/badge.svg?flat=1)](https://scan.coverity.com/projects/obgm-libcoap)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/libcoap.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:libcoap)
-![CMake](https://github.com/obgm/libcoap/workflows/CMake/badge.svg)
 
 Copyright (C) 2010—2021 by Olaf Bergmann <bergmann@tzi.org> and others
 

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -23,7 +23,7 @@
 #include <signal.h>
 
 #include "uthash.h"
-#include "coap.h"
+#include <coap2/coap.h>
 
 #define COAP_RESOURCE_CHECK_TIME_SEC  1
 

--- a/examples/tiny.c
+++ b/examples/tiny.c
@@ -19,7 +19,7 @@
 #include <netdb.h>
 #include <signal.h>
 
-#include "coap.h"
+#include <coap2/coap.h>
 
 #ifdef __GNUC__
 #define UNUSED_PARAM __attribute__ ((unused))

--- a/scripts/github_dist.sh
+++ b/scripts/github_dist.sh
@@ -1,0 +1,24 @@
+#! /bin/sh
+
+# This script creates a libcoap archive, unpacks it and does an
+# out-of-tree build and installation afterwards.
+#
+# Copyright (C) 2021 Olaf Bergmann <bergmann@tzi.org>
+#
+# This file is part of the CoAP C library libcoap. Please see README
+# and COPYING for terms of use.
+#
+
+PREFIX=--prefix=`pwd`/libcoap-install
+ARCHIVE=`ls -1t libcoap-*.tar.bz2 |head -1`
+err=$?
+echo $ARCHIVE
+if test $err = 0 -a "x$ARCHIVE" != "x"; then
+    DIR=`pwd`/`tar taf $ARCHIVE |cut -d/ -f1|head -1`
+    tar xaf $ARCHIVE && cd $DIR && \
+        $DIR/configure $PREFIX --enable-tests  --enable-silent-rules --enable-documentation --enable-examples --disable-dtls && \
+        make && make install
+    err=$?
+fi
+
+exit $err


### PR DESCRIPTION
.github/workflows/main.yml:

Do a 'make check' for matrix builds.
Move documentation into separate job to reduce matrix build times
Add in CMake job.
Add in distribution job.

scripts/github_dist.sh:

Do the distribution checks using a script.

examples/etsi_iot_01.c:
examples/tiny.c:

Fix include coap.h directory in old examples.

README.md:
    
Update status badges to get only the branch actions and remove CMake status badge.