### PR TITLE
net.h: Make request PDUs const in functions

### DIFF
--- a/include/coap3/net.h
+++ b/include/coap3/net.h
@@ -383,8 +383,8 @@ void *coap_get_app_data(const coap_context_t *context);
  *
  * @return        A pointer to the new message or @c NULL on error.
  */
-coap_pdu_t *coap_new_error_response(coap_pdu_t *request,
-                                    unsigned char code,
+coap_pdu_t *coap_new_error_response(const coap_pdu_t *request,
+                                    coap_pdu_code_t code,
                                     coap_opt_filter_t *opts);
 
 /**
@@ -403,8 +403,8 @@ coap_pdu_t *coap_new_error_response(coap_pdu_t *request,
  *                        COAP_INVALID_MID otherwise.
  */
 coap_mid_t coap_send_error(coap_session_t *session,
-                           coap_pdu_t *request,
-                           unsigned char code,
+                           const coap_pdu_t *request,
+                           coap_pdu_code_t code,
                            coap_opt_filter_t *opts);
 
 /**
@@ -419,7 +419,8 @@ coap_mid_t coap_send_error(coap_session_t *session,
  *                        otherwise.
  */
 coap_mid_t
-coap_send_message_type(coap_session_t *session, coap_pdu_t *request, unsigned char type);
+coap_send_message_type(coap_session_t *session, const coap_pdu_t *request,
+                       coap_pdu_type_t type);
 
 /**
  * Sends an ACK message with code @c 0 for the specified @p request to @p dst.
@@ -432,7 +433,7 @@ coap_send_message_type(coap_session_t *session, coap_pdu_t *request, unsigned ch
  * @return                The message id if ACK was sent or @c
  *                        COAP_INVALID_MID on error.
  */
-coap_mid_t coap_send_ack(coap_session_t *session, coap_pdu_t *request);
+coap_mid_t coap_send_ack(coap_session_t *session, const coap_pdu_t *request);
 
 /**
  * Sends an RST message with code @c 0 for the specified @p request to @p dst.
@@ -446,7 +447,7 @@ coap_mid_t coap_send_ack(coap_session_t *session, coap_pdu_t *request);
  *                        COAP_INVALID_MID on error.
  */
 COAP_STATIC_INLINE coap_mid_t
-coap_send_rst(coap_session_t *session, coap_pdu_t *request) {
+coap_send_rst(coap_session_t *session, const coap_pdu_t *request) {
   return coap_send_message_type(session, request, COAP_MESSAGE_RST);
 }
 

--- a/src/net.c
+++ b/src/net.c
@@ -747,7 +747,7 @@ coap_option_check_critical(coap_context_t *ctx,
 }
 
 coap_mid_t
-coap_send_ack(coap_session_t *session, coap_pdu_t *request) {
+coap_send_ack(coap_session_t *session, const coap_pdu_t *request) {
   coap_pdu_t *response;
   coap_mid_t result = COAP_INVALID_MID;
 
@@ -898,8 +898,8 @@ coap_send_pdu(coap_session_t *session, coap_pdu_t *pdu, coap_queue_t *node) {
 
 coap_mid_t
 coap_send_error(coap_session_t *session,
-  coap_pdu_t *request,
-  unsigned char code,
+  const coap_pdu_t *request,
+  coap_pdu_code_t code,
   coap_opt_filter_t *opts) {
   coap_pdu_t *response;
   coap_mid_t result = COAP_INVALID_MID;
@@ -915,7 +915,8 @@ coap_send_error(coap_session_t *session,
 }
 
 coap_mid_t
-coap_send_message_type(coap_session_t *session, coap_pdu_t *request, unsigned char type) {
+coap_send_message_type(coap_session_t *session, const coap_pdu_t *request,
+                       coap_pdu_type_t type) {
   coap_pdu_t *response;
   coap_mid_t result = COAP_INVALID_MID;
 
@@ -2054,7 +2055,7 @@ coap_cancel_all_messages(coap_context_t *context, coap_session_t *session,
 }
 
 coap_pdu_t *
-coap_new_error_response(coap_pdu_t *request, unsigned char code,
+coap_new_error_response(const coap_pdu_t *request, coap_pdu_code_t code,
   coap_opt_filter_t *opts) {
   coap_opt_iterator_t opt_iter;
   coap_pdu_t *response;


### PR DESCRIPTION
Now that coap_method_handler_t passes in the request PDU as const, make
functions that have request PDUs as a parameter const for that parameter.