### PR TITLE
cert_chain_verify_depth: Handle value of 0

### DIFF
--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -1357,7 +1357,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
   if (setup_data->cert_chain_validation) {
     gnutls_certificate_set_verify_limits(*pki_credentials,
                                          0,
-                                         setup_data->cert_chain_verify_depth);
+                                      setup_data->cert_chain_verify_depth + 2);
   }
 
   /*

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -401,7 +401,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
     }
   }
   if (setup_data->cert_chain_validation &&
-      depth > (setup_data->cert_chain_verify_depth)) {
+      depth > (setup_data->cert_chain_verify_depth + 1)) {
     *flags |= MBEDTLS_X509_BADCERT_OTHER;
     coap_log(LOG_WARNING,
              "   %s: %s: '%s' depth %d\n",


### PR DESCRIPTION
If cert_chain_verify_depth is 0 and cert_chain_validation is set in
coap_dtls_pki_t, then a Cert + its signing CA should be valid (no intermediary
CAs).

src/coap_gnutls.c:
src/coap_mbedtls.c:
src/coap_openssl.c:

Correct set and check cert_chain_verify_depth.

src/coap_openssl.c:

Fix building on openssl-1.1.0