### PR TITLE
Ubuntu 20.4: Fix builds as Ubuntu 20.4 will be used by github workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,6 @@ jobs:
         TLS: ["no", "openssl", "gnutls", "mbedtls"]
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: recursive
       - name: setup
         run: |
           sudo apt-get update && sudo apt-get install -y libcunit1-dev libmbedtls-dev libgnutls28-dev libtool libtool-bin exuberant-ctags valgrind
@@ -36,13 +34,13 @@ jobs:
         run: |
           mkdir build-${{matrix.TLS}}-${{matrix.CC}}
           cd build-${{matrix.TLS}}-${{matrix.CC}}
-          $GITHUB_WORKSPACE/configure --disable-documentation --enable-examples --enable-tests --disable-dtls CC=${{matrix.CC}}
+          $GITHUB_WORKSPACE/configure --disable-silent-rules --disable-documentation --enable-examples --enable-tests --disable-dtls CC=${{matrix.CC}}
       - name: configure TLS
         if: matrix.TLS != 'no'
         run: |
           mkdir build-${{matrix.TLS}}-${{matrix.CC}}
           cd build-${{matrix.TLS}}-${{matrix.CC}}
-          "$GITHUB_WORKSPACE/configure" --disable-documentation --enable-examples --enable-tests --with-${{matrix.TLS}} CC=${{matrix.CC}}
+          "$GITHUB_WORKSPACE/configure" --disable-silent-rules --disable-documentation --enable-examples --enable-tests --with-${{matrix.TLS}} CC=${{matrix.CC}}
       - name: compile
         run: |
           cd build-${{matrix.TLS}}-${{matrix.CC}}
@@ -63,7 +61,7 @@ jobs:
           ./autogen.sh
       - name: configure
         run: |
-          $GITHUB_WORKSPACE/configure --disable-documentation --enable-examples --enable-tests --with-tinydtls
+          $GITHUB_WORKSPACE/configure --disable-silent-rules --disable-documentation --enable-examples --enable-tests --with-tinydtls
       - name: compile
         run: |
           make EXTRA_CFLAGS=-Werror && make check EXTRA_CFLAGS=-Werror
@@ -72,21 +70,30 @@ jobs:
           LD_LIBRARY_PATH=ext/tinydtls libtool --mode=execute valgrind --track-origins=yes --leak-check=yes --show-reachable=yes --error-exitcode=123 --quiet --suppressions=$GITHUB_WORKSPACE/tests/valgrind_suppression tests/testdriver
   cmake-build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        TLS: ["no", "openssl", "gnutls", "mbedtls", "tinydtls"]
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: setup
         run: |
-          sudo apt-get update && sudo apt-get install -y libcunit1-dev libgnutls28-dev
-          cmake -E make_directory $GITHUB_WORKSPACE}/build
-      - name: configure
+          sudo apt-get update && sudo apt-get install -y libcunit1-dev libmbedtls-dev libgnutls28-dev
+          cmake -E make_directory $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
+      - name: configure no-TLS
+        if: matrix.TLS == 'no'
         run: |
-          cd $GITHUB_WORKSPACE}/build
-          cmake $GITHUB_WORKSPACE -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -DENABLE_DTLS=ON -DDTLS_BACKEND=gnutls
+          cd $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
+          cmake $GITHUB_WORKSPACE -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -DENABLE_DTLS=OFF -DENABLE_DOCS=OFF
+      - name: configure TLS
+        if: matrix.TLS != 'no'
+        run: |
+          cd $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
+          cmake $GITHUB_WORKSPACE -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -DENABLE_DTLS=ON -DENABLE_DOCS=OFF -DDTLS_BACKEND=${{matrix.TLS}}
       - name: build
         run: |
-          cd $GITHUB_WORKSPACE}/build
+          cd $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
           cmake --build .
   other-build:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,7 @@ target_sources(
           ${CMAKE_CURRENT_LIST_DIR}/src/option.c
           ${CMAKE_CURRENT_LIST_DIR}/src/async.c
           ${CMAKE_CURRENT_LIST_DIR}/src/block.c
+          ${CMAKE_CURRENT_LIST_DIR}/src/coap_asn1.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_cache.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_debug.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_event.c

--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -41,7 +41,7 @@ vpath %.c $(top_srcdir)/src
 
 COAPOBJS = net.o coap_cache.o coap_debug.o option.o resource.o pdu.o encode.o subscribe.o coap_io_lwip.o block.o uri.o str.o coap_session.o coap_notls.o coap_hashkey.o address.o coap_tcp.o async.o
 
-CFLAGS += -g3 -Wall -Wextra -pedantic -O0 -fpack-struct
+CFLAGS += -g3 -Wall -Wextra -pedantic -O0
 # not sorted out yet
 CFLAGS += -Wno-unused-parameter
 

--- a/include/coap2/encode.h
+++ b/include/coap2/encode.h
@@ -18,15 +18,6 @@
 
 #include <stdint.h>
 
-#define Nn 8  /* duplicate definition of N if built on sky motes */
-#define ENCODE_HEADER_SIZE 4
-#define HIBIT (1 << (Nn - 1))
-#define EMASK ((1 << ENCODE_HEADER_SIZE) - 1)
-#define MMASK ((1 << Nn) - 1 - EMASK)
-#define MAX_VALUE ( (1 << Nn) - (1 << ENCODE_HEADER_SIZE) ) * (1 << ((1 << ENCODE_HEADER_SIZE) - 1))
-
-#define COAP_PSEUDOFP_DECODE_8_4(r) (r < HIBIT ? r : (r & MMASK) << (r & EMASK))
-
 #ifndef HAVE_FLS
 /* include this only if fls() is not available */
 extern int coap_fls(unsigned int i);
@@ -40,10 +31,6 @@ extern int coap_flsll(long long i);
 #else
 #define coap_flsll(i) flsll(i)
 #endif
-
-/* ls and s must be integer variables */
-#define COAP_PSEUDOFP_ENCODE_8_4_DOWN(v,ls) (v < HIBIT ? v : (ls = coap_fls(v) - Nn, (v >> ls) & MMASK) + ls)
-#define COAP_PSEUDOFP_ENCODE_8_4_UP(v,ls,s) (v < HIBIT ? v : (ls = coap_fls(v) - Nn, (s = (((v + ((1<<ENCODE_HEADER_SIZE<<ls)-1)) >> ls) & MMASK)), s == 0 ? HIBIT + ls + 1 : s + ls))
 
 /**
  * @defgroup encode Encode / Decode API

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -43,6 +43,8 @@
   -Wunused \
   -Wwrite-strings \
   -Wno-unused-function \
+  -Wno-unused-but-set-variable \
+  -Werror \
   "
 #endif /* ! _WIN32 */
 
@@ -137,7 +139,7 @@ int main(int argc, char* argv[])
         if (in_synopsis) {
           /* Working in SYNOPSIS section */
           size_t len;
-          char outbuf[512];
+          char outbuf[1024];
           char *cp;
           char *ecp;
 


### PR DESCRIPTION
CMakeLists.txt:

Add in missing file.

configure.ac:

Add in -Werror option so warnings are easily caught.

examples/tiny.c:
include/coap2/encode.h:

Fix COAP_PSEUDOFP_ENCODE_8_4_DOWN 'ls' ordering complaint.

man/examples-code-check.c:

Fix compile warning, allow 'Unused but set variables' in examples and set
-Werror when compling the examples.

examples/lwip/Makefile:

Add in compilation option -Wno-address-of-packed-member to remove warnings.