### PR TITLE
RFC7959: session->lg_xmit not being released for a server

### DIFF
--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -191,6 +191,9 @@ int coap_handle_response_get_block(coap_context_t *context,
 void coap_block_delete_lg_xmit(coap_session_t *session,
                                coap_lg_xmit_t *lg_xmit);
 
+coap_tick_t coap_block_check_lg_xmit_timeouts(coap_session_t *session,
+                                              coap_tick_t now);
+
 /**
  * The function that does all the work for the coap_add_data_large*()
  * functions.

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1113,6 +1113,12 @@ coap_io_prepare_io(coap_context_t *ctx,
           if (timeout == 0 || s_timeout < timeout)
             timeout = s_timeout;
         }
+        /* Check if any server large sending have timed out */
+        if (s->lg_xmit) {
+          s_timeout = coap_block_check_lg_xmit_timeouts(s, now);
+          if (timeout == 0 || s_timeout < timeout)
+            timeout = s_timeout;
+        }
 #ifndef COAP_EPOLL_SUPPORT
         if (s->sock.flags & (COAP_SOCKET_WANT_READ | COAP_SOCKET_WANT_WRITE)) {
           if (*num_sockets < max_sockets)


### PR DESCRIPTION
Following transmission of a large body by a server using BLOCK2,
session->lg_xmit is not getting released. It does get released when the session
is freed off.

A client doing transmission of a large body idoes release session->lg_xmit.

Timeout lg_xmit after 4 * ACK_TIMEOUT seconds after final block is transmitted.