### PR TITLE
LICENSE: Install in documentation root (--docdir)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,7 +76,7 @@ EXTRA_DIST = \
 
 AM_CFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include $(WARNING_CFLAGS) $(DTLS_CFLAGS) -std=c99 $(EXTRA_CFLAGS)
 
-SUBDIRS = $(subdirs) . man $(DOC_DIR) tests examples
+SUBDIRS = $(subdirs) . man doc tests examples
 
 ## Define a libtool archive target "libcoap-@LIBCOAP_NAME_SUFFIX@.la", with
 ## @LIBCOAP_NAME_SUFFIX@ substituted into the generated Makefile at configure

--- a/configure.ac
+++ b/configure.ac
@@ -214,8 +214,6 @@ if test "x$build_doxygen" = "xyes"; then
             AC_MSG_ERROR([==> Install required doxygen version or disable the doxygen documentation using '--disable-doxygen'.])
         else
             # we found doxygen and the version is valid
-            DOC_DIR=doc
-            AC_SUBST(DOC_DIR)
             # now checking dot (needed for graphics)
             AC_PATH_PROG([DOT], [dot])
             if test "x$DOT" = "x"; then
@@ -643,6 +641,16 @@ if test "x$build_gcov" = "xyes"; then
         AX_CHECK_COMPILE_FLAG([--coverage], [CFLAGS="$CFLAGS --coverage -O0" LDFLAGS="$LDFLAGS --coverage"])
    fi
 fi
+
+# configure options
+# __license-install__
+AC_ARG_ENABLE([license-install],
+              [AS_HELP_STRING([--enable-license-install],
+                              [Enable installing LICENSE to DOCDIR [default=yes]])],
+              [build_license_install="$enableval"],
+              [build_license_install="yes"])
+
+AM_CONDITIONAL(BUILD_LICENSE_INSTALL, [test "x$build_license_install" = "xyes"])
 
 # configure options
 # __tcp__

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -134,23 +134,6 @@ man-page-build: upg-page-build man-page-start
 		echo "finalized addition $${BASE}.html" ;\
 	done
 
-# This target has no check for automated install data! It's simply assumed that
-# that the 'all' target is running before, in short: the user has to run first
-# 'make' before running 'make install'!
-install-data-am:
-	@if [ ! -d $(top_builddir)/doc/html ]; then \
-		echo ;\
-		echo "     No install data in '$(top_builddir)/doc/html'found! Please run 'make all' first." ;\
-		echo ;\
-		exit 1 ;\
-	fi
-	$(MKDIR_P) $(DESTDIR)$(htmldir)/html || exit 1
-	cp -a -f $(top_builddir)/doc/html $(DESTDIR)$(htmldir)
-	find $(DESTDIR)$(htmldir) -type f -name "*.md5" -exec rm {} \;
-
-uninstall-am:
-	-rm -rf $(DESTDIR)$(htmldir)/html
-
 if BUILD_MANPAGES
 UPG_LIST = upgrade_4.2.1_4.3.0.txt
 
@@ -175,6 +158,35 @@ clean-local:
 
 distclean-local: clean-local
 
+endif # HAVE_DOXYGEN
+
+install-data-hook:
+if HAVE_DOXYGEN
+	@if [ ! -d $(top_builddir)/doc/html ]; then \
+		echo ;\
+		echo "     No install data in '$(top_builddir)/doc/html'found! Please run 'make all' first." ;\
+		echo ;\
+		exit 1 ;\
+	fi
+	$(MKDIR_P) $(DESTDIR)$(htmldir)/html || exit 1
+	cp -a -f $(top_builddir)/doc/html $(DESTDIR)$(htmldir)
+	find $(DESTDIR)$(htmldir) -type f -name "*.md5" -delete
+endif # HAVE_DOXYGEN
+if BUILD_LICENSE_INSTALL
+	$(MKDIR_P) $(DESTDIR)$(docdir) || exit 1
+	$(INSTALL_DATA) $(top_srcdir)/LICENSE $(DESTDIR)$(docdir)
+	$(INSTALL_DATA) $(top_srcdir)/COPYING $(DESTDIR)$(docdir)
+	$(INSTALL_DATA) $(top_srcdir)/README $(DESTDIR)$(docdir)
+endif # BUILD_LICENSE_INSTALL
+
+uninstall-hook:
+if BUILD_LICENSE_INSTALL
+	@if [ -d $(DESTDIR)$(docdir) ] ; then \
+		(cd $(DESTDIR)$(docdir) ; rm -f LICENSE README COPYING) ; \
+	fi
+endif # BUILD_LICENSE_INSTALL
+if HAVE_DOXYGEN
+	-rm -rf $(DESTDIR)$(htmldir)/html
 endif # HAVE_DOXYGEN
 
 .PHONY: man-page-cleanup man-page-prepare man-page-start man-page-build


### PR DESCRIPTION
Include README and COPYING as well, so that they can be a part of a library
distribution.

Make this optional with ./configure --enable-license-install
which is enabled by default.