### PR TITLE
message id: clean up documentation usage of transaction which is message id

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -115,7 +115,7 @@ typedef unsigned char method_t;
 method_t method = 1;                    /* the method we are using in our requests */
 
 coap_block_t block = { .num = 0, .m = 0, .szx = 6 };
-uint16_t last_block1_tid = 0;
+uint16_t last_block1_mid = 0;
 
 
 unsigned int wait_seconds = 90;                /* default timeout in seconds */
@@ -197,7 +197,7 @@ coap_new_request(coap_context_t *ctx,
     return NULL;
 
   pdu->type = msgtype;
-  pdu->tid = coap_new_message_id(session);
+  pdu->mid = coap_new_message_id(session);
   pdu->code = m;
 
   if ( !coap_add_token(pdu, the_token.length, the_token.s)) {
@@ -292,7 +292,7 @@ nack_handler(coap_context_t *context COAP_UNUSED,
              coap_session_t *session COAP_UNUSED,
              coap_pdu_t *sent COAP_UNUSED,
              coap_nack_reason_t reason,
-             const coap_tid_t id COAP_UNUSED) {
+             const coap_mid_t id COAP_UNUSED) {
 
   switch(reason) {
   case COAP_NACK_TOO_MANY_RETRIES:
@@ -316,7 +316,7 @@ message_handler(struct coap_context_t *ctx COAP_UNUSED,
                 coap_session_t *session COAP_UNUSED,
                 coap_pdu_t *sent,
                 coap_pdu_t *received,
-                const coap_tid_t id COAP_UNUSED) {
+                const coap_mid_t id COAP_UNUSED) {
 
   coap_opt_t *block_opt;
   coap_opt_iterator_t opt_iter;

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -212,7 +212,7 @@ hnd_put_resource(coap_context_t  *ctx COAP_UNUSED,
   if (request->hdr->token_length)
     coap_add_token(response, request->hdr->token_length, request->hdr->token);
 
-  if (coap_send(ctx, peer, response) == COAP_INVALID_TID) {
+  if (coap_send(ctx, peer, response) == COAP_INVALID_MID) {
     coap_log(LOG_DEBUG, "hnd_get_rd: cannot send response for mid=0x%x\n",
     request->hdr->id);
   }
@@ -457,7 +457,7 @@ hnd_post_rd(coap_context_t  *ctx,
   } else {      /* generate node identifier */
     loc_size +=
       snprintf((char *)(loc + loc_size), LOCSIZE - loc_size - 1,
-               "%x", request->tid);
+               "%x", request->mid);
 
     if (loc_size > 1) {
       if (ins.length) {

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -375,7 +375,7 @@ hnd_get_async(coap_context_t *ctx,
   size_t size;
 
   if (async) {
-    if (async->id != request->tid) {
+    if (async->id != request->mid) {
       coap_opt_filter_t f;
       coap_option_filter_clear(&f);
       response->code = COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE;
@@ -433,14 +433,14 @@ check_async(coap_context_t *ctx,
     return;
   }
 
-  response->tid = coap_new_message_id(async->session);
+  response->mid = coap_new_message_id(async->session);
 
   if (async->tokenlen)
     coap_add_token(response, async->tokenlen, async->token);
 
   coap_add_data(response, 4, (const uint8_t *)"done");
 
-  if (coap_send_large(async->session, response) == COAP_INVALID_TID) {
+  if (coap_send_large(async->session, response) == COAP_INVALID_MID) {
     coap_log(LOG_DEBUG, "check_async: cannot send response for message\n");
   }
   coap_remove_async(ctx, async->session, async->id, &tmp);
@@ -895,7 +895,7 @@ remove_proxy_association(coap_session_t *session, int send_failure) {
       }
 
       if (coap_send_large(proxy_list[i].incoming, response) ==
-                                                          COAP_INVALID_TID) {
+                                                          COAP_INVALID_MID) {
         coap_log(LOG_INFO, "Failed to send PDU with 5.02 gateway issue\n");
       }
       break;
@@ -1636,7 +1636,7 @@ proxy_message_handler(struct coap_context_t *ctx COAP_UNUSED,
                 coap_session_t *session,
                 coap_pdu_t *sent COAP_UNUSED,
                 coap_pdu_t *received,
-                const coap_tid_t id COAP_UNUSED) {
+                const coap_mid_t id COAP_UNUSED) {
 
   coap_pdu_t *pdu = NULL;
   coap_session_t *incoming = NULL;
@@ -1757,7 +1757,7 @@ proxy_nack_handler(coap_context_t *context COAP_UNUSED,
              coap_session_t *session,
              coap_pdu_t *sent COAP_UNUSED,
              coap_nack_reason_t reason,
-             const coap_tid_t id COAP_UNUSED) {
+             const coap_mid_t id COAP_UNUSED) {
 
   switch(reason) {
   case COAP_NACK_TOO_MANY_RETRIES:

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -371,7 +371,7 @@ hnd_get_separate(coap_context_t *ctx,
   unsigned long delay = 5;
 
   if (async) {
-    if (async->id != request->tid) {
+    if (async->id != request->mid) {
       coap_option_filter_clear(&f);
       response->code = COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE;
     }
@@ -441,16 +441,16 @@ check_async(coap_context_t *ctx,
     return;
   }
 
-  response->tid = coap_new_message_id(async->session);
+  response->mid = coap_new_message_id(async->session);
 
   if (async->tokenlen)
     coap_add_token(response, async->tokenlen, async->token);
 
   coap_add_data(response, 4, (const uint8_t *)"done");
 
-  if (coap_send(async->session, response) == COAP_INVALID_TID) {
+  if (coap_send(async->session, response) == COAP_INVALID_MID) {
     coap_log(LOG_DEBUG, "check_async: cannot send response for mid=0x%x\n",
-          response->tid);
+          response->mid);
   }
   coap_remove_async(ctx, async->session, async->id, &tmp);
   coap_free_async(async);

--- a/examples/tiny.c
+++ b/examples/tiny.c
@@ -40,7 +40,7 @@ COAP_PSEUDOFP_ENCODE_8_4_DOWN(unsigned int v, int *ls) {
 }
 #define COAP_PSEUDOFP_ENCODE_8_4_UP(v,ls,s) (v < HIBIT ? v : (ls = coap_fls(v) - Nn, (s = (((v + ((1<<ENCODE_HEADER_SIZE<<ls)-1)) >> ls) & MMASK)), s == 0 ? HIBIT + ls + 1 : s + ls))
 
-static coap_tid_t id;
+static coap_mid_t id;
 static int quit = 0;
 
 /* SIGINT handler: set quit to 1 for graceful termination */
@@ -61,7 +61,7 @@ make_pdu( unsigned int value ) {
 
   pdu->type = COAP_MESSAGE_NON;
   pdu->code = COAP_REQUEST_POST;
-  pdu->tid = id++;
+  pdu->mid = id++;
 
   enc = COAP_PSEUDOFP_ENCODE_8_4_DOWN(value, &ls);
 

--- a/include/coap2/async.h
+++ b/include/coap2/async.h
@@ -43,7 +43,7 @@ typedef struct coap_async_state_t {
    */
   void *appdata;
   coap_session_t *session;         /**< transaction session */
-  coap_tid_t id;                   /**< transaction id */
+  coap_mid_t id;                   /**< message id */
   struct coap_async_state_t *next; /**< internally used for linking */
   size_t tokenlen;                 /**< length of the token */
   uint8_t token[8];                /**< the token to use in a response */
@@ -103,7 +103,7 @@ coap_register_async(coap_context_t *context,
  */
 int coap_remove_async(coap_context_t *context,
                       coap_session_t *session,
-                      coap_tid_t id,
+                      coap_mid_t id,
                       coap_async_state_t **s);
 
 /**
@@ -129,7 +129,7 @@ coap_free_async(coap_async_state_t *state);
  * @return        A pointer to the object identified by @p id or @c NULL if
  *                not found.
  */
-coap_async_state_t *coap_find_async(coap_context_t *context, coap_session_t *session, coap_tid_t id);
+coap_async_state_t *coap_find_async(coap_context_t *context, coap_session_t *session, coap_mid_t id);
 
 /**
  * Updates the time stamp of @p s.

--- a/include/coap2/coap_block_internal.h
+++ b/include/coap2/coap_block_internal.h
@@ -140,7 +140,7 @@ struct coap_lg_srcv_t {
   coap_rblock_t rec_blocks; /** < list of received blocks */
   uint8_t last_token[8]; /**< last used token */
   size_t last_token_length; /**< length of token */
-  coap_tid_t last_mid;   /**< Last received mid for this set of packets */
+  coap_mid_t last_mid;   /**< Last received mid for this set of packets */
   coap_tick_t last_used; /**< Last time data sent or 0 */
   uint16_t block_option; /**< Block option in use */
 };

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -75,7 +75,7 @@ typedef struct coap_session_t {
   uint16_t tx_mid;                  /**< the last message id that was used in this session */
   uint8_t con_active;               /**< Active CON request sent */
   uint8_t csm_block_supported;      /**< CSM TCP blocks supported */
-  coap_tid_t last_ping_mid;         /**< the last keepalive message id that was used in this session */
+  coap_mid_t last_ping_mid;         /**< the last keepalive message id that was used in this session */
   struct coap_queue_t *delayqueue;  /**< list of delayed messages waiting to be sent */
   coap_lg_xmit_t *lg_xmit;          /**< list of large transmissions */
   coap_lg_crcv_t *lg_crcv;       /**< Client list of expected large receives */
@@ -650,9 +650,9 @@ coap_fixed_point_t coap_session_get_ack_random_factor(coap_session_t *session);
  * Send a ping message for the session.
  * @param session The CoAP session.
  *
- * @return COAP_INVALID_TID if there is an error
+ * @return COAP_INVALID_MID if there is an error
  */
-coap_tid_t coap_session_send_ping(coap_session_t *session);
+coap_mid_t coap_session_send_ping(coap_session_t *session);
 
 #define SESSIONS_ADD(e, obj) \
   HASH_ADD(hh, (e), addr_info, sizeof((obj)->addr_info), (obj))

--- a/include/coap2/coap_subscribe_internal.h
+++ b/include/coap2/coap_subscribe_internal.h
@@ -51,10 +51,10 @@ struct coap_subscription_t {
   unsigned int dirty:1;    /**< set if the notification temporarily could not be
                             *   sent (in that case, the resource's partially
                             *   dirty flag is set too) */
-  unsigned int has_block2:1; /**< request had Block2 definition */
+  unsigned int has_block2:1; /**< GET request had Block2 definition */
   uint8_t code;            /** request type code (GET/FETCH)*/
+  uint16_t mid;             /**< message id, if any, in regular host byte order */
   coap_block_t block;      /**< GET/FETCH request Block definition */
-  uint16_t tid;            /**< transaction id, if any, in regular host byte order */
   size_t token_length;     /**< actual length of token */
   unsigned char token[8];  /**< token used for subscription */
   struct coap_string_t *query; /**< query string used for subscription, if any */

--- a/include/coap2/net.h
+++ b/include/coap2/net.h
@@ -41,7 +41,7 @@ typedef struct coap_queue_t {
                                  *    when zero */
   unsigned int timeout;         /**< the randomized timeout value */
   coap_session_t *session;      /**< the CoAP session */
-  coap_tid_t id;                /**< CoAP transaction id */
+  coap_mid_t id;                /**< CoAP message id */
   coap_pdu_t *pdu;              /**< the CoAP PDU to send */
 } coap_queue_t;
 
@@ -101,7 +101,7 @@ typedef coap_response_t (*coap_response_handler_t)(struct coap_context_t *contex
                                                    coap_session_t *session,
                                                    coap_pdu_t *sent,
                                                    coap_pdu_t *received,
-                                                   const coap_tid_t id);
+                                                   const coap_mid_t id);
 
 /**
  * Negative Acknowedge handler that is used as callback in coap_context_t.
@@ -110,13 +110,13 @@ typedef coap_response_t (*coap_response_handler_t)(struct coap_context_t *contex
  * @param session CoAP session.
  * @param sent The PDU that was transmitted.
  * @param reason The reason for the NACK.
- * @param id CoAP transaction ID.
+ * @param id CoAP message ID.
  */
 typedef void (*coap_nack_handler_t)(struct coap_context_t *context,
                                     coap_session_t *session,
                                     coap_pdu_t *sent,
                                     coap_nack_reason_t reason,
-                                    const coap_tid_t id);
+                                    const coap_mid_t id);
 
 /**
  * Received Ping handler that is used as callback in coap_context_t.
@@ -124,12 +124,12 @@ typedef void (*coap_nack_handler_t)(struct coap_context_t *context,
  * @param context CoAP session.
  * @param session CoAP session.
  * @param received The PDU that was received.
- * @param id CoAP transaction ID.
+ * @param id CoAP message ID.
  */
 typedef void (*coap_ping_handler_t)(struct coap_context_t *context,
                                     coap_session_t *session,
                                     coap_pdu_t *received,
-                                    const coap_tid_t id);
+                                    const coap_mid_t id);
 
 /**
  * Received Pong handler that is used as callback in coap_context_t.
@@ -137,12 +137,12 @@ typedef void (*coap_ping_handler_t)(struct coap_context_t *context,
  * @param context CoAP session.
  * @param session CoAP session.
  * @param received The PDU that was received.
- * @param id CoAP transaction ID.
+ * @param id CoAP message ID.
  */
 typedef void (*coap_pong_handler_t)(struct coap_context_t *context,
                                     coap_session_t *session,
                                     coap_pdu_t *received,
-                                    const coap_tid_t id);
+                                    const coap_mid_t id);
 
 /**
  * The CoAP stack's global state is stored in a coap_context_t object.
@@ -161,7 +161,7 @@ struct coap_context_t {
 
 #ifndef WITHOUT_ASYNC
   /**
-   * list of asynchronous transactions */
+   * list of asynchronous message ids */
   struct coap_async_state_t *async_state;
 #endif /* WITHOUT_ASYNC */
 
@@ -229,8 +229,8 @@ struct coap_context_t {
 };
 
 /**
- * Registers a new message handler that is called whenever a response was
- * received that matches an ongoing transaction.
+ * Registers a new message handler that is called whenever a response is
+ * received.
  *
  * @param context The context to register the handler for.
  * @param handler The response handler to register.
@@ -469,8 +469,8 @@ coap_pdu_t *coap_new_error_response(coap_pdu_t *request,
 /**
  * Sends an error response with code @p code for request @p request to @p dst.
  * @p opts will be passed to coap_new_error_response() to copy marked options
- * from the request. This function returns the transaction id if the message was
- * sent, or @c COAP_INVALID_TID otherwise.
+ * from the request. This function returns the message id if the message was
+ * sent, or @c COAP_INVALID_MID otherwise.
  *
  * @param session         The CoAP session.
  * @param request         The original request to respond to.
@@ -478,53 +478,53 @@ coap_pdu_t *coap_new_error_response(coap_pdu_t *request,
  * @param opts            A filter that specifies the options to copy from the
  *                        @p request.
  *
- * @return                The transaction id if the message was sent, or @c
- *                        COAP_INVALID_TID otherwise.
+ * @return                The message id if the message was sent, or @c
+ *                        COAP_INVALID_MID otherwise.
  */
-coap_tid_t coap_send_error(coap_session_t *session,
+coap_mid_t coap_send_error(coap_session_t *session,
                            coap_pdu_t *request,
                            unsigned char code,
                            coap_opt_filter_t *opts);
 
 /**
  * Helper function to create and send a message with @p type (usually ACK or
- * RST). This function returns @c COAP_INVALID_TID when the message was not
+ * RST). This function returns @c COAP_INVALID_MID when the message was not
  * sent, a valid transaction id otherwise.
  *
  * @param session         The CoAP session.
  * @param request         The request that should be responded to.
  * @param type            Which type to set.
- * @return                transaction id on success or @c COAP_INVALID_TID
+ * @return                message id on success or @c COAP_INVALID_MID
  *                        otherwise.
  */
-coap_tid_t
+coap_mid_t
 coap_send_message_type(coap_session_t *session, coap_pdu_t *request, unsigned char type);
 
 /**
  * Sends an ACK message with code @c 0 for the specified @p request to @p dst.
- * This function returns the corresponding transaction id if the message was
- * sent or @c COAP_INVALID_TID on error.
+ * This function returns the corresponding message id if the message was
+ * sent or @c COAP_INVALID_MID on error.
  *
  * @param session         The CoAP session.
  * @param request         The request to be acknowledged.
  *
- * @return                The transaction id if ACK was sent or @c
- *                        COAP_INVALID_TID on error.
+ * @return                The message id if ACK was sent or @c
+ *                        COAP_INVALID_MID on error.
  */
-coap_tid_t coap_send_ack(coap_session_t *session, coap_pdu_t *request);
+coap_mid_t coap_send_ack(coap_session_t *session, coap_pdu_t *request);
 
 /**
  * Sends an RST message with code @c 0 for the specified @p request to @p dst.
- * This function returns the corresponding transaction id if the message was
- * sent or @c COAP_INVALID_TID on error.
+ * This function returns the corresponding message id if the message was
+ * sent or @c COAP_INVALID_MID on error.
  *
  * @param session         The CoAP session.
  * @param request         The request to be reset.
  *
- * @return                The transaction id if RST was sent or @c
- *                        COAP_INVALID_TID on error.
+ * @return                The message id if RST was sent or @c
+ *                        COAP_INVALID_MID on error.
  */
-COAP_STATIC_INLINE coap_tid_t
+COAP_STATIC_INLINE coap_mid_t
 coap_send_rst(coap_session_t *session, coap_pdu_t *request) {
   return coap_send_message_type(session, request, COAP_MESSAGE_RST);
 }
@@ -538,9 +538,9 @@ coap_send_rst(coap_session_t *session, coap_pdu_t *request) {
 * @param pdu             The CoAP PDU to send.
 *
 * @return                The message id of the sent message or @c
-*                        COAP_INVALID_TID on error.
+*                        COAP_INVALID_MID on error.
 */
-coap_tid_t coap_send( coap_session_t *session, coap_pdu_t *pdu );
+coap_mid_t coap_send( coap_session_t *session, coap_pdu_t *pdu );
 
 /**
  * Sends a CoAP message to given peer. The memory that is
@@ -555,9 +555,9 @@ coap_tid_t coap_send( coap_session_t *session, coap_pdu_t *pdu );
  * @param pdu       The CoAP PDU to send.
  *
  * @return          The message id of the sent message or @c
- *                  COAP_INVALID_TID on error.
+ *                  COAP_INVALID_MID on error.
  */
-coap_tid_t coap_send_large(coap_session_t *session, coap_pdu_t *pdu);
+coap_mid_t coap_send_large(coap_session_t *session, coap_pdu_t *pdu);
 
 /**
  * Handles retransmissions of confirmable messages
@@ -566,9 +566,9 @@ coap_tid_t coap_send_large(coap_session_t *session, coap_pdu_t *pdu);
  * @param node         The node to retransmit.
  *
  * @return             The message id of the sent message or @c
- *                     COAP_INVALID_TID on error.
+ *                     COAP_INVALID_MID on error.
  */
-coap_tid_t coap_retransmit(coap_context_t *context, coap_queue_t *node);
+coap_mid_t coap_retransmit(coap_context_t *context, coap_queue_t *node);
 
 /**
  * Parses and interprets a CoAP datagram with context @p ctx. This function
@@ -608,7 +608,7 @@ int coap_handle_event(coap_context_t *context,
  *
  * @param queue The queue to search for @p id.
  * @param session The session to look for.
- * @param id    The transaction id to look for.
+ * @param id    The message id to look for.
  * @param node  If found, @p node is updated to point to the removed node. You
  *              must release the storage pointed to by @p node manually.
  *
@@ -616,23 +616,12 @@ int coap_handle_event(coap_context_t *context,
  */
 int coap_remove_from_queue(coap_queue_t **queue,
                            coap_session_t *session,
-                           coap_tid_t id,
+                           coap_mid_t id,
                            coap_queue_t **node);
 
-coap_tid_t
+coap_mid_t
 coap_wait_ack( coap_context_t *context, coap_session_t *session,
                coap_queue_t *node);
-
-/**
- * Retrieves transaction from the queue.
- *
- * @param queue The transaction queue to be searched.
- * @param session The session to find.
- * @param id    The transaction id to find.
- *
- * @return      A pointer to the transaction object or @c NULL if not found.
- */
-coap_queue_t *coap_find_transaction(coap_queue_t *queue, coap_session_t *session, coap_tid_t id);
 
 /**
  * Cancels all outstanding messages for session @p session that have the specified

--- a/include/coap2/pdu.h
+++ b/include/coap2/pdu.h
@@ -238,14 +238,13 @@ const char *coap_response_phrase(unsigned char code);
 #define COAP_MEDIATYPE_ANY                         0xff /* any media type */
 
 /**
- * coap_tid_t is used to store CoAP transaction id, i.e. a hash value
- * built from the remote transport address and the message id of a
- * CoAP PDU.  Valid transaction ids are greater or equal zero.
+ * coap_mid_t is used to store the CoAP Message ID of a CoAP PDU.
+ * Valid message ids are 0 to 2^16.  Negative values are error codes.
  */
-typedef int coap_tid_t;
+typedef int coap_mid_t;
 
-/** Indicates an invalid transaction id. */
-#define COAP_INVALID_TID -1
+/** Indicates an invalid message id. */
+#define COAP_INVALID_MID -1
 
 /**
  * Indicates that a response is suppressed. This will occur for error
@@ -291,7 +290,7 @@ struct coap_pdu_t {
   uint8_t max_hdr_size;     /**< space reserved for protocol-specific header */
   uint8_t hdr_size;         /**< actual size used for protocol-specific header */
   uint8_t token_length;     /**< length of Token */
-  uint16_t tid;             /**< transaction id, if any, in regular host byte order */
+  uint16_t mid;             /**< message id, if any, in regular host byte order */
   uint16_t max_opt;         /**< highest option number in PDU */
   size_t alloc_size;        /**< allocated storage for token, options and payload */
   size_t used_size;         /**< used bytes of storage for token, options and payload */
@@ -401,12 +400,12 @@ enum coap_response_code {
  * @param type The type of the PDU (one of COAP_MESSAGE_CON, COAP_MESSAGE_NON,
  *             COAP_MESSAGE_ACK, COAP_MESSAGE_RST).
  * @param code The message code.
- * @param tid  The transcation id to set or 0 if unknown / not applicable.
+ * @param mid  The transcation id to set or 0 if unknown / not applicable.
  * @param size The maximum allowed number of byte for the message.
  * @return     A pointer to the new PDU object or @c NULL on error.
  */
 coap_pdu_t *
-coap_pdu_init(uint8_t type, uint8_t code, uint16_t tid, size_t size);
+coap_pdu_init(uint8_t type, uint8_t code, uint16_t mid, size_t size);
 
 /**
  * Dynamically grows the size of @p pdu to @p new_size. The new size

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -67,7 +67,6 @@ global:
   coap_endpoint_str;
   coap_find_async;
   coap_find_attr;
-  coap_find_transaction;
   coap_fls;
   coap_flsll;
   coap_free_async;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -65,7 +65,6 @@ coap_endpoint_set_default_mtu
 coap_endpoint_str
 coap_find_async
 coap_find_attr
-coap_find_transaction
 coap_fls
 coap_flsll
 coap_free_async

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -43,7 +43,7 @@ const uint8_t **_data_, size_t *_offset_, size_t *_total_);*
 coap_block_build_body(coap_binary_t *_body_data_, size_t _length_,
 const uint8_t *_data_, size_t _offset_, size_t _total_);*
 
-*coap_tid_t coap_send_large(coap_session_t *_session_, coap_pdu_t *_pdu_);*
+*coap_mid_t coap_send_large(coap_session_t *_session_, coap_pdu_t *_pdu_);*
 
 Link with *-lcoap-@LIBCOAP_API_VERSION@*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
 *-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*
@@ -192,7 +192,7 @@ The *coap_add_data_large_request*(), *coap_add_data_large_response*(), and
 *coap_get_data_large*() functions return 0 on failure, 1 on success.
 
 The *coap_send_large*() function returns the CoAP message ID on success or
-COAP_INVALID_TID on failure.
+COAP_INVALID_MID on failure.
 
 The  *coap_block_build_body*() returns the current state of the body's data
 (which may have some missing gaps) or NULL on error.
@@ -283,7 +283,7 @@ unsigned char *data, size_t length, int observe) {
       goto error;
   }
 
-  if (coap_send_large(session, pdu) == COAP_INVALID_TID)
+  if (coap_send_large(session, pdu) == COAP_INVALID_MID)
     goto error;
   return 1;
 

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -102,7 +102,7 @@ typedef coap_response_t (*coap_response_handler_t)(coap_context_t *context,
                                                    coap_session_t *session,
                                                    coap_pdu_t *sent,
                                                    coap_pdu_t *received,
-                                                   const coap_tid_t id);
+                                                   const coap_mid_t id);
 ----
 
 *NOTE:* _sent_ will only be non NULL when the request PDU is Confirmable and
@@ -125,7 +125,7 @@ typedef void (*coap_nack_handler_t)(coap_context_t *context,
                                     coap_session_t *session,
                                     coap_pdu_t *sent,
                                     coap_nack_reason_t reason,
-                                    const coap_tid_t id);
+                                    const coap_mid_t mid);
 ----
 NACKs can be one of the following
 ----
@@ -146,7 +146,7 @@ The ping handler function prototype is defined as:
 typedef void (*coap_ping_handler_t)(coap_context_t *context,
                                     coap_session_t *session,
                                     coap_pdu_t *received,
-                                    const coap_tid_t id);
+                                    const coap_mid_t mid);
 ----
 
 The *coap_register_pong_handler*() function defines a _handler_ for tracking
@@ -159,7 +159,7 @@ The pong handler function prototype is defined as:
 typedef void (*coap_pong_handler_t)(coap_context_t *context,
                                     coap_session_t *session,
                                     coap_pdu_t *received,
-                                    const coap_tid_t id);
+                                    const coap_mid_t mid);
 ----
 
 The *coap_register_event_handler*() function defines a _handler_ for tracking
@@ -275,11 +275,11 @@ static int check_token(coap_pdu_t *received) {
 
 static coap_response_t
 response_handler(coap_context_t *ctx, coap_session_t *session,
-coap_pdu_t *sent, coap_pdu_t *received, const coap_tid_t id) {
+coap_pdu_t *sent, coap_pdu_t *received, const coap_mid_t mid) {
   /* Remove (void) definition if variable is used */
   (void)ctx;
   (void)session;
-  (void)id;
+  (void)mid;
 
   /* check if this is a response to our original request */
   if (!check_token(received)) {

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -71,7 +71,7 @@ coap_session_t *_session_, coap_pdu_t *_request_, coap_pdu_t *_response_,
 const coap_binary_t *_token_, uint16_t _media_type_, int _maxage_,
 size_t _length_, const uint8_t *_data_);*
 
-*coap_tid_t coap_send(coap_session_t *_session_, coap_pdu_t *_pdu_);*
+*coap_mid_t coap_send(coap_session_t *_session_, coap_pdu_t *_pdu_);*
 
 *int coap_split_path(const uint8_t *_path_, size_t _length_, uint8_t *_buffer_,
 size_t *_buflen_);*
@@ -309,7 +309,7 @@ The *coap_encode_var_safe8*() function returns either the length of bytes
 encoded or 0 on failure.
 
 The *coap_send*() function returns the CoAP message ID on success or
-COAP_INVALID_TID on failure.
+COAP_INVALID_MID on failure.
 
 EXAMPLES
 --------
@@ -397,7 +397,7 @@ unsigned char *data, size_t length, int observe) {
       goto error;
   }
 
-  if (coap_send(session, pdu) == COAP_INVALID_TID)
+  if (coap_send(session, pdu) == COAP_INVALID_MID)
     goto error;
   return 1;
 

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -184,10 +184,10 @@ int main(int argc, char* argv[])
                          sizeof("*unsigned int *")-1) != 0) {
               is_number_func = 1;
             }
-            else if (strncmp(buffer, "*coap_tid_t ",
-                              sizeof("*coap_tid_t ")-1) == 0 &&
-                strncmp(buffer, "*coap_tid_t *",
-                         sizeof("*coap_tid_t *")-1) != 0) {
+            else if (strncmp(buffer, "*coap_mid_t ",
+                              sizeof("*coap_mid_t ")-1) == 0 &&
+                strncmp(buffer, "*coap_mid_t *",
+                         sizeof("*coap_mid_t *")-1) != 0) {
               is_number_func = 1;
             }
             /* Look specifically for inline prefixes */

--- a/src/async.c
+++ b/src/async.c
@@ -30,7 +30,7 @@ coap_async_state_t *
 coap_register_async(coap_context_t *context, coap_session_t *session,
                     coap_pdu_t *request, unsigned char flags, void *data) {
   coap_async_state_t *s;
-  coap_tid_t id = request->tid;
+  coap_mid_t id = request->mid;
 
   SEARCH_PAIR(context->async_state,s,session,session,id,id);
 
@@ -74,7 +74,7 @@ coap_register_async(coap_context_t *context, coap_session_t *session,
 }
 
 coap_async_state_t *
-coap_find_async(coap_context_t *context, coap_session_t *session, coap_tid_t id) {
+coap_find_async(coap_context_t *context, coap_session_t *session, coap_mid_t id) {
   coap_async_state_t *tmp;
   SEARCH_PAIR(context->async_state,tmp,session,session,id,id);
   return tmp;
@@ -82,7 +82,7 @@ coap_find_async(coap_context_t *context, coap_session_t *session, coap_tid_t id)
 
 int
 coap_remove_async(coap_context_t *context, coap_session_t *session,
-                  coap_tid_t id, coap_async_state_t **s) {
+                  coap_mid_t id, coap_async_state_t **s) {
   coap_async_state_t *tmp = coap_find_async(context, session, id);
 
   if (tmp)

--- a/src/block.c
+++ b/src/block.c
@@ -304,7 +304,7 @@ coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
           full_match(token->s, token->length, cq->app_token->s,
                      cq->app_token->length)) {
         uint8_t buf[4];
-        coap_tid_t mid;
+        coap_mid_t mid;
         coap_pdu_t * pdu = coap_pdu_duplicate(&cq->pdu,
                                               session,
                                               cq->base_token_length,
@@ -322,7 +322,7 @@ coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
                                                 COAP_OBSERVE_CANCEL),
                            buf);
         mid = coap_send(session, pdu);
-        if (mid != COAP_INVALID_TID)
+        if (mid != COAP_INVALID_MID)
           return 1;
         break;
       }
@@ -1333,7 +1333,7 @@ coap_handle_request_put_block(coap_context_t *context,
         response->code = COAP_RESPONSE_CODE(408);
         goto free_lg_recv;
       }
-      p->last_mid = pdu->tid;
+      p->last_mid = pdu->mid;
       p->last_type = pdu->type;
       memcpy(p->last_token, pdu->token, pdu->token_length);
       p->last_token_length = pdu->token_length;
@@ -1556,7 +1556,7 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *rcvd) {
                             block.num,
                             block.szx))
           goto fail_body;
-        if (coap_send(session, pdu) == COAP_INVALID_TID)
+        if (coap_send(session, pdu) == COAP_INVALID_MID)
           goto fail_body;
         return 1;
       }
@@ -1748,7 +1748,7 @@ coap_handle_response_get_block(coap_context_t *context,
                                       (0 << 4) | (0 << 3) | block.szx),
                                buf);
 
-            if (coap_send(session, pdu) == COAP_INVALID_TID)
+            if (coap_send(session, pdu) == COAP_INVALID_MID)
               goto fail_resp;
 
             goto skip_app_handler;
@@ -1825,7 +1825,7 @@ coap_handle_response_get_block(coap_context_t *context,
                                     (block.m << 3) | block.szx),
                                  buf);
 
-              if (coap_send(session, pdu) == COAP_INVALID_TID)
+              if (coap_send(session, pdu) == COAP_INVALID_MID)
                 goto fail_resp;
             }
             if (session->block_mode & (COAP_BLOCK_SINGLE_BODY))
@@ -1862,7 +1862,7 @@ coap_handle_response_get_block(coap_context_t *context,
               coap_show_pdu(LOG_DEBUG, rcvd);
             }
             context->response_handler(context, session, sent, rcvd,
-                                      rcvd->tid);
+                                      rcvd->mid);
           }
           app_has_response = 1;
           /* Set up for the next data body if observing */
@@ -1900,7 +1900,7 @@ block_mode:
             coap_log(LOG_DEBUG, "Client app vesion of updated PDU\n");
             coap_show_pdu(LOG_DEBUG, rcvd);
             context->response_handler(context, session, sent, rcvd,
-                                        rcvd->tid);
+                                        rcvd->mid);
           }
           app_has_response = 1;
         }

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -138,7 +138,7 @@ coap_new_cache_entry(coap_session_t *session, const coap_pdu_t *pdu,
   memset(entry, 0, sizeof(coap_cache_entry_t));
   entry->session = session;
   if (record_pdu == COAP_CACHE_RECORD_PDU) {
-    entry->pdu = coap_pdu_init(pdu->type, pdu->code, pdu->tid, pdu->alloc_size);
+    entry->pdu = coap_pdu_init(pdu->type, pdu->code, pdu->mid, pdu->alloc_size);
     if (entry->pdu) {
       coap_pdu_resize(entry->pdu, pdu->alloc_size);
       /* Need to get the appropriate data across */

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -510,7 +510,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
 
   snprintf(outbuf, sizeof(outbuf), "v:%d t:%s c:%s i:%04x {",
           COAP_DEFAULT_VERSION, msg_type_string(pdu->type),
-          msg_code_string(pdu->code), pdu->tid);
+          msg_code_string(pdu->code), pdu->mid);
 
   for (i = 0; i < pdu->token_length; i++) {
     outbuflen = strlen(outbuf);

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1105,7 +1105,7 @@ coap_io_prepare_io(coap_context_t *ctx,
       coap_tick_t s_timeout;
       if (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND <= now) {
         if ((s->last_ping > 0 && s->last_pong < s->last_ping)
-          || ((s->last_ping_mid = coap_session_send_ping(s)) == COAP_INVALID_TID))
+          || ((s->last_ping_mid = coap_session_send_ping(s)) == COAP_INVALID_MID))
         {
           /* Make sure the session object is not deleted in the callback */
           coap_session_reference(s);

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -42,7 +42,7 @@ coap_pdu_clear(coap_pdu_t *pdu, size_t size) {
   pdu->code = 0;
   pdu->hdr_size = 0;
   pdu->token_length = 0;
-  pdu->tid = 0;
+  pdu->mid = 0;
   pdu->max_opt = 0;
   pdu->max_size = size;
   pdu->used_size = 0;
@@ -82,7 +82,7 @@ coap_pdu_from_pbuf( struct pbuf *pbuf )
 #endif
 
 coap_pdu_t *
-coap_pdu_init(uint8_t type, uint8_t code, uint16_t tid, size_t size) {
+coap_pdu_init(uint8_t type, uint8_t code, uint16_t mid, size_t size) {
   coap_pdu_t *pdu;
 
   pdu = coap_malloc_type(COAP_PDU, sizeof(coap_pdu_t));
@@ -115,7 +115,7 @@ coap_pdu_init(uint8_t type, uint8_t code, uint16_t tid, size_t size) {
   pdu->token = buf + pdu->max_hdr_size;
 #endif /* WITH_LWIP */
   coap_pdu_clear(pdu, size);
-  pdu->tid = tid;
+  pdu->mid = mid;
   pdu->type = type;
   pdu->code = code;
   return pdu;
@@ -826,13 +826,13 @@ coap_pdu_parse_header(coap_pdu_t *pdu, coap_proto_t proto) {
     pdu->type = (hdr[0] >> 4) & 0x03;
     pdu->token_length = hdr[0] & 0x0f;
     pdu->code = hdr[1];
-    pdu->tid = (uint16_t)hdr[2] << 8 | hdr[3];
+    pdu->mid = (uint16_t)hdr[2] << 8 | hdr[3];
   } else if (proto == COAP_PROTO_TCP || proto == COAP_PROTO_TLS) {
     assert(pdu->hdr_size >= 2 && pdu->hdr_size <= 6);
     pdu->type = COAP_MESSAGE_CON;
     pdu->token_length = hdr[0] & 0x0f;
     pdu->code = hdr[pdu->hdr_size-1];
-    pdu->tid = 0;
+    pdu->mid = 0;
   } else {
     coap_log(LOG_DEBUG, "coap_pdu_parse: unsupported protocol\n");
     return 0;
@@ -1129,8 +1129,8 @@ coap_pdu_encode_header(coap_pdu_t *pdu, coap_proto_t proto) {
                    | pdu->type << 4
                    | pdu->token_length;
     pdu->token[-3] = pdu->code;
-    pdu->token[-2] = (uint8_t)(pdu->tid >> 8);
-    pdu->token[-1] = (uint8_t)(pdu->tid);
+    pdu->token[-2] = (uint8_t)(pdu->mid >> 8);
+    pdu->token[-1] = (uint8_t)(pdu->mid);
     pdu->hdr_size = 4;
   } else if (proto == COAP_PROTO_TCP || proto == COAP_PROTO_TLS) {
     size_t len;

--- a/src/resource.c
+++ b/src/resource.c
@@ -871,7 +871,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         continue;
       }
 
-      coap_tid_t tid = COAP_INVALID_TID;
+      coap_mid_t mid = COAP_INVALID_MID;
       obs->dirty = 0;
       /* initialize response */
       response = coap_pdu_init(COAP_MESSAGE_CON, 0, 0, coap_session_max_pdu_size(obs->session));
@@ -899,7 +899,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
       token.length = obs->token_length;
       token.s = obs->token;
 
-      obs->tid = response->tid = coap_new_message_id(obs->session);
+      obs->mid = response->mid = coap_new_message_id(obs->session);
       if ((r->flags & COAP_RESOURCE_FLAGS_NOTIFY_CON) == 0 &&
           ((r->flags & COAP_RESOURCE_FLAGS_NOTIFY_NON_ALWAYS) ||
            obs->non_cnt < COAP_OBS_MAX_NON)) {
@@ -933,9 +933,9 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         obs->non_cnt++;
       }
 
-      tid = coap_send( obs->session, response );
+      mid = coap_send( obs->session, response );
 
-      if (COAP_INVALID_TID == tid) {
+      if (COAP_INVALID_MID == mid) {
         coap_log(LOG_DEBUG,
                  "coap_check_notify: sending failed, resource stays "
                  "partially dirty\n");

--- a/tests/test_error_response.c
+++ b/tests/test_error_response.c
@@ -35,7 +35,7 @@ t_error_response1(void) {
 
   coap_pdu_clear(pdu, pdu->max_size);
   pdu->type = COAP_MESSAGE_CON;
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   /* result = coap_add_token(pdu, 5, (unsigned char *)"token"); */
   coap_option_filter_clear(&opts);
@@ -47,7 +47,7 @@ t_error_response1(void) {
   CU_ASSERT(response->type == COAP_MESSAGE_ACK);
   CU_ASSERT(response->token_length == 0);
   CU_ASSERT(response->code == 0x80);
-  CU_ASSERT(response->tid == 0x1234);
+  CU_ASSERT(response->mid == 0x1234);
   CU_ASSERT(coap_pdu_encode_header(response, COAP_PROTO_UDP) == 4);
   CU_ASSERT(memcmp(response->token - 4, teststr, sizeof(teststr)) == 0);
   coap_delete_pdu(response);
@@ -64,7 +64,7 @@ t_error_response2(void) {
 
   coap_pdu_clear(pdu, pdu->max_size);
   pdu->type = COAP_MESSAGE_NON;
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
   coap_add_token(pdu, 5, (const uint8_t *)"token");
   coap_add_option(pdu, COAP_OPTION_URI_HOST, 4, (const uint8_t *)"time");
 

--- a/tests/test_pdu.c
+++ b/tests/test_pdu.c
@@ -34,7 +34,7 @@ t_parse_pdu1(void) {
   CU_ASSERT(pdu->type == COAP_MESSAGE_CON);
   CU_ASSERT(pdu->token_length == 0);
   CU_ASSERT(pdu->code == COAP_REQUEST_GET);
-  CU_ASSERT(pdu->tid == 0x9334);
+  CU_ASSERT(pdu->mid == 0x9334);
   CU_ASSERT_PTR_NULL(pdu->data);
 }
 
@@ -50,7 +50,7 @@ t_parse_pdu2(void) {
   CU_ASSERT(pdu->type == COAP_MESSAGE_NON);
   CU_ASSERT(pdu->token_length == 5);
   CU_ASSERT(pdu->code == 0x69);
-  CU_ASSERT(pdu->tid == 0x1234);
+  CU_ASSERT(pdu->mid == 0x1234);
   CU_ASSERT(memcmp(pdu->token, teststr + 4, 5) == 0);
   CU_ASSERT_PTR_NULL(pdu->data);
 }
@@ -95,7 +95,7 @@ t_parse_pdu5(void) {
   CU_ASSERT(pdu->type == COAP_MESSAGE_NON);
   CU_ASSERT(pdu->token_length == 5);
   CU_ASSERT(pdu->code == 0x73);
-  CU_ASSERT(pdu->tid == 0x1234);
+  CU_ASSERT(pdu->mid == 0x1234);
   CU_ASSERT(memcmp(pdu->token, teststr + 4, 5) == 0);
   CU_ASSERT_PTR_NULL(pdu->data);
 
@@ -130,7 +130,7 @@ t_parse_pdu7(void) {
   CU_ASSERT(pdu->type == COAP_MESSAGE_NON);
   CU_ASSERT(pdu->token_length == 5);
   CU_ASSERT(pdu->code == 0x73);
-  CU_ASSERT(pdu->tid == 0x1234);
+  CU_ASSERT(pdu->mid == 0x1234);
   CU_ASSERT(memcmp(pdu->token, teststr + 4, 5) == 0);
 
   /* FIXME: check options */
@@ -155,7 +155,7 @@ t_parse_pdu8(void) {
   CU_ASSERT(pdu->type == COAP_MESSAGE_NON);
   CU_ASSERT(pdu->token_length == 0);
   CU_ASSERT(pdu->code == 0x73);
-  CU_ASSERT(pdu->tid == 0x1234);
+  CU_ASSERT(pdu->mid == 0x1234);
 
   /* FIXME: check options */
 
@@ -197,7 +197,7 @@ t_parse_pdu11(void) {
   CU_ASSERT(pdu->type == COAP_MESSAGE_ACK);
   CU_ASSERT(pdu->token_length == 0);
   CU_ASSERT(pdu->code == 0);
-  CU_ASSERT(pdu->tid == 0x1234);
+  CU_ASSERT(pdu->mid == 0x1234);
 }
 
 static void
@@ -213,7 +213,7 @@ t_parse_pdu12(void) {
   CU_ASSERT(pdu->type == COAP_MESSAGE_RST);
   CU_ASSERT(pdu->token_length == 0);
   CU_ASSERT(pdu->code == 0);
-  CU_ASSERT(pdu->tid == 0x1234);
+  CU_ASSERT(pdu->mid == 0x1234);
 }
 
 static void
@@ -337,7 +337,7 @@ t_encode_pdu1(void) {
   coap_pdu_clear(pdu, pdu->max_size);
   pdu->type = COAP_MESSAGE_CON;
   pdu->code = COAP_REQUEST_GET;
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   result = coap_add_token(pdu, 5, (const uint8_t *)"token");
 
@@ -357,7 +357,7 @@ t_encode_pdu2(void) {
 
   pdu->type = COAP_MESSAGE_CON;
   pdu->code = COAP_REQUEST_GET;
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   result = coap_add_token(pdu, 5, (const uint8_t *)"token");
 
@@ -391,7 +391,7 @@ t_encode_pdu4(void) {
 
   pdu->type = COAP_MESSAGE_ACK;
   pdu->code = 0x99;
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   CU_ASSERT(pdu->used_size == 0);
 
@@ -442,7 +442,7 @@ t_encode_pdu5(void) {
 
   pdu->type = COAP_MESSAGE_ACK;
   pdu->code = COAP_RESPONSE_CODE(404);
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   CU_ASSERT(pdu->used_size == 0);
 
@@ -480,7 +480,7 @@ t_encode_pdu6(void) {
 
   pdu->type = COAP_MESSAGE_NON;
   pdu->code = COAP_REQUEST_POST;
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   CU_ASSERT(pdu->used_size == 0);
   CU_ASSERT_PTR_NULL(pdu->data);
@@ -501,7 +501,7 @@ t_encode_pdu7(void) {
 
   pdu->type = COAP_MESSAGE_CON;
   pdu->code = COAP_RESPONSE_CODE(203);
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   CU_ASSERT(pdu->used_size == 0);
 
@@ -524,7 +524,7 @@ t_encode_pdu8(void) {
 
   pdu->type = COAP_MESSAGE_CON;
   pdu->code = COAP_RESPONSE_CODE(203);
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   CU_ASSERT(pdu->used_size == 0);
 
@@ -557,7 +557,7 @@ t_encode_pdu9(void) {
 
   pdu->type = COAP_MESSAGE_ACK;
   pdu->code = COAP_RESPONSE_CODE(204);
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   CU_ASSERT(pdu->used_size == 0);
 
@@ -639,7 +639,7 @@ t_encode_pdu10(void) {
 
   pdu->type = COAP_MESSAGE_ACK;
   pdu->code = COAP_RESPONSE_CODE(204);
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   CU_ASSERT(pdu->used_size == 0);
 
@@ -1005,7 +1005,7 @@ t_encode_pdu18(void) {
 
   pdu->type = COAP_MESSAGE_ACK;
   pdu->code = COAP_RESPONSE_CODE(204);
-  pdu->tid = 0x1234;
+  pdu->mid = 0x1234;
 
   CU_ASSERT(pdu->used_size == 0);
 

--- a/tests/test_wellknown.c
+++ b/tests/test_wellknown.c
@@ -227,7 +227,7 @@ t_wellknown6(void) {
 
     pdu->type = COAP_MESSAGE_NON;
     pdu->code = COAP_REQUEST_GET;
-    pdu->tid = 0x1234;
+    pdu->mid = 0x1234;
 
     CU_ASSERT_PTR_NOT_NULL(pdu);
 


### PR DESCRIPTION
CoAP transaction id was formerly defined as a hash of the remote address and
message id of the CoAP PDU.  It now only refers to, and is used as, the
message id.

Replace occurrences of 'transaction id' with 'message id' to reflect naming in
RFC7252.

Correct the definition of coap_tid_t to what it actually represents.

Replace occurrences of coap_tid_t with coap_mid_t.

Replace uses of tid with mid

Remove unused function coap_find_transaction().