### PR TITLE
coap_async_state_t: Obfuscate coap_async_state_t for applications

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ EXTRA_DIST = \
   include/coap$(LIBCOAP_API_VERSION)/coap_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_riot.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_asn1_internal.h \
+  include/coap$(LIBCOAP_API_VERSION)/coap_async_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_block_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_cache_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_net_internal.h \
@@ -164,6 +165,7 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_LDFLAGS =					\
 ## libcoap-$(LIBCOAP_API_VERSION).{map,sym} for the linker.
 CTAGS_IGNORE=-I " \
 coap_delete_all_async \
+coap_delete_all \
 coap_dtls_context_check_keys_enabled \
 coap_dtls_context_set_pki \
 coap_dtls_context_set_pki_root_cas \

--- a/configure.ac
+++ b/configure.ac
@@ -820,6 +820,7 @@ examples/Makefile
 include/coap$LIBCOAP_API_VERSION/coap.h
 include/coap$LIBCOAP_API_VERSION/coap.h.windows
 man/coap.txt
+man/coap_async.txt
 man/coap_attribute.txt
 man/coap_block.txt
 man/coap_cache.txt

--- a/include/coap2/coap_async_internal.h
+++ b/include/coap2/coap_async_internal.h
@@ -1,0 +1,65 @@
+/*
+ * coap_async_internal.h -- state management for asynchronous messages
+ *
+ * Copyright (C) 2010-2021 Olaf Bergmann <bergmann@tzi.org>
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_async_internal.h
+ * @brief CoAP async internal information
+ */
+
+#ifndef COAP_ASYNC_INTERNAL_H_
+#define COAP_ASYNC_INTERNAL_H_
+
+#include "coap2/net.h"
+
+#ifndef WITHOUT_ASYNC
+
+/**
+ * @defgroup coap_async_internal Asynchronous Messaging (Internal)
+ * @{
+ * CoAP Async Structures, Enums and Functions that are not exposed to
+ * applications.
+ * A coap_context_t object holds a list of coap_async_t objects that can be
+ * used to generate a separate response in the case a result of a request cannot
+ * be delivered immediately.
+ */
+struct coap_async_t {
+  struct coap_async_t *next; /**< internally used for linking */
+  coap_tick_t delay;    /**< When to delay to before triggering the response
+                             0 indicates never trigger */
+  coap_session_t *session;         /**< transaction session */
+  coap_pdu_t *pdu;                 /**< copy of request pdu */
+  void* appdata;                   /** User definable data pointer */
+};
+
+/**
+ * Checks if there are any pending Async requests - if so, send them off.
+ * Otherewise return the time remaining for the next Async to be triggered
+ * or 0 if nothing to do.
+ *
+ * @param context The current context.
+ * @param now     The current time in ticks.
+ *
+ * @return The tick time before the next Async needs to go, else 0 if
+ *         nothing to do.
+ */
+coap_tick_t coap_check_async(coap_context_t *context, coap_tick_t now);
+
+/**
+ * Removes and frees off all of the async entries for the given context.
+ *
+ * @param context The context to remove all async entries from.
+ */
+void
+coap_delete_all_async(coap_context_t *context);
+
+/** @} */
+
+#endif /*  WITHOUT_ASYNC */
+
+#endif /* COAP_ASYNC_INTERNAL_H_ */

--- a/include/coap2/coap_forward_decls.h
+++ b/include/coap2/coap_forward_decls.h
@@ -40,6 +40,13 @@ typedef struct coap_pdu_t coap_pdu_t;
  * typedef all the opaque structures that are defined in coap_*_internal.h
  */
 
+/* ************* coap_async_internal.h ***************** */
+
+/**
+ * Async Entry information.
+ */
+typedef struct coap_async_t coap_async_t;
+
 /* ************* coap_cache_internal.h ***************** */
 
 /*

--- a/include/coap2/coap_internal.h
+++ b/include/coap2/coap_internal.h
@@ -47,6 +47,7 @@
 
 /* Specifically defined internal .h files */
 #include "coap_asn1_internal.h"
+#include "coap_async_internal.h"
 #include "coap_block_internal.h"
 #include "coap_cache_internal.h"
 #include "coap_net_internal.h"

--- a/include/coap2/coap_net_internal.h
+++ b/include/coap2/coap_net_internal.h
@@ -55,7 +55,7 @@ struct coap_context_t {
 #ifndef WITHOUT_ASYNC
   /**
    * list of asynchronous message ids */
-  struct coap_async_state_t *async_state;
+  coap_async_t *async_state;
 #endif /* WITHOUT_ASYNC */
 
   /**

--- a/libcoap-2.map
+++ b/libcoap-2.map
@@ -15,6 +15,9 @@ global:
   coap_address_init;
   coap_address_set_port;
   coap_add_token;
+  coap_async_get_app_data;
+  coap_async_set_app_data;
+  coap_async_set_delay;
   coap_attr_get_value;
   coap_block_build_body;
   coap_cache_derive_key;
@@ -157,7 +160,6 @@ global:
   coap_register_ping_handler;
   coap_register_pong_handler;
   coap_register_response_handler;
-  coap_remove_async;
   coap_resize_binary;
   coap_resource_get_uri_path;
   coap_resource_get_userdata;

--- a/libcoap-2.sym
+++ b/libcoap-2.sym
@@ -13,6 +13,9 @@ coap_address_get_port
 coap_address_init
 coap_address_set_port
 coap_add_token
+coap_async_get_app_data
+coap_async_set_app_data
+coap_async_set_delay
 coap_attr_get_value
 coap_block_build_body
 coap_cache_derive_key
@@ -155,7 +158,6 @@ coap_register_option
 coap_register_ping_handler
 coap_register_pong_handler
 coap_register_response_handler
-coap_remove_async
 coap_resize_binary
 coap_resource_get_uri_path
 coap_resource_get_userdata

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -18,7 +18,8 @@ if BUILD_MANPAGES
 
 # building the manpages
 
-TXT3 = coap_attribute.txt \
+TXT3 = coap_async.txt \
+        coap_attribute.txt \
 	coap_block.txt \
 	coap_cache.txt \
 	coap_context.txt \

--- a/man/coap_async.txt.in
+++ b/man/coap_async.txt.in
@@ -64,9 +64,13 @@ application request handler will get called with a copy of _request_ after
 _delay_ ticks which will then cause a response to be sent.  If _delay_ is 0,
 then the application request handler will not get called.
 
-The coap_async_set_delay*() function is used to update the reamining _delay_
+The *coap_async_set_delay*() function is used to update the remaining _delay_
 before the application request handler is called for the _async_ definition. If
 _delay_ is set to 0, then the application request handler will not get called.
+
+An example of usage here is *coap_register_async*() sets _delay_ to 0, and
+then when the response is ready at an indeterminate point in the future,
+*coap_async_set_delay*() is called setting _delay_ to 1.
 
 The *coap_free_async*() function is used to delete an _async_ definition.
 

--- a/man/coap_async.txt.in
+++ b/man/coap_async.txt.in
@@ -1,0 +1,180 @@
+// -*- mode:doc; -*-
+// vim: set syntax=asciidoc,tw=0:
+
+coap_async(3)
+=============
+:doctype: manpage
+:man source:   coap_async
+:man version:  @PACKAGE_VERSION@
+:man manual:   libcoap Manual
+
+NAME
+----
+coap_async,
+coap_register_async,
+coap_async_set_delay,
+coap_find_async,
+coap_free_async,
+coap_async_set_app_data,
+coap_async_get_app_data
+- Work with CoAP async support
+
+SYNOPSIS
+--------
+*#include <coap@LIBCOAP_API_VERSION@/coap.h>*
+
+*coap_async_t *coap_register_async(coap_context_t *_context_,
+coap_session_t *_session_, coap_pdu_t *_request_, coap_tick_t _delay_);*
+
+*void coap_async_set_delay(coap_async_t *_async_, coap_tick_t _delay_);*
+
+*void coap_free_async(coap_context_t *_context_, coap_async_t *_async_);*
+
+*coap_async_t *coap_find_async(coap_context_t *_context_,
+coap_session_t *_session_, coap_mid_t _mid_);*
+
+*void coap_async_set_app_data(coap_async_t *_async_, void *_app_data_);*
+
+*void *coap_async_get_app_data(const coap_async_t *_async_);*
+
+For specific (D)TLS library support, link with
+*-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
+*-lcoap-@LIBCOAP_API_VERSION@* to get the default (D)TLS library support.
+
+DESCRIPTION
+-----------
+CoAP server responses can be piggybacked (RFC7252 5.2.1) or separate
+(RFC7252 5.2.2).
+
+For piggybacked responses, the response packet contains both the status and
+any data.
+
+For separate responses, there is an initial empty ACK response (Confirmable
+only - to stop the client re-transmitting the request) followed at a later time
+by the packet containing the status and any data.
+
+Usually responses are piggybacked, but this man page focuses on separate
+(async) support.
+
+The *coap_register_async*() function is used to set up an asynchronous delayed
+request for the _request_ PDU associated with the _context_ and _session_. The
+application request handler will get called with a copy of _request_ after
+_delay_ ticks which will then cause a response to be sent.  If _delay_ is 0,
+then the application request handler will not get called.
+
+The coap_async_set_delay*() function is used to update the reamining _delay_
+before the application request handler is called for the _async_ definition. If
+_delay_ is set to 0, then the application request handler will not get called.
+
+The *coap_free_async*() function is used to delete an _async_ definition.
+
+The *coap_find_async*() function is used to determine if there is an async
+definition based on the _context_, _session_ and message id _mid_.
+
+The *coap_async_set_app_data*() function is used to add in user defined
+_app_data_ to the _async_ definition.  It is the responsibility of the
+application to release this data if appropriate.
+
+The *coap_async_get_app_data*() function is used to retrieve any defines
+application data from the  _async_ definition.
+
+RETURN VALUES
+-------------
+
+*coap_register_async*() and *coap_find_async*() return a pointer to an async
+definition or NULL if there is an error.
+
+*coap_async_get_app_data*() returns a pointer to the user defined data.
+
+EXAMPLES
+--------
+*CoAP Server Non-Encrypted Setup*
+
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+/*
+ * This example is used to demonstrate how to set up and use a "separate"
+ * response (empty ACK followed by data response at a later stage).
+ */
+static void
+hnd_get_with_delay(coap_context_t *context,
+              coap_resource_t *resource,
+              coap_session_t *session,
+              coap_pdu_t *request,
+              coap_binary_t *token,
+              coap_string_t *query,
+              coap_pdu_t *response) {
+  unsigned long delay = 5;
+  size_t size;
+  coap_async_t *async;
+
+  /*
+   * See if this is the initial, or delayed request
+   */
+  async = coap_find_async(context, session, request->mid);
+  if (!async) {
+    /* Set up an async request to trigger delay in the future */
+    if (query) {
+      const uint8_t *p = query->s;
+
+      delay = 0;
+      for (size = query->length; size; --size, ++p)
+        delay = delay * 10 + (*p - '0');
+      if (delay == 0) {
+        coap_log(LOG_INFO, "async: delay of 0 not supported\n");
+        response->code = COAP_RESPONSE_CODE_BAD_REQUEST;
+        return;
+      }
+    }
+    async = coap_register_async(context,
+                                session,
+                                request,
+                                COAP_TICKS_PER_SECOND * delay);
+    if (async == NULL) {
+      response->code = COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE;
+      return;
+    }
+    /*
+     * Not setting response code will cause empty ACK to be sent
+     * if Confirmable
+     */
+    return;
+  }
+  /* async set up, so this is the delayed request */
+
+  /* Send back the appropriate data */
+  coap_add_data_large_response(resource, session, request, response, token,
+                               query, COAP_MEDIATYPE_TEXT_PLAIN, -1, 0, 4,
+                               (const uint8_t *)"done", NULL, NULL);
+  response->code = COAP_RESPONSE_CODE_CONTENT;
+
+  /* async is automatically removed by libcoap on return from this handler */
+}
+
+----
+
+SEE ALSO
+--------
+*coap_handler*(3)
+
+FURTHER INFORMATION
+-------------------
+See
+
+"RFC7252: The Constrained Application Protocol (CoAP)"
+
+for further information.
+
+BUGS
+----
+Please report bugs on the mailing list for libcoap:
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
+
+AUTHORS
+-------
+The libcoap project <libcoap-developers@lists.sourceforge.net>


### PR DESCRIPTION
Move coap_async_state_t to coap_async_internal.h and rename to coap_async_t
as it no longer has any state.

Refactor the async logic to simplify usage and provide libcoap based delay
functionality support for request/response traffic such as multicast.  Let
libcoap decide when the delayed response is to be sent.

Move internal async based function definitions to coap_async_internal.h.

Replace most references to "struct coap_async_state_t" with
"coap_async_t".

Provide new functions to allow applications to access parts of
coap_async_t as appropriate.

Update examples to use these new access functions where appropriate.

Add in new man page.