### PR TITLE
TLS Support: Move common TLS support descriptions into libcoap

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -410,7 +410,6 @@ static void
 usage( const char *program, const char *version) {
   const char *p;
   char buffer[72];
-  coap_tls_version_t *tls_version = coap_get_tls_library_version();
   const char *lib_version = coap_package_version();
 
   p = strrchr( program, '/' );
@@ -423,27 +422,7 @@ usage( const char *program, const char *version) {
      "%s\n"
     , program, version, lib_version,
     coap_string_tls_version(buffer, sizeof(buffer)));
-  switch (tls_version->type) {
-  case COAP_TLS_LIBRARY_NOTLS:
-    break;
-  case COAP_TLS_LIBRARY_TINYDTLS:
-    fprintf(stderr, "(DTLS and no TLS support; PSK and RPK support)\n");
-    break;
-  case COAP_TLS_LIBRARY_OPENSSL:
-    fprintf(stderr, "(DTLS and TLS support; PSK, PKI and no RPK support)\n");
-    break;
-  case COAP_TLS_LIBRARY_GNUTLS:
-    if (tls_version->version >= 0x030606)
-      fprintf(stderr, "(DTLS and TLS support; PSK, PKI and RPK support)\n");
-    else
-      fprintf(stderr, "(DTLS and TLS support; PSK, PKI and no RPK support)\n");
-    break;
-  case COAP_TLS_LIBRARY_MBEDTLS:
-    fprintf(stderr, "(DTLS and no TLS support; PSK, PKI and no RPK support)\n");
-    break;
-  default:
-    break;
-  }
+  fprintf(stderr, "%s\n", coap_string_tls_support(buffer, sizeof(buffer)));
   fprintf(stderr, "\n"
      "Usage: %s [-a addr] [-b [num,]size] [-e text] [-f file] [-l loss]\n"
      "\t\t[-m method] [-o file] [-p port] [-r] [-s duration] [-t type]\n"

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -570,7 +570,6 @@ static void
 usage( const char *program, const char *version) {
   const char *p;
   char buffer[72];
-  coap_tls_version_t *tls_version = coap_get_tls_library_version();
   const char *lib_version = coap_package_version();
 
   p = strrchr( program, '/' );
@@ -583,27 +582,7 @@ usage( const char *program, const char *version) {
      "%s\n"
     , program, version, lib_version,
     coap_string_tls_version(buffer, sizeof(buffer)));
-  switch (tls_version->type) {
-  case COAP_TLS_LIBRARY_NOTLS:
-    break;
-  case COAP_TLS_LIBRARY_TINYDTLS:
-    fprintf(stderr, "(DTLS and no TLS support; PSK and RPK support)\n");
-    break;
-  case COAP_TLS_LIBRARY_OPENSSL:
-    fprintf(stderr, "(DTLS and TLS support; PSK, PKI and no RPK support)\n");
-    break;
-  case COAP_TLS_LIBRARY_GNUTLS:
-    if (tls_version->version >= 0x030606)
-      fprintf(stderr, "(DTLS and TLS support; PSK, PKI and RPK support)\n");
-    else
-      fprintf(stderr, "(DTLS and TLS support; PSK, PKI and no RPK support)\n");
-    break;
-  case COAP_TLS_LIBRARY_MBEDTLS:
-    fprintf(stderr, "(DTLS and no TLS support; PSK, PKI and no RPK support)\n");
-    break;
-  default:
-    break;
-  }
+  fprintf(stderr, "%s\n", coap_string_tls_support(buffer, sizeof(buffer)));
   fprintf(stderr, "\n"
      "Usage: %s [-g group] [-G group_if] [-p port] [-v num] [-A address]\n"
      "\t       [[-h hint] [-k key]]\n"

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2103,7 +2103,6 @@ static void
 usage( const char *program, const char *version) {
   const char *p;
   char buffer[72];
-  coap_tls_version_t *tls_version = coap_get_tls_library_version();
   const char *lib_version = coap_package_version();
 
   p = strrchr( program, '/' );
@@ -2116,27 +2115,7 @@ usage( const char *program, const char *version) {
      "%s\n"
     , program, version, lib_version,
     coap_string_tls_version(buffer, sizeof(buffer)));
-  switch (tls_version->type) {
-  case COAP_TLS_LIBRARY_NOTLS:
-    break;
-  case COAP_TLS_LIBRARY_TINYDTLS:
-    fprintf(stderr, "(DTLS and no TLS support; PSK and RPK support)\n");
-    break;
-  case COAP_TLS_LIBRARY_OPENSSL:
-    fprintf(stderr, "(DTLS and TLS support; PSK, PKI and no RPK support)\n");
-    break;
-  case COAP_TLS_LIBRARY_GNUTLS:
-    if (tls_version->version >= 0x030606)
-      fprintf(stderr, "(DTLS and TLS support; PSK, PKI and RPK support)\n");
-    else
-      fprintf(stderr, "(DTLS and TLS support; PSK, PKI and no RPK support)\n");
-    break;
-  case COAP_TLS_LIBRARY_MBEDTLS:
-    fprintf(stderr, "(DTLS and no TLS support; PSK, PKI and no RPK support)\n");
-    break;
-  default:
-    break;
-  }
+  fprintf(stderr, "%s\n", coap_string_tls_support(buffer, sizeof(buffer)));
   fprintf(stderr, "\n"
      "Usage: %s [-d max] [-e] [-g group] [-G group_if] [-l loss] [-p port]\n"
      "\t\t[-v num] [-A address] [-L value] [-N]\n"

--- a/include/coap3/coap_debug.h
+++ b/include/coap3/coap_debug.h
@@ -192,6 +192,16 @@ void coap_show_tls_version(coap_log_t level);
 char *coap_string_tls_version(char *buffer, size_t bufsize);
 
 /**
+ * Build a string containing the current (D)TLS library support
+ *
+ * @param buffer The buffer to put the string into.
+ * @param bufsize The size of the buffer to put the string into.
+ *
+ * @return A pointer to the provided buffer.
+ */
+char *coap_string_tls_support(char *buffer, size_t bufsize);
+
+/**
  * Print the address into the defined buffer.
  *
  * Internal Function.

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -218,6 +218,7 @@ global:
   coap_split_query;
   coap_split_uri;
   coap_startup;
+  coap_string_tls_support;
   coap_string_tls_version;
   coap_tcp_is_supported;
   coap_ticks;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -216,6 +216,7 @@ coap_split_proxy_uri
 coap_split_query
 coap_split_uri
 coap_startup
+coap_string_tls_support
 coap_string_tls_version
 coap_tcp_is_supported
 coap_ticks

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -15,6 +15,7 @@ coap_dtls_is_supported,
 coap_tls_is_supported,
 coap_tcp_is_supported,
 coap_get_tls_library_version,
+coap_string_tls_support,
 coap_string_tls_version,
 coap_show_tls_version
 - Work with CoAP TLS libraries
@@ -30,6 +31,8 @@ SYNOPSIS
 *int coap_tcp_is_supported(void);*
 
 *coap_tls_version_t *coap_get_tls_library_version(void);*
+
+*char *coap_string_tls_support(char *_buffer_, size_t _bufsize_);*
 
 *char *coap_string_tls_version(char *_buffer_, size_t _bufsize_);*
 
@@ -82,6 +85,12 @@ enabled, otherwise 0.
 
 The *coap_get_tls_library_version*() function returns the TLS implementation
 type and library version in a coap_tls_version_t* structure.
+
+The *coap_string_tls_support*() function is used to update the provided buffer
+with ascii readable information about what type of PSK, PKI etc. keys the
+current (D)TLS library supports.
+_buffer_ defines the buffer to provide the information and _bufsize_ is the
+size of _buffer_.
 
 The *coap_string_tls_version*() function is used to update the provided buffer
 with information about the current (D)TLS library that libcoap was built

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -840,6 +840,41 @@ char *coap_string_tls_version(char *buffer, size_t bufsize)
   return buffer;
 }
 
+char *coap_string_tls_support(char *buffer, size_t bufsize)
+{
+  coap_tls_version_t *tls_version = coap_get_tls_library_version();
+
+  switch (tls_version->type) {
+  case COAP_TLS_LIBRARY_NOTLS:
+    snprintf(buffer, bufsize, "(No DTLS or TLS support)");
+    break;
+  case COAP_TLS_LIBRARY_TINYDTLS:
+    snprintf(buffer, bufsize,
+             "(DTLS and no TLS support; PSK and RPK support)");
+    break;
+  case COAP_TLS_LIBRARY_OPENSSL:
+    snprintf(buffer, bufsize,
+             "(DTLS and TLS support; PSK, PKI, PKCS11 and no RPK support)");
+    break;
+  case COAP_TLS_LIBRARY_GNUTLS:
+    if (tls_version->version >= 0x030606)
+      snprintf(buffer, bufsize,
+               "(DTLS and TLS support; PSK, PKI, PKCS11 and RPK support)");
+    else
+      snprintf(buffer, bufsize,
+               "(DTLS and TLS support; PSK, PKI, PKCS11 and no RPK support)");
+    break;
+  case COAP_TLS_LIBRARY_MBEDTLS:
+    snprintf(buffer, bufsize,
+             "(DTLS and no TLS support; PSK, PKI and no RPK support)");
+    break;
+  default:
+    buffer[0] = '\000';
+    break;
+  }
+  return buffer;
+}
+
 static coap_log_handler_t log_handler = NULL;
 
 void coap_set_log_handler(coap_log_handler_t handler) {


### PR DESCRIPTION
Added new function coap_string_tls_support() for outputting what key types the
TLS library supports to remove duplicated code out of the examples.