### PR TITLE
async: Correct MID usage in response

### DIFF
--- a/src/async.c
+++ b/src/async.c
@@ -38,7 +38,6 @@ coap_async_t *
 coap_register_async(coap_session_t *session,
                     const coap_pdu_t *request, coap_tick_t delay) {
   coap_async_t *s;
-  coap_mid_t mid = request->mid;
   size_t len;
   const uint8_t *data;
 
@@ -52,7 +51,7 @@ coap_register_async(coap_session_t *session,
 
   if (s != NULL) {
     coap_log(LOG_DEBUG,
-         "asynchronous state for mid=0x%x already registered\n", mid);
+         "asynchronous state for mid=0x%x already registered\n", request->mid);
     return NULL;
   }
 
@@ -65,6 +64,7 @@ coap_register_async(coap_session_t *session,
 
   memset(s, 0, sizeof(coap_async_t));
 
+  /* Note that this generates a new MID */
   s->pdu = coap_pdu_duplicate(request, session, request->token_length,
                               request->token, NULL);
   if (s->pdu == NULL) {
@@ -72,7 +72,6 @@ coap_register_async(coap_session_t *session,
     coap_log(LOG_CRIT, "coap_register_async: insufficient memory\n");
     return NULL;
   }
-  s->pdu->mid = mid; /* coap_pdu_duplicate() created one */
 
   if (coap_get_data(request, &len, &data)) {
     coap_add_data(s->pdu, len, data);


### PR DESCRIPTION
There currently are 2 requirements for async (delayed response)

1. Application support to delay separate response while doing other processing
2. Delay any response for random time if receiving multicast request

The MID is used by the client to match initial response (empty ack or
piggy-backed response).  Any subsequent response (usually the separate
response or unsolicited Observe) should have a different MID as generated by
the server (and are matched using the token).

Fix is to move the tracking of the client MID from coap_register_async()
(so 1. is supported correctly) into handle_request() for multicast requests
(so that 2. continues to be supported correctly).

coap_check_async() will then call the appropriate request handler with the 
appropriate MID (application different, multicast same).

See #726.