### PR TITLE
configure.ac: Add in --enable-add-default-names option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,9 +78,12 @@ man/*.7
 examples/.deps/
 examples/*.o
 examples/coap-client
+examples/coap-client-*
 examples/coap-etsi_iot_01
 examples/coap-rd
+examples/coap-rd-*
 examples/coap-server
+examples/coap-server-*
 examples/coap-tiny
 examples/*.exe
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,10 +1,14 @@
-2021-04-22  Olaf Bergmann  <bergmann@tzi.org>
+2021-05-04  Olaf Bergmann  <bergmann@tzi.org>
 
 	Change summary for version 4.3.0:
 
         * Include directory updated from include/coap2 to include/coap3 as
           this is a major version change.
             * Other code references updated from coap2 to coap3.
+        * Examples now have the underlying (D)TLS library name as a suffix.
+          E.g. coap-server-openssl
+        * Examples and libraries can be installed with default names using
+          ./configure --enable-add-default-names
         * Many call-back handlers have had their parameter lists changed, some
           variables are made const and other ones removed as they can be easily
           reconstructed if needed.

--- a/Makefile.am
+++ b/Makefile.am
@@ -221,14 +221,17 @@ dist_noinst_SCRIPTS = autogen.sh
 
 ## Set up a common library that causes linking against the common library
 ## to link with the actual library with (D)TLS support
+if BUILD_ADD_DEFAULT_NAMES
 install-exec-hook:
 	(cd $(DESTDIR)$(libdir) ; \
+	if [ -f libcoap-$(LIBCOAP_NAME_SUFFIX).so ] ; then \
+		rm -f libcoap-$(LIBCOAP_API_VERSION).so ; \
+		$(LN_S) libcoap-$(LIBCOAP_NAME_SUFFIX).so libcoap-$(LIBCOAP_API_VERSION).so ; \
+	fi ; \
 	rm -f libcoap-$(LIBCOAP_API_VERSION).a ; \
 	rm -f libcoap-$(LIBCOAP_API_VERSION).la ; \
-	rm -f libcoap-$(LIBCOAP_API_VERSION).so ; \
 	$(LN_S) libcoap-$(LIBCOAP_NAME_SUFFIX).a libcoap-$(LIBCOAP_API_VERSION).a ; \
 	$(LN_S) libcoap-$(LIBCOAP_NAME_SUFFIX).la libcoap-$(LIBCOAP_API_VERSION).la ; \
-	$(LN_S) libcoap-$(LIBCOAP_NAME_SUFFIX).so libcoap-$(LIBCOAP_API_VERSION).so ; \
 	$(MKDIR_P) $(DESTDIR)$(pkgconfigdir) ; \
 	cd $(DESTDIR)$(pkgconfigdir) ; \
 	rm -f libcoap-$(LIBCOAP_API_VERSION).pc ; \
@@ -241,6 +244,7 @@ uninstall-hook:
 	rm -f libcoap-$(LIBCOAP_API_VERSION).so ; \
 	cd $(DESTDIR)$(pkgconfigdir) ; \
 	rm -f libcoap-$(LIBCOAP_API_VERSION).pc)
+endif # BUILD_ADD_DEFAULT_NAMES
 
 ## various *-local targets
 ## Remove the helper files for the linker and the pkg-config file if there

--- a/configure.ac
+++ b/configure.ac
@@ -675,6 +675,16 @@ AC_ARG_ENABLE([async],
 AS_IF([test "x$build_async" != "xyes"],
       [AC_DEFINE(WITHOUT_ASYNC, [1], [Define to build without support for separate responses.])])
 
+# configure options
+# __add_default_names__
+AC_ARG_ENABLE([add-default-names],
+              [AS_HELP_STRING([--enable-add-default-names],
+                              [Enable adding libraries / examples with default names [default=yes]])],
+              [build_add_default_names="$enableval"],
+              [build_add_default_names="yes"])
+
+AM_CONDITIONAL(BUILD_ADD_DEFAULT_NAMES, [test "x$build_add_default_names" = "xyes"])
+
 # end configure options
 #######################
 
@@ -919,6 +929,11 @@ if test "x$with_tinydtls" = "xyes"; then
 fi
 if test "x$build_dtls" != "xyes"; then
     AC_MSG_RESULT([      build DTLS support       : "no"])
+fi
+if test "x$build_add_default_names" = "xyes"; then
+    AC_MSG_RESULT([      add default names        : "yes"])
+else
+    AC_MSG_RESULT([      add default names        : "no"])
 fi
 if test "x$have_epoll" = "xyes"; then
     AC_MSG_RESULT([      build using epoll        : "$with_epoll"])

--- a/doc/upgrade_4.2.1_4.3.0.txt
+++ b/doc/upgrade_4.2.1_4.3.0.txt
@@ -7,6 +7,9 @@ throw up many errors as the API has been updated to make future coding simpler,
 adds more functionality and adds more rigorous coding checks.  Updating your
 code with the following steps will significantly reduce the reported issues.
 
+The examples are now also named with the (D)TLS library type as a suffix.
+E.g. coap-client is now coap-client-openssl.
+
 == Include directory changes
 
 Because of the API changes, the libcoap's include file directory has changed from `coap2/` to `coap3/`. Also, there is now no need to define additional include paths to the compiler options such as `-I include/coap3`.
@@ -184,13 +187,13 @@ their calling parameters. Note that `coap_tid_t` has been replaced with
 Example
 ----
 4.2.1
-  void 
+  void
   pong_handler(coap_context_t *context,
                coap_session_t *session,
                coap_pdu_t *received,
                const coap_tid_t id);
 4.3.0
-  void 
+  void
   pong_handler(coap_session_t *session,
                const coap_pdu_t *received,
                const coap_mid_t mid);

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -12,27 +12,58 @@ if BUILD_EXAMPLES
 
 # picking up the default warning CFLAGS into AM_CFLAGS
 AM_CFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include \
-            -I$(top_srcdir)/include/coap$(LIBCOAP_API_VERSION) \
             $(WARNING_CFLAGS) $(DTLS_CFLAGS) -std=c99
 
 #
-bin_PROGRAMS = coap-client coap-server coap-rd
+
+if BUILD_ADD_DEFAULT_NAMES
+bin_PROGRAMS = coap-client \
+               coap-server \
+               coap-rd \
+               coap-client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
+               coap-server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
+               coap-rd@LIBCOAP_DTLS_LIB_EXTENSION_NAME@
+else # BUILD_ADD_DEFAULT_NAMES
+bin_PROGRAMS = coap-client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
+               coap-server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
+               coap-rd@LIBCOAP_DTLS_LIB_EXTENSION_NAME@
+endif # BUILD_ADD_DEFAULT_NAMES
+
 check_PROGRAMS = coap-etsi_iot_01 coap-tiny
 
+if BUILD_ADD_DEFAULT_NAMES
 coap_client_SOURCES = coap-client.c
-coap_client_LDADD =  $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+coap_client_LDADD =  $(DTLS_LIBS) \
+             $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
 
 coap_server_SOURCES = coap-server.c
-coap_server_LDADD = $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+coap_server_LDADD = $(DTLS_LIBS) \
+             $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
 
 coap_rd_SOURCES = coap-rd.c
-coap_rd_LDADD = $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+coap_rd_LDADD = $(DTLS_LIBS) \
+             $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+endif # BUILD_ADD_DEFAULT_NAMES
+
+coap_client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@_SOURCES = coap-client.c
+coap_client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@_LDADD =  $(DTLS_LIBS) \
+             $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+
+coap_server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@_SOURCES = coap-server.c
+coap_server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@_LDADD = $(DTLS_LIBS) \
+             $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+
+coap_rd@LIBCOAP_DTLS_LIB_EXTENSION_NAME@_SOURCES = coap-rd.c
+coap_rd@LIBCOAP_DTLS_LIB_EXTENSION_NAME@_LDADD = $(DTLS_LIBS) \
+             $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
 
 coap_etsi_iot_01_SOURCES = etsi_iot_01.c
-coap_etsi_iot_01_LDADD = $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+coap_etsi_iot_01_LDADD = $(DTLS_LIBS) \
+             $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
 
 coap_tiny_SOURCES = tiny.c
-coap_tiny_LDADD = $(DTLS_LIBS) $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
+coap_tiny_LDADD = $(DTLS_LIBS) \
+             $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
 
 endif # BUILD_EXAMPLES
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -71,8 +71,10 @@ man7_MANS = $(MAN7)
 
 # Man pages built by a2x based on the NAMES section of the .txt file.
 # Note - this list includes all the defined entries, but a2x only builds the first 10.
-A2X_EXTRA_PAGES = @DOLLAR_SIGN@(shell for fil in $(TXT3) ; do sed -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $${fil} | \
+A2X_EXTRA_PAGES_3 = @DOLLAR_SIGN@(shell for fil in $(TXT3) ; do sed -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $${fil} | \
 	sed -ne '/coap_/{ s/ *, */\n/g; p }' | sed -ne 's/^\(coap_[a-zA-Z_0-9]\+\).*$$/\1.3/p' ; done)
+A2X_EXTRA_PAGES_5 = @DOLLAR_SIGN@(shell for fil in $(TXT5) ; do sed -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $${fil} | \
+	sed -ne '/coap-/{ s/ *, */\n/g; p }' | sed -ne 's/^\(coap-[a-zA-Z0-9-]\+\).*$$/\1.5/p' ; done)
 
 # a2x builds alternative .3 files up to a limit of 10 names from the
 # NAME section, so that 'man' works against the alternative different
@@ -127,12 +129,13 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_string.3" > coap_make_str_const.3
 	@echo ".so man3/coap_string.3" > coap_string_equal.3
 	@echo ".so man3/coap_string.3" > coap_binary_equal.3
-	$(INSTALL_DATA) $(A2X_EXTRA_PAGES) "$(DESTDIR)$(man3dir)"
+	$(INSTALL_DATA) $(A2X_EXTRA_PAGES_3) "$(DESTDIR)$(man3dir)"
+	$(INSTALL_DATA) $(A2X_EXTRA_PAGES_5) "$(DESTDIR)$(man5dir)"
 
 # As well as removing the base 'man' pages, remove other .3 files built by
 # a2x, as well as build by install-man specials.
 uninstall-man: uninstall-man3 uninstall-man5 uninstall-man7
-	-(cd $(DESTDIR)$(man3dir) ; rm -f $(A2X_EXTRA_PAGES) )
+	-(cd $(DESTDIR)$(man3dir) ; rm -f $(A2X_EXTRA_PAGES_3) $(A2X_EXTRA_PAGES_5) )
 
 endif # BUILD_MANPAGES
 

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -10,7 +10,11 @@ coap-client(5)
 
 NAME
 -----
-coap-client - CoAP Client based on libcoap
+coap-client,
+coap-client-gnutls,
+coap-client-mbedtls,
+coap-client-openssl,
+coap-client-notls - CoAP Client based on libcoap
 
 SYNOPSIS
 --------
@@ -22,6 +26,11 @@ SYNOPSIS
               [[*-h* match_hint_file] [*-k* key] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [-n] [*-C* cafile]
               [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* trust_casfile]] URI
+
+For *coap-client* versions that use libcoap compiled for different
+(D)TLS libraries, *coap-client-notls*, *coap-client-gnutls*,
+*coap-client-openssl*, *coap-client-mbedtls* or *coap-client-tinydtls* may be
+available.  Otherwise, *coap-client* uses the default libcoap (D)TLS support.
 
 DESCRIPTION
 -----------

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -10,13 +10,22 @@ coap-rd(5)
 
 NAME
 -----
-coap-rd - A CoAP Resource Directory based on libcoap
+coap-rd,
+coap-rd-gnutls ,
+coap-rd-mbedtls,
+coap-rd-openssl,
+coap-rd-notls - A CoAP Resource Directory based on libcoap
 
 SYNOPSIS
 --------
 *coap-rd* [*-g* group] [*-G* group_if] [*-p* port] [*-v* num] [*-A* address]
           [[*-h* hint] [*-k* key]]
           [[*-c* certfile] [*-n*] [*-C* cafile] [*-R* trusted_casfile]]
+
+For *coap-rd* versions that use libcoap compiled for different
+(D)TLS libraries, *coap-rd-notls*, *coap-rd-gnutls*,
+*coap-rd-openssl*, *coap-rd-mbedtls* or *coap-rd-tinydtls* may be
+available.  Otherwise, *coap-rd* uses the default libcoap (D)TLS support.
 
 DESCRIPTION
 -----------

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -10,7 +10,11 @@ coap-server(5)
 
 NAME
 -----
-coap-server - CoAP Server based on libcoap
+coap-server,
+coap-server-gnutls,
+coap-server-mbedtls,
+coap-server-openssl,
+coap-server-notls - CoAP Server based on libcoap
 
 SYNOPSIS
 --------
@@ -22,6 +26,11 @@ SYNOPSIS
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
               [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* trust_casfile]
               [*-S* match_pki_sni_file]]
+
+For *coap-server* versions that use libcoap compiled for different
+(D)TLS libraries, *coap-server-notls*, *coap-server-gnutls*,
+*coap-server-openssl*, *coap-server-mbedtls* or *coap-server-tinydtls* may be
+available.  Otherwise, *coap-server* uses the default libcoap (D)TLS support.
 
 DESCRIPTION
 -----------


### PR DESCRIPTION
If --enable-add-default-names is set (the default), then the installed default
libraries and installed default example executables will point to the
appropriate object that has the (D)TLS library type in the name.  E.g.

libcoap-3.so -> libcoap-3-openssl.so
coap-client -> coap-client-openssl

If --enable-add-default-names is not set, then this will not happen.

As well as the libraries, the example binaries are now created with the (D)TLS
library extension in all cases.