### PR TITLE
COAP_UNUSED: Remove UNUSED and UNUSED_PARAM and use COAP_UNUSED instead

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -131,17 +131,11 @@ int doing_observe = 0;
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #endif
 
-#ifdef __GNUC__
-#define UNUSED_PARAM __attribute__ ((unused))
-#else /* not a GCC */
-#define UNUSED_PARAM
-#endif /* GCC */
-
 static int quit = 0;
 
 /* SIGINT handler: set quit to 1 for graceful termination */
 static void
-handle_sigint(int signum UNUSED_PARAM) {
+handle_sigint(int signum COAP_UNUSED) {
   quit = 1;
 }
 
@@ -184,7 +178,7 @@ close_output(void) {
 }
 
 static void
-free_xmit_data(coap_session_t *session UNUSED_PARAM, void *app_ptr) {
+free_xmit_data(coap_session_t *session COAP_UNUSED, void *app_ptr) {
   coap_free(app_ptr);
   return;
 }
@@ -277,9 +271,9 @@ check_token(coap_pdu_t *received) {
 }
 
 static int
-event_handler(coap_context_t *ctx UNUSED_PARAM,
+event_handler(coap_context_t *ctx COAP_UNUSED,
               coap_event_t event,
-              struct coap_session_t *session UNUSED_PARAM) {
+              struct coap_session_t *session COAP_UNUSED) {
 
   switch(event) {
   case COAP_EVENT_DTLS_CLOSED:
@@ -294,11 +288,11 @@ event_handler(coap_context_t *ctx UNUSED_PARAM,
 }
 
 static void
-nack_handler(coap_context_t *context UNUSED_PARAM,
-             coap_session_t *session UNUSED_PARAM,
-             coap_pdu_t *sent UNUSED_PARAM,
+nack_handler(coap_context_t *context COAP_UNUSED,
+             coap_session_t *session COAP_UNUSED,
+             coap_pdu_t *sent COAP_UNUSED,
              coap_nack_reason_t reason,
-             const coap_tid_t id UNUSED_PARAM) {
+             const coap_tid_t id COAP_UNUSED) {
 
   switch(reason) {
   case COAP_NACK_TOO_MANY_RETRIES:
@@ -318,11 +312,11 @@ nack_handler(coap_context_t *context UNUSED_PARAM,
  * Response handler used for coap_send_large() responses
  */
 static coap_response_t
-message_handler(struct coap_context_t *ctx UNUSED_PARAM,
-                coap_session_t *session UNUSED_PARAM,
+message_handler(struct coap_context_t *ctx COAP_UNUSED,
+                coap_session_t *session COAP_UNUSED,
                 coap_pdu_t *sent,
                 coap_pdu_t *received,
-                const coap_tid_t id UNUSED_PARAM) {
+                const coap_tid_t id COAP_UNUSED) {
 
   coap_opt_t *block_opt;
   coap_opt_iterator_t opt_iter;
@@ -1176,12 +1170,12 @@ static uint8_t *read_file_mem(const char* filename, size_t *length) {
 
 static int
 verify_cn_callback(const char *cn,
-                   const uint8_t *asn1_public_cert UNUSED_PARAM,
-                   size_t asn1_length UNUSED_PARAM,
-                   coap_session_t *session UNUSED_PARAM,
+                   const uint8_t *asn1_public_cert COAP_UNUSED,
+                   size_t asn1_length COAP_UNUSED,
+                   coap_session_t *session COAP_UNUSED,
                    unsigned depth,
-                   int validated UNUSED_PARAM,
-                   void *arg UNUSED_PARAM
+                   int validated COAP_UNUSED,
+                   void *arg COAP_UNUSED
 ) {
   coap_log(LOG_INFO, "CN '%s' presented by server (%s)\n",
            cn, depth ? "CA" : "Certificate");
@@ -1190,7 +1184,7 @@ verify_cn_callback(const char *cn,
 
 static const coap_dtls_cpsk_info_t *
 verify_ih_callback(coap_str_const_t *hint,
-                   coap_session_t *c_session UNUSED_PARAM,
+                   coap_session_t *c_session COAP_UNUSED,
                    void *arg
 ) {
   coap_dtls_cpsk_info_t *psk_info = (coap_dtls_cpsk_info_t *)arg;

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -74,12 +74,6 @@ typedef struct rd_t {
 
 rd_t *resources = NULL;
 
-#ifdef __GNUC__
-#define UNUSED_PARAM __attribute__ ((unused))
-#else /* not a GCC */
-#define UNUSED_PARAM
-#endif /* GCC */
-
 static ssize_t
 cmdline_read_key(char *arg, unsigned char *buf, size_t maxlen) {
   size_t len = strnlen(arg, maxlen);
@@ -112,17 +106,17 @@ static int quit = 0;
 
 /* SIGINT handler: set quit to 1 for graceful termination */
 static void
-handle_sigint(int signum UNUSED_PARAM) {
+handle_sigint(int signum COAP_UNUSED) {
   quit = 1;
 }
 
 static void
-hnd_get_resource(coap_context_t  *ctx UNUSED_PARAM,
+hnd_get_resource(coap_context_t  *ctx COAP_UNUSED,
                  coap_resource_t *resource,
-                 coap_session_t *session UNUSED_PARAM,
-                 coap_pdu_t *request UNUSED_PARAM,
-                 coap_binary_t *token UNUSED_PARAM,
-                 coap_string_t *query UNUSED_PARAM,
+                 coap_session_t *session COAP_UNUSED,
+                 coap_pdu_t *request COAP_UNUSED,
+                 coap_binary_t *token COAP_UNUSED,
+                 coap_string_t *query COAP_UNUSED,
                  coap_pdu_t *response) {
   rd_t *rd = NULL;
   unsigned char buf[3];
@@ -147,12 +141,12 @@ hnd_get_resource(coap_context_t  *ctx UNUSED_PARAM,
 }
 
 static void
-hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
-                 coap_resource_t *resource UNUSED_PARAM,
-                 coap_session_t *session UNUSED_PARAM,
-                 coap_pdu_t *request UNUSED_PARAM,
-                 coap_binary_t *token UNUSED_PARAM,
-                 coap_string_t *query UNUSED_PARAM,
+hnd_put_resource(coap_context_t  *ctx COAP_UNUSED,
+                 coap_resource_t *resource COAP_UNUSED,
+                 coap_session_t *session COAP_UNUSED,
+                 coap_pdu_t *request COAP_UNUSED,
+                 coap_binary_t *token COAP_UNUSED,
+                 coap_string_t *query COAP_UNUSED,
                  coap_pdu_t *response) {
 #if 1
   response->code = COAP_RESPONSE_CODE_NOT_IMPLEMENTED;
@@ -228,10 +222,10 @@ hnd_put_resource(coap_context_t  *ctx UNUSED_PARAM,
 static void
 hnd_delete_resource(coap_context_t  *ctx,
                     coap_resource_t *resource,
-                    coap_session_t *session UNUSED_PARAM,
-                    coap_pdu_t *request UNUSED_PARAM,
-                    coap_binary_t *token UNUSED_PARAM,
-                    coap_string_t *query UNUSED_PARAM,
+                    coap_session_t *session COAP_UNUSED,
+                    coap_pdu_t *request COAP_UNUSED,
+                    coap_binary_t *token COAP_UNUSED,
+                    coap_string_t *query COAP_UNUSED,
                     coap_pdu_t *response) {
   rd_t *rd = NULL;
   coap_str_const_t* uri_path = coap_resource_get_uri_path(resource);
@@ -250,12 +244,12 @@ hnd_delete_resource(coap_context_t  *ctx,
 }
 
 static void
-hnd_get_rd(coap_context_t  *ctx UNUSED_PARAM,
-           coap_resource_t *resource UNUSED_PARAM,
-           coap_session_t *session UNUSED_PARAM,
-           coap_pdu_t *request UNUSED_PARAM,
-           coap_binary_t *token UNUSED_PARAM,
-           coap_string_t *query UNUSED_PARAM,
+hnd_get_rd(coap_context_t  *ctx COAP_UNUSED,
+           coap_resource_t *resource COAP_UNUSED,
+           coap_session_t *session COAP_UNUSED,
+           coap_pdu_t *request COAP_UNUSED,
+           coap_binary_t *token COAP_UNUSED,
+           coap_string_t *query COAP_UNUSED,
            coap_pdu_t *response) {
   unsigned char buf[3];
 
@@ -416,11 +410,11 @@ make_rd(coap_pdu_t *pdu) {
 
 static void
 hnd_post_rd(coap_context_t  *ctx,
-            coap_resource_t *resource UNUSED_PARAM,
+            coap_resource_t *resource COAP_UNUSED,
             coap_session_t *session,
             coap_pdu_t *request,
-            coap_binary_t *token UNUSED_PARAM,
-            coap_string_t *query UNUSED_PARAM,
+            coap_binary_t *token COAP_UNUSED,
+            coap_string_t *query COAP_UNUSED,
             coap_pdu_t *response) {
   coap_resource_t *r;
 #define LOCSIZE 68

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -165,15 +165,9 @@ typedef struct transient_value_t {
 static transient_value_t *example_data_value = NULL;
 static int example_data_media_type = COAP_MEDIATYPE_TEXT_PLAIN;
 
-#ifdef __GNUC__
-#define UNUSED_PARAM __attribute__ ((unused))
-#else /* not a GCC */
-#define UNUSED_PARAM
-#endif /* GCC */
-
 /* SIGINT handler: set quit to 1 for graceful termination */
 static void
-handle_sigint(int signum UNUSED_PARAM) {
+handle_sigint(int signum COAP_UNUSED) {
   quit = 1;
 }
 
@@ -202,7 +196,7 @@ alloc_resource_data(coap_binary_t *value) {
  * being read by a blocked response to GET.
  */
 static void
-release_resource_data(coap_session_t *session UNUSED_PARAM,
+release_resource_data(coap_session_t *session COAP_UNUSED,
                       void *app_ptr) {
   transient_value_t *transient_value = (transient_value_t *)app_ptr;
 
@@ -219,12 +213,12 @@ release_resource_data(coap_session_t *session UNUSED_PARAM,
               "Copyright (C) 2010--2021 Olaf Bergmann <bergmann@tzi.org> and others\n\n"
 
 static void
-hnd_get_index(coap_context_t *ctx UNUSED_PARAM,
+hnd_get_index(coap_context_t *ctx COAP_UNUSED,
               coap_resource_t *resource,
               coap_session_t *session,
               coap_pdu_t *request,
               coap_binary_t *token,
-              coap_string_t *query UNUSED_PARAM,
+              coap_string_t *query COAP_UNUSED,
               coap_pdu_t *response) {
 
   response->code = COAP_RESPONSE_CODE_CONTENT;
@@ -235,7 +229,7 @@ hnd_get_index(coap_context_t *ctx UNUSED_PARAM,
 }
 
 static void
-hnd_get_time(coap_context_t  *ctx UNUSED_PARAM,
+hnd_get_time(coap_context_t  *ctx COAP_UNUSED,
              coap_resource_t *resource,
              coap_session_t *session,
              coap_pdu_t *request,
@@ -284,12 +278,12 @@ hnd_get_time(coap_context_t  *ctx UNUSED_PARAM,
 }
 
 static void
-hnd_put_time(coap_context_t *ctx UNUSED_PARAM,
+hnd_put_time(coap_context_t *ctx COAP_UNUSED,
              coap_resource_t *resource,
-             coap_session_t *session UNUSED_PARAM,
+             coap_session_t *session COAP_UNUSED,
              coap_pdu_t *request,
-             coap_binary_t *token UNUSED_PARAM,
-             coap_string_t *query UNUSED_PARAM,
+             coap_binary_t *token COAP_UNUSED,
+             coap_string_t *query COAP_UNUSED,
              coap_pdu_t *response) {
   coap_tick_t t;
   size_t size;
@@ -334,13 +328,13 @@ hnd_put_time(coap_context_t *ctx UNUSED_PARAM,
 }
 
 static void
-hnd_delete_time(coap_context_t *ctx UNUSED_PARAM,
-                coap_resource_t *resource UNUSED_PARAM,
-                coap_session_t *session UNUSED_PARAM,
-                coap_pdu_t *request UNUSED_PARAM,
-                coap_binary_t *token UNUSED_PARAM,
-                coap_string_t *query UNUSED_PARAM,
-                coap_pdu_t *response UNUSED_PARAM) {
+hnd_delete_time(coap_context_t *ctx COAP_UNUSED,
+                coap_resource_t *resource COAP_UNUSED,
+                coap_session_t *session COAP_UNUSED,
+                coap_pdu_t *request COAP_UNUSED,
+                coap_binary_t *token COAP_UNUSED,
+                coap_string_t *query COAP_UNUSED,
+                coap_pdu_t *response COAP_UNUSED) {
   my_clock_base = 0;    /* mark clock as "deleted" */
 
   /* type = request->hdr->type == COAP_MESSAGE_CON  */
@@ -350,11 +344,11 @@ hnd_delete_time(coap_context_t *ctx UNUSED_PARAM,
 #ifndef WITHOUT_ASYNC
 static void
 hnd_get_async(coap_context_t *ctx,
-              coap_resource_t *resource UNUSED_PARAM,
+              coap_resource_t *resource COAP_UNUSED,
               coap_session_t *session,
               coap_pdu_t *request,
-              coap_binary_t *token UNUSED_PARAM,
-              coap_string_t *query UNUSED_PARAM,
+              coap_binary_t *token COAP_UNUSED,
+              coap_string_t *query COAP_UNUSED,
               coap_pdu_t *response) {
   unsigned long delay = 5;
   size_t size;
@@ -439,7 +433,7 @@ check_async(coap_context_t *ctx,
  */
 
 static void
-hnd_get_example_data(coap_context_t *ctx UNUSED_PARAM,
+hnd_get_example_data(coap_context_t *ctx COAP_UNUSED,
         coap_resource_t *resource,
         coap_session_t *session,
         coap_pdu_t *request,
@@ -483,12 +477,12 @@ cache_free_app_data(void *data) {
  */
 
 static void
-hnd_put_example_data(coap_context_t *ctx UNUSED_PARAM,
+hnd_put_example_data(coap_context_t *ctx COAP_UNUSED,
         coap_resource_t *resource,
         coap_session_t *session,
         coap_pdu_t *request,
-        coap_binary_t *token UNUSED_PARAM,
-        coap_string_t *query UNUSED_PARAM,
+        coap_binary_t *token COAP_UNUSED,
+        coap_string_t *query COAP_UNUSED,
         coap_pdu_t *response
 ) {
   size_t size;
@@ -986,14 +980,14 @@ get_ongoing_proxy_session(coap_session_t *session, coap_pdu_t *response,
 }
 
 static void
-release_proxy_body_data(coap_session_t *session UNUSED_PARAM,
+release_proxy_body_data(coap_session_t *session COAP_UNUSED,
                        void *app_ptr) {
   coap_delete_binary(app_ptr);
 }
 
 static void
-hnd_proxy_uri(coap_context_t *ctx UNUSED_PARAM,
-                coap_resource_t *resource UNUSED_PARAM,
+hnd_proxy_uri(coap_context_t *ctx COAP_UNUSED,
+                coap_resource_t *resource COAP_UNUSED,
                 coap_session_t *session,
                 coap_pdu_t *request,
                 coap_binary_t *token,
@@ -1244,10 +1238,10 @@ static dynamic_resource_t *dynamic_entry = NULL;
 static void
 hnd_delete(coap_context_t *ctx,
            coap_resource_t *resource,
-           coap_session_t *session,
+           coap_session_t *session COAP_UNUSED,
            coap_pdu_t *request,
-           coap_binary_t *token UNUSED_PARAM,
-           coap_string_t *query UNUSED_PARAM,
+           coap_binary_t *token COAP_UNUSED,
+           coap_string_t *query COAP_UNUSED,
            coap_pdu_t *response
 ) {
   int i;
@@ -1287,7 +1281,7 @@ hnd_delete(coap_context_t *ctx,
  */
 
 static void
-hnd_get(coap_context_t *ctx UNUSED_PARAM,
+hnd_get(coap_context_t *ctx COAP_UNUSED,
         coap_resource_t *resource,
         coap_session_t *session,
         coap_pdu_t *request,
@@ -1343,12 +1337,12 @@ hnd_get(coap_context_t *ctx UNUSED_PARAM,
  */
 
 static void
-hnd_put(coap_context_t *ctx UNUSED_PARAM,
+hnd_put(coap_context_t *ctx COAP_UNUSED,
         coap_resource_t *resource,
-        coap_session_t *session UNUSED_PARAM,
+        coap_session_t *session,
         coap_pdu_t *request,
-        coap_binary_t *token UNUSED_PARAM,
-        coap_string_t *query UNUSED_PARAM,
+        coap_binary_t *token COAP_UNUSED,
+        coap_string_t *query COAP_UNUSED,
         coap_pdu_t *response
 ) {
   coap_string_t *uri_path;
@@ -1538,7 +1532,7 @@ hnd_put(coap_context_t *ctx UNUSED_PARAM,
 
 static void
 hnd_unknown_put(coap_context_t *ctx,
-                coap_resource_t *resource UNUSED_PARAM,
+                coap_resource_t *resource COAP_UNUSED,
                 coap_session_t *session,
                 coap_pdu_t *request,
                 coap_binary_t *token,
@@ -1581,7 +1575,7 @@ hnd_unknown_put(coap_context_t *ctx,
 
 #if SERVER_CAN_PROXY
 static int
-proxy_event_handler(coap_context_t *ctx UNUSED_PARAM,
+proxy_event_handler(coap_context_t *ctx COAP_UNUSED,
               coap_event_t event,
               struct coap_session_t *session) {
 
@@ -1599,11 +1593,11 @@ proxy_event_handler(coap_context_t *ctx UNUSED_PARAM,
 }
 
 static coap_response_t
-proxy_message_handler(struct coap_context_t *ctx UNUSED_PARAM,
+proxy_message_handler(struct coap_context_t *ctx COAP_UNUSED,
                 coap_session_t *session,
-                coap_pdu_t *sent UNUSED_PARAM,
+                coap_pdu_t *sent COAP_UNUSED,
                 coap_pdu_t *received,
-                const coap_tid_t id UNUSED_PARAM) {
+                const coap_tid_t id COAP_UNUSED) {
 
   coap_pdu_t *pdu = NULL;
   coap_session_t *incoming = NULL;
@@ -1720,11 +1714,11 @@ proxy_message_handler(struct coap_context_t *ctx UNUSED_PARAM,
 }
 
 static void
-proxy_nack_handler(coap_context_t *context UNUSED_PARAM,
+proxy_nack_handler(coap_context_t *context COAP_UNUSED,
              coap_session_t *session,
-             coap_pdu_t *sent UNUSED_PARAM,
+             coap_pdu_t *sent COAP_UNUSED,
              coap_nack_reason_t reason,
-             const coap_tid_t id UNUSED_PARAM) {
+             const coap_tid_t id COAP_UNUSED) {
 
   switch(reason) {
   case COAP_NACK_TOO_MANY_RETRIES:
@@ -1807,11 +1801,11 @@ init_resources(coap_context_t *ctx) {
 
 static int
 verify_cn_callback(const char *cn,
-                   const uint8_t *asn1_public_cert UNUSED_PARAM,
-                   size_t asn1_length UNUSED_PARAM,
-                   coap_session_t *session UNUSED_PARAM,
+                   const uint8_t *asn1_public_cert COAP_UNUSED,
+                   size_t asn1_length COAP_UNUSED,
+                   coap_session_t *session COAP_UNUSED,
                    unsigned depth,
-                   int validated UNUSED_PARAM,
+                   int validated COAP_UNUSED,
                    void *arg
 ) {
   union {
@@ -1858,7 +1852,7 @@ static uint8_t *read_file_mem(const char* file, size_t *length) {
 
 static coap_dtls_key_t *
 verify_pki_sni_callback(const char *sni,
-                    void *arg UNUSED_PARAM
+                    void *arg COAP_UNUSED
 ) {
   static coap_dtls_key_t dtls_key;
 
@@ -1915,8 +1909,8 @@ verify_pki_sni_callback(const char *sni,
 
 static const coap_dtls_spsk_info_t *
 verify_psk_sni_callback(const char *sni,
-                    coap_session_t *c_session UNUSED_PARAM,
-                    void *arg UNUSED_PARAM
+                    coap_session_t *c_session COAP_UNUSED,
+                    void *arg COAP_UNUSED
 ) {
   static coap_dtls_spsk_info_t psk_info;
 
@@ -1953,7 +1947,7 @@ verify_psk_sni_callback(const char *sni,
 static const coap_bin_const_t *
 verify_id_callback(coap_bin_const_t *identity,
                    coap_session_t *c_session,
-                   void *arg UNUSED_PARAM
+                   void *arg COAP_UNUSED
 ) {
   static coap_bin_const_t psk_key;
   size_t i;

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -27,12 +27,6 @@
 
 #define COAP_RESOURCE_CHECK_TIME_SEC  1
 
-#ifdef __GNUC__
-#define UNUSED_PARAM __attribute__ ((unused))
-#else /* not a GCC */
-#define UNUSED_PARAM
-#endif /* GCC */
-
 #ifndef min
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #endif
@@ -63,7 +57,7 @@ typedef union {
 
 /* SIGINT handler: set quit to 1 for graceful termination */
 static void
-handle_sigint(int signum UNUSED_PARAM) {
+handle_sigint(int signum COAP_UNUSED) {
   quit = 1;
 }
 
@@ -107,12 +101,12 @@ coap_free_userdata(void *data) {
 
 #if 0
 static void
-hnd_get_index(coap_context_t *ctx UNUSED_PARAM,
-              coap_resource_t *resource UNUSED_PARAM,
-              coap_session_t *session UNUSED_PARAM,
-              coap_pdu_t *request UNUSED_PARAM,
-              coap_binary_t *token UNUSED_PARAM,
-              coap_string_t *query UNUSED_PARAM,
+hnd_get_index(coap_context_t *ctx COAP_UNUSED,
+              coap_resource_t *resource COAP_UNUSED,
+              coap_session_t *session COAP_UNUSED,
+              coap_pdu_t *request COAP_UNUSED,
+              coap_binary_t *token COAP_UNUSED,
+              coap_string_t *query COAP_UNUSED,
               coap_pdu_t *response) {
   unsigned char buf[3];
 
@@ -131,12 +125,12 @@ hnd_get_index(coap_context_t *ctx UNUSED_PARAM,
 #endif
 
 static void
-hnd_get_resource(coap_context_t *ctx UNUSED_PARAM,
+hnd_get_resource(coap_context_t *ctx COAP_UNUSED,
                  coap_resource_t *resource,
-                 coap_session_t *session UNUSED_PARAM,
+                 coap_session_t *session COAP_UNUSED,
                  coap_pdu_t *request,
-                 coap_binary_t *token UNUSED_PARAM,
-                 coap_string_t *query UNUSED_PARAM,
+                 coap_binary_t *token COAP_UNUSED,
+                 coap_string_t *query COAP_UNUSED,
                  coap_pdu_t *response) {
   coap_payload_t *test_payload;
 
@@ -160,10 +154,10 @@ hnd_get_resource(coap_context_t *ctx UNUSED_PARAM,
 static void
 hnd_delete_resource(coap_context_t *ctx,
                     coap_resource_t *resource,
-                    coap_session_t *session UNUSED_PARAM,
-                    coap_pdu_t *request UNUSED_PARAM,
-                    coap_binary_t *token UNUSED_PARAM,
-                    coap_string_t *query UNUSED_PARAM,
+                    coap_session_t *session COAP_UNUSED,
+                    coap_pdu_t *request COAP_UNUSED,
+                    coap_binary_t *token COAP_UNUSED,
+                    coap_string_t *query COAP_UNUSED,
                     coap_pdu_t *response) {
   coap_payload_t *payload;
 
@@ -179,11 +173,11 @@ hnd_delete_resource(coap_context_t *ctx,
 
 static void
 hnd_post_test(coap_context_t *ctx,
-              coap_resource_t *resource UNUSED_PARAM,
-              coap_session_t *session UNUSED_PARAM,
+              coap_resource_t *resource COAP_UNUSED,
+              coap_session_t *session COAP_UNUSED,
               coap_pdu_t *request,
-              coap_binary_t *token UNUSED_PARAM,
-              coap_string_t *query UNUSED_PARAM,
+              coap_binary_t *token COAP_UNUSED,
+              coap_string_t *query COAP_UNUSED,
               coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
@@ -246,12 +240,12 @@ hnd_post_test(coap_context_t *ctx,
 }
 
 static void
-hnd_put_test(coap_context_t *ctx UNUSED_PARAM,
+hnd_put_test(coap_context_t *ctx COAP_UNUSED,
              coap_resource_t *resource,
-             coap_session_t *session UNUSED_PARAM,
+             coap_session_t *session COAP_UNUSED,
              coap_pdu_t *request,
-             coap_binary_t *token UNUSED_PARAM,
-             coap_string_t *query UNUSED_PARAM,
+             coap_binary_t *token COAP_UNUSED,
+             coap_string_t *query COAP_UNUSED,
              coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
@@ -301,12 +295,12 @@ hnd_put_test(coap_context_t *ctx UNUSED_PARAM,
 }
 
 static void
-hnd_delete_test(coap_context_t *ctx UNUSED_PARAM,
-                coap_resource_t *resource UNUSED_PARAM,
-                coap_session_t *session UNUSED_PARAM,
-                coap_pdu_t *request UNUSED_PARAM,
-                coap_binary_t *token UNUSED_PARAM,
-                coap_string_t *query UNUSED_PARAM,
+hnd_delete_test(coap_context_t *ctx COAP_UNUSED,
+                coap_resource_t *resource COAP_UNUSED,
+                coap_session_t *session COAP_UNUSED,
+                coap_pdu_t *request COAP_UNUSED,
+                coap_binary_t *token COAP_UNUSED,
+                coap_string_t *query COAP_UNUSED,
                 coap_pdu_t *response) {
   /* the ETSI validation tool does not like empty resources... */
 #if 0
@@ -321,12 +315,12 @@ hnd_delete_test(coap_context_t *ctx UNUSED_PARAM,
 }
 
 static void
-hnd_get_query(coap_context_t *ctx UNUSED_PARAM,
-              coap_resource_t *resource UNUSED_PARAM,
-              coap_session_t *session UNUSED_PARAM,
+hnd_get_query(coap_context_t *ctx COAP_UNUSED,
+              coap_resource_t *resource COAP_UNUSED,
+              coap_session_t *session COAP_UNUSED,
               coap_pdu_t *request,
-              coap_binary_t *token UNUSED_PARAM,
-              coap_string_t *query UNUSED_PARAM,
+              coap_binary_t *token COAP_UNUSED,
+              coap_string_t *query COAP_UNUSED,
               coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_filter_t f;
@@ -366,11 +360,11 @@ hnd_get_query(coap_context_t *ctx UNUSED_PARAM,
 /* handler for TD_COAP_CORE_16 */
 static void
 hnd_get_separate(coap_context_t *ctx,
-                 coap_resource_t *resource UNUSED_PARAM,
+                 coap_resource_t *resource COAP_UNUSED,
                  coap_session_t *session,
                  coap_pdu_t *request,
-                 coap_binary_t *token UNUSED_PARAM,
-                 coap_string_t *query UNUSED_PARAM,
+                 coap_binary_t *token COAP_UNUSED,
+                 coap_string_t *query COAP_UNUSED,
                  coap_pdu_t *response) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;

--- a/examples/tiny.c
+++ b/examples/tiny.c
@@ -21,12 +21,6 @@
 
 #include <coap2/coap.h>
 
-#ifdef __GNUC__
-#define UNUSED_PARAM __attribute__ ((unused))
-#else /* not a GCC */
-#define UNUSED_PARAM
-#endif /* GCC */
-
 #define Nn 8  /* duplicate definition of N if built on sky motes */
 #define ENCODE_HEADER_SIZE 4
 #define HIBIT (1 << (Nn - 1))
@@ -51,7 +45,7 @@ static int quit = 0;
 
 /* SIGINT handler: set quit to 1 for graceful termination */
 static void
-handle_sigint(int signum UNUSED_PARAM) {
+handle_sigint(int signum COAP_UNUSED) {
   quit = 1;
 }
 

--- a/include/coap2/libcoap.h
+++ b/include/coap2/libcoap.h
@@ -46,6 +46,13 @@ typedef USHORT in_port_t;
 #    define COAP_DEPRECATED __attribute__ ((deprecated))
 #  endif
 #endif
+#ifndef COAP_UNUSED
+#  ifdef __GNUC__
+#    define COAP_UNUSED __attribute__((unused))
+#  else /* __GNUC__ */
+#    define COAP_UNUSED
+#  endif /* __GNUC__ */
+#endif /* COAP_UNUSED */
 
 void coap_startup(void);
 

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -65,12 +65,6 @@
                             GNUTLS_KEY_KEY_CERT_SIGN
 #endif /* GNUTLS_VERSION_NUMBER >= 0x030606 */
 
-#ifdef __GNUC__
-#define UNUSED __attribute__((unused))
-#else /* __GNUC__ */
-#define UNUSED
-#endif /* __GNUC__ */
-
 #ifdef _WIN32
 #define strcasecmp _stricmp
 #endif
@@ -243,7 +237,7 @@ coap_gnutls_log_func(int level, const char* text)
 int
 coap_dtls_context_set_pki(coap_context_t *c_context,
                           const coap_dtls_pki_t* setup_data,
-                          const coap_dtls_role_t role UNUSED)
+                          const coap_dtls_role_t role COAP_UNUSED)
 {
   coap_gnutls_context_t *g_context =
                          ((coap_gnutls_context_t *)c_context->dtls_context);
@@ -410,7 +404,7 @@ coap_dtls_get_log_level(void) {
  *        NULL failure
  */
 void *
-coap_dtls_new_context(struct coap_context_t *c_context UNUSED) {
+coap_dtls_new_context(struct coap_context_t *c_context COAP_UNUSED) {
   const char *err;
   int ret;
   struct coap_gnutls_context_t *g_context =
@@ -895,8 +889,9 @@ static int cert_verify_callback_gnutls(gnutls_session_t g_session)
 
 static int
 pin_callback(void *user_data, int attempt,
-             const char *token_url UNUSED,
-             const char *token_label UNUSED, unsigned int flags UNUSED,
+             const char *token_url COAP_UNUSED,
+             const char *token_label COAP_UNUSED,
+             unsigned int flags COAP_UNUSED,
              char *pin,
              size_t pin_max)
 {
@@ -1381,7 +1376,7 @@ fail:
  */
 static int
 setup_psk_credentials(gnutls_psk_server_credentials_t *psk_credentials,
-                      coap_gnutls_context_t *g_context UNUSED,
+                      coap_gnutls_context_t *g_context COAP_UNUSED,
                       coap_dtls_spsk_t *setup_data)
 {
   int ret;
@@ -1924,7 +1919,7 @@ coap_dgram_write(gnutls_transport_ptr_t context, const void *send_buffer,
  *        -1 error (error in errno)
  */
 static int
-receive_timeout(gnutls_transport_ptr_t context, unsigned int ms UNUSED) {
+receive_timeout(gnutls_transport_ptr_t context, unsigned int ms COAP_UNUSED) {
   coap_session_t *c_session = (struct coap_session_t *)context;
 
   if (c_session) {
@@ -2288,7 +2283,7 @@ int coap_dtls_is_context_timeout(void) {
   return 0;
 }
 
-coap_tick_t coap_dtls_get_context_timeout(void *dtls_context UNUSED) {
+coap_tick_t coap_dtls_get_context_timeout(void *dtls_context COAP_UNUSED) {
   return 0;
 }
 
@@ -2514,7 +2509,7 @@ coap_dtls_hello(coap_session_t *c_session,
   return ret;
 }
 
-unsigned int coap_dtls_get_overhead(coap_session_t *c_session UNUSED) {
+unsigned int coap_dtls_get_overhead(coap_session_t *c_session COAP_UNUSED) {
   return 37;
 }
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -518,12 +518,6 @@ struct in_pktinfo {
 #define SOL_IP IPPROTO_IP
 #endif
 
-#ifdef __GNUC__
-#define UNUSED_PARAM __attribute__ ((unused))
-#else /* not a GCC */
-#define UNUSED_PARAM
-#endif /* GCC */
-
 #if defined(_WIN32)
 #include <mswsock.h>
 static __declspec(thread) LPFN_WSARECVMSG lpWSARecvMsg = NULL;

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -67,12 +67,6 @@
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
 #endif /* ! MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
 
-#ifdef __GNUC__
-#define UNUSED __attribute__((unused))
-#else /* __GNUC__ */
-#define UNUSED
-#endif /* __GNUC__ */
-
 #ifdef _WIN32
 #define strcasecmp _stricmp
 #endif
@@ -1232,7 +1226,7 @@ reset:
 }
 
 static void
-mbedtls_debug_out(void *ctx UNUSED, int level,
+mbedtls_debug_out(void *ctx COAP_UNUSED, int level,
                   const char *file, int line, const char *str) {
   int log_level;
   /*
@@ -1407,7 +1401,7 @@ coap_dtls_context_set_cpsk(coap_context_t *c_context,
 
 int coap_dtls_context_set_pki(coap_context_t *c_context,
                               const coap_dtls_pki_t *setup_data,
-                              const coap_dtls_role_t role UNUSED)
+                              const coap_dtls_role_t role COAP_UNUSED)
 {
   coap_mbedtls_context_t *m_context =
              ((coap_mbedtls_context_t *)c_context->dtls_context);
@@ -1637,7 +1631,7 @@ int coap_dtls_is_context_timeout(void)
   return 0;
 }
 
-coap_tick_t coap_dtls_get_context_timeout(void *dtls_context UNUSED)
+coap_tick_t coap_dtls_get_context_timeout(void *dtls_context COAP_UNUSED)
 {
   return 0;
 }
@@ -1892,31 +1886,33 @@ unsigned int coap_dtls_get_overhead(coap_session_t *c_session)
 }
 
 #if !COAP_DISABLE_TCP
-void *coap_tls_new_client_session(coap_session_t *c_session UNUSED, int *connected UNUSED)
+void *coap_tls_new_client_session(coap_session_t *c_session COAP_UNUSED,
+                                  int *connected COAP_UNUSED)
 {
   return NULL;
 }
 
-void *coap_tls_new_server_session(coap_session_t *c_session UNUSED, int *connected UNUSED)
+void *coap_tls_new_server_session(coap_session_t *c_session COAP_UNUSED,
+                                  int *connected COAP_UNUSED)
 {
   return NULL;
 }
 
-void coap_tls_free_session( coap_session_t *c_session UNUSED)
+void coap_tls_free_session( coap_session_t *c_session COAP_UNUSED)
 {
 }
 
-ssize_t coap_tls_write(coap_session_t *c_session UNUSED,
-                       const uint8_t *data UNUSED,
-                       size_t data_len UNUSED
+ssize_t coap_tls_write(coap_session_t *c_session COAP_UNUSED,
+                       const uint8_t *data COAP_UNUSED,
+                       size_t data_len COAP_UNUSED
                        )
 {
   return 0;
 }
 
-ssize_t coap_tls_read(coap_session_t *c_session UNUSED,
-                      uint8_t *data UNUSED,
-                      size_t data_len UNUSED
+ssize_t coap_tls_read(coap_session_t *c_session COAP_UNUSED,
+                      uint8_t *data COAP_UNUSED,
+                      size_t data_len COAP_UNUSED
                       )
 {
   return 0;

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -11,12 +11,6 @@
 
 #if !defined(HAVE_LIBTINYDTLS) && !defined(HAVE_OPENSSL) && !defined(HAVE_LIBGNUTLS) && !defined(HAVE_MBEDTLS)
 
-#ifdef __GNUC__
-#define UNUSED __attribute__((unused))
-#else /* __GNUC__ */
-#define UNUSED
-#endif /* __GNUC__ */
-
 int
 coap_dtls_is_supported(void) {
   return 0;
@@ -36,37 +30,37 @@ coap_get_tls_library_version(void) {
 }
 
 int
-coap_dtls_context_set_pki(coap_context_t *ctx UNUSED,
-                          const coap_dtls_pki_t* setup_data UNUSED,
-                          const coap_dtls_role_t role UNUSED
+coap_dtls_context_set_pki(coap_context_t *ctx COAP_UNUSED,
+                          const coap_dtls_pki_t* setup_data COAP_UNUSED,
+                          const coap_dtls_role_t role COAP_UNUSED
 ) {
   return 0;
 }
 
 int
-coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx UNUSED,
-                                   const char *ca_file UNUSED,
-                                   const char *ca_path UNUSED
+coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx COAP_UNUSED,
+                                   const char *ca_file COAP_UNUSED,
+                                   const char *ca_path COAP_UNUSED
 ) {
   return 0;
 }
 
 int
-coap_dtls_context_set_cpsk(coap_context_t *ctx UNUSED,
-                          coap_dtls_cpsk_t* setup_data UNUSED
+coap_dtls_context_set_cpsk(coap_context_t *ctx COAP_UNUSED,
+                          coap_dtls_cpsk_t* setup_data COAP_UNUSED
 ) {
   return 0;
 }
 
 int
-coap_dtls_context_set_spsk(coap_context_t *ctx UNUSED,
-                          coap_dtls_spsk_t* setup_data UNUSED
+coap_dtls_context_set_spsk(coap_context_t *ctx COAP_UNUSED,
+                          coap_dtls_spsk_t* setup_data COAP_UNUSED
 ) {
   return 0;
 }
 
 int
-coap_dtls_context_check_keys_enabled(coap_context_t *ctx UNUSED)
+coap_dtls_context_check_keys_enabled(coap_context_t *ctx COAP_UNUSED)
 {
   return 0;
 }
@@ -90,32 +84,32 @@ coap_dtls_get_log_level(void) {
 }
 
 void *
-coap_dtls_new_context(struct coap_context_t *coap_context UNUSED) {
+coap_dtls_new_context(struct coap_context_t *coap_context COAP_UNUSED) {
   return NULL;
 }
 
 void
-coap_dtls_free_context(void *handle UNUSED) {
+coap_dtls_free_context(void *handle COAP_UNUSED) {
 }
 
-void *coap_dtls_new_server_session(coap_session_t *session UNUSED) {
+void *coap_dtls_new_server_session(coap_session_t *session COAP_UNUSED) {
   return NULL;
 }
 
-void *coap_dtls_new_client_session(coap_session_t *session UNUSED) {
+void *coap_dtls_new_client_session(coap_session_t *session COAP_UNUSED) {
   return NULL;
 }
 
-void coap_dtls_free_session(coap_session_t *coap_session UNUSED) {
+void coap_dtls_free_session(coap_session_t *coap_session COAP_UNUSED) {
 }
 
-void coap_dtls_session_update_mtu(coap_session_t *session UNUSED) {
+void coap_dtls_session_update_mtu(coap_session_t *session COAP_UNUSED) {
 }
 
 int
-coap_dtls_send(coap_session_t *session UNUSED,
-  const uint8_t *data UNUSED,
-  size_t data_len UNUSED
+coap_dtls_send(coap_session_t *session COAP_UNUSED,
+  const uint8_t *data COAP_UNUSED,
+  size_t data_len COAP_UNUSED
 ) {
   return -1;
 }
@@ -124,59 +118,59 @@ int coap_dtls_is_context_timeout(void) {
   return 1;
 }
 
-coap_tick_t coap_dtls_get_context_timeout(void *dtls_context UNUSED) {
+coap_tick_t coap_dtls_get_context_timeout(void *dtls_context COAP_UNUSED) {
   return 0;
 }
 
 coap_tick_t
-coap_dtls_get_timeout(coap_session_t *session UNUSED, coap_tick_t now UNUSED) {
+coap_dtls_get_timeout(coap_session_t *session COAP_UNUSED, coap_tick_t now COAP_UNUSED) {
   return 0;
 }
 
-void coap_dtls_handle_timeout(coap_session_t *session UNUSED) {
+void coap_dtls_handle_timeout(coap_session_t *session COAP_UNUSED) {
 }
 
 int
-coap_dtls_receive(coap_session_t *session UNUSED,
-  const uint8_t *data UNUSED,
-  size_t data_len UNUSED
+coap_dtls_receive(coap_session_t *session COAP_UNUSED,
+  const uint8_t *data COAP_UNUSED,
+  size_t data_len COAP_UNUSED
 ) {
   return -1;
 }
 
 int
-coap_dtls_hello(coap_session_t *session UNUSED,
-  const uint8_t *data UNUSED,
-  size_t data_len UNUSED
+coap_dtls_hello(coap_session_t *session COAP_UNUSED,
+  const uint8_t *data COAP_UNUSED,
+  size_t data_len COAP_UNUSED
 ) {
   return 0;
 }
 
-unsigned int coap_dtls_get_overhead(coap_session_t *session UNUSED) {
+unsigned int coap_dtls_get_overhead(coap_session_t *session COAP_UNUSED) {
   return 0;
 }
 
-void *coap_tls_new_client_session(coap_session_t *session UNUSED, int *connected UNUSED) {
+void *coap_tls_new_client_session(coap_session_t *session COAP_UNUSED, int *connected COAP_UNUSED) {
   return NULL;
 }
 
-void *coap_tls_new_server_session(coap_session_t *session UNUSED, int *connected UNUSED) {
+void *coap_tls_new_server_session(coap_session_t *session COAP_UNUSED, int *connected COAP_UNUSED) {
   return NULL;
 }
 
-void coap_tls_free_session(coap_session_t *coap_session UNUSED) {
+void coap_tls_free_session(coap_session_t *coap_session COAP_UNUSED) {
 }
 
-ssize_t coap_tls_write(coap_session_t *session UNUSED,
-                       const uint8_t *data UNUSED,
-                       size_t data_len UNUSED
+ssize_t coap_tls_write(coap_session_t *session COAP_UNUSED,
+                       const uint8_t *data COAP_UNUSED,
+                       size_t data_len COAP_UNUSED
 ) {
   return -1;
 }
 
-ssize_t coap_tls_read(coap_session_t *session UNUSED,
-                      uint8_t *data UNUSED,
-                      size_t data_len UNUSED
+ssize_t coap_tls_read(coap_session_t *session COAP_UNUSED,
+                      uint8_t *data COAP_UNUSED,
+                      size_t data_len COAP_UNUSED
 ) {
   return -1;
 }
@@ -224,9 +218,6 @@ coap_digest_final(coap_digest_ctx_t *digest_ctx,
   coap_digest_free(digest_ctx);
   return 1;
 }
-
-
-#undef UNUSED
 
 #else /* !HAVE_LIBTINYDTLS && !HAVE_OPENSSL && !HAVE_LIBGNUTLS */
 

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -71,12 +71,6 @@
 #error Must be compiled against OpenSSL 1.1.0 or later
 #endif
 
-#ifdef __GNUC__
-#define UNUSED __attribute__((unused))
-#else
-#define UNUSED
-#endif /* __GNUC__ */
-
 #ifdef _WIN32
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
@@ -914,12 +908,12 @@ map_key_type(int asn1_private_key_type
 static uint8_t coap_alpn[] = { 4, 'c', 'o', 'a', 'p' };
 
 static int
-server_alpn_callback (SSL *ssl UNUSED,
+server_alpn_callback (SSL *ssl COAP_UNUSED,
                       const unsigned char **out,
                       unsigned char *outlen,
                       const unsigned char *in,
                       unsigned int inlen,
-                      void *arg UNUSED
+                      void *arg COAP_UNUSED
 ) {
   unsigned char *tout = NULL;
   int ret;
@@ -1942,7 +1936,7 @@ tls_secret_call_back(SSL *ssl,
   void *secret,
   int *secretlen,
   STACK_OF(SSL_CIPHER) *peer_ciphers,
-  const SSL_CIPHER **cipher UNUSED,
+  const SSL_CIPHER **cipher COAP_UNUSED,
   void *arg
 ) {
   int     ii;
@@ -2038,7 +2032,7 @@ tls_secret_call_back(SSL *ssl,
  */
 static int
 tls_server_name_call_back(SSL *ssl,
-                          int *sd UNUSED,
+                          int *sd COAP_UNUSED,
                           void *arg
 ) {
   coap_dtls_pki_t *setup_data = (coap_dtls_pki_t*)arg;
@@ -2134,7 +2128,7 @@ error:
  */
 static int
 psk_tls_server_name_call_back(SSL *ssl,
-                          int *sd UNUSED,
+                          int *sd COAP_UNUSED,
                           void *arg
 ) {
   coap_dtls_spsk_t *setup_data = (coap_dtls_spsk_t*)arg;
@@ -2243,7 +2237,7 @@ error:
 static int
 tls_client_hello_call_back(SSL *ssl,
                           int *al,
-                          void *arg UNUSED
+                          void *arg COAP_UNUSED
 ) {
   coap_session_t *session;
   coap_openssl_context_t *dtls_context;
@@ -2449,7 +2443,7 @@ is_x509:
 static int
 psk_tls_client_hello_call_back(SSL *ssl,
                           int *al,
-                          void *arg UNUSED
+                          void *arg COAP_UNUSED
 ) {
   coap_session_t *c_session;
   coap_openssl_context_t *o_context;
@@ -2980,7 +2974,7 @@ coap_tick_t coap_dtls_get_context_timeout(void *dtls_context) {
   return 0;
 }
 
-coap_tick_t coap_dtls_get_timeout(coap_session_t *session, coap_tick_t now UNUSED) {
+coap_tick_t coap_dtls_get_timeout(coap_session_t *session, coap_tick_t now COAP_UNUSED) {
   SSL *ssl = (SSL *)session->tls;
   coap_ssl_data *ssl_data;
 

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -967,7 +967,7 @@ pem_decode_mem_asn1(const char *begstr, const uint8_t *str)
 int
 coap_dtls_context_set_pki(coap_context_t *ctx,
                           const coap_dtls_pki_t* setup_data,
-                          const coap_dtls_role_t role UNUSED
+                          const coap_dtls_role_t role COAP_UNUSED
 ) {
 #ifdef DTLS_ECC
   coap_tiny_context_t *t_context;
@@ -1126,16 +1126,16 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
 }
 
 int
-coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx UNUSED,
-  const char *ca_file UNUSED,
-  const char *ca_path UNUSED
+coap_dtls_context_set_pki_root_cas(struct coap_context_t *ctx COAP_UNUSED,
+  const char *ca_file COAP_UNUSED,
+  const char *ca_path COAP_UNUSED
 ) {
   coap_log(LOG_WARNING, "Root CAs PKI not supported\n");
   return 0;
 }
 
 int
-coap_dtls_context_set_cpsk(coap_context_t *coap_context UNUSED,
+coap_dtls_context_set_cpsk(coap_context_t *coap_context COAP_UNUSED,
   coap_dtls_cpsk_t *setup_data
 ) {
   if (!setup_data)
@@ -1145,7 +1145,7 @@ coap_dtls_context_set_cpsk(coap_context_t *coap_context UNUSED,
 }
 
 int
-coap_dtls_context_set_spsk(coap_context_t *coap_context UNUSED,
+coap_dtls_context_set_spsk(coap_context_t *coap_context COAP_UNUSED,
   coap_dtls_spsk_t *setup_data
 ) {
   if (!setup_data)
@@ -1160,33 +1160,33 @@ coap_dtls_context_set_spsk(coap_context_t *coap_context UNUSED,
 }
 
 int
-coap_dtls_context_check_keys_enabled(coap_context_t *ctx UNUSED)
+coap_dtls_context_check_keys_enabled(coap_context_t *ctx COAP_UNUSED)
 {
   return 1;
 }
 
 #if !COAP_DISABLE_TCP
-void *coap_tls_new_client_session(coap_session_t *session UNUSED, int *connected UNUSED) {
+void *coap_tls_new_client_session(coap_session_t *session COAP_UNUSED, int *connected COAP_UNUSED) {
   return NULL;
 }
 
-void *coap_tls_new_server_session(coap_session_t *session UNUSED, int *connected UNUSED) {
+void *coap_tls_new_server_session(coap_session_t *session COAP_UNUSED, int *connected COAP_UNUSED) {
   return NULL;
 }
 
-void coap_tls_free_session(coap_session_t *coap_session UNUSED) {
+void coap_tls_free_session(coap_session_t *coap_session COAP_UNUSED) {
 }
 
-ssize_t coap_tls_write(coap_session_t *session UNUSED,
-                       const uint8_t *data UNUSED,
-                       size_t data_len UNUSED
+ssize_t coap_tls_write(coap_session_t *session COAP_UNUSED,
+                       const uint8_t *data COAP_UNUSED,
+                       size_t data_len COAP_UNUSED
 ) {
   return -1;
 }
 
-ssize_t coap_tls_read(coap_session_t *session UNUSED,
-                      uint8_t *data UNUSED,
-                      size_t data_len UNUSED
+ssize_t coap_tls_read(coap_session_t *session COAP_UNUSED,
+                      uint8_t *data COAP_UNUSED,
+                      size_t data_len COAP_UNUSED
 ) {
   return -1;
 }
@@ -1225,8 +1225,6 @@ coap_digest_final(coap_digest_ctx_t *digest_ctx,
   coap_digest_free(digest_ctx);
   return 1;
 }
-
-#undef UNUSED
 
 #else /* !HAVE_LIBTINYDTLS */
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -333,12 +333,6 @@ void
 coap_memory_init(void) {
 }
 
-#ifdef __GNUC__
-#define UNUSED_PARAM __attribute__((unused))
-#else
-#define UNUSED_PARAM
-#endif /* __GNUC__ */
-
 void *
 coap_malloc_type(coap_memory_tag_t type, size_t size) {
   (void)type;

--- a/src/resource.c
+++ b/src/resource.c
@@ -163,7 +163,7 @@ match(const coap_str_const_t *text, const coap_str_const_t *pattern, int match_p
 coap_print_status_t
 coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen,
                 size_t offset,
-                coap_opt_t *query_filter __attribute__ ((unused))) {
+                coap_opt_t *query_filter COAP_UNUSED) {
 #else /* not a GCC */
 coap_print_status_t
 coap_print_wellknown(coap_context_t *context, unsigned char *buf, size_t *buflen,

--- a/tests/testdriver.c
+++ b/tests/testdriver.c
@@ -16,14 +16,8 @@
 #include "test_tls.h"
 #include "libcoap.h"
 
-#ifdef __GNUC__
-#define UNUSED_PARAM __attribute__ ((unused))
-#else /* not a GCC */
-#define UNUSED_PARAM
-#endif /* GCC */
-
 int
-main(int argc UNUSED_PARAM, char **argv UNUSED_PARAM) {
+main(int argc COAP_UNUSED, char **argv COAP_UNUSED) {
   CU_ErrorCode result;
   CU_BasicRunMode run_mode = CU_BRM_VERBOSE;
 


### PR DESCRIPTION
Remove the UNUSED and UNUSED_PARAM definitions and use a single definition
of COAP_UNUSED as defined in libcoap.h

Replace all UNUSED / UNUSED_PARAM usages with COAP_UNUSED.