### PR TITLE
mcast block2: Support mcast request with block2 responses

### DIFF
--- a/include/coap2/coap_io.h
+++ b/include/coap2/coap_io.h
@@ -45,6 +45,15 @@ typedef int coap_fd_t;
 
 typedef uint16_t coap_socket_flags_t;
 
+/**
+ * Only used for servers for hashing incoming packets. Cannot have local
+ * address as this may be an initial multicast and subsequent unicast address
+ */
+typedef struct coap_addr_hash_t {
+  coap_address_t remote;       /**< remote address and port */
+  uint16_t lport;              /**< local port */
+} coap_addr_hash_t;
+
 typedef struct coap_addr_tuple_t {
   coap_address_t remote;       /**< remote address and port */
   coap_address_t local;        /**< local address and port */

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -63,8 +63,8 @@ typedef struct coap_session_t {
   coap_session_state_t state;       /**< current state of relationaship with peer */
   unsigned ref;                     /**< reference count from queues */
   size_t tls_overhead;              /**< overhead of TLS layer */
-  size_t mtu;                     /**< path or CSM mtu */
-  coap_address_t local_if;          /**< optional local interface address */
+  size_t mtu;                       /**< path or CSM mtu */
+  coap_addr_hash_t addr_hash;  /**< Address hash for server incoming packets */
   UT_hash_handle hh;
   coap_addr_tuple_t addr_info;      /**< key: remote/local address info */
   int ifindex;                      /**< interface index */
@@ -655,7 +655,7 @@ coap_fixed_point_t coap_session_get_ack_random_factor(coap_session_t *session);
 coap_tid_t coap_session_send_ping(coap_session_t *session);
 
 #define SESSIONS_ADD(e, obj) \
-  HASH_ADD(hh, (e), addr_info, sizeof((obj)->addr_info), (obj))
+  HASH_ADD(hh, (e), addr_hash, sizeof((obj)->addr_hash), (obj))
 
 #define SESSIONS_DELETE(e, obj) \
   HASH_DELETE(hh, (e), (obj))

--- a/src/net.c
+++ b/src/net.c
@@ -778,8 +778,9 @@ coap_send_pdu(coap_session_t *session, coap_pdu_t *pdu, coap_queue_t *node) {
 #if !COAP_DISABLE_TCP
     } else if(COAP_PROTO_RELIABLE(session->proto)) {
       if (!coap_socket_connect_tcp1(
-        &session->sock, &session->local_if, &session->addr_info.remote,
-        session->proto == COAP_PROTO_TLS ? COAPS_DEFAULT_PORT : COAP_DEFAULT_PORT,
+        &session->sock, &session->addr_info.local, &session->addr_info.remote,
+        session->proto == COAP_PROTO_TLS ? COAPS_DEFAULT_PORT :
+                                           COAP_DEFAULT_PORT,
         &session->addr_info.local, &session->addr_info.remote
       )) {
         coap_handle_event(session->context, COAP_EVENT_TCP_FAILED, session);


### PR DESCRIPTION
The first block response is unicast, and the client requests the further blocks
using unicast.  https://tools.ietf.org/html/rfc7959#section-2.8

However, the hash for the server lookup of incoming data is based on
coap_addr_tuple_t which includes the local address - which changes between
receipt of mcast and unicast requests.  This causes 2 sessions to be set up,
and the subsequent request/responses are treated as individual block random
access causing mismatch of information by the client.

Fix is to hash only on the remote address (IP + port) and local port for
servers.