### PR TITLE
cmake: Fix missing directories error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,6 +579,10 @@ if(ENABLE_DOCS)
     set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile.in)
     set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
+    # Make necessary temporary directories
+    file(MAKE_DIRECTORY  ${CMAKE_BINARY_DIR}/doc/man_tmp)
+    file(MAKE_DIRECTORY  ${CMAKE_BINARY_DIR}/doc/man_html)
+
     # request to configure the file
     configure_file(
       ${DOXYGEN_IN}

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -66,6 +66,7 @@ man-page-build: man-page-start
 	## Close off the insert_file
 	echo '    </tab>' >> $(top_builddir)/doc/insert_file ;\
 	echo '    <tab type="user" visible="yes" url="@ref deprecated" title="Deprecated Items" intro=""/>' >> $(top_builddir)/doc/insert_file ;\
+	echo '    <tab type="user" visible="yes" url="@ref bug" title="Bug List" intro=""/>' >> $(top_builddir)/doc/insert_file ;\
 	## Create and Update the DoxygenLayout.xml file
 	$(DOXYGEN) -l ;\
 	$(SED) -i 's/<tab type="pages" visible="yes" /<tab type="pages" visible="no" /g' $(top_builddir)/doc/DoxygenLayout.xml ;\


### PR DESCRIPTION
The man pages are still not built - otherwise all the doxygen documentation 
is built.

Add back in missing "Bug List" to the Makefile version which is there in
the cmake version.

Fixes #652