### PR TITLE
Multicast: Add in response delay

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -366,11 +366,12 @@ hnd_get_async(coap_context_t *context,
   unsigned long delay = 5;
   size_t size;
   coap_async_t *async;
+  coap_binary_t zero_token = {0, NULL};
 
   /*
    * See if this is the initial, or delayed request
    */
-  async = coap_find_async(context, session, request->mid);
+  async = coap_find_async(context, session, token ? *token : zero_token);
   if (!async) {
     /* Set up an async request to trigger delay in the future */
     if (query) {

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -360,8 +360,9 @@ hnd_get_separate(coap_context_t *ctx,
   coap_opt_filter_t f;
   unsigned long delay = 5;
   coap_async_t *async;
+  coap_binary_t zero_token = {0, NULL};
 
-  async = coap_find_async(ctx, session, request->mid);
+  async = coap_find_async(ctx, session, token ? *token : zero_token);
   if (!async) {
     /* Set up an async request to trigger delay in the future */
 

--- a/include/coap2/async.h
+++ b/include/coap2/async.h
@@ -77,20 +77,20 @@ void
 coap_free_async(coap_context_t *context, coap_async_t *async);
 
 /**
- * Retrieves the object identified by @p mid from the list of asynchronous
+ * Retrieves the object identified by @p token from the list of asynchronous
  * transactions that are registered with @p context. This function returns a
  * pointer to that object or @c NULL if not found.
  *
  * @param context The context where the asynchronous objects are registered
  *                with.
  * @param session The session that is used for asynchronous transmissions.
- * @param mid     The mid of the object to retrieve.
+ * @param token   The PDU's token of the object to retrieve.
  *
- * @return        A pointer to the object identified by @p mid or @c NULL if
+ * @return        A pointer to the object identified by @p token or @c NULL if
  *                not found.
  */
 coap_async_t *coap_find_async(coap_context_t *context,
-                                    coap_session_t *session, coap_mid_t mid);
+                              coap_session_t *session, coap_binary_t token);
 
 /**
  * Set the application data pointer held in @p async. This overwrites any

--- a/include/coap2/coap_session.h
+++ b/include/coap2/coap_session.h
@@ -416,6 +416,15 @@ coap_session_t *coap_session_get_by_peer(const coap_context_t *ctx,
 #define COAP_DEFAULT_NSTART 1
 
   /**
+   * The maximum number of seconds before sending back a response to a
+   * multicast request.
+   * RFC 7252, Section 4.8 DEFAULT_LEISURE is 5.
+   */
+#ifndef COAP_DEFAULT_LEISURE
+#define COAP_DEFAULT_LEISURE (5U)
+#endif /* COAP_DEFAULT_LEISURE */
+
+  /**
    * The MAX_TRANSMIT_SPAN definition for the session (s).
    *
    * RFC 7252, Section 4.8.2 Calculation of MAX_TRAMSMIT_SPAN

--- a/man/coap_async.txt.in
+++ b/man/coap_async.txt.in
@@ -31,7 +31,7 @@ coap_session_t *_session_, coap_pdu_t *_request_, coap_tick_t _delay_);*
 *void coap_free_async(coap_context_t *_context_, coap_async_t *_async_);*
 
 *coap_async_t *coap_find_async(coap_context_t *_context_,
-coap_session_t *_session_, coap_mid_t _mid_);*
+coap_session_t *_session_, coap_binary_t _token_);*
 
 *void coap_async_set_app_data(coap_async_t *_async_, void *_app_data_);*
 
@@ -75,7 +75,7 @@ then when the response is ready at an indeterminate point in the future,
 The *coap_free_async*() function is used to delete an _async_ definition.
 
 The *coap_find_async*() function is used to determine if there is an async
-definition based on the _context_, _session_ and message id _mid_.
+definition based on the _context_, _session_ and token _token_.
 
 The *coap_async_set_app_data*() function is used to add in user defined
 _app_data_ to the _async_ definition.  It is the responsibility of the
@@ -115,11 +115,12 @@ hnd_get_with_delay(coap_context_t *context,
   unsigned long delay = 5;
   size_t size;
   coap_async_t *async;
+  coap_binary_t zero_token = {0, NULL};
 
   /*
    * See if this is the initial, or delayed request
    */
-  async = coap_find_async(context, session, request->mid);
+  async = coap_find_async(context, session, token ? *token : zero_token);
   if (!async) {
     /* Set up an async request to trigger delay in the future */
     if (query) {


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc7252#section-8.2

Also updated coap_find_async() to search on token instead of mid as
mid is not used in reliable transports.