### PR TITLE
fix: UDP heartbeat(ping/pong) not available

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -384,7 +384,7 @@ coap_mid_t coap_session_send_ping(coap_session_t *session) {
     return COAP_INVALID_MID;
   if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
     uint16_t mid = coap_new_message_id (session);
-    ping = coap_pdu_init(COAP_MESSAGE_CON, 0, mid, 0);
+    ping = coap_pdu_init(COAP_MESSAGE_CON, COAP_SIGNALING_CODE_PING, mid, 0);
   }
 #if !COAP_DISABLE_TCP
   else {
@@ -478,6 +478,8 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
     session->state = COAP_SESSION_STATE_NONE;
 
   session->con_active = 0;
+  session->last_ping = 0;
+  session->last_pong = 0;
 
   if (session->partial_pdu) {
     coap_delete_pdu(session->partial_pdu);

--- a/src/net.c
+++ b/src/net.c
@@ -2956,7 +2956,7 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
     if (session->state == COAP_SESSION_STATE_CSM)
       coap_session_connected(session);
   } else if (pdu->code == COAP_SIGNALING_CODE_PING) {
-    coap_pdu_t *pong = coap_pdu_init(COAP_MESSAGE_CON, COAP_SIGNALING_CODE_PONG, 0, 1);
+    coap_pdu_t *pong = coap_pdu_init(COAP_MESSAGE_ACK, COAP_SIGNALING_CODE_PONG, pdu->mid, 1);
     if (context->ping_handler) {
       context->ping_handler(session, pdu, pdu->mid);
     }


### PR DESCRIPTION
解决的两个问题:
1. UDP协议下ping/pong不能有效工作的问题。
2. 服务端断开客户端ping包超时情况下，重建连接后再触发心跳会直接超时。