### PR TITLE
handlers: Make parameters const where appropriate

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -261,7 +261,7 @@ resolve_address(const coap_str_const_t *server, struct sockaddr *dst) {
     (Pdu)->hdr->code == COAP_RESPONSE_CODE_CHANGED))
 
 static inline int
-check_token(coap_pdu_t *received) {
+check_token(const coap_pdu_t *received) {
   coap_bin_const_t token = coap_pdu_get_token(received);
 
   return token.length == the_token.length &&
@@ -269,9 +269,8 @@ check_token(coap_pdu_t *received) {
 }
 
 static int
-event_handler(coap_context_t *ctx COAP_UNUSED,
-              coap_event_t event,
-              coap_session_t *session COAP_UNUSED) {
+event_handler(coap_session_t *session COAP_UNUSED,
+              const coap_event_t event) {
 
   switch(event) {
   case COAP_EVENT_DTLS_CLOSED:
@@ -286,10 +285,9 @@ event_handler(coap_context_t *ctx COAP_UNUSED,
 }
 
 static void
-nack_handler(coap_context_t *context COAP_UNUSED,
-             coap_session_t *session COAP_UNUSED,
-             coap_pdu_t *sent COAP_UNUSED,
-             coap_nack_reason_t reason,
+nack_handler(coap_session_t *session COAP_UNUSED,
+             const coap_pdu_t *sent COAP_UNUSED,
+             const coap_nack_reason_t reason,
              const coap_mid_t id COAP_UNUSED) {
 
   switch(reason) {
@@ -310,10 +308,9 @@ nack_handler(coap_context_t *context COAP_UNUSED,
  * Response handler used for coap_send_large() responses
  */
 static coap_response_t
-message_handler(coap_context_t *ctx COAP_UNUSED,
-                coap_session_t *session COAP_UNUSED,
-                coap_pdu_t *sent,
-                coap_pdu_t *received,
+message_handler(coap_session_t *session COAP_UNUSED,
+                const coap_pdu_t *sent,
+                const coap_pdu_t *received,
                 const coap_mid_t id COAP_UNUSED) {
 
   coap_opt_t *block_opt;

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -111,12 +111,10 @@ handle_sigint(int signum COAP_UNUSED) {
 }
 
 static void
-hnd_get_resource(coap_context_t  *ctx COAP_UNUSED,
-                 coap_resource_t *resource,
+hnd_get_resource(coap_resource_t *resource,
                  coap_session_t *session COAP_UNUSED,
-                 coap_pdu_t *request COAP_UNUSED,
-                 coap_binary_t *token COAP_UNUSED,
-                 coap_string_t *query COAP_UNUSED,
+                 const coap_pdu_t *request COAP_UNUSED,
+                 const coap_string_t *query COAP_UNUSED,
                  coap_pdu_t *response) {
   rd_t *rd = NULL;
   unsigned char buf[3];
@@ -141,12 +139,10 @@ hnd_get_resource(coap_context_t  *ctx COAP_UNUSED,
 }
 
 static void
-hnd_put_resource(coap_context_t  *ctx COAP_UNUSED,
-                 coap_resource_t *resource COAP_UNUSED,
+hnd_put_resource(coap_resource_t *resource COAP_UNUSED,
                  coap_session_t *session COAP_UNUSED,
-                 coap_pdu_t *request COAP_UNUSED,
-                 coap_binary_t *token COAP_UNUSED,
-                 coap_string_t *query COAP_UNUSED,
+                 const coap_pdu_t *request COAP_UNUSED,
+                 const coap_string_t *query COAP_UNUSED,
                  coap_pdu_t *response) {
 #if 1
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_NOT_IMPLEMENTED);
@@ -220,12 +216,10 @@ hnd_put_resource(coap_context_t  *ctx COAP_UNUSED,
 }
 
 static void
-hnd_delete_resource(coap_context_t  *ctx,
-                    coap_resource_t *resource,
+hnd_delete_resource(coap_resource_t *resource,
                     coap_session_t *session COAP_UNUSED,
-                    coap_pdu_t *request COAP_UNUSED,
-                    coap_binary_t *token COAP_UNUSED,
-                    coap_string_t *query COAP_UNUSED,
+                    const coap_pdu_t *request COAP_UNUSED,
+                    const coap_string_t *query COAP_UNUSED,
                     coap_pdu_t *response) {
   rd_t *rd = NULL;
   coap_str_const_t* uri_path = coap_resource_get_uri_path(resource);
@@ -238,18 +232,16 @@ hnd_delete_resource(coap_context_t  *ctx,
   }
   /* FIXME: link attributes for resource have been created dynamically
    * using coap_malloc() and must be released. */
-  coap_delete_resource(ctx, resource);
+  coap_delete_resource(coap_session_get_context(session), resource);
 
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_DELETED);
 }
 
 static void
-hnd_get_rd(coap_context_t  *ctx COAP_UNUSED,
-           coap_resource_t *resource COAP_UNUSED,
+hnd_get_rd(coap_resource_t *resource COAP_UNUSED,
            coap_session_t *session COAP_UNUSED,
-           coap_pdu_t *request COAP_UNUSED,
-           coap_binary_t *token COAP_UNUSED,
-           coap_string_t *query COAP_UNUSED,
+           const coap_pdu_t *request COAP_UNUSED,
+           const coap_string_t *query COAP_UNUSED,
            coap_pdu_t *response) {
   unsigned char buf[3];
 
@@ -376,7 +368,7 @@ add_source_address(coap_resource_t *resource,
 }
 
 static rd_t *
-make_rd(coap_pdu_t *pdu) {
+make_rd(const coap_pdu_t *pdu) {
   rd_t *rd;
   const uint8_t *data;
   coap_opt_iterator_t opt_iter;
@@ -409,12 +401,10 @@ make_rd(coap_pdu_t *pdu) {
 }
 
 static void
-hnd_post_rd(coap_context_t  *ctx,
-            coap_resource_t *resource COAP_UNUSED,
+hnd_post_rd(coap_resource_t *resource COAP_UNUSED,
             coap_session_t *session,
-            coap_pdu_t *request,
-            coap_binary_t *token COAP_UNUSED,
-            coap_string_t *query COAP_UNUSED,
+            const coap_pdu_t *request,
+            const coap_string_t *query COAP_UNUSED,
             coap_pdu_t *response) {
   coap_resource_t *r;
 #define LOCSIZE 68
@@ -535,7 +525,7 @@ hnd_post_rd(coap_context_t  *ctx,
     }
   }
 
-  coap_add_resource(ctx, r);
+  coap_add_resource(coap_session_get_context(session), r);
 
 
   /* create response */

--- a/examples/contiki/server.c
+++ b/examples/contiki/server.c
@@ -91,10 +91,8 @@ init_coap_server(coap_context_t **ctx) {
 #endif
 
 void
-hnd_get_time(coap_context_t  *ctx, struct coap_resource_t *resource,
-             coap_session_t *session,
-             coap_pdu_t *request, coap_binary_t *token,
-             coap_string_t *query,
+hnd_get_time(coap_resource_t *resource, coap_session_t *session,
+             const coap_pdu_t *request, const coap_string_t *query,
              coap_pdu_t *response) {
   unsigned char buf[40];
   size_t len;
@@ -125,7 +123,7 @@ hnd_get_time(coap_context_t  *ctx, struct coap_resource_t *resource,
         len = strftime((char *)buf, sizeof(buf), "%b %d %H:%M:%S", tmp);
       }
     }
-    coap_add_data_blocked_response(resource, session, request, response, token,
+    coap_add_data_blocked_response(request, response,
                                    COAP_MEDIATYPE_TEXT_PLAIN, 1,
                                    len,
                                    buf);

--- a/examples/lwip/server-coap.c
+++ b/examples/lwip/server-coap.c
@@ -13,10 +13,8 @@ static coap_resource_t *time_resource = NULL; /* just for testing */
 #endif
 
 void
-hnd_get_time(coap_context_t  *ctx, struct coap_resource_t *resource,
-             coap_session_t *session,
-             coap_pdu_t *request, coap_binary_t *token,
-             coap_string_t *query,
+hnd_get_time(coap_resource_t *resource, coap_session_t  *session,
+             const coap_pdu_t *request, const coap_string_t *query,
              coap_pdu_t *response) {
   unsigned char buf[40];
   size_t len;
@@ -29,13 +27,6 @@ hnd_get_time(coap_context_t  *ctx, struct coap_resource_t *resource,
   /* if my_clock_base was deleted, we pretend to have no such resource */
   response->code =
     my_clock_base ? COAP_RESPONSE_CODE(205) : COAP_RESPONSE_CODE(404);
-
-  if (coap_find_observer(resource, session, token)) {
-    coap_add_option(response, COAP_OPTION_OBSERVE,
-                    coap_encode_var_safe(buf, sizeof(buf),
-                                         resource->observe),
-                    buf);
-  }
 
   if (my_clock_base)
     coap_add_option(response, COAP_OPTION_CONTENT_FORMAT,

--- a/include/coap3/async.h
+++ b/include/coap3/async.h
@@ -42,7 +42,6 @@ int coap_async_is_supported(void);
  * When the delay expires, a copy of the @p request will get sent to the
  * appropriate request handler.
  *
- * @param context  The context to use.
  * @param session  The session that is used for asynchronous transmissions.
  * @param request  The request that is handled asynchronously.
  * @param delay    The amount of time to delay before sending response, 0 means
@@ -52,9 +51,8 @@ int coap_async_is_supported(void);
  *                 NULL in case of an error.
  */
 coap_async_t *
-coap_register_async(coap_context_t *context,
-                    coap_session_t *session,
-                    coap_pdu_t *request,
+coap_register_async(coap_session_t *session,
+                    const coap_pdu_t *request,
                     coap_tick_t delay);
 
 /**
@@ -71,30 +69,27 @@ void
 coap_async_set_delay(coap_async_t *async, coap_tick_t delay);
 
 /**
- * Releases the memory that was allocated by coap_async_state_init() for the
+ * Releases the memory that was allocated by coap_register_async() for the
  * object @p async.
  *
- * @param context  The context to use.
+ * @param session  The session to use.
  * @param async The object to delete.
  */
 void
-coap_free_async(coap_context_t *context, coap_async_t *async);
+coap_free_async(coap_session_t *session, coap_async_t *async);
 
 /**
  * Retrieves the object identified by @p token from the list of asynchronous
  * transactions that are registered with @p context. This function returns a
  * pointer to that object or @c NULL if not found.
  *
- * @param context The context where the asynchronous objects are registered
- *                with.
  * @param session The session that is used for asynchronous transmissions.
  * @param token   The PDU's token of the object to retrieve.
  *
  * @return        A pointer to the object identified by @p token or @c NULL if
  *                not found.
  */
-coap_async_t *coap_find_async(coap_context_t *context,
-                              coap_session_t *session, coap_binary_t token);
+coap_async_t *coap_find_async(coap_session_t *session, coap_bin_const_t token);
 
 /**
  * Set the application data pointer held in @p async. This overwrites any

--- a/include/coap3/block.h
+++ b/include/coap3/block.h
@@ -93,7 +93,7 @@ coap_opt_block_set_m(coap_opt_t *block_opt, int m) {
  *
  * @return       @c 1 on success, @c 0 otherwise.
  */
-int coap_get_block(coap_pdu_t *pdu, coap_option_num_t number,
+int coap_get_block(const coap_pdu_t *pdu, coap_option_num_t number,
                    coap_block_t *block);
 
 /**
@@ -166,11 +166,8 @@ coap_block_build_body(coap_binary_t *body_data, size_t length,
  * Note: The application will get called for every packet of a large body to
  * process. Consider using coap_add_data_response_large() instead.
  *
- * @param resource   The resource the data is associated with.
- * @param session    The coap session.
  * @param request    The requesting pdu.
  * @param response   The response pdu.
- * @param token      The token taken from the (original) requesting pdu.
  * @param media_type The format of the data.
  * @param maxage     The maxmimum life of the data. If @c -1, then there
  *                   is no maxage.
@@ -179,11 +176,8 @@ coap_block_build_body(coap_binary_t *body_data, size_t length,
  *
  */
 void
-coap_add_data_blocked_response(coap_resource_t *resource,
-                               coap_session_t *session,
-                               coap_pdu_t *request,
+coap_add_data_blocked_response(const coap_pdu_t *request,
                                coap_pdu_t *response,
-                               const coap_binary_t *token,
                                uint16_t media_type,
                                int maxage,
                                size_t length,
@@ -282,7 +276,6 @@ int coap_add_data_large_request(coap_session_t *session,
  * @param session    The coap session.
  * @param request    The requesting pdu.
  * @param response   The response pdu.
- * @param token      The token taken from the (original) requesting pdu.
  * @param query      The query taken from the (original) requesting pdu.
  * @param media_type The format of the data.
  * @param maxage     The maxmimum life of the data. If @c -1, then there
@@ -300,9 +293,8 @@ int coap_add_data_large_request(coap_session_t *session,
 int
 coap_add_data_large_response(coap_resource_t *resource,
                              coap_session_t *session,
-                             coap_pdu_t *request,
+                             const coap_pdu_t *request,
                              coap_pdu_t *response,
-                             const coap_binary_t *token,
                              const coap_string_t *query,
                              uint16_t media_type,
                              int maxage,

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -174,7 +174,6 @@ int coap_handle_request_put_block(coap_context_t *context,
                                   coap_resource_t *resource,
                                   coap_string_t *uri_path,
                                   coap_opt_t *observe,
-                                  coap_binary_t *token,
                                   coap_string_t *query,
                                   coap_method_handler_t h,
                                   int *added_block);

--- a/include/coap3/coap_event.h
+++ b/include/coap3/coap_event.h
@@ -54,14 +54,12 @@
 /**
  * Type for event handler functions that can be registered with a CoAP
  * context using the unction coap_set_event_handler(). When called by
- * the library, the first argument will be the coap_context_t object
- * where the handler function has been registered. The second argument
- * is the event type that may be complemented by event-specific data
- * passed as the third argument.
+ * the library, the first argument will be the current coap_session_t object
+ * which is associated with the original CoAP context. The second parameter
+ * is the event type.
  */
-typedef int (*coap_event_handler_t)(coap_context_t *,
-                                    coap_event_t event,
-                                    coap_session_t *session);
+typedef int (*coap_event_handler_t)(coap_session_t *session,
+                                    const coap_event_t event);
 
 /**
  * Registers the function @p hnd as callback for events from the given

--- a/include/coap3/net.h
+++ b/include/coap3/net.h
@@ -41,60 +41,52 @@ typedef enum coap_response_t {
 /**
  * Response handler that is used as callback in coap_context_t.
  *
- * @param context CoAP session.
  * @param session CoAP session.
  * @param sent The PDU that was transmitted.
  * @param received The PDU that was received.
- * @param id CoAP transaction ID.
+ * @param mid CoAP transaction ID.
 
  * @return @c COAP_RESPONSE_OK if successful, else @c COAP_RESPONSE_FAIL which
  *         triggers sending a RST packet.
  */
-typedef coap_response_t (*coap_response_handler_t)(coap_context_t *context,
-                                                   coap_session_t *session,
-                                                   coap_pdu_t *sent,
-                                                   coap_pdu_t *received,
-                                                   const coap_mid_t id);
+typedef coap_response_t (*coap_response_handler_t)(coap_session_t *session,
+                                                   const coap_pdu_t *sent,
+                                                   const coap_pdu_t *received,
+                                                   const coap_mid_t mid);
 
 /**
  * Negative Acknowedge handler that is used as callback in coap_context_t.
  *
- * @param context CoAP session.
  * @param session CoAP session.
  * @param sent The PDU that was transmitted.
  * @param reason The reason for the NACK.
  * @param id CoAP message ID.
  */
-typedef void (*coap_nack_handler_t)(coap_context_t *context,
-                                    coap_session_t *session,
-                                    coap_pdu_t *sent,
-                                    coap_nack_reason_t reason,
+typedef void (*coap_nack_handler_t)(coap_session_t *session,
+                                    const coap_pdu_t *sent,
+                                    const coap_nack_reason_t reason,
                                     const coap_mid_t id);
 
 /**
  * Received Ping handler that is used as callback in coap_context_t.
  *
- * @param context CoAP session.
  * @param session CoAP session.
  * @param received The PDU that was received.
  * @param id CoAP message ID.
  */
-typedef void (*coap_ping_handler_t)(coap_context_t *context,
-                                    coap_session_t *session,
-                                    coap_pdu_t *received,
+typedef void (*coap_ping_handler_t)(coap_session_t *session,
+                                    const coap_pdu_t *received,
                                     const coap_mid_t id);
 
 /**
  * Received Pong handler that is used as callback in coap_context_t.
  *
- * @param context CoAP session.
  * @param session CoAP session.
  * @param received The PDU that was received.
  * @param id CoAP message ID.
  */
-typedef void (*coap_pong_handler_t)(coap_context_t *context,
-                                    coap_session_t *session,
-                                    coap_pdu_t *received,
+typedef void (*coap_pong_handler_t)(coap_session_t *session,
+                                    const coap_pdu_t *received,
                                     const coap_mid_t id);
 
 /**

--- a/include/coap3/resource.h
+++ b/include/coap3/resource.h
@@ -38,12 +38,10 @@
  * Definition of message handler function
  */
 typedef void (*coap_method_handler_t)
-  (coap_context_t  *,
-   coap_resource_t *,
+  (coap_resource_t *,
    coap_session_t *,
-   coap_pdu_t *,
-   coap_binary_t * /* token */,
-   coap_string_t * /* query string */,
+   const coap_pdu_t * /* request */,
+   const coap_string_t * /* query string */,
    coap_pdu_t * /* response */);
 
 #define COAP_ATTR_FLAGS_RELEASE_NAME  0x1

--- a/man/coap_async.txt.in
+++ b/man/coap_async.txt.in
@@ -23,15 +23,15 @@ SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
 
-*coap_async_t *coap_register_async(coap_context_t *_context_,
-coap_session_t *_session_, coap_pdu_t *_request_, coap_tick_t _delay_);*
+*coap_async_t *coap_register_async(coap_session_t *_session_,
+const coap_pdu_t *_request_, coap_tick_t _delay_);*
 
 *void coap_async_set_delay(coap_async_t *_async_, coap_tick_t _delay_);*
 
-*void coap_free_async(coap_context_t *_context_, coap_async_t *_async_);*
+*void coap_free_async(coap_session_t *_session_, coap_async_t *_async_);*
 
-*coap_async_t *coap_find_async(coap_context_t *_context_,
-coap_session_t *_session_, coap_binary_t _token_);*
+*coap_async_t *coap_find_async(coap_session_t *_session_,
+coap_bin_const_t _token_);*
 
 *void coap_async_set_app_data(coap_async_t *_async_, void *_app_data_);*
 
@@ -59,7 +59,7 @@ Usually responses are piggybacked, but this man page focuses on separate
 (async) support.
 
 The *coap_register_async*() function is used to set up an asynchronous delayed
-request for the _request_ PDU associated with the _context_ and _session_. The
+request for the _request_ PDU associated with the _session_. The
 application request handler will get called with a copy of _request_ after
 _delay_ ticks which will then cause a response to be sent.  If _delay_ is 0,
 then the application request handler will not get called.
@@ -75,7 +75,7 @@ then when the response is ready at an indeterminate point in the future,
 The *coap_free_async*() function is used to delete an _async_ definition.
 
 The *coap_find_async*() function is used to determine if there is an async
-definition based on the _context_, _session_ and token _token_.
+definition based on the _session_ and token _token_.
 
 The *coap_async_set_app_data*() function is used to add in user defined
 _app_data_ to the _async_ definition.  It is the responsibility of the
@@ -105,54 +105,54 @@ EXAMPLES
  * response (empty ACK followed by data response at a later stage).
  */
 static void
-hnd_get_with_delay(coap_context_t *context,
+hnd_get_with_delay(coap_session_t *session,
               coap_resource_t *resource,
-              coap_session_t *session,
               coap_pdu_t *request,
-              coap_binary_t *token,
               coap_string_t *query,
               coap_pdu_t *response) {
   unsigned long delay = 5;
   size_t size;
-  coap_async_t *async;
-  coap_binary_t zero_token = {0, NULL};
 
   /*
    * See if this is the initial, or delayed request
    */
-  async = coap_find_async(context, session, token ? *token : zero_token);
-  if (!async) {
-    /* Set up an async request to trigger delay in the future */
-    if (query) {
-      const uint8_t *p = query->s;
+  if (request) {
+    coap_async_t *async;
+    coap_bin_const_t token = coap_pdu_get_token(request);
 
-      delay = 0;
-      for (size = query->length; size; --size, ++p)
-        delay = delay * 10 + (*p - '0');
-      if (delay == 0) {
-        coap_log(LOG_INFO, "async: delay of 0 not supported\n");
-        coap_pdu_set_code(response, COAP_RESPONSE_CODE_BAD_REQUEST);
+    async = coap_find_async(session, token);
+    if (!async) {
+      /* Set up an async request to trigger delay in the future */
+      if (query) {
+        const uint8_t *p = query->s;
+
+        delay = 0;
+        for (size = query->length; size; --size, ++p)
+          delay = delay * 10 + (*p - '0');
+        if (delay == 0) {
+          coap_log(LOG_INFO, "async: delay of 0 not supported\n");
+          coap_pdu_set_code(response, COAP_RESPONSE_CODE_BAD_REQUEST);
+          return;
+        }
+      }
+      async = coap_register_async(session,
+                                  request,
+                                  COAP_TICKS_PER_SECOND * delay);
+      if (async == NULL) {
+        coap_pdu_set_code(response, COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE);
         return;
       }
-    }
-    async = coap_register_async(context,
-                                session,
-                                request,
-                                COAP_TICKS_PER_SECOND * delay);
-    if (async == NULL) {
-      coap_pdu_set_code(response, COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE);
+      /*
+       * Not setting response code will cause empty ACK to be sent
+       * if Confirmable
+       */
       return;
     }
-    /*
-     * Not setting response code will cause empty ACK to be sent
-     * if Confirmable
-     */
-    return;
   }
-  /* async set up, so this is the delayed request */
+  /* no request (observe) or async set up, so this is the delayed request */
 
   /* Send back the appropriate data */
-  coap_add_data_large_response(resource, session, request, response, token,
+  coap_add_data_large_response(resource, session, request, response,
                                query, COAP_MEDIATYPE_TEXT_PLAIN, -1, 0, 4,
                                (const uint8_t *)"done", NULL, NULL);
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTENT);

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -26,14 +26,14 @@ SYNOPSIS
 *void coap_context_set_block_mode(coap_context_t *_context_,
 uint8_t _block_mode_);*
 
-*int coap_add_data_large_request(coap_session_t *_session_, coap_pdu_t *_pdu_,
-size_t _length_, const uint8_t *_data_,
+*int coap_add_data_large_request(coap_session_t *_session_,
+coap_pdu_t *_pdu_, size_t _length_, const uint8_t *_data_,
 coap_release_large_data_t _release_func_, void *_app_ptr_);*
 
 *int coap_add_data_large_response(coap_resource_t *_resource_,
-coap_session_t *_session_, coap_pdu_t *_request_, coap_pdu_t *_response_,
-const coap_binary_t *_token_, const coap_string_t *query, uint16_t _media_type_,
-int _maxage_, uint64_t etag, size_t _length_, const uint8_t *_data_,
+coap_session_t *_session_, const coap_pdu_t *_request_, coap_pdu_t *_response_,
+const coap_string_t *query, uint16_t _media_type_, int _maxage_,
+uint64_t etag, size_t _length_, const uint8_t *_data_,
 coap_release_large_data_t _release_func_, void *_app_ptr_);*
 
 *int coap_get_data_large(const coap_pdu_t *_pdu_, size_t *_length,
@@ -143,7 +143,7 @@ _length_ to the PDU _pdu_. _release_func_ (if not NULL) and _app_ptr_ are
 used for releasing the data when the body transfer is complete.  It also adds
 in the appropriate CoAP options such as BLOCK2, SIZE2 and ETAG to handle
 Block-Wise transfer if the data does not fit into a single PDU.
-_resource_, _query_, _session_, _request_, _response_ and _token_ are the same
+_resource_, _query_, _session_, _request_, and _response_ are the same
 parameters as in the called resource handler that invokes
 *coap_add_data_large_response*(). If _etag_ is 0, then a unique ETag value will
 be generated, else is the ETag value to use.
@@ -333,19 +333,14 @@ int main(int argc, char *argv[]) {
 #include <stdio.h>
 
 static void
-hnd_get_time(coap_context_t *context, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_get_time(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
 
   unsigned char buf[40];
   size_t len;
   time_t now;
-  /* Remove (void) definition if variable is used */
-  (void)context;
 
   /* Note that request may be NULL if triggered by an observe response */
-
-  /* Note that token is already in the response pdu */
 
   /* ... Additional analysis code for resource, request pdu etc.  ... */
 
@@ -381,7 +376,7 @@ coap_string_t *query, coap_pdu_t *response) {
    * SIZE2 Option added internally
    * ETAG Option added internally
    */
-  coap_add_data_large_response(resource, session, request, response, token,
+  coap_add_data_large_response(resource, session, request, response,
                                query, COAP_MEDIATYPE_TEXT_PLAIN, 1, 0,
                                len,
                                buf,

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -208,21 +208,16 @@ EXAMPLES
 #include <stdio.h>
 
 static void
-hnd_get_time(coap_context_t *context, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_get_time(coap_resource_t *resource, coap_session_t *session,
+coap_pdu_t *request, coap_string_t *query, coap_pdu_t *response) {
 
   unsigned char buf[40];
   size_t len;
   time_t now;
-  /* Remove (void) definition if variable is used */
-  (void)context;
 
   /* ... Additional analysis code for resource, request pdu etc.  ... */
 
   /* After analysis, generate a suitable response */
-
-  /* Note that token, if set, is already in the response pdu */
 
   now = time(NULL);
 
@@ -252,7 +247,7 @@ coap_string_t *query, coap_pdu_t *response) {
    * BLOCK2 Option added internally if output too large
    * ETAG Option added internally
    */
-  coap_add_data_large_response(resource, session, request, response, token,
+  coap_add_data_large_response(resource, session, request, response,
                                query, COAP_MEDIATYPE_TEXT_PLAIN, 1, 0,
                                len,
                                buf, NULL, 0);

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -139,15 +139,14 @@ coap_resource_t *time_resource = NULL;
 /* specific GET "time" handler, called from hnd_get_generic() */
 
 static void
-hnd_get_time(coap_context_t *context, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_get_time(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
 
   unsigned char buf[40];
   size_t len;
   time_t now;
-  /* Remove (void) definition if variable is used */
-  (void)context;
+  (void)resource;
+  (void)session;
 
   /* ... Additional analysis code for resource, request pdu etc.  ... */
 
@@ -184,18 +183,15 @@ coap_string_t *query, coap_pdu_t *response) {
    * SIZE2 Option added internally
    * ETAG Option added internally
    */
-  coap_add_data_blocked_response(resource, session, request, response, token,
-                                 COAP_MEDIATYPE_TEXT_PLAIN, 1,
-                                 len,
-                                 buf);
+  coap_add_data_blocked_response(request, response, COAP_MEDIATYPE_TEXT_PLAIN,
+                                 1, len, buf);
 }
 
 /* Generic GET handler */
 
 static void
-hnd_get_generic(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_get_generic(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
 
   coap_str_const_t *uri_path = coap_resource_get_uri_path(resource);
 
@@ -207,8 +203,7 @@ coap_string_t *query, coap_pdu_t *response) {
 
   /* Is this the "time" resource" ? */
   if (coap_string_equal(uri_path, coap_make_str_const("time"))) {
-    hnd_get_time(ctx, resource, session, request, token, query,
-                 response);
+    hnd_get_time(resource, session, request, query, response);
     return;
   }
 

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -73,10 +73,9 @@ const uint8_t *_data_);*
 
 *int coap_add_data(coap_pdu_t *_pdu_, size_t _length_, const uint8_t *_data_);*
 
-*void coap_add_data_blocked_response(coap_resource_t *_resource_,
-coap_session_t *_session_, coap_pdu_t *_request_, coap_pdu_t *_response_,
-const coap_binary_t *_token_, uint16_t _media_type_, int _maxage_,
-size_t _length_, const uint8_t *_data_);*
+*void coap_add_data_blocked_response(const coap_pdu_t *_request_,
+coap_pdu_t *_response_, uint16_t _media_type_, int _maxage_, size_t _length_,
+const uint8_t *_data_);*
 
 *coap_mid_t coap_send(coap_session_t *_session_, coap_pdu_t *_pdu_);*
 
@@ -361,9 +360,8 @@ of the payload _data_ of length _length_ to the PDU _pdu_. It should be used
 as a direct replacement for *coap_add_data*() if it is possible that the data
 will not fit into a single pdu. It also adds in the appropriate
 CoAP options to handle Block-Wise transfer. This function is usually used for
-a server's GET / FETCH response.  The _resource_, _session_, _request_,
-_response_ and _token_ are the same parameters for the registered GET / FETCH
-resource handler.
+a server's GET / FETCH response.  The _request_ and _response_ are the same
+parameters for the registered GET / FETCH resource handler.
 The _media_type_ is for the format of the _data_ and _maxage_ defines the
 lifetime of the response.  If set to -1,  then the MAXAGE option does not get
 included.  This function must only be called once per _pdu_.
@@ -512,21 +510,18 @@ error:
 #include <stdio.h>
 
 static void
-hnd_get_time(coap_context_t *context, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_get_time(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
 
   unsigned char buf[40];
   size_t len;
   time_t now;
-  /* Remove (void) definition if variable is used */
-  (void)context;
+  (void)resource;
+  (void)session;
 
   /* ... Additional analysis code for resource, request pdu etc.  ... */
 
   /* After analysis, generate a suitable response */
-
-  /* Note that token is already in the response pdu */
 
   now = time(NULL);
 
@@ -557,10 +552,8 @@ coap_string_t *query, coap_pdu_t *response) {
    * SIZE2 Option added internally
    * ETAG Option added internally
    */
-  coap_add_data_blocked_response(resource, session, request, response, token,
-                                 COAP_MEDIATYPE_TEXT_PLAIN, 1,
-                                 len,
-                                 buf);
+  coap_add_data_blocked_response(request, response, COAP_MEDIATYPE_TEXT_PLAIN,
+                                 1, len, buf);
 
 }
 ----

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -195,16 +195,13 @@ EXAMPLES
 #define INDEX "This is an example server using libcoap\n"
 
 static void
-hnd_get_index(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_get_index(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   unsigned char buf[3];
   /* Remove (void) definition if variable is used */
-  (void)ctx;
   (void)resource;
   (void)session;
   (void)request;
-  (void)token;
   (void)query;
 
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTENT);
@@ -225,15 +222,12 @@ coap_string_t *query, coap_pdu_t *response) {
 }
 
 static void
-hnd_delete_time(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_delete_time(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   /* Remove (void) definition if variable is used */
-  (void)ctx;
   (void)resource;
   (void)session;
   (void)request;
-  (void)token;
   (void)query;
 
   /* .. code .. */
@@ -242,15 +236,12 @@ coap_string_t *query, coap_pdu_t *response) {
 }
 
 static void
-hnd_get_time(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_get_time(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   /* Remove (void) definition if variable is used */
-  (void)ctx;
   (void)resource;
   (void)session;
   (void)request;
-  (void)token;
   (void)query;
   (void)response;
 
@@ -260,15 +251,12 @@ coap_string_t *query, coap_pdu_t *response) {
 }
 
 static void
-hnd_put_time(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_put_time(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   /* Remove (void) definition if variable is used */
-  (void)ctx;
   (void)resource;
   (void)session;
   (void)request;
-  (void)token;
   (void)query;
   (void)response;
 
@@ -325,20 +313,18 @@ init_resources(coap_context_t *ctx) {
  * Unknown Resource PUT handler */
 
 static void
-hnd_delete(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_delete(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   /* Remove (void) definition if variable is used */
   (void)session;
   (void)request;
-  (void)token;
   (void)query;
   (void)response;
 
   /* .. code .. */
 
   /* Dynamic resource no longer required - delete it */
-  coap_delete_resource(ctx, resource);
+  coap_delete_resource(coap_session_get_context(session), resource);
 
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_DELETED);
 }
@@ -347,17 +333,14 @@ coap_string_t *query, coap_pdu_t *response) {
  * Unknown Resource PUT handler */
 
 static void
-hnd_get(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_get(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
 
   coap_str_const_t *get_uri_path;
   /* Remove (void) definition if variable is used */
-  (void)ctx;
   (void)resource;
   (void)session;
   (void)request;
-  (void)token;
   (void)query;
   (void)response;
 
@@ -378,14 +361,11 @@ coap_string_t *query, coap_pdu_t *response) {
  * Unknown Resource PUT handler */
 
 static void
-hnd_put(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_put(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   /* Remove (void) definition if variable is used */
-  (void)ctx;
   (void)resource;
   (void)session;
-  (void)token;
   (void)query;
 
   coap_string_t *put_uri_path;
@@ -430,11 +410,9 @@ check_url_fn(coap_string_t *uri_path, uint8_t code) {
 /* Unknown Resource PUT handler */
 
 static void
-hnd_unknown_put(coap_context_t *ctx, coap_resource_t *resource,
-coap_session_t *session, coap_pdu_t *request, coap_binary_t *token,
-coap_string_t *query, coap_pdu_t *response) {
+hnd_unknown_put(coap_resource_t *resource, coap_session_t *session,
+const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   /* Remove (void) definition if variable is used */
-  (void)ctx;
   (void)resource;
   coap_pdu_code_t req_code = coap_pdu_get_code(request);
 
@@ -466,10 +444,10 @@ coap_string_t *query, coap_pdu_t *response) {
   /* We possibly want to Observe the GETs */
   coap_resource_set_get_observable(r, 1);
   coap_register_handler(r, COAP_REQUEST_GET, hnd_get);
-  coap_add_resource(ctx, r);
+  coap_add_resource(coap_session_get_context(session), r);
 
   /* Do the PUT for this first call */
-  hnd_put(ctx, r, session, request, token, query, response);
+  hnd_put(r, session, request, query, response);
 
   return;
 

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -207,7 +207,7 @@ void coap_session_mfree(coap_session_t *session) {
   }
   LL_FOREACH_SAFE(session->delayqueue, q, tmp) {
     if (q->pdu->type==COAP_MESSAGE_CON && session->context && session->context->nack_handler)
-      session->context->nack_handler(session->context, session, q->pdu, session->proto == COAP_PROTO_DTLS ? COAP_NACK_TLS_FAILED : COAP_NACK_NOT_DELIVERABLE, q->id);
+      session->context->nack_handler(session, q->pdu, session->proto == COAP_PROTO_DTLS ? COAP_NACK_TLS_FAILED : COAP_NACK_NOT_DELIVERABLE, q->id);
     coap_delete_node(q);
   }
   LL_FOREACH_SAFE(session->lg_xmit, lq, ltmp) {
@@ -496,8 +496,7 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
       /* Make sure that we try a re-transmit later on ICMP error */
       if (coap_wait_ack(session->context, session, q) >= 0) {
         if (session->context->nack_handler) {
-          session->context->nack_handler(session->context, session, q->pdu,
-                                         reason, q->id);
+          session->context->nack_handler(session, q->pdu, reason, q->id);
         }
         q = NULL;
       }
@@ -505,8 +504,7 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
     if (q && q->pdu->type == COAP_MESSAGE_CON
       && session->context->nack_handler)
     {
-      session->context->nack_handler(session->context, session, q->pdu,
-                                     reason, q->id);
+      session->context->nack_handler(session, q->pdu, reason, q->id);
     }
     if (q)
       coap_delete_node(q);
@@ -518,8 +516,7 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
     coap_queue_t *q = session->context->sendqueue;
     while (q) {
       if (q->session == session) {
-        session->context->nack_handler(session->context, session, q->pdu,
-                                       reason, q->id);
+        session->context->nack_handler(session, q->pdu, reason, q->id);
       }
       q = q->next;
     }


### PR DESCRIPTION
Also remove the unneeded parameters which can easily be derived - e.g context
and token.

This is a last opportunity to get these call-back handlers simplified and generally tidied up.