### PR TITLE
coap-rd: Remove requirement for uthash.h

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -12,11 +12,10 @@ if BUILD_EXAMPLES
 
 # picking up the default warning CFLAGS into AM_CFLAGS
 AM_CFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include \
+            -I$(top_srcdir)/include/coap$(LIBCOAP_API_VERSION) \
             $(WARNING_CFLAGS) $(DTLS_CFLAGS) -std=c99
 
-# add coap include path for coap_rd for uthash.h
-coap_rd_CPPFLAGS=-I$(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)
-
+#
 bin_PROGRAMS = coap-client coap-server coap-rd
 check_PROGRAMS = coap-etsi_iot_01 coap-tiny
 

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -99,6 +99,11 @@ rd_delete(rd_t *rd) {
   }
 }
 
+static void
+resource_rd_delete(void *ptr) {
+  rd_delete(ptr);
+}
+
 static int quit = 0;
 
 /* SIGINT handler: set quit to 1 for graceful termination */
@@ -352,7 +357,8 @@ add_source_address(coap_resource_t *resource,
   coap_add_attr(resource,
                 coap_make_str_const("A"),
                 &attr_val,
-                COAP_ATTR_FLAGS_RELEASE_VALUE);
+                0);
+  coap_free(buf);
 #undef BUFSIZE
 }
 
@@ -463,7 +469,7 @@ hnd_post_rd(coap_resource_t *resource COAP_UNUSED,
 
   resource_val.s = loc;
   resource_val.length = loc_size;
-  r = coap_resource_init(&resource_val, COAP_RESOURCE_FLAGS_RELEASE_URI);
+  r = coap_resource_init(&resource_val, 0);
   coap_register_handler(r, COAP_REQUEST_GET, hnd_get_resource);
   coap_register_handler(r, COAP_REQUEST_PUT, hnd_put_resource);
   coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_resource);
@@ -480,7 +486,8 @@ hnd_post_rd(coap_resource_t *resource COAP_UNUSED,
       coap_add_attr(r,
                     coap_make_str_const("ins"),
                     &attr_val,
-                    COAP_ATTR_FLAGS_RELEASE_VALUE);
+                    0);
+      coap_free(buf);
     }
   }
 
@@ -496,7 +503,8 @@ hnd_post_rd(coap_resource_t *resource COAP_UNUSED,
       coap_add_attr(r,
                     coap_make_str_const("rt"),
                     &attr_val,
-                    COAP_ATTR_FLAGS_RELEASE_VALUE);
+                    0);
+      coap_free(buf);
     }
   }
 
@@ -534,6 +542,7 @@ hnd_post_rd(coap_resource_t *resource COAP_UNUSED,
       b += coap_opt_size(b);
     }
   }
+  coap_free(loc);
 }
 
 static void
@@ -550,6 +559,7 @@ init_resources(coap_context_t *ctx) {
 
   coap_add_resource(ctx, r);
 
+  coap_resource_release_userdata_handler(ctx, resource_rd_delete);
 }
 
 static void


### PR DESCRIPTION
Add rd_t information as user data to the resource (which has hashed lookup)
rather than maintaining a separate hash within coap-rd.

Fix calls to coap_resource_init() and coap_add_attr() where proper
coap_str_const_t * were not being passed in that were safe to free off.

Bringing coap-rd up to the latest draft-ietf-core-resource-directory is to be
done separately.