### PR TITLE
examples: Fix truncated usage() output

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -409,7 +409,7 @@ message_handler(coap_session_t *session COAP_UNUSED,
 static void
 usage( const char *program, const char *version) {
   const char *p;
-  char buffer[64];
+  char buffer[72];
   coap_tls_version_t *tls_version = coap_get_tls_library_version();
   const char *lib_version = coap_package_version();
 

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -568,7 +568,7 @@ init_resources(coap_context_t *ctx) {
 static void
 usage( const char *program, const char *version) {
   const char *p;
-  char buffer[64];
+  char buffer[72];
   coap_tls_version_t *tls_version = coap_get_tls_library_version();
   const char *lib_version = coap_package_version();
 

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2102,7 +2102,7 @@ fill_keystore(coap_context_t *ctx) {
 static void
 usage( const char *program, const char *version) {
   const char *p;
-  char buffer[64];
+  char buffer[72];
   coap_tls_version_t *tls_version = coap_get_tls_library_version();
   const char *lib_version = coap_package_version();
 


### PR DESCRIPTION
Increase scratch buffer size (needed for Mbed TLS)