### PR TITLE
coap_dtls_pki_sni_callback_t: Include coap_session_t in the parameter…

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1893,7 +1893,8 @@ update_pki_key(coap_dtls_key_t *dtls_key, const char *key_name,
 
 static coap_dtls_key_t *
 verify_pki_sni_callback(const char *sni,
-                    void *arg COAP_UNUSED
+                        coap_session_t *c_session COAP_UNUSED,
+                        void *arg COAP_UNUSED
 ) {
   static coap_dtls_key_t dtls_key;
 
@@ -1923,8 +1924,8 @@ verify_pki_sni_callback(const char *sni,
 
 static const coap_dtls_spsk_info_t *
 verify_psk_sni_callback(const char *sni,
-                    coap_session_t *c_session COAP_UNUSED,
-                    void *arg COAP_UNUSED
+                        coap_session_t *c_session COAP_UNUSED,
+                        void *arg COAP_UNUSED
 ) {
   static coap_dtls_spsk_info_t psk_info;
 

--- a/include/coap3/coap_dtls.h
+++ b/include/coap3/coap_dtls.h
@@ -227,13 +227,16 @@ typedef struct coap_dtls_key_t {
  * based on the requesting SNI.
  *
  * @param sni  The requested SNI
+ * @param coap_session  The CoAP session associated with the SNI
  * @param arg  The same as was passed into coap_context_set_pki()
  *             in setup_data->sni_call_back_arg
  *
  * @return New set of certificates to use, or @c NULL if SNI is to be rejected.
  */
-typedef coap_dtls_key_t *(*coap_dtls_pki_sni_callback_t)(const char *sni,
-             void* arg);
+typedef coap_dtls_key_t *(*coap_dtls_pki_sni_callback_t)(
+                                 const char *sni,
+                                 coap_session_t *coap_session,
+                                 void *arg);
 
 
 #define COAP_DTLS_PKI_SETUP_VERSION 1 /**< Latest PKI setup version */

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -449,7 +449,7 @@ typedef struct coap_dtls_pki_t {
    * a certificate set back to the client so that the appropriate certificate
    * set can be used based on the requesting SNI.
    */
-  coap_dtls_sni_callback_t validate_sni_call_back;
+  coap_dtls_pki_sni_callback_t validate_sni_call_back;
   void *sni_call_back_arg;  /* Passed in to the SNI callback function */
 
   /** Additional Security callback handler that is invoked when libcoap has
@@ -609,13 +609,15 @@ typedef struct coap_dtls_key_t {
  * based on the requesting SNI.
  *
  * @param sni  The requested SNI
+ * @param coap_session  The CoAP session associated with the SNI
  * @param arg  The same as was passed into coap_context_set_pki()
  *             in setup_data->sni_call_back_arg
  *
  * @return new set of certificates to use, or NULL if SNI is to be rejected.
  */
 typedef coap_dtls_key_t *(*coap_dtls_sni_callback_t)(const char *sni,
-             void* arg);
+                                 coap_session_t *coap_session,
+                                 void* arg);
 ----
 
 *validate_sni_call_back* points to an application provided SNI callback
@@ -914,10 +916,13 @@ typedef struct valid_snis_t {
  */
 static coap_dtls_key_t *
 verify_pki_sni_callback(const char *sni,
+                        coap_session_t *session,
                         void *arg
 ) {
   valid_snis_t *valid_sni_list = (valid_snis_t *)arg;
   int i;
+  /* Remove (void) definition if variable is used */
+  (void)session;
 
   /* Check that the SNI is valid */
   for (i = 0; i < valid_sni_list->count; i++) {

--- a/man/coap_endpoint_server.txt.in
+++ b/man/coap_endpoint_server.txt.in
@@ -256,11 +256,13 @@ typedef struct valid_snis_t {
  * Subject Name Identifier (SNI) callback verifier
  */
 static coap_dtls_key_t *
-verify_pki_sni_callback(const char *sni,
+verify_pki_sni_callback(const char *sni, coap_session_t *session,
                         void *arg
 ) {
   valid_snis_t *valid_sni_list = (valid_snis_t *)arg;
   size_t i;
+  /* Remove (void) definition if variable is used */
+  (void)session;
 
   /* Check that the SNI is valid */
   for (i = 0; i < valid_sni_list->count; i++) {

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -1641,7 +1641,7 @@ post_client_hello_gnutls_pki(gnutls_session_t g_session)
        * New SNI request
        */
       coap_dtls_key_t *new_entry =
-        g_context->setup_data.validate_sni_call_back(name,
+        g_context->setup_data.validate_sni_call_back(name, c_session,
                                    g_context->setup_data.sni_call_back_arg);
       if (!new_entry) {
         G_ACTION(gnutls_alert_send(g_session, GNUTLS_AL_FATAL,

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -765,7 +765,7 @@ pki_sni_callback(void *p_info, mbedtls_ssl_context *ssl,
     pki_sni_entry *pki_sni_entry_list;
 
     new_entry =
-      m_context->setup_data.validate_sni_call_back(name,
+      m_context->setup_data.validate_sni_call_back(name, c_session,
                                  m_context->setup_data.sni_call_back_arg);
     if (!new_entry) {
       mbedtls_free(name);

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -2074,7 +2074,7 @@ tls_server_name_call_back(SSL *ssl,
       SSL_CTX *ctx;
       coap_dtls_pki_t sni_setup_data;
       coap_dtls_key_t *new_entry = setup_data->validate_sni_call_back(sni,
-                                               setup_data->sni_call_back_arg);
+                                       session, setup_data->sni_call_back_arg);
       if (!new_entry) {
         return SSL_TLSEXT_ERR_ALERT_FATAL;
       }
@@ -2387,7 +2387,7 @@ is_x509:
        * New SNI request
        */
       coap_dtls_key_t *new_entry = setup_data->validate_sni_call_back(sni,
-                                               setup_data->sni_call_back_arg);
+                                       session, setup_data->sni_call_back_arg);
       if (!new_entry) {
         *al = SSL_AD_UNRECOGNIZED_NAME;
         return SSL_CLIENT_HELLO_ERROR;


### PR DESCRIPTION
… list

coap_dtls_psk_sni_callback_t already includes the session, but unfortunately
coap_dtls_pki_sni_callback_t has no way of signalling back to the application
(e.g. using coap_session_set_app_data()) as to which PKI information was used
for the (D)TLS session set up.

Including the session does break the API, but very few people are likely to
be using the validate_sni_call_back to modify the PKI information for the
(D)TLS session and so is a small coding change if needed.