### PR TITLE
Block2: Fix ordering issue when calling coap_add_data_large_response()

### DIFF
--- a/include/coap2/coap_block_internal.h
+++ b/include/coap2/coap_block_internal.h
@@ -220,6 +220,18 @@ int coap_add_data_large_internal(struct coap_session_t *session,
                         coap_release_large_data_t release_func,
                         void *app_ptr);
 
+/**
+ * The function checks that the code in a newly formed lg_xmit created by
+ * coap_add_data_large_response() is updated.
+ *
+ * @param session  The session
+ * @param response The response PDU to to check
+ * @param resource The requested resource
+ * @param query    The requested query
+ */
+void coap_check_code_lg_xmit(coap_session_t *session, coap_pdu_t *response,
+                             coap_resource_t *resource, coap_string_t *query);
+
 /** @} */
 
 #endif /* COAP_BLOCK_INTERNAL_H_ */

--- a/src/net.c
+++ b/src/net.c
@@ -2726,6 +2726,9 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
        */
       h(context, resource, session, pdu, &token, query, response);
 
+      /* Check if lg_xmit generated and update PDU code if so */
+      coap_check_code_lg_xmit(session, response, resource, query);
+
 skip_handler:
       respond = no_response(pdu, response, session);
       if (respond != RESPONSE_DROP) {

--- a/src/resource.c
+++ b/src/resource.c
@@ -915,6 +915,8 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         assert(h);      /* we do not allow subscriptions if no
                          * GET/FETCH handler is defined */
         h(context, r, obs->session, NULL, &token, obs->query, response);
+        /* Check if lg_xmit generated and update PDU code if so */
+        coap_check_code_lg_xmit(obs->session, response, r, obs->query);
         if (COAP_RESPONSE_CLASS(response->code) > 2) {
           coap_delete_observer(r, obs->session, &token);
         }


### PR DESCRIPTION
If the response code was set after calling coap_add_data_large_response(),
the continuing blocks were sent with code 0.00.

Now check following call to response handler that the correct code is held
within the lg_xmit information.