### PR TITLE
variables: Remove size changing warnings when using Visual Studio

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -18,6 +18,7 @@
 #ifdef _WIN32
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
+#define fileno _fileno
 #include "getopt.c"
 #if !defined(S_ISDIR)
 #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -631,7 +631,7 @@ resolve_address(const coap_str_const_t *server, struct sockaddr *dst) {
     switch (ainfo->ai_family) {
     case AF_INET6:
     case AF_INET:
-      len = ainfo->ai_addrlen;
+      len = (int)ainfo->ai_addrlen;
       memcpy(dst, ainfo->ai_addr, len);
       goto finish;
     default:
@@ -2898,6 +2898,9 @@ main(int argc, char **argv) {
   free(proxy_list);
   proxy_list = NULL;
   proxy_list_count = 0;
+#ifdef _WIN32
+#pragma warning( disable : 4090 )
+#endif
   coap_free(proxy_host_name_list);
 #endif /* SERVER_CAN_PROXY */
 

--- a/include/coap2/coap_block_internal.h
+++ b/include/coap2/coap_block_internal.h
@@ -105,7 +105,7 @@ struct coap_lg_crcv_t {
   uint8_t last_type;     /**< Last request type (CON/NON) */
   uint8_t initial;       /**< If set, has not been used yet */
   uint8_t szx;           /**< size of individual blocks */
-  uint32_t total_len;    /**< Length as indicated by SIZE2 option */
+  size_t total_len;      /**< Length as indicated by SIZE2 option */
   coap_binary_t *body_data; /**< Used for re-assembling entire body */
   coap_binary_t *app_token; /**< app requesting PDU token */
   uint8_t base_token[8]; /**< established base PDU token */
@@ -132,7 +132,7 @@ struct coap_lg_srcv_t {
   uint16_t content_format; /**< Content format for the set of blocks */
   uint8_t last_type;     /**< Last request type (CON/NON) */
   uint8_t szx;           /**< size of individual blocks */
-  uint32_t total_len;    /**< Length as indicated by SIZE1 option */
+  size_t total_len;      /**< Length as indicated by SIZE1 option */
   coap_binary_t *body_data; /**< Used for re-assembling entire body */
   size_t amount_so_far;  /**< Amount of data seen so far */
   coap_resource_t *resource; /**< associated resource */

--- a/include/coap2/coap_prng.h
+++ b/include/coap2/coap_prng.h
@@ -89,7 +89,7 @@ void coap_set_prng(coap_rand_func_t rng);
  *
  * @param seed  The seed for the pseudo random number generator.
  */
-void coap_prng_init(unsigned long seed);
+void coap_prng_init(unsigned int seed);
 
 /**
  * Fills @p buf with @p len random bytes using the default pseudo

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -62,8 +62,8 @@ typedef struct coap_session_t {
   coap_session_type_t type;         /**< client or server side socket */
   coap_session_state_t state;       /**< current state of relationaship with peer */
   unsigned ref;                     /**< reference count from queues */
-  unsigned tls_overhead;            /**< overhead of TLS layer */
-  uint64_t mtu;                     /**< path or CSM mtu */
+  size_t tls_overhead;              /**< overhead of TLS layer */
+  size_t mtu;                     /**< path or CSM mtu */
   coap_address_t local_if;          /**< optional local interface address */
   UT_hash_handle hh;
   coap_addr_tuple_t addr_info;      /**< key: remote/local address info */

--- a/include/coap2/encode.h
+++ b/include/coap2/encode.h
@@ -47,7 +47,7 @@ extern int coap_flsll(long long i);
  *
  * @return      The decoded value
  */
-unsigned int coap_decode_var_bytes(const uint8_t *buf, unsigned int length);
+unsigned int coap_decode_var_bytes(const uint8_t *buf, size_t length);
 
 /**
  * Decodes multiple-length byte sequences. @p buf points to an input byte
@@ -58,7 +58,7 @@ unsigned int coap_decode_var_bytes(const uint8_t *buf, unsigned int length);
  *
  * @return      The decoded value
  */
-uint64_t coap_decode_var_bytes8(const uint8_t *buf, unsigned int length);
+uint64_t coap_decode_var_bytes8(const uint8_t *buf, size_t length);
 
 /**
  * Encodes multiple-length byte sequences. @p buf points to an output buffer of

--- a/include/coap2/pdu.h
+++ b/include/coap2/pdu.h
@@ -618,7 +618,7 @@ size_t coap_insert_option(coap_pdu_t *pdu, uint16_t type,
  *
  * Internal use only.
  */
-int coap_update_option(coap_pdu_t *pdu,
+size_t coap_update_option(coap_pdu_t *pdu,
                        uint16_t type,
                        size_t len,
                        const uint8_t *data);

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -2215,7 +2215,8 @@ void coap_dtls_session_update_mtu(coap_session_t *c_session) {
   int ret;
 
   if (g_env)
-    G_CHECK(gnutls_dtls_set_data_mtu(g_env->g_session, c_session->mtu),
+    G_CHECK(gnutls_dtls_set_data_mtu(g_env->g_session,
+                                     (unsigned int)c_session->mtu),
             "gnutls_dtls_set_data_mtu");
 fail:
   ;;

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -542,6 +542,7 @@ static __declspec(thread) LPFN_WSARECVMSG lpWSARecvMsg = NULL;
 #undef CMSG_DATA
 #define CMSG_DATA WSA_CMSG_DATA
 #define ipi_spec_dst ipi_addr
+#pragma warning( disable : 4116 )
 #else
 #define iov_len_t size_t
 #endif

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -938,7 +938,7 @@ static int setup_server_ssl_session(coap_session_t *c_session,
                                 mbedtls_ssl_cookie_check,
                                 &m_env->cookie_ctx );
 #if MBEDTLS_VERSION_NUMBER >= 0x02100100
-  mbedtls_ssl_set_mtu(&m_env->ssl, c_session->mtu);
+  mbedtls_ssl_set_mtu(&m_env->ssl, (uint16_t)c_session->mtu);
 #endif /* MBEDTLS_VERSION_NUMBER >= 0x02100100 */
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
 fail:
@@ -1111,7 +1111,7 @@ static int setup_client_ssl_session(coap_session_t *c_session,
     }
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 #if MBEDTLS_VERSION_NUMBER >= 0x02100100
-    mbedtls_ssl_set_mtu(&m_env->ssl, c_session->mtu);
+    mbedtls_ssl_set_mtu(&m_env->ssl, (uint16_t)c_session->mtu);
 #endif /* MBEDTLS_VERSION_NUMBER >= 0x02100100 */
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
     set_ciphersuites(&m_env->conf, COAP_ENC_PKI);
@@ -1543,7 +1543,7 @@ void *coap_dtls_new_server_session(coap_session_t *c_session)
   if (m_env) {
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 #if MBEDTLS_VERSION_NUMBER >= 0x02100100
-    mbedtls_ssl_set_mtu(&m_env->ssl, c_session->mtu);
+    mbedtls_ssl_set_mtu(&m_env->ssl, (uint16_t)c_session->mtu);
 #endif /* MBEDTLS_VERSION_NUMBER >= 0x02100100 */
 #endif /* MBEDTLS_SSL_PROTO_DTLS */
   }
@@ -1567,7 +1567,7 @@ void coap_dtls_session_update_mtu(coap_session_t *c_session)
          (coap_mbedtls_env_t *)c_session->tls;
   if (m_env) {
 #if MBEDTLS_VERSION_NUMBER >= 0x02100100
-    mbedtls_ssl_set_mtu(&m_env->ssl, c_session->mtu);
+    mbedtls_ssl_set_mtu(&m_env->ssl, (uint16_t)c_session->mtu);
 #endif /* MBEDTLS_VERSION_NUMBER >= 0x02100100 */
   }
 #endif /* MBEDTLS_SSL_PROTO_DTLS */

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -2754,7 +2754,7 @@ void * coap_dtls_new_server_session(coap_session_t *session) {
   SSL_set_bio(nssl, nbio, nbio);
   SSL_set_app_data(nssl, NULL);
   SSL_set_options(nssl, SSL_OP_COOKIE_EXCHANGE);
-  SSL_set_mtu(nssl, session->mtu);
+  SSL_set_mtu(nssl, (long)session->mtu);
   ssl = dtls->ssl;
   dtls->ssl = nssl;
   nssl = NULL;
@@ -2888,7 +2888,7 @@ void *coap_dtls_new_client_session(coap_session_t *session) {
   SSL_set_bio(ssl, bio, bio);
   SSL_set_app_data(ssl, session);
   SSL_set_options(ssl, SSL_OP_COOKIE_EXCHANGE);
-  SSL_set_mtu(ssl, session->mtu);
+  SSL_set_mtu(ssl, (long)session->mtu);
 
   if (!setup_client_ssl_session(session, ssl))
     goto error;
@@ -2916,7 +2916,7 @@ error:
 void coap_dtls_session_update_mtu(coap_session_t *session) {
   SSL *ssl = (SSL *)session->tls;
   if (ssl)
-    SSL_set_mtu(ssl, session->mtu);
+    SSL_set_mtu(ssl, (long)session->mtu);
 }
 
 void coap_dtls_free_session(coap_session_t *session) {
@@ -3006,7 +3006,7 @@ int coap_dtls_hello(coap_session_t *session,
   coap_ssl_data *ssl_data;
   int r;
 
-  SSL_set_mtu(dtls->ssl, session->mtu);
+  SSL_set_mtu(dtls->ssl, (long)session->mtu);
   ssl_data = (coap_ssl_data*)BIO_get_data(SSL_get_rbio(dtls->ssl));
   assert(ssl_data != NULL);
   if (ssl_data->pdu_len) {

--- a/src/coap_prng.c
+++ b/src/coap_prng.c
@@ -71,7 +71,7 @@ coap_set_prng(coap_rand_func_t rng) {
 }
 
 void
-coap_prng_init(unsigned long seed) {
+coap_prng_init(unsigned int seed) {
 #ifdef HAVE_GETRANDOM
   /* No seed to seed the random source if getrandom() is used,
    * see dtls_prng(). */

--- a/src/encode.c
+++ b/src/encode.c
@@ -26,7 +26,7 @@ int coap_flsll(long long i)
 #endif
 
 unsigned int
-coap_decode_var_bytes(const uint8_t *buf,unsigned int len) {
+coap_decode_var_bytes(const uint8_t *buf, size_t len) {
   unsigned int i, n = 0;
   for (i = 0; i < len; ++i)
     n = (n << 8) + buf[i];
@@ -55,7 +55,7 @@ coap_encode_var_safe(uint8_t *buf, size_t length, unsigned int val) {
 }
 
 uint64_t
-coap_decode_var_bytes8(const uint8_t *buf,unsigned int len) {
+coap_decode_var_bytes8(const uint8_t *buf, size_t len) {
   unsigned int i;
   uint64_t n = 0;
   for (i = 0; i < len; ++i)

--- a/src/net.c
+++ b/src/net.c
@@ -1095,7 +1095,7 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
     if (coap_print_addr(&session->addr_info.local, (uint8_t*)addr_str,
                             sizeof(addr_str) - 1)) {
       char *cp;
-      int len;
+      size_t len;
 
       if (addr_str[0] == '[') {
         cp = strchr(addr_str, ']');
@@ -3094,7 +3094,7 @@ void coap_startup(void) {
   coap_ticks(&now);
   us = coap_ticks_to_rt_us(now);
   /* Be accurate to the nearest (approx) us */
-  coap_prng_init(us);
+  coap_prng_init((unsigned int)us);
   coap_memory_init();
   coap_dtls_startup();
 }

--- a/win32/coap-client/coap-client.vcxproj
+++ b/win32/coap-client/coap-client.vcxproj
@@ -333,7 +333,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\examples\client.c" />
+    <ClCompile Include="..\..\examples\coap-client.c" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libcoap.vcxproj">


### PR DESCRIPTION
Change some of the types of variables, and cast change sizes where known to
be safe.

There still are some C4116 warning and a couple of C4090 warning which are OK,
so disabled by a #pragma.