### PR TITLE
coap_resource_init: Leading '/' is not required for uri_path

### DIFF
--- a/include/coap3/resource.h
+++ b/include/coap3/resource.h
@@ -83,7 +83,8 @@ typedef void (*coap_method_handler_t)
  * variable of coap_str_const_t has to point to constant text, or point to data
  * within the allocated coap_str_const_t parameter.
  *
- * @param uri_path The string URI path of the new resource.
+ * @param uri_path The string URI path of the new resource. The leading '/' is
+ *                 not normally required - e.g. just "full/path/for/resource".
  * @param flags    Flags for memory management (in particular release of
  *                 memory). Possible values:@n
  *

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -91,7 +91,8 @@ handle matching the URI which then can be Observable.
 
 The *coap_resource_init*() function returns a newly created _resource_ of
 type _coap_resource_t_ * .  _uri_path_ specifies the uri string path to match
-against.  _flags_ is used to define whether the
+against.  Normally there is no need for the leading '/' - e.g. just
+"full/path/for/resource".  _flags_ is used to define whether the
 _resource_ is of type Confirmable Message or Non-Confirmable Message for
 any "observe" responses.  See *coap_observe*(3).
 _flags_ can be one of the following definitions or'ed together.


### PR DESCRIPTION
Remind users in the documentation that the full path defining the resource in
the uri_path parameter does not normally need a leading '/'.

E.g. It should be "full/path/for/resource", not "/full/path/for/resource".

See #714