### PR TITLE
coap-client: Add in support for generating multiple requests

### DIFF
--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -21,7 +21,7 @@ SYNOPSIS
 *coap-client* [*-a* addr] [*-b* [num,]size] [*-e* text] [*-f* file] [*-l* loss]
               [*-m* method] [*-o* file] [*-p* port] [*-r*] [*-s duration*]
               [*-t* type] [*-v* num] [*-w*] [*-A* type] [*-B* seconds]
-              [*-H* hoplimit] [*-K* interval] [*-L* value] [*-N*]
+              [*-G* count] [*-H* hoplimit] [*-K* interval] [*-L* value] [*-N*]
               [*-O* num,text] [*-P* scheme://addr[:port]] [*-T* token] [*-U*]
               [[*-h* match_hint_file] [*-k* key] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [-n] [*-C* cafile]
@@ -40,7 +40,7 @@ command line. The URI must have the scheme 'coap', 'coap+tcp', 'coaps' or
 'coaps+tcp'. 'coaps' and 'coaps+tcp' are only supported when coap-client is
 built with support for secure (D)TLS communication.
 
-If 'coaps' or 'coap+tcp' is being used, provided the CoAP server supports PKI
+If 'coaps' or 'coaps+tcp' is being used, provided the CoAP server supports PKI
 and is configured with a certificate and private key, the coap-client does not
 need to have a Pre-Shared Key (-k) or certificate (-c) configured.
 
@@ -124,6 +124,10 @@ OPTIONS - General
 
 *-B* seconds::
    Break operation after waiting given seconds (default is 90).
+
+*-G* count ::
+   Repeat the Request 'count' times. Must have a value between 1 and 255
+   inclusive. Default is '1'.
 
 *-H* hoplimit::
    Set the Hop Limit count to hoplimit for proxies. Must have a value between


### PR DESCRIPTION
Demonstrate Token usage for tracking the multiple requests so
that it is easy to see how to extend this for bespoke applications.