### PR TITLE
nits: Fix runtime warnings

### DIFF
--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -743,7 +743,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
 
 void coap_show_tls_version(coap_log_t level)
 {
-  char buffer[64];
+  char buffer[128];
   coap_string_tls_version(buffer, sizeof(buffer));
   coap_log(level, "%s\n", buffer);
 }

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -1856,12 +1856,13 @@ coap_dgram_read(gnutls_transport_ptr_t context, void *out, size_t outl)
 {
   ssize_t ret = 0;
   coap_session_t *c_session = (struct coap_session_t *)context;
-  coap_ssl_t *data = &((coap_gnutls_env_t *)c_session->tls)->coap_ssl_data;
+  coap_ssl_t *data;
 
   if (!c_session->tls) {
     errno = EAGAIN;
     return -1;
   }
+  data = &((coap_gnutls_env_t *)c_session->tls)->coap_ssl_data;
 
   if (out != NULL) {
     if (data != NULL && data->pdu_len > 0) {


### PR DESCRIPTION
src/coap_debug.c:

Increase available buffer space.

src/coap_gnutls.c

Do not access NULL pointer offset.