### PR TITLE
man: Extra checks on function definitions

### DIFF
--- a/man/coap_attribute.txt.in
+++ b/man/coap_attribute.txt.in
@@ -19,11 +19,11 @@ SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
 
-*coap_attr_t *coap_add_attr(coap_resource_t *_resource_, coap_str_const_t
-*_name_, coap_str_const_t *_value_, int _flags_);*
+*coap_attr_t *coap_add_attr(coap_resource_t *_resource_,
+coap_str_const_t *_name_, coap_str_const_t *_value_, int _flags_);*
 
-*coap_attr_t *coap_find_attr(coap_resource_t *_resource_, coap_str_const_t
-*_name_);*
+*coap_attr_t *coap_find_attr(coap_resource_t *_resource_,
+coap_str_const_t *_name_);*
 
 *coap_str_const_t *coap_attr_get_value(coap_attr_t *_attribute_);*
 

--- a/man/coap_keepalive.txt.in
+++ b/man/coap_keepalive.txt.in
@@ -18,7 +18,7 @@ SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
 
-*void void coap_context_set_keepalive(coap_context_t *_context_,
+*void coap_context_set_keepalive(coap_context_t *_context_,
 unsigned int _seconds_);*
 
 For specific (D)TLS library support, link with

--- a/man/coap_recovery.txt.in
+++ b/man/coap_recovery.txt.in
@@ -33,12 +33,13 @@ coap_fixed_point_t _value_)*;
 *void coap_session_set_ack_random_factor(coap_session_t *_session_,
 coap_fixed_point_t _value_)*;
 
-*unsigned int coap_session_get_max_transmit(coap_session_t *_session_)*;
+*unsigned int coap_session_get_max_transmit(const coap_session_t *_session_)*;
 
-*coap_fixed_point_t coap_session_get_ack_timeout(coap_session_t *_session_)*;
+*coap_fixed_point_t coap_session_get_ack_timeout(
+const coap_session_t *_session_)*;
 
-*coap_fixed_point_t coap_session_get_ack_random_factor(coap_session_t
-*_session_)*;
+*coap_fixed_point_t coap_session_get_ack_random_factor(
+const coap_session_t *_session_)*;
 
 *int coap_debug_set_packet_loss(const char *_loss_level_)*;
 

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -51,23 +51,17 @@ const coap_session_t *_session_);*
 *const coap_address_t *coap_session_get_addr_remote(
 const coap_session_t *_session_);*
 
-*coap_context_t *coap_session_get_context(
-const coap_session_t *_session_);*
+*coap_context_t *coap_session_get_context(const coap_session_t *_session_);*
 
-*int coap_session_get_ifindex(
-const coap_session_t *_session_);*
+*int coap_session_get_ifindex(const coap_session_t *_session_);*
 
-*coap_proto_t coap_session_get_proto(
-const coap_session_t *_session_);*
+*coap_proto_t coap_session_get_proto(const coap_session_t *_session_);*
 
-*coap_session_state_t coap_session_get_state(
-const coap_session_t *_session_);*
+*coap_session_state_t coap_session_get_state(const coap_session_t *_session_);*
 
-*void *coap_session_get_tls(
-const coap_session_t *_session_);*
+*void *coap_session_get_tls(const coap_session_t *_session_);*
 
-*coap_session_type_t coap_session_get_type(
-const coap_session_t *_session_);*
+*coap_session_type_t coap_session_get_type(const coap_session_t *_session_);*
 
 *const coap_bin_const_t *coap_session_get_psk_hint(
 const coap_session_t *_session_);*

--- a/man/coap_string.txt.in
+++ b/man/coap_string.txt.in
@@ -39,7 +39,7 @@ SYNOPSIS
 
 *coap_str_const_t *coap_make_str_const(const char *_string_);*
 
-*int coap_string_equal(coap_string_t _string1_, coap_string_t _string2_);*
+*int coap_string_equal(coap_string_t *_string1_, coap_string_t *_string2_);*
 
 *coap_binary_t *coap_new_binary(size_t _size_);*
 
@@ -51,7 +51,7 @@ SYNOPSIS
 
 *void coap_delete_bin_const(coap_bin_const_t *_binary_);*
 
-*int coap_binary_equal(coap_binary_t _binary1_, coap_binary_t _binary2_);*
+*int coap_binary_equal(coap_binary_t *_binary1_, coap_binary_t *_binary2_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -53,12 +53,79 @@ const char *inline_list[] = {
   "coap_free(",
 };
 
+const char *define_list[] = {
+  "coap_string_equal(",
+  "coap_binary_equal(",
+  "coap_log(",
+};
+
+const char *struct_list[] = {
+  "coap_fixed_point_t ",
+  "coap_string_t ",
+  "coap_str_const_t ",
+  "coap_binary_t ",
+  "coap_bin_const_t ",
+  "coap_opt_iterator_t ",
+  "coap_opt_t ",
+};
+
+const char *number_list[] = {
+  "coap_log_t ",
+  "coap_pdu_type_t ",
+  "coap_mid_t ",
+  "coap_pdu_code_t ",
+  "coap_proto_t ",
+  "coap_session_state_t ",
+  "coap_session_type_t ",
+  "int ",
+  "uint32_t ",
+  "uint64_t ",
+  "unsigned int ",
+  "size_t ",
+  "const uint8_t ",
+};
+
+int exit_code = 0;
+
+static void check_synopsis(const char* file) {
+  char buffer[1024];
+  char file_name[300];
+  FILE *fpcode;
+  int  status;
+
+  snprintf(file_name, sizeof (file_name), "tmp/%s-header.c", file);
+  fpcode = fopen(file_name, "w");
+  if (!fpcode) {
+    fprintf(stderr, "fopen: %s: %s (%d)\n", file_name, strerror(errno), errno);
+    exit_code = 1;
+    return;
+  }
+  fprintf(fpcode, "#include <coap2/coap.h>\n");
+  fprintf(fpcode, "#ifdef __GNUC__\n");
+  fprintf(fpcode, "#define U __attribute__ ((unused))\n");
+  fprintf(fpcode, "#else /* not a GCC */\n");
+  fprintf(fpcode, "#define U\n");
+  fprintf(fpcode, "#endif /* GCC */\n");
+  fprintf(fpcode, "\n");
+  fprintf(fpcode, "#include \"%s.h\"\n", file);
+  fclose(fpcode);
+  file_name[strlen(file_name)-1] = '\000';
+  snprintf (buffer, sizeof (buffer),
+           "gcc " GCC_OPTIONS " -c %sc -o %so",
+           file_name, file_name);
+  status = system(buffer);
+  if (WEXITSTATUS(status)) {
+    exit_code = WEXITSTATUS(status);
+  }
+  return;
+}
+
 int main(int argc, char* argv[])
 {
   DIR *pdir;
   struct dirent *pdir_ent;
-  int exit_code = 0;
   char buffer[1024];
+  int  status;
 
   if (argc != 2) {
     fprintf(stderr, "usage: %s man_directory\n", argv[0]);
@@ -83,19 +150,20 @@ int main(int argc, char* argv[])
     if (!strncmp(pdir_ent->d_name, "coap_", sizeof ("coap_")-1) &&
         strstr (pdir_ent->d_name, ".txt.in")) {
       FILE*  fp;
-      int  skip = 1;
-      int  in_examples = 0;
+      int skip = 1;
+      int in_examples = 0;
       int in_synopsis = 0;
-      int  count = 1;
-      char  keep_line[1024] = {0};
-      FILE*  fpcode = NULL;
-      FILE*  fpheader = NULL;
-      char  file_name[300];
+      int count = 1;
+      char keep_line[1024] = {0};
+      FILE* fpcode = NULL;
+      FILE* fpheader = NULL;
+      char file_name[300];
       int is_void_func = 0;
       int is_number_func = 0;
       int is_inline_func = 0;
-      int is_struct = 0;
+      int is_struct_func = 0;
       char *func_start = NULL;
+      int is_struct = 0;
       unsigned int i;
 
       fprintf(stderr, "Processing: %s\n", pdir_ent->d_name);
@@ -124,6 +192,7 @@ int main(int argc, char* argv[])
           if (fpheader)
             fclose(fpheader);
           fpheader = NULL;
+          check_synopsis(pdir_ent->d_name);
           continue;
         }
         if (strncmp(buffer, "EXAMPLES", sizeof("EXAMPLES")-1) == 0) {
@@ -146,8 +215,12 @@ int main(int argc, char* argv[])
           if (buffer[0] == '-')
             continue;
           if (buffer[0] == 'F') {
-            /* Link with ..... is the end */
+            /* For specific ..... is the end */
             in_synopsis = 0;
+            if (fpheader)
+              fclose(fpheader);
+            fpheader = NULL;
+            check_synopsis(pdir_ent->d_name);
             continue;
           }
           if (buffer[0] == '*' && buffer[1] == '#')
@@ -156,74 +229,71 @@ int main(int argc, char* argv[])
             /* start of a new function */
             is_void_func = 0;
             is_number_func = 0;
-            is_struct = 0;
+            is_struct_func = 0;
             is_inline_func = 0;
+            is_struct = 0;
             func_start = NULL;
 
-            if (strncmp(buffer, "*void ", sizeof("*void ")-1) == 0 &&
-                strncmp(buffer, "*void *", sizeof("*void *")-1) != 0) {
-              is_void_func = 1;
-              func_start = &buffer[sizeof("*void ")-1];
+            if (strncmp(buffer, "*void ", sizeof("*void ")-1) == 0) {
+              if (strncmp(buffer, "*void *", sizeof("*void *")-1) == 0) {
+                func_start = &buffer[sizeof("*void *")-1];
+              }
+              else {
+                is_void_func = 1;
+                func_start = &buffer[sizeof("*void ")-1];
+              }
             }
-            else if (strncmp(buffer, "*struct ", sizeof("*struct ")-1) == 0) {
+
+            for (i = 0; i < sizeof(number_list)/sizeof(number_list[0]); i++) {
+              if (strncmp(&buffer[1], number_list[i],
+                          strlen(number_list[i])) == 0) {
+                if (buffer[1 + strlen(number_list[i])] == '*') {
+                  func_start = &buffer[2 + strlen(number_list[i])];
+                }
+                else {
+                  is_number_func = 1;
+                  func_start = &buffer[1 + strlen(number_list[i])];
+                }
+                break;
+              }
+            }
+
+            for (i = 0; i < sizeof(struct_list)/sizeof(struct_list[0]); i++) {
+              if (strncmp(&buffer[1], struct_list[i],
+                          strlen(struct_list[i])) == 0) {
+                if (buffer[1 + strlen(struct_list[i])] == '*') {
+                  func_start = &buffer[2 + strlen(struct_list[i])];
+                }
+                else {
+                  is_struct_func = i + 1;
+                  func_start = &buffer[1 + strlen(struct_list[i])];
+                }
+                break;
+              }
+            }
+
+            if (strncmp(buffer, "*struct ", sizeof("*struct ")-1) == 0) {
               is_struct = 1;
-            }
-            else if (strncmp(buffer, "*int ", sizeof("*int ")-1) == 0 &&
-                strncmp(buffer, "*int *", sizeof("*int *")-1) != 0) {
-              is_number_func = 1;
-            }
-            else if (strncmp(buffer, "*size_t ", sizeof("*size_t ")-1) == 0 &&
-                strncmp(buffer, "*size_t *", sizeof("*size_t *")-1) != 0) {
-              is_number_func = 1;
-            }
-            else if (strncmp(buffer, "*unsigned int ",
-                              sizeof("*unsigned int ")-1) == 0 &&
-                strncmp(buffer, "*unsigned int *",
-                         sizeof("*unsigned int *")-1) != 0) {
-              is_number_func = 1;
-            }
-            else if (strncmp(buffer, "*coap_mid_t ",
-                              sizeof("*coap_mid_t ")-1) == 0 &&
-                strncmp(buffer, "*coap_mid_t *",
-                         sizeof("*coap_mid_t *")-1) != 0) {
-              is_number_func = 1;
-            }
-            else if (strncmp(buffer, "*coap_proto_t ",
-                              sizeof("*coap_proto_t ")-1) == 0 &&
-                strncmp(buffer, "*coap_proto_t *",
-                         sizeof("*coap_proto_t *")-1) != 0) {
-              is_number_func = 1;
-            }
-            else if (strncmp(buffer, "*coap_session_state_t ",
-                              sizeof("*coap_session_state_t ")-1) == 0 &&
-                strncmp(buffer, "*coap_session_state_t *",
-                         sizeof("*coap_session_state_t *")-1) != 0) {
-              is_number_func = 1;
-            }
-            else if (strncmp(buffer, "*coap_session_type_t ",
-                              sizeof("*coap_session_type_t ")-1) == 0 &&
-                strncmp(buffer, "*coap_session_type_t *",
-                         sizeof("*coap_session_type_t *")-1) != 0) {
-              is_number_func = 1;
-            }
-            /* Look specifically for inline prefixes */
-            else if (strncmp(buffer, "*void *", sizeof("*void *")-1) == 0) {
-              func_start = &buffer[sizeof("*void *")-1];
-            }
-            else if (strncmp(buffer, "*coap_str_const_t *",
-                              sizeof("*coap_str_const_t *")-1) == 0) {
-              func_start = &buffer[sizeof("*coap_str_const_t *")-1];
             }
           }
 
           if (func_start) {
             /* see if COAP_STATIC_INLINE function */
             for (i = 0; i < sizeof(inline_list)/sizeof(inline_list[0]); i++) {
-              if (strncmp(func_start, inline_list[i], strlen(inline_list[i])) == 0) {
+              if (strncmp(func_start, inline_list[i],
+                          strlen(inline_list[i])) == 0) {
                 is_inline_func = 1;
                 break;
               }
             }
+            /* see if #define function */
+            for (i = 0; i < sizeof(define_list)/sizeof(define_list[0]); i++) {
+              if (strncmp(func_start, define_list[i], strlen(define_list[i])) == 0) {
+                break;
+              }
+            }
+            if (i != sizeof(define_list)/sizeof(define_list[0]))
+              continue;
           }
 
           /* Need to include use of U for unused parameters just before comma */
@@ -233,8 +303,12 @@ int main(int argc, char* argv[])
           outbuf[0] = '\000';
           while (ecp) {
             len = strlen(outbuf);
-            snprintf(&outbuf[len], sizeof(outbuf)-len, "%*.*s U%c",
-                    (int)(ecp-cp), (int)(ecp-cp), cp, *ecp);
+            if (strncmp(cp, "void", ecp-cp) == 0)
+              snprintf(&outbuf[len], sizeof(outbuf)-len, "%*.*s%c",
+                      (int)(ecp-cp), (int)(ecp-cp), cp, *ecp);
+            else
+              snprintf(&outbuf[len], sizeof(outbuf)-len, "%*.*s U%c",
+                      (int)(ecp-cp), (int)(ecp-cp), cp, *ecp);
             cp = ecp+1;
             if(*cp) {
               ecp = strchr(cp, ',');
@@ -261,6 +335,11 @@ int main(int argc, char* argv[])
             }
             else if (is_number_func) {
               strcpy(&outbuf[len-3], "{return 0;}\n");
+            }
+            else if (is_struct_func) {
+              snprintf(&outbuf[len-3], sizeof(outbuf)-(len-3),
+                     "{%s v; memset(&v, 0, sizeof(v)); return v;}\n",
+                     struct_list[is_struct_func - 1]);
             }
             else if (is_struct) {
               strcpy(&outbuf[len-3], ";\n");
@@ -317,7 +396,6 @@ int main(int argc, char* argv[])
             !strcmp(buffer, "--\n") || !strcmp(buffer, "-\n") ||
             !strcmp(buffer, "-----\n")) {
           /* Found end of code */
-          int  status;
 
           skip = 1;
           if (fpcode) fclose(fpcode);


### PR DESCRIPTION
Correct man pages as appropriate to line up with the header files.
If there were no EXAMPLES, previously this was not caught.