### PR TITLE
coap_session.c: Correct coap_session_get_max_retransmit() name

### DIFF
--- a/include/coap3/coap_session.h
+++ b/include/coap3/coap_session.h
@@ -551,7 +551,7 @@ void coap_session_set_ack_random_factor(coap_session_t *session,
 *
 * @return Current maximum retransmit value
 */
-unsigned int coap_session_get_max_transmit(const coap_session_t *session);
+unsigned int coap_session_get_max_retransmit(const coap_session_t *session);
 
 /**
 * Get the CoAP initial ack response timeout before the next re-transmit

--- a/man/coap_recovery.txt.in
+++ b/man/coap_recovery.txt.in
@@ -14,7 +14,7 @@ coap_recovery,
 coap_session_set_max_retransmit,
 coap_session_set_ack_timeout,
 coap_session_set_ack_random_factor,
-coap_session_get_max_transmit,
+coap_session_get_max_retransmit,
 coap_session_get_ack_timeout,
 coap_session_get_ack_random_factor,
 coap_debug_set_packet_loss
@@ -33,7 +33,7 @@ coap_fixed_point_t _value_)*;
 *void coap_session_set_ack_random_factor(coap_session_t *_session_,
 coap_fixed_point_t _value_)*;
 
-*unsigned int coap_session_get_max_transmit(const coap_session_t *_session_)*;
+*unsigned int coap_session_get_max_retransmit(const coap_session_t *_session_)*;
 
 *coap_fixed_point_t coap_session_get_ack_timeout(
 const coap_session_t *_session_)*;
@@ -79,7 +79,7 @@ The CoAP message retry rules are (with the default values to compute the time)
 4th retransmit after 4 * ack_timeout * ack_random factor (24 seconds)
 5th retransmit after 5 * ack_timeout * ack_random factor (48 seconds)
 
-As max_transmit (by default) is 4, then the 5th retransmit does not get sent,
+As max_retransmit (by default) is 4, then the 5th retransmit does not get sent,
 but at that point COAP_NACK_TOO_MANY_RETRIES gets raised in the nack_handler
 (if defined). Note that the sum of the seconds is 93 matching RFC7252.
 ----

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -50,7 +50,7 @@ coap_session_set_ack_random_factor (coap_session_t *session,
 }
 
 unsigned int
-coap_session_get_max_transmit (const coap_session_t *session) {
+coap_session_get_max_retransmit (const coap_session_t *session) {
   return session->max_retransmit;
 }
 

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -51,7 +51,7 @@ t_session2(void) {
   CU_ASSERT(fpeq(session->ack_timeout, COAP_DEFAULT_ACK_TIMEOUT));
   CU_ASSERT(fpeq(session->ack_random_factor, COAP_DEFAULT_ACK_RANDOM_FACTOR));
 
-  CU_ASSERT(coap_session_get_max_transmit(session) == COAP_DEFAULT_MAX_RETRANSMIT);
+  CU_ASSERT(coap_session_get_max_retransmit(session) == COAP_DEFAULT_MAX_RETRANSMIT);
   CU_ASSERT(fpeq(coap_session_get_ack_timeout(session), COAP_DEFAULT_ACK_TIMEOUT));
   CU_ASSERT(fpeq(coap_session_get_ack_random_factor(session), COAP_DEFAULT_ACK_RANDOM_FACTOR));
 }


### PR DESCRIPTION
Make things consistent.