### PR TITLE
Observe: Support FETCH with data for triggered responses

### DIFF
--- a/include/coap3/coap_cache.h
+++ b/include/coap3/coap_cache.h
@@ -69,6 +69,38 @@ coap_cache_key_t *coap_cache_derive_key(const coap_session_t *session,
                                    coap_cache_session_based_t session_based);
 
 /**
+ * Calculates a cache-key for the given CoAP PDU. See
+ * https://tools.ietf.org/html/rfc7252#section-5.6
+ * for an explanation of CoAP cache keys.
+ *
+ * Specific CoAP options can be removed from the cache-key.  Examples of
+ * this are the BLOCK1 and BLOCK2 options - which make no real sense including
+ * them in a client or server environment, but should be included in a proxy
+ * caching environment where things are cached on a per block basis.
+ * This is done individually by specifying @p cache_ignore_count and
+ * @p cache_ignore_options .
+ *
+ * NOTE: The returned cache-key needs to be freed off by the caller by
+ * calling coap_cache_delete_key().
+ *
+ * @param session The session to add into cache-key if @p session_based
+ *                is set.
+ * @param pdu     The CoAP PDU for which a cache-key is to be
+ *                calculated.
+ * @param session_based COAP_CACHE_IS_SESSION_BASED if session based
+ *                      cache-key, else COAP_CACHE_NOT_SESSION_BASED.
+ * @param ignore_options The array of options to ignore.
+ * @param ignore_count   The number of options to ignore.
+ *
+ * @return        The returned cache-key or @c NULL if failure.
+ */
+coap_cache_key_t *coap_cache_derive_key_w_ignore(const coap_session_t *session,
+                                      const coap_pdu_t *pdu,
+                                      coap_cache_session_based_t session_based,
+                                      const uint16_t *ignore_options,
+                                      size_t ignore_count);
+
+/**
  * Delete the cache-key.
  *
  * @param cache_key The cache-key to delete.

--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -51,13 +51,8 @@ struct coap_subscription_t {
   unsigned int dirty:1;    /**< set if the notification temporarily could not be
                             *   sent (in that case, the resource's partially
                             *   dirty flag is set too) */
-  unsigned int has_block2:1; /**< GET request had Block2 definition */
-  coap_pdu_code_t code;    /** request type code (GET/FETCH)*/
-  coap_mid_t mid;          /**< message id, if any, in regular host byte order */
-  coap_block_t block;      /**< GET/FETCH request Block definition */
-  size_t token_length;     /**< actual length of token */
-  unsigned char token[8];  /**< token used for subscription */
-  struct coap_string_t *query; /**< query string used for subscription, if any */
+  coap_cache_key_t *cache_key; /** cache_key to identify requester */
+  coap_pdu_t *pdu;         /**< PDU to use for additional requests */
 };
 
 void coap_subscription_init(coap_subscription_t *);
@@ -91,12 +86,7 @@ void coap_check_notify(coap_context_t *context);
  * @param resource        The observed resource.
  * @param session         The observer's session
  * @param token           The token that identifies this subscription.
- * @param query           The query string, if any. subscription will
- *                        take ownership of the string unless this
- *                        function returns NULL.
- * @param has_block2      If Option Block2 defined.
- * @param block2          Contents of Block2 if Block 2 defined.
- * @param code            Request type code.
+ * @param pdu             The requesting pdu.
  *
  * @return                A pointer to the added/updated subscription
  *                        information or @c NULL on error.
@@ -104,10 +94,7 @@ void coap_check_notify(coap_context_t *context);
 coap_subscription_t *coap_add_observer(coap_resource_t *resource,
                                        coap_session_t *session,
                                        const coap_binary_t *token,
-                                       coap_string_t *query,
-                                       int has_block2,
-                                       coap_block_t block2,
-                                       coap_pdu_code_t code);
+                                       const coap_pdu_t *pdu);
 
 /**
  * Returns a subscription object for given @p peer.

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -22,6 +22,7 @@ global:
   coap_attr_get_value;
   coap_block_build_body;
   coap_cache_derive_key;
+  coap_cache_derive_key_w_ignore;
   coap_cache_get_app_data;
   coap_cache_get_by_key;
   coap_cache_get_by_pdu;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -20,6 +20,7 @@ coap_async_set_delay
 coap_attr_get_value
 coap_block_build_body
 coap_cache_derive_key
+coap_cache_derive_key_w_ignore
 coap_cache_get_app_data
 coap_cache_get_by_key
 coap_cache_get_by_pdu

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -84,6 +84,7 @@ A2X_EXTRA_PAGES = @DOLLAR_SIGN@(shell for fil in $(TXT3) ; do sed -ne '/^NAME/,/
 # Then all the alternative names as well as the extras defined below need
 # to be cleaned up in a 'make unistall'.
 install-man: install-man3 install-man5 install-man7
+	@echo ".so man3/coap_cache.3" > coap_cache_get_pdu.3
 	@echo ".so man3/coap_cache.3" > coap_cache_get_app_data.3
 	@echo ".so man3/coap_cache.3" > coap_cache_set_app_data.3
 	@echo ".so man3/coap_context.3" > coap_context_get_session_timeout.3

--- a/man/coap_cache.txt.in
+++ b/man/coap_cache.txt.in
@@ -12,6 +12,7 @@ NAME
 ----
 coap_cache,
 coap_cache_derive_key,
+coap_cache_derive_key_w_ignore,
 coap_cache_delete_key,
 coap_cache_ignore_options,
 coap_new_cache_entry,
@@ -29,6 +30,11 @@ SYNOPSIS
 
 *coap_cache_key_t *coap_cache_derive_key(const coap_session_t *_session_,
 const coap_pdu_t *_pdu_, coap_cache_session_based_t _session_based_);*
+
+*coap_cache_key_t *coap_cache_derive_key_w_ignore(
+const coap_session_t *_session_, const coap_pdu_t *_pdu_,
+coap_cache_session_based_t _session_based_,
+const uint16_t *_ignore_options_, size_t _ignore_count_);*
 
 *void coap_delete_cache_key(coap_cache_key_t *_cache_key_);*
 
@@ -109,9 +115,16 @@ typedef enum coap_cache_record_pdu_t {
 
 The *coap_cache_derive_key*() function abstracts all the non NoCacheKey CoAP
 options, ignores the CoAP Observer option and includes a FETCH body from _pdu_.
-If _session_based_ is COAP_CACHE_IS_SESSION_BASED, then _session_ is also
-included. CoAP options can be specifically ignored by the use of
+If _session_based_ is COAP_CACHE_IS_SESSION_BASED, then _session_ pointer is
+also included. CoAP options can be specifically ignored by the use of
 *coap_cache_ignore_options*().  A digest is then built from all of the
+information and returned. NULL is returned on error.
+
+The *coap_cache_derive_key_w_ignore*() function abstracts all the non
+NoCacheKey CoAP options, ignores the CoAP Observer option and includes a FETCH
+body from _pdu_. Further options to ignore are specified by the _ignore_count_
+of _ignore_options_.  If _session_based_ is COAP_CACHE_IS_SESSION_BASED, then
+_session_ pointer is also included. A digest is then built from all of the
 information and returned. NULL is returned on error.
 
 The *coap_delete_cache_key*() function deletes the _cache_key_ that was
@@ -170,8 +183,8 @@ _data_ in the _cache_entry_.
 
 RETURN VALUES
 -------------
-*coap_cache_derive_key*() function returns a newly created Cache Key or
-NULL if there is a creation failure.
+*coap_cache_derive_key*() and *coap_cache_derive_key_w_ignore*() functions
+returns a newly created Cache Key or NULL if there is a creation failure.
 
 *coap_cache_ignore_options*() function returns 1 if success, 0 on failure.
 

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -108,7 +108,7 @@ as required by some higher layer protocols.
 
 The *coap_resource_notify_observers*() function needs to be called whenever the
 server application determines that there has been a change to the state of
-_resource_, possibly only matching a specific _query_ if _query_ is not NULL.
+_resource_.  The _query_ parameter is obsolete and ignored.
 
 The *coap_cancel_observe*() function can be used by the client to cancel an
 observe request that is being tracked following the use of *coap_send_large*()

--- a/src/block.c
+++ b/src/block.c
@@ -289,6 +289,8 @@ coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
                      cq->app_token->length))) {
         uint8_t buf[4];
         coap_mid_t mid;
+        size_t size;
+        const uint8_t *data;
         coap_pdu_t * pdu = coap_pdu_duplicate(&cq->pdu,
                                               session,
                                               cq->base_token_length,
@@ -301,6 +303,9 @@ coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
         /* Need to make sure that this is the correct type */
         pdu->type = type;
 
+        if (coap_get_data(&cq->pdu, &size, &data)) {
+          coap_add_data(pdu, size, data);
+        }
         coap_update_option(pdu, COAP_OPTION_OBSERVE,
                            coap_encode_var_safe(buf, sizeof(buf),
                                                 COAP_OBSERVE_CANCEL),


### PR DESCRIPTION
The original requesting PDU is now kept with the Observe request along with
its data and used whenever an additional response needs to be generated.

Abstracted information from the requesting PDU is no longer kept in
coap_subscription_t as it can be obtained from the kept PDU.

No longer any need to check for request PDU in request handlers as it is now
always provided.

coap_resource_notify_observers() now ignores the query parameter, as a
cache_key is now used for request matching.

Add in hnd_get_fetch_time() to coap-server for testing.