### PR TITLE
examples: Fix RPM Package Manager complaining about duplicate objects

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -16,22 +16,15 @@ AM_CFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include \
 
 #
 
-if BUILD_ADD_DEFAULT_NAMES
-bin_PROGRAMS = coap-client \
-               coap-server \
-               coap-rd \
-               coap-client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
-               coap-server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
-               coap-rd@LIBCOAP_DTLS_LIB_EXTENSION_NAME@
-else # BUILD_ADD_DEFAULT_NAMES
 bin_PROGRAMS = coap-client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
                coap-server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
                coap-rd@LIBCOAP_DTLS_LIB_EXTENSION_NAME@
-endif # BUILD_ADD_DEFAULT_NAMES
 
 check_PROGRAMS = coap-etsi_iot_01 coap-tiny
 
 if BUILD_ADD_DEFAULT_NAMES
+noinst_PROGRAMS = coap-client coap-server coap-rd
+
 coap_client_SOURCES = coap-client.c
 coap_client_LDADD =  $(DTLS_LIBS) \
              $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
@@ -70,15 +63,42 @@ endif # BUILD_EXAMPLES
 if BUILD_EXAMPLES_SOURCE
 EXAMPLES_DIR = $(DESTDIR)$(datadir)/libcoap/examples
 EXAMPLES_SRC = coap-client.c coap-server.c
+endif # BUILD_EXAMPLES_SOURCE
 
 ## Install example files
 install-exec-hook:
+if BUILD_EXAMPLES_SOURCE
 	$(MKDIR_P) $(EXAMPLES_DIR)
 	(cd $(top_srcdir)/examples ; \
 	$(INSTALL_DATA) $(EXAMPLES_SRC) ../LICENSE ../COPYING $(EXAMPLES_DIR) ; \
 	$(INSTALL_DATA) share.libcoap.examples.Makefile $(EXAMPLES_DIR)/Makefile; \
 	$(INSTALL_DATA) share.libcoap.examples.README $(EXAMPLES_DIR)/README)
+endif # BUILD_EXAMPLES_SOURCE
+if BUILD_ADD_DEFAULT_NAMES
+	if [ -d "$(DESTDIR)$(bindir)" ] ; then \
+		(cd $(DESTDIR)$(bindir) && \
+			(if [ -f coap-client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ ] ; then \
+				rm -f coap-client ; \
+				$(LN_S) coap-client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ coap-client ; \
+			fi ; \
+			if [ -f coap-server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ ] ; then \
+				rm -f coap-server ; \
+				$(LN_S) coap-server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ coap-server ; \
+			fi ; \
+			if [ -f coap-rd@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ ] ; then \
+				rm -f coap-rd ; \
+				$(LN_S) coap-rd@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ coap-rd ; \
+			fi) \
+		) ; \
+	fi
+endif # BUILD_ADD_DEFAULT_NAMES
 
 uninstall-hook:
+if BUILD_EXAMPLES_SOURCE
 	rm -rf $(DESTDIR)$(datadir)/libcoap/examples
 endif # BUILD_EXAMPLES_SOURCE
+if BUILD_ADD_DEFAULT_NAMES
+	rm -f $(DESTDIR)$(bindir)/coap-client
+	rm -f $(DESTDIR)$(bindir)/coap-server
+	rm -f $(DESTDIR)$(bindir)/coap-rd
+endif # BUILD_ADD_DEFAULT_NAMES


### PR DESCRIPTION
For example (when building OpenSSL variant), coap-client and
coap-client-openssl are identically built and debug information is being
abstracted, it complains that the two binaries are identical.

Make coap-server, coap-client and coap-rd non-installable, (they still need
to be built in the examples directory, so cannot use check_PROGRAMS) and then
soft-link them as appropriate in the target $(bindir).