### PR TITLE
net.c: Handle duplicate empty ACK

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -2926,7 +2926,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
         coap_touch_observer(context, sent->session, &token);
       }
 
-      if (pdu->code == 0 && sent) {
+      if (pdu->code == 0) {
         /* an empty ACK needs no further handling */
         goto cleanup;
       }


### PR DESCRIPTION
An empty response ACK is ignored if there was a request on the Send-Q.

However if there was a subsequent duplicate ACK this would then fall through
to the general handling logic in coap_dispatch(), and would trigger the ping
handler (if set) and send a RST (if not mcast) which is not correct.

Correct a change added in by #554 so that all empty response ACKs are ignored.