### PR TITLE
man pages: Indicate where to raise issues

### DIFF
--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -272,7 +272,8 @@ EXIT STATUS
 BUGS
 -----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -145,7 +145,8 @@ EXIT STATUS
 BUGS
 -----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -241,7 +241,8 @@ EXIT STATUS
 BUGS
 -----
 Please report bugs on the mailing list for libcoap:
-libcoap-developers@lists.sourceforge.net
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
 
 AUTHORS
 -------


### PR DESCRIPTION
Document where to raise an issue for the examples inline with the other man
pages.