### PR TITLE
PKCS11: Fix -C ca option

### DIFF
--- a/HOWTO.dual.softhsm2
+++ b/HOWTO.dual.softhsm2
@@ -50,13 +50,17 @@ cd ..
 #
 #  module: /usr/local/lib/softhsm/libsofthsm2.so
 
-# If /var/lib/softhsm/tokens is owned by user ods (because softhsm2 package is
-# alread installed), make the logged in <user> a part of the group ods so
-# that the tokens can be accessed.
-sudo usermod -a -G ods <user>
-# log out and then log back in again
-# Confirm that you have ods in your group
-id
+# The user you are running this as needs to be in the group defined for
+# /var/lib/softhsm/tokens/.  E.g.
+#  $ sudo ls -ld  /var/lib/softhsm/tokens/
+#  drwxrws--- 3 root softhsm 4096 May  3 09:52 /var/lib/softhsm/tokens/
+# which is softhsm in this case (It could be ods). To verify if you are in
+# the correct group
+#  $ id
+# To add user to this group
+#  $ sudo usermod -a -G softhsm <user>
+# and log out and back in again.
+#
 
 ############################################################################
 #

--- a/HOWTO.pkcs11
+++ b/HOWTO.pkcs11
@@ -29,6 +29,20 @@
 #
 # Tokens will be stored under /var/lib/softhsm/tokens/
 #
+# The user you are running this as needs to be in the group defined for
+# /var/lib/softhsm/tokens/.  E.g.
+#  $ sudo ls -ld  /var/lib/softhsm/tokens/
+#  drwxrws--- 3 root softhsm 4096 May  3 09:52 /var/lib/softhsm/tokens/
+# which is softhsm in this case (It could be ods). To verify if you are in
+# the correct group
+#  $ id
+# To add user to this group
+#  $ sudo usermod -a -G softhsm <user>
+# and log out and back in again.
+#
+
+# Set libsofthsm2.so to use (may be /usr/lib/softhsm/libsofthsm2.so)
+LIBSOFTHSM=/usr/local/lib/softhsm/libsofthsm2.so
 
 # Initialize Soft HSM token
 #  Note: slot 0 is re-allocated to slot XXX.  This is presented as a decimal
@@ -37,10 +51,9 @@
 softhsm2-util --init-token --slot 0 --label "token-0" --pin 1234 --so-pin 4321
 
 # CA Certificate (different id to Server/Client Public Certificate)
-openssl x509 -in ca-cert.pem -out ca-cert.der -outform DER
-pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so --pin 1234 \
-  --write-object ./ca-cert.der --type cert --id cc00 --label "ca-cert" \
-  --token-label "token-0"
+# (GnuTLS requires this to be trusted)
+p11tool --so-login --load-certificate ca-cert.pem --write --label ca-cert \
+  --set-so-pin 4321 --id cc00 --mark-trusted "pkcs11:token=token-0"
 
 # Server Private Key
 openssl pkcs8 -topk8 -inform PEM -outform PEM -in server-key.pem \
@@ -51,7 +64,7 @@ softhsm2-util --import server-key.pk8 --label "server-key" --id aa00 \
 # Server Public Certificate
 # (Use different id to private key, but not the same as CA/Client cert)
 openssl x509 -in server-cert.pem -out server-cert.der -outform DER
-pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so --pin 1234 \
+pkcs11-tool --module $LIBSOFTHSM --pin 1234 \
   --write-object ./server-cert.der --type cert --id aa01 \
   --label "server-cert" --token-label "token-0"
 
@@ -64,31 +77,32 @@ softhsm2-util --import client-key.pk8 --label "client-key" --id bb00 \
 # Client Public Certificate
 # (Use different id to private key, but not the same as CA/Client cert)
 openssl x509 -in client-cert.pem -out client-cert.der -outform DER
-pkcs11-tool --module /usr/local/lib/softhsm/libsofthsm2.so --pin 1234 \
+pkcs11-tool --module $LIBSOFTHSM --pin 1234 \
   --write-object ./client-cert.der --type cert --id bb01 \
   --label "client-cert" --token-label "token-0"
 
 # Verify token is correctly populated
-pkcs11-tool --module=/usr/local/lib/softhsm/libsofthsm2.so -t
-pkcs11-tool --module=/usr/local/lib/softhsm/libsofthsm2.so --list-objects \
+pkcs11-tool --module=$LIBSOFTHSM -t
+pkcs11-tool --module=$LIBSOFTHSM --list-objects \
   --pin 1234 --token-label "token-0"
+p11tool --list-all pkcs11:model=SoftHSM%20v2
 
 #
 # Run coap-server using PKCS11 (-C option may need to be -C cert.der)
 #
 coap-server -C 'pkcs11:token=token-0;id=%cc%00?pin-value=1234' \
   -c 'pkcs11:token=token-0;id=%aa%01?pin-value=1234' \
-  -j 'pkcs11:token=token-0;id=%aa%00?pin-value=1234' -v9 -n
+  -j 'pkcs11:token=token-0;id=%aa%00?pin-value=1234' -v9
 
 # or
 coap-server -C 'pkcs11:token=token-0;id=%cc%00' \
   -c 'pkcs11:token=token-0;id=%aa%01' \
-  -j 'pkcs11:token=token-0;id=%aa%00' -J 1234 -v9 -n
+  -j 'pkcs11:token=token-0;id=%aa%00' -J 1234 -v9
 
 # or
 coap-server -C 'pkcs11:token=token-0;object=ca-cert' \
   -c 'pkcs11:token=token-0;object=server-cert' \
-  -j 'pkcs11:token=token-0;object=server-key' -J 1234 -v9 -n
+  -j 'pkcs11:token=token-0;object=server-key' -J 1234 -v9
 
 #
 # Run coap-client using PKCS11 (-C option may need to be -C cert.der)
@@ -110,6 +124,6 @@ coap-client -C 'pkcs11:token=token-0;object=ca-cert' \
 #
 # Client and Server using RPK (GnuTLS only)
 #
-coap-server -M 'pkcs11:token=token-0;object=server-key' -J 1234 -v9 -n
+coap-server -M 'pkcs11:token=token-0;object=server-key' -J 1234 -v9
 # and
 coap-client -M 'pkcs11:token=token-0;object=client-key' -J 1234 -v9 coaps://[::1]

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1601,7 +1601,7 @@ setup_pki_ssl(SSL *ssl,
       ssl_engine = ENGINE_by_id("pkcs11");
       if (!ssl_engine) {
         coap_log(LOG_ERR,
-           "*** setup_pki: (D)TLS: No PKCS11 support\nn");
+           "*** setup_pki: (D)TLS: No PKCS11 support - need OpenSSL pkcs11 engine\n");
         return 0;
       }
       if (!ENGINE_init(ssl_engine)) {
@@ -1609,7 +1609,7 @@ setup_pki_ssl(SSL *ssl,
         ENGINE_free(ssl_engine);
         ssl_engine = NULL;
         coap_log(LOG_ERR,
-           "*** setup_pki: (D)TLS: PKCS11 engine initialize failed\nn");
+           "*** setup_pki: (D)TLS: PKCS11 engine initialize failed\n");
         return 0;
       }
     }
@@ -1727,7 +1727,7 @@ setup_pki_ssl(SSL *ssl,
         SSL_CTX *ctx = SSL_get_SSL_CTX(ssl);
 
         x509 = missing_ENGINE_load_cert(
-                           setup_data->pki_key.key.pkcs11.public_cert);
+                           setup_data->pki_key.key.pkcs11.ca);
         if (!x509) {
           coap_log(LOG_WARNING,
                    "*** setup_pki: (D)TLS: %s: Unable to load "


### PR DESCRIPTION
For OpenSSL, correct typo in src/coap_openssl.c

For GnuTLS, make sure that the PKCS11 CA Certificate is trusted.
Updated HOWTO.pkcs11 for how to do this. Unfortunatately, this cannot be
done using pkcs11-tool.

The coap-server -n option (don't check peer) is no longer a requirement, so
removed from the HOWTO.