### PR TITLE
client+server: Reduce code size by building libcoap for client or server only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,14 @@ option(
   "compile with the tinydtls project in the submodule if on, otherwise try to find the compiled lib with find_package"
   ON)
 option(
+  ENABLE_CLIENT_MODE
+  "compile with support for client mode code"
+  ON)
+option(
+  ENABLE_SERVER_MODE
+  "compile with support for server mode code"
+  ON)
+option(
   WITH_EPOLL
   "compile with epoll support"
   ON)
@@ -162,6 +170,20 @@ else()
     cmsghdr
     sys/socket.h
     HAVE_STRUCT_CMSGHDR)
+endif()
+
+if(${ENABLE_CLIENT_MODE})
+  set(COAP_CLIENT_SUPPORT "1")
+  message(STATUS "compiling with client support")
+else()
+  message(STATUS "compiling without client support")
+endif()
+
+if(${ENABLE_SERVER_MODE})
+  set(COAP_SERVER_SUPPORT "1")
+  message(STATUS "compiling with server support")
+else()
+  message(STATUS "compiling without server support")
 endif()
 
 if(${WITH_EPOLL}
@@ -359,6 +381,8 @@ endif()
 
 message(STATUS "ENABLE_DTLS:.....................${ENABLE_DTLS}")
 message(STATUS "ENABLE_TCP:......................${ENABLE_TCP}")
+message(STATUS "ENABLE_CLIENT_MODE:..............${ENABLE_CLIENT_MODE}")
+message(STATUS "ENABLE_SERVER_MODE:..............${ENABLE_SERVER_MODE}")
 message(STATUS "ENABLE_DOCS:.....................${ENABLE_DOCS}")
 message(STATUS "ENABLE_EXAMPLES:.................${ENABLE_EXAMPLES}")
 message(STATUS "DTLS_BACKEND:....................${DTLS_BACKEND}")
@@ -370,7 +394,7 @@ message(STATUS "HAVE_LIBTINYDTLS:................${HAVE_LIBTINYDTLS}")
 message(STATUS "HAVE_LIBGNUTLS:..................${HAVE_LIBGNUTLS}")
 message(STATUS "HAVE_OPENSSL:....................${HAVE_OPENSSL}")
 message(STATUS "HAVE_MBEDTLS:....................${HAVE_MBEDTLS}")
-message(STATUS "COAP_EPOLL_SUPPORT:..............${COAP_EPOLL_SUPPORT}")
+message(STATUS "WITH_EPOLL:......................${WITH_EPOLL}")
 message(STATUS "CMAKE_C_COMPILER:................${CMAKE_C_COMPILER}")
 message(STATUS "BUILD_SHARED_LIBS:...............${BUILD_SHARED_LIBS}")
 message(STATUS "CMAKE_BUILD_TYPE:................${CMAKE_BUILD_TYPE}")

--- a/cmake_coap_config.h.in
+++ b/cmake_coap_config.h.in
@@ -21,6 +21,12 @@
 /* Define to 1 if you have <winsock2.h> header file. */
 #cmakedefine HAVE_WINSOCK2_H "@HAVE_WINSOCK2_H@"
 
+/* Define if the library has client support */
+#cmakedefine COAP_CLIENT_SUPPORT @COAP_CLIENT_SUPPORT@
+
+/* Define if the library has server support */
+#cmakedefine COAP_SERVER_SUPPORT @COAP_SERVER_SUPPORT@
+
 /* Define if the system has epoll support */
 #cmakedefine COAP_EPOLL_SUPPORT "@COAP_EPOLL_SUPPORT@"
 

--- a/configure.ac
+++ b/configure.ac
@@ -766,6 +766,31 @@ if test "x$enable_small_stack" = "xyes"; then
     AC_DEFINE(COAP_CONSTRAINED_STACK, 1, [Define if the system has small stack size])
 fi
 
+AC_ARG_ENABLE([server-mode],
+        [AS_HELP_STRING([--enable-server-mode],
+                        [Enable CoAP server mode supporting code [default=yes]])],
+        [enable_server_mode="$enableval"],
+        [enable_server_mode="yes"])
+
+if test "x$enable_server_mode" = "xyes"; then
+    AC_DEFINE(COAP_SERVER_SUPPORT, 1, [Define if libcoap supports server mode code])
+fi
+AM_CONDITIONAL(HAVE_SERVER_SUPPORT, [test "x$enable_server_mode" = "xyes"])
+
+AC_ARG_ENABLE([client-mode],
+        [AS_HELP_STRING([--enable-client-mode],
+                        [Enable CoAP client mode supporting code [default=yes]])],
+        [enable_client_mode="$enableval"],
+        [enable_client_mode="yes"])
+
+if test "x$enable_client_mode" = "xyes"; then
+    AC_DEFINE(COAP_CLIENT_SUPPORT, 1, [Define if libcoap supports client mode code])
+fi
+AM_CONDITIONAL(HAVE_CLIENT_SUPPORT, [test "x$enable_client_mode" = "xyes"])
+if test "x$enable_server_mode" != "xyes" -a "x$enable_client_mode" != "xyes" ; then
+    AC_MSG_ERROR([==> One or both of '--enable-server-mode' and '--enable-client-mode' need to be set!])
+fi
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T
@@ -904,6 +929,16 @@ libcoap configuration summary:
       libcoap API version      : "$LIBCOAP_API_VERSION"
       libcoap DTLS lib extn    : "$LIBCOAP_DTLS_LIB_EXTENSION_NAME"
       host system              : "$host"]);
+if test "x$enable_server_mode" = "xyes"; then
+    AC_MSG_RESULT([      build with server support: "yes"])
+else
+    AC_MSG_RESULT([      build with server support: "no"])
+fi
+if test "x$enable_client_mode" = "xyes"; then
+    AC_MSG_RESULT([      build with client support: "yes"])
+else
+    AC_MSG_RESULT([      build with client support: "no"])
+fi
 if test "x$build_tcp" != "xno"; then
     AC_MSG_RESULT([      build with TCP support   : "yes"])
 else

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -19,14 +19,37 @@ AM_CFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include \
 
 #
 
-bin_PROGRAMS = coap-client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
-               coap-server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
-               coap-rd@LIBCOAP_DTLS_LIB_EXTENSION_NAME@
+bin_PROGRAMS =
+noinst_PROGRAMS =
+check_PROGRAMS =
 
-check_PROGRAMS = coap-etsi_iot_01 coap-tiny
+if HAVE_CLIENT_SUPPORT
+
+bin_PROGRAMS += coap-client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@
+check_PROGRAMS += coap-tiny
 
 if BUILD_ADD_DEFAULT_NAMES
-noinst_PROGRAMS = coap-client coap-server coap-rd
+noinst_PROGRAMS += coap-client
+endif # BUILD_ADD_DEFAULT_NAMES
+
+endif # HAVE_CLIENT_SUPPORT
+
+if HAVE_SERVER_SUPPORT
+
+bin_PROGRAMS += coap-server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@ \
+                coap-rd@LIBCOAP_DTLS_LIB_EXTENSION_NAME@
+check_PROGRAMS += coap-etsi_iot_01
+
+if BUILD_ADD_DEFAULT_NAMES
+noinst_PROGRAMS += coap-server coap-rd
+endif # BUILD_ADD_DEFAULT_NAMES
+
+if ! HAVE_CLIENT_SUPPORT
+coap_server_CPPFLAGS=-DSERVER_CAN_PROXY=0
+coap_server@LIBCOAP_DTLS_LIB_EXTENSION_NAME@_CPPFLAGS=-DSERVER_CAN_PROXY=0
+endif # HAVE_CLIENT_SUPPORT
+
+endif # HAVE_SERVER_SUPPORT
 
 coap_client_SOURCES = coap-client.c
 coap_client_LDADD =  $(DTLS_LIBS) \
@@ -39,7 +62,6 @@ coap_server_LDADD = $(DTLS_LIBS) \
 coap_rd_SOURCES = coap-rd.c
 coap_rd_LDADD = $(DTLS_LIBS) \
              $(top_builddir)/.libs/libcoap-$(LIBCOAP_NAME_SUFFIX).la
-endif # BUILD_ADD_DEFAULT_NAMES
 
 coap_client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@_SOURCES = coap-client.c
 coap_client@LIBCOAP_DTLS_LIB_EXTENSION_NAME@_LDADD =  $(DTLS_LIBS) \

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -51,6 +51,10 @@ static char* strndup(const char* s1, size_t n)
 #include <dirent.h>
 #endif
 
+/*
+ * SERVER_CAN_PROXY=0 can be set by build system if
+ * "./configure --disable-client-mode" is used.
+ */
 #ifndef SERVER_CAN_PROXY
 #define SERVER_CAN_PROXY 1
 #endif
@@ -1796,7 +1800,7 @@ init_resources(coap_context_t *ctx) {
   coap_add_attr(r, coap_make_str_const("title"), coap_make_str_const("\"Example Data\""), 0);
   coap_add_resource(ctx, r);
 
-#ifdef SERVER_CAN_PROXY
+#if SERVER_CAN_PROXY
   if (proxy_host_name_count) {
     r = coap_resource_proxy_uri_init(hnd_proxy_uri, proxy_host_name_count,
                                      proxy_host_name_list);

--- a/include/coap3/coap_asn1_internal.h
+++ b/include/coap3/coap_asn1_internal.h
@@ -17,6 +17,7 @@
 #ifndef COAP_ASN1_INTERNAL_H_
 #define COAP_ASN1_INTERNAL_H_
 
+#include "coap_internal.h"
 
 /**
  * @defgroup asn1 ASN.1 Support (Internal)

--- a/include/coap3/coap_async_internal.h
+++ b/include/coap3/coap_async_internal.h
@@ -17,8 +17,10 @@
 #ifndef COAP_ASYNC_INTERNAL_H_
 #define COAP_ASYNC_INTERNAL_H_
 
-#include "coap3/net.h"
+#include "coap_internal.h"
+#include "net.h"
 
+/* Note that if COAP_SERVER_SUPPORT is not set, then WITHOUT_ASYNC undefined */
 #ifndef WITHOUT_ASYNC
 
 /**

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -19,6 +19,7 @@
 #ifndef COAP_BLOCK_INTERNAL_H_
 #define COAP_BLOCK_INTERNAL_H_
 
+#include "coap_internal.h"
 #include "coap_pdu_internal.h"
 #include "resource.h"
 
@@ -93,6 +94,7 @@ struct coap_lg_xmit_t {
   void *app_ptr;         /**< applicaton provided ptr for de-alloc function */
 };
 
+#if COAP_CLIENT_SUPPORT
 /**
  * Structure to hold large body (many blocks) client receive information
  */
@@ -120,7 +122,9 @@ struct coap_lg_crcv_t {
   coap_tick_t last_used; /**< Last time all data sent or 0 */
   uint16_t block_option; /**< Block option in use */
 };
+#endif /* COAP_CLIENT_SUPPORT */
 
+#if COAP_SERVER_SUPPORT
 /**
  * Structure to hold large body (many blocks) server receive information
  */
@@ -147,7 +151,9 @@ struct coap_lg_srcv_t {
   coap_tick_t last_used; /**< Last time data sent or 0 */
   uint16_t block_option; /**< Block option in use */
 };
+#endif /* COAP_SERVER_SUPPORT */
 
+#if COAP_CLIENT_SUPPORT
 coap_lg_crcv_t * coap_block_new_lg_crcv(coap_session_t *session,
                                         coap_pdu_t *pdu);
 
@@ -156,7 +162,9 @@ void coap_block_delete_lg_crcv(coap_session_t *session,
 
 coap_tick_t coap_block_check_lg_crcv_timeouts(coap_session_t *session,
                                               coap_tick_t now);
+#endif /* COAP_CLIENT_SUPPORT */
 
+#if COAP_SERVER_SUPPORT
 void coap_block_delete_lg_srcv(coap_session_t *session,
                                coap_lg_srcv_t *lg_srcv);
 
@@ -179,7 +187,9 @@ int coap_handle_request_put_block(coap_context_t *context,
                                   coap_string_t *query,
                                   coap_method_handler_t h,
                                   int *added_block);
+#endif /* COAP_SERVER_SUPPORT */
 
+#if COAP_CLIENT_SUPPORT
 int coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *rcvd);
 
 int coap_handle_response_get_block(coap_context_t *context,
@@ -187,6 +197,7 @@ int coap_handle_response_get_block(coap_context_t *context,
                                    coap_pdu_t *sent,
                                    coap_pdu_t *rcvd,
                                    coap_recurse_t recursive);
+#endif /* COAP_CLIENT_SUPPORT */
 
 void coap_block_delete_lg_xmit(coap_session_t *session,
                                coap_lg_xmit_t *lg_xmit);

--- a/include/coap3/coap_cache_internal.h
+++ b/include/coap3/coap_cache_internal.h
@@ -17,8 +17,10 @@
 #ifndef COAP_CACHE_INTERNAL_H_
 #define COAP_CACHE_INTERNAL_H_
 
+#include "coap_internal.h"
 #include "coap_io.h"
 
+#if COAP_SERVER_SUPPORT
 /**
  * @defgroup cache_internal Cache Support (Internal)
  * CoAP Cache Structures, Enums and Functions that are not exposed to
@@ -107,5 +109,7 @@ int coap_digest_final(coap_digest_ctx_t *digest_ctx,
                       coap_digest_t *digest_buffer);
 
 /** @} */
+
+#endif /* COAP_SERVER_SUPPORT */
 
 #endif /* COAP_CACHE_INTERNAL_H_ */

--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -13,6 +13,8 @@
 #ifndef COAP_DTLS_INTERNAL_H_
 #define COAP_DTLS_INTERNAL_H_
 
+#include "coap_internal.h"
+
 /**
  * @defgroup dtls_internal DTLS Support (Internal)
  * CoAP DTLS Structures, Enums and Functions that are not exposed to
@@ -41,6 +43,7 @@
 void *
 coap_dtls_new_context(coap_context_t *coap_context);
 
+#if COAP_SERVER_SUPPORT
 /**
  * Set the DTLS context's default server PSK information.
  * This does the PSK specifics following coap_dtls_new_context().
@@ -55,7 +58,9 @@ coap_dtls_new_context(coap_context_t *coap_context);
 int
 coap_dtls_context_set_spsk(coap_context_t *coap_context,
                           coap_dtls_spsk_t *setup_data);
+#endif /* COAP_SERVER_SUPPORT */
 
+#if COAP_CLIENT_SUPPORT
 /**
  * Set the DTLS context's default client PSK information.
  * This does the PSK specifics following coap_dtls_new_context().
@@ -70,6 +75,7 @@ coap_dtls_context_set_spsk(coap_context_t *coap_context,
 int
 coap_dtls_context_set_cpsk(coap_context_t *coap_context,
                           coap_dtls_cpsk_t *setup_data);
+#endif /* COAP_CLIENT_SUPPORT */
 
 /**
  * Set the DTLS context's default server PKI information.
@@ -128,6 +134,7 @@ int coap_dtls_context_check_keys_enabled(coap_context_t *coap_context);
  */
 void coap_dtls_free_context(void *dtls_context);
 
+#if COAP_CLIENT_SUPPORT
 /**
  * Create a new client-side session. This should send a HELLO to the server.
  *
@@ -137,7 +144,9 @@ void coap_dtls_free_context(void *dtls_context);
  *         parameters for the session.
 */
 void *coap_dtls_new_client_session(coap_session_t *coap_session);
+#endif /* COAP_CLIENT_SUPPORT */
 
+#if COAP_SERVER_SUPPORT
 /**
  * Create a new DTLS server-side session.
  * Called after coap_dtls_hello() has returned @c 1, signalling that a validated
@@ -150,6 +159,7 @@ void *coap_dtls_new_client_session(coap_session_t *coap_session);
  *         parameters for the DTLS session.
  */
 void *coap_dtls_new_server_session(coap_session_t *coap_session);
+#endif /* COAP_SERVER_SUPPORT */
 
 /**
  * Terminates the DTLS session (may send an ALERT if necessary) then frees the
@@ -230,6 +240,7 @@ int coap_dtls_receive(coap_session_t *coap_session,
                       const uint8_t *data,
                       size_t data_len);
 
+#if COAP_SERVER_SUPPORT
 /**
  * Handling client HELLO messages from a new candiate peer.
  * Note that session->tls is empty.
@@ -245,6 +256,7 @@ int coap_dtls_receive(coap_session_t *coap_session,
 int coap_dtls_hello(coap_session_t *coap_session,
                     const uint8_t *data,
                     size_t data_len);
+#endif /* COAP_SERVER_SUPPORT */
 
 /**
  * Get DTLS overhead over cleartext PDUs.
@@ -255,6 +267,7 @@ int coap_dtls_hello(coap_session_t *coap_session,
  */
 unsigned int coap_dtls_get_overhead(coap_session_t *coap_session);
 
+#if COAP_CLIENT_SUPPORT
 /**
  * Create a new TLS client-side session.
  *
@@ -266,7 +279,9 @@ unsigned int coap_dtls_get_overhead(coap_session_t *coap_session);
  *         parameters for the session.
 */
 void *coap_tls_new_client_session(coap_session_t *coap_session, int *connected);
+#endif /* COAP_CLIENT_SUPPORT */
 
+#if COAP_SERVER_SUPPORT
 /**
  * Create a TLS new server-side session.
  *
@@ -278,6 +293,7 @@ void *coap_tls_new_client_session(coap_session_t *coap_session, int *connected);
  *         parameters for the session.
  */
 void *coap_tls_new_server_session(coap_session_t *coap_session, int *connected);
+#endif /* COAP_SERVER_SUPPORT */
 
 /**
  * Terminates the TLS session (may send an ALERT if necessary) then frees the

--- a/include/coap3/coap_internal.h
+++ b/include/coap3/coap_internal.h
@@ -35,6 +35,21 @@
 # include <assert.h>
 #endif
 
+/* By default without either configured, these need to be set */
+#ifndef COAP_SERVER_SUPPORT
+#ifndef COAP_CLIENT_SUPPORT
+#define COAP_SERVER_SUPPORT 1
+#define COAP_CLIENT_SUPPORT 1
+#endif /* COAP_CLIENT_SUPPORT */
+#endif /* COAP_SERVER_SUPPORT */
+
+#if ! COAP_SERVER_SUPPORT
+#ifndef WITHOUT_ASYNC
+/* ASYNC is only there for Server code */
+#define WITHOUT_ASYNC
+#endif /* WITHOUT_ASYNC */
+#endif /* COAP_SERVER_SUPPORT */
+
 #include "coap3/coap.h"
 
 /*

--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -12,6 +12,7 @@
 #ifndef COAP_IO_INTERNAL_H_
 #define COAP_IO_INTERNAL_H_
 
+#include "coap_internal.h"
 #include <sys/types.h>
 
 #include "address.h"
@@ -54,11 +55,14 @@ struct coap_socket_t {
 #define COAP_SOCKET_CAN_CONNECT  0x0800  /**< non blocking client socket can now connect without blocking */
 #define COAP_SOCKET_MULTICAST    0x1000  /**< socket is used for multicast communication */
 
+#if COAP_SERVER_SUPPORT
 coap_endpoint_t *coap_malloc_endpoint( void );
 void coap_mfree_endpoint( coap_endpoint_t *ep );
+#endif /* COAP_SERVER_SUPPORT */
 
 const char *coap_socket_format_errno(int error);
 
+#if COAP_CLIENT_SUPPORT
 int
 coap_socket_connect_udp(coap_socket_t *sock,
                         const coap_address_t *local_if,
@@ -66,6 +70,7 @@ coap_socket_connect_udp(coap_socket_t *sock,
                         int default_port,
                         coap_address_t *local_addr,
                         coap_address_t *remote_addr);
+#endif /* COAP_CLIENT_SUPPORT */
 
 int
 coap_socket_bind_udp(coap_socket_t *sock,

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -18,6 +18,8 @@
 #ifndef COAP_NET_INTERNAL_H_
 #define COAP_NET_INTERNAL_H_
 
+#include "coap_internal.h"
+
 /**
  * @defgroup context_internal Context Handling (Internal)
  * CoAP Context Structures, Enums and Functions that are not exposed to
@@ -44,6 +46,7 @@ struct coap_queue_t {
  */
 struct coap_context_t {
   coap_opt_filter_t known_options;
+#if COAP_SERVER_SUPPORT
   coap_resource_t *resources; /**< hash table or list of known
                                    resources */
   coap_resource_t *unknown_resource; /**< can be used for handling
@@ -53,6 +56,7 @@ struct coap_context_t {
   coap_resource_release_userdata_handler_t release_userdata;
                                         /**< function to  release user_data
                                              when resource is deleted */
+#endif /* COAP_SERVER_SUPPORT */
 
 #ifndef WITHOUT_ASYNC
   /**
@@ -65,8 +69,12 @@ struct coap_context_t {
    * to sendqueue_basetime. */
   coap_tick_t sendqueue_basetime;
   coap_queue_t *sendqueue;
+#if COAP_SERVER_SUPPORT
   coap_endpoint_t *endpoint;      /**< the endpoints used for listening  */
+#endif /* COAP_SERVER_SUPPORT */
+#if COAP_CLIENT_SUPPORT
   coap_session_t *sessions;       /**< client sessions */
+#endif /* COAP_CLIENT_SUPPORT */
 
 #ifdef WITH_CONTIKI
   struct uip_udp_conn *conn;      /**< uIP connection object */
@@ -81,7 +89,9 @@ struct coap_context_t {
                                    *   context, otherwise 0. */
 #endif /* WITH_LWIP */
 
+#if COAP_CLIENT_SUPPORT
   coap_response_handler_t response_handler;
+#endif /* COAP_CLIENT_SUPPORT */
   coap_nack_handler_t nack_handler;
   coap_ping_handler_t ping_handler;
   coap_pong_handler_t pong_handler;
@@ -97,20 +107,26 @@ struct coap_context_t {
 
   ssize_t (*network_read)(coap_socket_t *sock, coap_packet_t *packet);
 
+#if COAP_CLIENT_SUPPORT
   size_t(*get_client_psk)(const coap_session_t *session, const uint8_t *hint,
                           size_t hint_len, uint8_t *identity,
                           size_t *identity_len, size_t max_identity_len,
                           uint8_t *psk, size_t max_psk_len);
+#endif /* COAP_CLIENT_SUPPORT */
+#if COAP_SERVER_SUPPORT
   size_t(*get_server_psk)(const coap_session_t *session,
                           const uint8_t *identity, size_t identity_len,
                           uint8_t *psk, size_t max_psk_len);
   size_t(*get_server_hint)(const coap_session_t *session, uint8_t *hint,
                           size_t max_hint_len);
+#endif /* COAP_SERVER_SUPPORT */
 
   void *dtls_context;
 
+#if COAP_SERVER_SUPPORT
   coap_dtls_spsk_t spsk_setup_data;  /**< Contains the initial PSK server setup
                                           data */
+#endif /* COAP_SERVER_SUPPORT */
 
   unsigned int session_timeout;    /**< Number of seconds of inactivity after
                                         which an unused session will be closed.
@@ -126,15 +142,19 @@ struct coap_context_t {
                                             disabled. */
   unsigned int csm_timeout;           /**< Timeout for waiting for a CSM from
                                            the remote side. 0 means disabled. */
+#if COAP_SERVER_SUPPORT
   uint8_t observe_pending;         /**< Observe response pending */
+#endif /* COAP_SERVER_SUPPORT */
   uint8_t block_mode;              /**< Zero or more COAP_BLOCK_ or'd options */
   uint64_t etag;                   /**< Next ETag to use */
 
+#if COAP_SERVER_SUPPORT
   coap_cache_entry_t *cache;       /**< CoAP cache-entry cache */
   uint16_t *cache_ignore_options;  /**< CoAP options to ignore when creating a
                                         cache-key */
   size_t cache_ignore_count;       /**< The number of CoAP options to ignore
                                         when creating a cache-key */
+#endif /* COAP_SERVER_SUPPORT */
   void *app;                       /**< application-specific data */
 #ifdef COAP_EPOLL_SUPPORT
   int epfd;                        /**< External FD for epoll */

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -17,6 +17,8 @@
 #ifndef COAP_COAP_PDU_INTERNAL_H_
 #define COAP_COAP_PDU_INTERNAL_H_
 
+#include "coap_internal.h"
+
 #ifdef WITH_LWIP
 #include <lwip/pbuf.h>
 #endif

--- a/include/coap3/coap_resource_internal.h
+++ b/include/coap3/coap_resource_internal.h
@@ -17,8 +17,10 @@
 #ifndef COAP_RESOURCE_INTERNAL_H_
 #define COAP_RESOURCE_INTERNAL_H_
 
+#include "coap_internal.h"
 #include "uthash.h"
 
+#if COAP_SERVER_SUPPORT
 /**
  * @defgroup coap_resource_internal Resources (Internal)
  * Structures, Enums and Functions that are not exposed to applications
@@ -135,7 +137,8 @@ coap_print_status_t coap_print_wellknown(coap_context_t *,
                                          size_t *, size_t,
                                          coap_opt_t *);
 
-
 /** @} */
+
+#endif /* COAP_SERVER_SUPPORT */
 
 #endif /* COAP_RESOURCE_INTERNAL_H_ */

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -18,6 +18,7 @@
 #ifndef COAP_SESSION_INTERNAL_H_
 #define COAP_SESSION_INTERNAL_H_
 
+#include "coap_internal.h"
 #include "coap_io_internal.h"
 
 #define COAP_DEFAULT_SESSION_TIMEOUT 300
@@ -59,7 +60,9 @@ struct coap_session_t {
   int ifindex;                      /**< interface index */
   coap_socket_t sock;               /**< socket object for the session, if
                                          any */
+#if COAP_SERVER_SUPPORT
   coap_endpoint_t *endpoint;        /**< session's endpoint */
+#endif /* COAP_SERVER_SUPPORT */
   coap_context_t *context;          /**< session's context */
   void *tls;                        /**< security parameters */
   uint16_t tx_mid;                  /**< the last message id that was used in
@@ -71,8 +74,12 @@ struct coap_session_t {
   coap_queue_t *delayqueue;         /**< list of delayed messages waiting to
                                          be sent */
   coap_lg_xmit_t *lg_xmit;          /**< list of large transmissions */
+#if COAP_CLIENT_SUPPORT
   coap_lg_crcv_t *lg_crcv;       /**< Client list of expected large receives */
+#endif /* COAP_CLIENT_SUPPORT */
+#if COAP_SERVER_SUPPORT
   coap_lg_srcv_t *lg_srcv;       /**< Server list of expected large receives */
+#endif /* COAP_SERVER_SUPPORT */
   size_t partial_write;             /**< if > 0 indicates number of bytes
                                          already written from the pdu at the
                                          head of sendqueue */
@@ -129,6 +136,7 @@ struct coap_session_t {
   uint64_t tx_token;              /**< Next token number to use */
 };
 
+#if COAP_SERVER_SUPPORT
 /**
  * Abstraction of virtual endpoint that can be attached to coap_context_t. The
  * keys (port, bind_addr) must uniquely identify this endpoint.
@@ -143,6 +151,7 @@ struct coap_endpoint_t {
   coap_address_t bind_addr;       /**< local interface address */
   coap_session_t *sessions;       /**< hash table or list of active sessions */
 };
+#endif /* COAP_SERVER_SUPPORT */
 
 /**
  * Notify session transport has just connected and CSM exchange can now start.
@@ -184,6 +193,7 @@ int coap_session_refresh_psk_hint(coap_session_t *session,
 int coap_session_refresh_psk_key(coap_session_t *session,
                                  const coap_bin_const_t *psk_key);
 
+#if COAP_SERVER_SUPPORT
 /**
  * Creates a new server session for the specified endpoint.
  * @param ctx The CoAP context.
@@ -196,6 +206,7 @@ coap_session_t *coap_new_server_session(
   coap_context_t *ctx,
   coap_endpoint_t *ep
 );
+#endif /* COAP_SERVER_SUPPORT */
 
 /**
  * Function interface for datagram data transmission. This function returns
@@ -245,6 +256,7 @@ ssize_t
 coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
                        coap_queue_t *node);
 
+#if COAP_SERVER_SUPPORT
 /**
  * Lookup the server session for the packet received on an endpoint, or create
  * a new one.
@@ -256,6 +268,7 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
  */
 coap_session_t *coap_endpoint_get_session(coap_endpoint_t *endpoint,
   const coap_packet_t *packet, coap_tick_t now);
+#endif /* COAP_SERVER_SUPPORT */
 
 /**
  * Create a new DTLS session for the @p session.

--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -18,6 +18,10 @@
 #ifndef COAP_SUBSCRIBE_INTERNAL_H_
 #define COAP_SUBSCRIBE_INTERNAL_H_
 
+#include "coap_internal.h"
+
+#if COAP_SERVER_SUPPORT
+
 /**
  * @defgroup subscribe_internal Observe Subscription (Internal)
  * CoAP Observe Subscription Structures, Enums and Functions that are not
@@ -148,4 +152,5 @@ void coap_delete_observers(coap_context_t *context, coap_session_t *session);
 
 /** @} */
 
+#endif /* COAP_SERVER_SUPPORT */
 #endif /* COAP_SUBSCRIBE_INTERNAL_H_ */

--- a/include/coap3/coap_tcp_internal.h
+++ b/include/coap3/coap_tcp_internal.h
@@ -17,6 +17,7 @@
 #ifndef COAP_TCP_INTERNAL_H_
 #define COAP_TCP_INTERNAL_H_
 
+#include "coap_internal.h"
 #include "coap_io.h"
 
 /**

--- a/src/async.c
+++ b/src/async.c
@@ -154,7 +154,7 @@ coap_async_get_app_data(const coap_async_t *async) {
   return async->appdata;
 }
 
-#else
+#else /* WITHOUT_ASYNC */
 
 int
 coap_async_is_supported(void) {

--- a/src/block.c
+++ b/src/block.c
@@ -275,6 +275,7 @@ full_match(const uint8_t *a, size_t alen,
   return alen == blen && (alen == 0 || memcmp(a, b, alen) == 0);
 }
 
+#if COAP_CLIENT_SUPPORT
 int
 coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
                     coap_pdu_type_t type) {
@@ -328,6 +329,7 @@ coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
   }
   return 0;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
 int
 coap_add_data_large_internal(coap_session_t *session,
@@ -623,6 +625,7 @@ fail:
   return 0;
 }
 
+#if COAP_CLIENT_SUPPORT
 int
 coap_add_data_large_request(coap_session_t *session,
                             coap_pdu_t *pdu,
@@ -633,7 +636,9 @@ coap_add_data_large_request(coap_session_t *session,
   return coap_add_data_large_internal(session, pdu, NULL, NULL, -1,
                                  0, length, data, release_func, app_ptr);
 }
+#endif /* ! COAP_CLIENT_SUPPORT */
 
+#if COAP_SERVER_SUPPORT
 int
 coap_add_data_large_response(coap_resource_t *resource,
                              coap_session_t *session,
@@ -729,6 +734,7 @@ error:
                 (const unsigned char *)coap_response_phrase(response->code));
   return 0;
 }
+#endif /* ! COAP_SERVER_SUPPORT */
 
 coap_tick_t
 coap_block_check_lg_xmit_timeouts(coap_session_t *session, coap_tick_t now) {
@@ -755,6 +761,7 @@ coap_block_check_lg_xmit_timeouts(coap_session_t *session, coap_tick_t now) {
   return tim_rem;
 }
 
+#if COAP_CLIENT_SUPPORT
 coap_tick_t
 coap_block_check_lg_crcv_timeouts(coap_session_t *session, coap_tick_t now) {
   coap_lg_crcv_t *p;
@@ -777,6 +784,7 @@ coap_block_check_lg_crcv_timeouts(coap_session_t *session, coap_tick_t now) {
   }
   return tim_rem;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
 static int
 check_if_received_block(coap_rblock_t *rec_blocks, uint32_t block_num) {
@@ -809,6 +817,7 @@ check_all_blocks_in(coap_rblock_t *rec_blocks, size_t total_blocks) {
   return 1;
 }
 
+#if COAP_SERVER_SUPPORT
 coap_tick_t
 coap_block_check_lg_srcv_timeouts(coap_session_t *session, coap_tick_t now) {
   coap_lg_srcv_t *p;
@@ -830,7 +839,9 @@ coap_block_check_lg_srcv_timeouts(coap_session_t *session, coap_tick_t now) {
   }
   return tim_rem;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
+#if COAP_CLIENT_SUPPORT
 coap_lg_crcv_t *
 coap_block_new_lg_crcv(coap_session_t *session, coap_pdu_t *pdu) {
   coap_lg_crcv_t *lg_crcv;
@@ -897,7 +908,9 @@ coap_block_delete_lg_crcv(coap_session_t *session,
   coap_delete_binary(lg_crcv->app_token);
   coap_free_type(COAP_LG_CRCV, lg_crcv);
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
+#if COAP_SERVER_SUPPORT
 void
 coap_block_delete_lg_srcv(coap_session_t *session,
                                coap_lg_srcv_t *lg_srcv) {
@@ -910,6 +923,7 @@ coap_block_delete_lg_srcv(coap_session_t *session,
          coap_session_str(session), (void*)lg_srcv);
   coap_free_type(COAP_LG_SRCV, lg_srcv);
 }
+#endif /* COAP_SERVER_SUPPORT */
 
 void
 coap_block_delete_lg_xmit(coap_session_t *session,
@@ -933,6 +947,7 @@ coap_block_delete_lg_xmit(coap_session_t *session,
   coap_free_type(COAP_LG_XMIT, lg_xmit);
 }
 
+#if COAP_SERVER_SUPPORT
 static int
 add_block_send(uint32_t num, uint32_t *out_blocks,
                           uint32_t *count, uint32_t max_count) {
@@ -1179,6 +1194,7 @@ internal_issue:
 skip_app_handler:
   return 1;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
 static int
 update_received_blocks(coap_rblock_t *rec_blocks, uint32_t block_num) {
@@ -1235,6 +1251,7 @@ update_received_blocks(coap_rblock_t *rec_blocks, uint32_t block_num) {
   return 1;
 }
 
+#if COAP_SERVER_SUPPORT
 /*
  * Need to check if this is a large PUT / POST using multiple blocks
  *
@@ -1453,7 +1470,9 @@ call_app_handler:
 skip_app_handler:
   return 1;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
+#if COAP_CLIENT_SUPPORT
 /*
  * Need to see if this is a response to a large body request transfer. If so,
  * need to initiate the request containing the next block and not trouble the
@@ -1576,6 +1595,7 @@ fail_body:
   } /* end of LL_FOREACH_SAFE */
   return 0;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
 /*
  * Re-assemble payloads into a body
@@ -1621,6 +1641,7 @@ coap_block_build_body(coap_binary_t *body_data, size_t length,
   return body_data;
 }
 
+#if COAP_CLIENT_SUPPORT
 /*
  * Need to see if this is a large body response to a request. If so,
  * need to initiate the request for the next block and not trouble the
@@ -1967,6 +1988,7 @@ call_app_handler:
 skip_app_handler:
   return 1;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
 /* Check if lg_xmit generated and update PDU code if so */
 void

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -10,6 +10,7 @@
 
 #include "coap3/coap_internal.h"
 
+#if COAP_SERVER_SUPPORT
 /* Determines if the given option_type denotes an option type that can
  * be used as CacheKey. Options that can be cache keys are not Unsafe
  * and not marked explicitly as NoCacheKey. */
@@ -267,3 +268,4 @@ coap_expire_cache_entries(coap_context_t *ctx) {
   }
 }
 
+#endif /* ! COAP_SERVER_SUPPORT */

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -47,19 +47,23 @@ coap_dtls_context_set_pki_root_cas(coap_context_t *ctx COAP_UNUSED,
   return 0;
 }
 
+#if COAP_CLIENT_SUPPORT
 int
 coap_dtls_context_set_cpsk(coap_context_t *ctx COAP_UNUSED,
                           coap_dtls_cpsk_t* setup_data COAP_UNUSED
 ) {
   return 0;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
+#if COAP_SERVER_SUPPORT
 int
 coap_dtls_context_set_spsk(coap_context_t *ctx COAP_UNUSED,
                           coap_dtls_spsk_t* setup_data COAP_UNUSED
 ) {
   return 0;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
 int
 coap_dtls_context_check_keys_enabled(coap_context_t *ctx COAP_UNUSED)
@@ -102,13 +106,17 @@ void
 coap_dtls_free_context(void *handle COAP_UNUSED) {
 }
 
+#if COAP_SERVER_SUPPORT
 void *coap_dtls_new_server_session(coap_session_t *session COAP_UNUSED) {
   return NULL;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
+#if COAP_CLIENT_SUPPORT
 void *coap_dtls_new_client_session(coap_session_t *session COAP_UNUSED) {
   return NULL;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
 void coap_dtls_free_session(coap_session_t *coap_session COAP_UNUSED) {
 }
@@ -148,6 +156,7 @@ coap_dtls_receive(coap_session_t *session COAP_UNUSED,
   return -1;
 }
 
+#if COAP_SERVER_SUPPORT
 int
 coap_dtls_hello(coap_session_t *session COAP_UNUSED,
   const uint8_t *data COAP_UNUSED,
@@ -155,18 +164,23 @@ coap_dtls_hello(coap_session_t *session COAP_UNUSED,
 ) {
   return 0;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
 unsigned int coap_dtls_get_overhead(coap_session_t *session COAP_UNUSED) {
   return 0;
 }
 
+#if COAP_CLIENT_SUPPORT
 void *coap_tls_new_client_session(coap_session_t *session COAP_UNUSED, int *connected COAP_UNUSED) {
   return NULL;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
+#if COAP_SERVER_SUPPORT
 void *coap_tls_new_server_session(coap_session_t *session COAP_UNUSED, int *connected COAP_UNUSED) {
   return NULL;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
 void coap_tls_free_session(coap_session_t *coap_session COAP_UNUSED) {
 }
@@ -185,6 +199,7 @@ ssize_t coap_tls_read(coap_session_t *session COAP_UNUSED,
   return -1;
 }
 
+#if COAP_SERVER_SUPPORT
 typedef struct coap_local_hash_t {
   size_t ofs;
   coap_key_t key[8];   /* 32 bytes in total */
@@ -228,6 +243,7 @@ coap_digest_final(coap_digest_ctx_t *digest_ctx,
   coap_digest_free(digest_ctx);
   return 1;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
 #else /* !HAVE_LIBTINYDTLS && !HAVE_OPENSSL && !HAVE_LIBGNUTLS */
 

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -206,13 +206,13 @@ get_psk_info(struct dtls_context_t *dtls_context,
   coap_context_t *coap_context = t_context ? t_context->coap_context : NULL;
   coap_session_t *coap_session;
   int fatal_error = DTLS_ALERT_INTERNAL_ERROR;
+#if COAP_CLIENT_SUPPORT
   size_t identity_length;
   uint8_t psk[COAP_DTLS_MAX_PSK];
   size_t psk_len = 0;
-  coap_address_t remote_addr;
   coap_dtls_cpsk_t *setup_cdata;
-  coap_dtls_spsk_t *setup_sdata;
-  coap_bin_const_t temp;
+#endif /* COAP_CLIENT_SUPPORT */
+  coap_address_t remote_addr;
 
   assert(coap_context);
   get_session_addr(dtls_session, &remote_addr);
@@ -225,15 +225,19 @@ get_psk_info(struct dtls_context_t *dtls_context,
   switch (type) {
   case DTLS_PSK_IDENTITY:
 
+#if COAP_CLIENT_SUPPORT
     if (!coap_context || !coap_context->get_client_psk ||
         coap_session->type != COAP_SESSION_TYPE_CLIENT)
       goto error;
 
     setup_cdata = &coap_session->cpsk_setup_data;
 
+#if COAP_SERVER_SUPPORT
+    coap_bin_const_t temp;
     temp.s = id;
     temp.length = id_len;
     coap_session_refresh_psk_hint(coap_session, &temp);
+#endif /* COAP_SERVER_SUPPORT */
 
     coap_log(LOG_DEBUG, "got psk_identity_hint: '%.*s'\n", (int)id_len, id ? (const char*)id : "");
 
@@ -275,8 +279,12 @@ get_psk_info(struct dtls_context_t *dtls_context,
       goto error;
     }
     return (int)identity_length;
+#else /* ! COAP_CLIENT_SUPPORT */
+    return 0;
+#endif /* ! COAP_CLIENT_SUPPORT */
 
   case DTLS_PSK_KEY:
+#if COAP_CLIENT_SUPPORT
     if (coap_session->type == COAP_SESSION_TYPE_CLIENT) {
       if (!coap_context || !coap_context->get_client_psk)
         goto error;
@@ -290,7 +298,10 @@ get_psk_info(struct dtls_context_t *dtls_context,
       }
       return (int)psk_len;
     }
+#endif /* COAP_CLIENT_SUPPORT */
+#if COAP_SERVER_SUPPORT
     if (coap_context->get_server_psk) {
+      coap_dtls_spsk_t *setup_sdata;
       setup_sdata = &coap_session->context->spsk_setup_data;
 
       if (!id)
@@ -324,11 +335,14 @@ get_psk_info(struct dtls_context_t *dtls_context,
 
       return (int)coap_context->get_server_psk(coap_session, (const uint8_t*)id, id_len, (uint8_t*)result, result_length);
     }
+#endif /* COAP_SERVER_SUPPORT */
     return 0;
 
   case DTLS_PSK_HINT:
+#if COAP_SERVER_SUPPORT
     if (coap_context->get_server_hint)
       return (int)coap_context->get_server_hint(coap_session, (uint8_t *)result, result_length);
+#endif /* COAP_SERVER_SUPPORT */
     return 0;
 
   default:
@@ -489,10 +503,13 @@ coap_dtls_new_session(coap_session_t *session) {
   return dtls_session;
 }
 
+#if COAP_SERVER_SUPPORT
 void *coap_dtls_new_server_session(coap_session_t *session) {
   return coap_dtls_new_session(session);
 }
+#endif /* COAP_SERVER_SUPPORT */
 
+#if COAP_CLIENT_SUPPORT
 void *coap_dtls_new_client_session(coap_session_t *session) {
   dtls_peer_t *peer;
   coap_tiny_context_t *t_context = (coap_tiny_context_t *)session->context->dtls_context;
@@ -522,6 +539,7 @@ void *coap_dtls_new_client_session(coap_session_t *session) {
 
   return dtls_session;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
 void
 coap_dtls_session_update_mtu(coap_session_t *session) {
@@ -644,6 +662,7 @@ coap_dtls_receive(coap_session_t *session,
   return err;
 }
 
+#if COAP_SERVER_SUPPORT
 int
 coap_dtls_hello(coap_session_t *session,
   const uint8_t *data,
@@ -670,6 +689,7 @@ coap_dtls_hello(coap_session_t *session,
   }
   return res;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
 unsigned int coap_dtls_get_overhead(coap_session_t *session) {
   (void)session;
@@ -1139,6 +1159,7 @@ coap_dtls_context_set_pki_root_cas(coap_context_t *ctx COAP_UNUSED,
   return 0;
 }
 
+#if COAP_CLIENT_SUPPORT
 int
 coap_dtls_context_set_cpsk(coap_context_t *coap_context COAP_UNUSED,
   coap_dtls_cpsk_t *setup_data
@@ -1148,7 +1169,9 @@ coap_dtls_context_set_cpsk(coap_context_t *coap_context COAP_UNUSED,
 
   return 1;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
+#if COAP_SERVER_SUPPORT
 int
 coap_dtls_context_set_spsk(coap_context_t *coap_context COAP_UNUSED,
   coap_dtls_spsk_t *setup_data
@@ -1163,6 +1186,7 @@ coap_dtls_context_set_spsk(coap_context_t *coap_context COAP_UNUSED,
 
   return 1;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
 int
 coap_dtls_context_check_keys_enabled(coap_context_t *ctx COAP_UNUSED)
@@ -1171,13 +1195,17 @@ coap_dtls_context_check_keys_enabled(coap_context_t *ctx COAP_UNUSED)
 }
 
 #if !COAP_DISABLE_TCP
+#if COAP_CLIENT_SUPPORT
 void *coap_tls_new_client_session(coap_session_t *session COAP_UNUSED, int *connected COAP_UNUSED) {
   return NULL;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
+#if COAP_SERVER_SUPPORT
 void *coap_tls_new_server_session(coap_session_t *session COAP_UNUSED, int *connected COAP_UNUSED) {
   return NULL;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
 void coap_tls_free_session(coap_session_t *coap_session COAP_UNUSED) {
 }
@@ -1197,6 +1225,7 @@ ssize_t coap_tls_read(coap_session_t *session COAP_UNUSED,
 }
 #endif /* !COAP_DISABLE_TCP */
 
+#if COAP_SERVER_SUPPORT
 coap_digest_ctx_t *
 coap_digest_setup(void) {
   dtls_sha256_ctx *digest_ctx = coap_malloc(sizeof(dtls_sha256_ctx));
@@ -1230,6 +1259,7 @@ coap_digest_final(coap_digest_ctx_t *digest_ctx,
   coap_digest_free(digest_ctx);
   return 1;
 }
+#endif /* COAP_SERVER_SUPPORT */
 
 #else /* !HAVE_LIBTINYDTLS */
 

--- a/src/resource.c
+++ b/src/resource.c
@@ -10,6 +10,7 @@
 
 #include "coap3/coap_internal.h"
 
+#if COAP_SERVER_SUPPORT
 #include <stdio.h>
 #include <errno.h>
 
@@ -1141,3 +1142,5 @@ coap_handle_failed_notify(coap_context_t *context,
         coap_remove_failed_observers(context, r, session, token);
   }
 }
+
+#endif /* ! COAP_SERVER_SUPPORT */

--- a/src/subscribe.c
+++ b/src/subscribe.c
@@ -11,8 +11,10 @@
 
 #include "coap3/coap_internal.h"
 
+#if COAP_SERVER_SUPPORT
 void
 coap_subscription_init(coap_subscription_t *s) {
   assert(s);
   memset(s, 0, sizeof(coap_subscription_t));
 }
+#endif /* COAP_SERVER_SUPPORT */

--- a/tests/test_sendqueue.c
+++ b/tests/test_sendqueue.c
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 
+#if COAP_CLIENT_SUPPORT
 static coap_context_t *ctx; /* Holds the coap context for most tests */
 static coap_session_t *session; /* Holds a reference-counted session object */
 
@@ -362,4 +363,5 @@ t_init_sendqueue_tests(void) {
 
   return suite;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -11,6 +11,7 @@
 #include "test_common.h"
 #include "test_session.h"
 
+#if COAP_CLIENT_SUPPORT
 #include <stdio.h>
 
 /* The error threshold for timeout calculations. The precision of
@@ -222,3 +223,4 @@ t_init_session_tests(void) {
 
   return suite;
 }
+#endif /* COAP_CLIENT_SUPPORT */

--- a/tests/test_wellknown.c
+++ b/tests/test_wellknown.c
@@ -11,6 +11,8 @@
 #include "test_common.h"
 #include "test_wellknown.h"
 
+#if COAP_SERVER_SUPPORT
+#if COAP_CLIENT_SUPPORT
 #include <assert.h>
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -337,4 +339,6 @@ t_init_wellknown_tests(void) {
 
   return suite;
 }
+#endif /* COAP_CLIENT_SUPPORT */
+#endif /* COAP_SERVER_SUPPORT */
 

--- a/tests/testdriver.c
+++ b/tests/testdriver.c
@@ -40,9 +40,13 @@ main(int argc COAP_UNUSED, char **argv COAP_UNUSED) {
   t_init_option_tests();
   t_init_pdu_tests();
   t_init_error_response_tests();
+#if COAP_CLIENT_SUPPORT
   t_init_session_tests();
   t_init_sendqueue_tests();
+#endif /* COAP_CLIENT_SUPPORT */
+#if COAP_SERVER_SUPPORT && COAP_CLIENT_SUPPORT
   t_init_wellknown_tests();
+#endif /* COAP_SERVER_SUPPORT && COAP_CLIENT_SUPPORT */
   t_init_tls_tests();
 
   CU_basic_set_mode(run_mode);


### PR DESCRIPTION
Add in new ./configure options --enable-client-mode or
--enable-server-mode  which by default are enabled.

If --disable-client-mode is set, then disable all the client specific code.
[ COAP_CLIENT_SUPPORT is not defined ]

If --disable-server-mode  is set, then disable all the server specific code.
[ COAP_SERVER_SUPPORT is not defined ]

Functions and variables are only #ifdef'd out in the include/coap3/*_internal.h
files.  They cannot be #ifdef'd out in the other include files as
COAP_CLIENT_SUPPORT and COAP_SERVER_SUPPORT are not available for application
compilations. The result of this is if, say, client only API functons are used
in a server application and COAP_CLIENT_SUPPORT is not defined, there will be
linking issues (missing functions).  Providing stub functions unecessarily
increases the code size.

For coap-server, if it is able to provide proxy support, requires both
COAP_SERVER_SUPPORT and COAP_CLIENT_SUPPORT to set up the ongoing sessions.
So, the build environment deliberatly sets SERVER_CAN_PROXY=0 if
COAP_CLIENT_SUPPORT is not available to allow linking.

Some of the tests have to be disabled if COAP_SERVER_SUPPORT or
COAP_CLIENT_SUPPORT is not set.

Code size change indications
````
   text    data     bss     sum   filename
 155912    1728   12080  169720   libcoap-3-notls.a                     
 138300    1728   12080  152108   libcoap-3-notls.a --disable-client-mode 
 106734    1632   10304  118670   libcoap-3-notls.a --disable-server-mode 

 180485    1733   12080  194298   libcoap-3-openssl.a 
 160306    1733   12080  174119   libcoap-3-openssl.a --disable-client-mode 
 125543    1637   10304  137484   libcoap-3-openssl.a --disable-server-mode 

 181755    1728   12080  195563   libcoap-3-gnutls.a 
 160972    1728   12080  174780   libcoap-3-gnutls.a --disable-client-mode 
 127178    1632   10304  139114   libcoap-3-gnutls.a --disable-server-mode 

 165879    1855   12128  179862   libcoap-3-tinydtls.a 
 147022    1855   12128  161005   libcoap-3-tinydtls.a --disable-client-mode 
 115618    1759   10352  127729   libcoap-3-tinydtls.a --disable-server-mode 

 171690    1728   13744  187162   libcoap-3-mbedtls.a 
 152099    1728   13712  167539   libcoap-3-mbedtls.a --disable-client-mode 
 118786    1632   11984  132402   libcoap-3-mbedtls.a --disable-server-mode 
````
Contiki and LwIP builds with missing support has not been tested. 

See https://github.com/espressif/esp-idf/pull/7106 