### PR TITLE
man pages: Update to use the coap_block(3) functions

### DIFF
--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -951,6 +951,10 @@ setup_server_context_pki (const char *public_cert_file,
   context = coap_new_context(NULL);
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   memset (&dtls_pki, 0, sizeof (dtls_pki));
 
@@ -1094,6 +1098,10 @@ setup_server_context_psk (const char *hint,
   context = coap_new_context(NULL);
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   memset (&dtls_psk, 0, sizeof (dtls_psk));
 
@@ -1173,6 +1181,10 @@ setup_client_session_psk (const char *uri,
 
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
@@ -1206,7 +1218,7 @@ setup_client_session_psk (const char *uri,
 
 SEE ALSO
 --------
-*coap_context*(3), *coap_resource*(3), *coap_session*(3) and
+*coap_block*(3), *coap_context*(3), *coap_resource*(3), *coap_session*(3) and
 *coap_tls_library*(3).
 
 FURTHER INFORMATION

--- a/man/coap_endpoint_client.txt.in
+++ b/man/coap_endpoint_client.txt.in
@@ -166,6 +166,10 @@ setup_client_session (struct in_addr ip_address) {
 
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
@@ -228,6 +232,10 @@ setup_client_session_pki (struct in_addr ip_address,
 
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
@@ -317,6 +325,10 @@ setup_client_session_psk (const char *uri,
 
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
@@ -364,6 +376,10 @@ setup_client_session_dtls (struct in_addr ip_address) {
 
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
@@ -383,8 +399,9 @@ setup_client_session_dtls (struct in_addr ip_address) {
 
 SEE ALSO
 --------
-*coap_context*(3), *coap_encryption*(3), *coap_endpoint_server*()3),
-*coap_resource*(3), *coap_session*(3) and *coap_tls_library*(3)
+*coap_block*(3), *coap_context*(3), *coap_encryption*(3),
+*coap_endpoint_server*()3), *coap_resource*(3), *coap_session*(3) and
+*coap_tls_library*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/man/coap_endpoint_server.txt.in
+++ b/man/coap_endpoint_server.txt.in
@@ -181,6 +181,10 @@ setup_server_context (void) {
 
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   coap_address_init(&listen_addr);
   listen_addr.addr.sa.sa_family = AF_INET;
@@ -289,6 +293,10 @@ setup_server_context_pki (const char *public_cert_file,
   context = coap_new_context(NULL);
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   memset (&dtls_pki, 0, sizeof (dtls_pki));
 
@@ -426,6 +434,10 @@ setup_server_context_psk (const char *hint,
   context = coap_new_context(NULL);
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   memset (&dtls_psk, 0, sizeof (dtls_psk));
 
@@ -506,6 +518,10 @@ setup_client_session_psk (const char *uri,
 
   if (!context)
     return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
@@ -540,8 +556,9 @@ setup_client_session_psk (const char *uri,
 
 SEE ALSO
 --------
-*coap_context*(3), *coap_encryption*(3), *coap_endpoint_client*()3),
-*coap_resource*(3), *coap_session*(3) and *coap_tls_library*(3)
+*coap_block*(3), *coap_context*(3), *coap_encryption*(3),
+*coap_endpoint_client*()3), *coap_resource*(3), *coap_session*(3) and
+*coap_tls_library*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -194,6 +194,10 @@ int main(int argc, char *argv[]){
   if (!ctx) {
     exit(1);
   }
+  /* See coap_block(3) */
+  coap_context_set_block_mode(ctx,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   /* Other Set up Code */
 
@@ -237,6 +241,10 @@ int main(int argc, char *argv[]){
   if (!ctx) {
     exit(1);
   }
+  /* See coap_block(3) */
+  coap_context_set_block_mode(ctx,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
 
   FD_ZERO(&readfds);
   /* Set up readfds and nfds to handle other non libcoap FDs */
@@ -287,6 +295,10 @@ int main(int argc, char *argv[]){
   if (!ctx) {
     exit(1);
   }
+  /* See coap_block(3) */
+  coap_context_set_block_mode(ctx,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
   coap_fd = coap_context_get_coap_fd(ctx);
   if (coap_fd == -1) {
     /* epoll is not supported */
@@ -359,6 +371,10 @@ int main(int argc, char *argv[]){
   if (!ctx) {
     exit(1);
   }
+  /* See coap_block(3) */
+  coap_context_set_block_mode(ctx,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
   coap_fd = coap_context_get_coap_fd(ctx);
   if (coap_fd == -1) {
     exit(1);
@@ -414,7 +430,7 @@ int main(int argc, char *argv[]){
 
 SEE ALSO
 --------
-*coap_context*(3)
+*coap_block*(3), *coap_context*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -173,18 +173,20 @@ const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   }
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTENT);
   /*
-   * Invoke coap_add_data_blocked_response() to do all the hard work.
+   * Invoke coap_add_data_large_response() to do all the hard work.
    *
    * Define the format - COAP_MEDIATYPE_TEXT_PLAIN - to add in
    * Define how long this response is valid for (secs) - 1 - to add in.
+   * ETAG Option added internally with unique value as param set to 0
    *
    * OBSERVE Option added internally if needed within the function
    * BLOCK2 Option added internally if output too large
    * SIZE2 Option added internally
-   * ETAG Option added internally
    */
-  coap_add_data_blocked_response(request, response, COAP_MEDIATYPE_TEXT_PLAIN,
-                                 1, len, buf);
+  coap_add_data_large_response(resource, session, request, response,
+                               query, COAP_MEDIATYPE_TEXT_PLAIN, 1, 0,
+                               len,
+                               buf, NULL, NULL);
 }
 
 /* Generic GET handler */
@@ -253,6 +255,10 @@ int main(int argc, char *argv[]){
   if (!ctx) {
     exit(1);
   }
+  /* See coap_block(3) */
+  coap_context_set_block_mode(ctx,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
   coap_address_init(&addr);
   addr.addr.sa.sa_family = AF_INET;
   addr.addr.sin.sin_port = ntohs(COAP_DEFAULT_PORT);

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -516,8 +516,6 @@ const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   unsigned char buf[40];
   size_t len;
   time_t now;
-  (void)resource;
-  (void)session;
 
   /* ... Additional analysis code for resource, request pdu etc.  ... */
 
@@ -542,18 +540,20 @@ const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   }
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTENT);
   /*
-   * Invoke coap_add_data_blocked_response() to do all the hard work.
+   * Invoke coap_add_data_large_response() to do all the hard work.
    *
    * Define the format - COAP_MEDIATYPE_TEXT_PLAIN - to add in
    * Define how long this response is valid for (secs) - 1 - to add in.
+   * ETAG Option added internally with unique value as param set to 0
    *
    * OBSERVE Option added internally if needed within the function
    * BLOCK2 Option added internally if output too large
    * SIZE2 Option added internally
-   * ETAG Option added internally
    */
-  coap_add_data_blocked_response(request, response, COAP_MEDIATYPE_TEXT_PLAIN,
-                                 1, len, buf);
+  coap_add_data_large_response(resource, session, request, response,
+                               query, COAP_MEDIATYPE_TEXT_PLAIN, 1, 0,
+                               len,
+                               buf, NULL, NULL);
 
 }
 ----


### PR DESCRIPTION
Use the updated functions that cause libcoap to do all of the
RFC7959 work in the man examples.