### PR TITLE
gnutls:  GNUTLS_CRT_RAW not defined

### DIFF
--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -68,6 +68,10 @@
                             GNUTLS_KEY_KEY_CERT_SIGN
 #endif /* GNUTLS_VERSION_NUMBER >= 0x030606 */
 
+#ifndef GNUTLS_CRT_RAW
+#define GNUTLS_CRT_RAW GNUTLS_CRT_RAWPK
+#endif /* GNUTLS_CRT_RAW */
+
 #ifdef _WIN32
 #define strcasecmp _stricmp
 #endif


### PR DESCRIPTION
Old version of GnuTLS, used in Raspbian,  contains no definition
for GNUTLS_CRT_RAW. This patch fixes build error:
`error: ‘GNUTLS_CRT_RAW’ undeclared`

Signed-off-by: Eug Krashtan <eug.krashtan@gmail.com>