### PR TITLE
doxygen: Tidy up Modules and Files tab information

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -855,6 +855,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @top_srcdir@/doc/main.md \
+                         @top_srcdir@/doc/module_api_wrap.h \
                          @top_srcdir@/src \
                          @top_srcdir@/include/coap@LIBCOAP_API_VERSION@ \
                          @top_builddir@/doc/man_tmp

--- a/doc/module_api_wrap.h
+++ b/doc/module_api_wrap.h
@@ -1,0 +1,21 @@
+/* doc/module_api_wrap.h
+ *
+ * Copyright (C) 2021 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP C library libcoap. Please see README and
+ * COPYING for terms of use.
+ */
+
+/**
+ * @file module_api_wrap.h
+ * @brief Doxygen specific wrapper for Modules layout
+ */
+
+/**
+ * @defgroup application_api Application API
+ * Application API Structures, Macros, Typedefs, Enums and Functions
+ * @defgroup internal_api Libcoap Internal API
+ * libcoap Internal API Structures, Macros, Typedefs, Enums and Functions
+ */

--- a/include/coap3/async.h
+++ b/include/coap3/async.h
@@ -20,9 +20,10 @@
 #include "net.h"
 
 /**
+ * @ingroup application_api
  * @defgroup coap_async Asynchronous Messaging
  * @{
- * API functions for  Async "separate" messages.
+ * API for delayed "separate" messages.
  * A coap_context_t object holds a list of coap_async_t objects that can
  * be used to generate a separate response in the case a result of a request
  * cannot be delivered immediately.

--- a/include/coap3/block.h
+++ b/include/coap3/block.h
@@ -9,6 +9,11 @@
  * of use.
  */
 
+/**
+ * @file block.h
+ * @brief CoAP Block information
+ */
+
 #ifndef COAP_BLOCK_H_
 #define COAP_BLOCK_H_
 
@@ -17,8 +22,9 @@
 #include "pdu.h"
 
 /**
+ * @ingroup application_api
  * @defgroup block Block Transfer
- * API functions for handling PDUs using CoAP BLOCK options
+ * API for handling PDUs using CoAP BLOCK options (RFC7959)
  * @{
  */
 

--- a/include/coap3/coap_asn1_internal.h
+++ b/include/coap3/coap_asn1_internal.h
@@ -11,7 +11,7 @@
 
 /**
  * @file coap_asn1_internal.h
- * @brief COAP ASN.1 internal information
+ * @brief CoAP ASN.1 internal information
  */
 
 #ifndef COAP_ASN1_INTERNAL_H_
@@ -20,9 +20,9 @@
 #include "coap_internal.h"
 
 /**
- * @defgroup asn1 ASN.1 Support (Internal)
- * CoAP ASN.1 Structures, Enums and Functions that are not exposed to
- * applications
+ * @ingroup internal_api
+ * @defgroup asn1 ASN.1 Support
+ * Internal API for CoAP ASN.1 handling
  * @{
  */
 

--- a/include/coap3/coap_async_internal.h
+++ b/include/coap3/coap_async_internal.h
@@ -24,10 +24,10 @@
 #ifndef WITHOUT_ASYNC
 
 /**
- * @defgroup coap_async_internal Asynchronous Messaging (Internal)
+ * @ingroup internal_api
+ * @defgroup coap_async_internal Asynchronous Messaging
  * @{
- * CoAP Async Structures, Enums and Functions that are not exposed to
- * applications.
+ * Internal API for CoAP Asynchronous processing.
  * A coap_context_t object holds a list of coap_async_t objects that can be
  * used to generate a separate response in the case a result of a request cannot
  * be delivered immediately.

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -13,7 +13,7 @@
 
 /**
  * @file coap_block_internal.h
- * @brief COAP block internal information
+ * @brief CoAP block internal information
  */
 
 #ifndef COAP_BLOCK_INTERNAL_H_
@@ -24,8 +24,9 @@
 #include "resource.h"
 
 /**
- * @defgroup block_internal Block (Internal)
- * Structures, Enums and Functions that are not exposed to applications
+ * @ingroup internal_api
+ * @defgroup block_internal Block Transfer
+ * Internal API for Block Transfer (RC7959)
  * @{
  */
 

--- a/include/coap3/coap_cache.h
+++ b/include/coap3/coap_cache.h
@@ -19,8 +19,10 @@
 #include "coap_forward_decls.h"
 
 /**
+ * @ingroup application_api
  * @defgroup cache Cache Support
- * API functions for CoAP Caching
+ * API for Cache-Key and Cache-Entry.
+ * See https://datatracker.ietf.org/doc/html/rfc7252#section-5.4.2
  * @{
  */
 
@@ -44,7 +46,7 @@ typedef enum coap_cache_record_pdu_t {
 
 /**
  * Calculates a cache-key for the given CoAP PDU. See
- * https://tools.ietf.org/html/rfc7252#section-5.6
+ * https://tools.ietf.org/html/rfc7252#section-5.4.2
  * for an explanation of CoAP cache keys.
  *
  * Specific CoAP options can be removed from the cache-key.  Examples of
@@ -72,7 +74,7 @@ coap_cache_key_t *coap_cache_derive_key(const coap_session_t *session,
 
 /**
  * Calculates a cache-key for the given CoAP PDU. See
- * https://tools.ietf.org/html/rfc7252#section-5.6
+ * https://tools.ietf.org/html/rfc7252#section-5.4.2
  * for an explanation of CoAP cache keys.
  *
  * Specific CoAP options can be removed from the cache-key.  Examples of

--- a/include/coap3/coap_cache_internal.h
+++ b/include/coap3/coap_cache_internal.h
@@ -11,7 +11,7 @@
 
 /**
  * @file coap_cache_internal.h
- * @brief COAP cache internal information
+ * @brief CoAP cache internal information
  */
 
 #ifndef COAP_CACHE_INTERNAL_H_
@@ -22,9 +22,9 @@
 
 #if COAP_SERVER_SUPPORT
 /**
- * @defgroup cache_internal Cache Support (Internal)
- * CoAP Cache Structures, Enums and Functions that are not exposed to
- * applications
+ * @ingroup internal_api
+ * @defgroup cache_internal Cache Support
+ * Internal API for Cache-Key and Cache-Entry support
  * @{
  */
 

--- a/include/coap3/coap_debug.h
+++ b/include/coap3/coap_debug.h
@@ -9,12 +9,18 @@
  * of use.
  */
 
+/**
+ * @file coap_debug.h
+ * @brief CoAP Logging support
+ */
+
 #ifndef COAP_DEBUG_H_
 #define COAP_DEBUG_H_
 
 /**
+ * @ingroup application_api
  * @defgroup logging Logging Support
- * API functions for logging support
+ * API for logging support
  * @{
  */
 

--- a/include/coap3/coap_dtls.h
+++ b/include/coap3/coap_dtls.h
@@ -10,6 +10,11 @@
  * of use.
  */
 
+/**
+ * @file coap_dtls.h
+ * @brief CoAP DTLS support
+ */
+
 #ifndef COAP_DTLS_H_
 #define COAP_DTLS_H_
 
@@ -17,8 +22,9 @@
 #include "str.h"
 
 /**
+ * @ingroup application_api
  * @defgroup dtls DTLS Support
- * API functions for interfacing with DTLS libraries.
+ * API for interfacing with DTLS libraries.
  * @{
  */
 

--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -10,15 +10,20 @@
  * of use.
  */
 
+/**
+ * @file coap_dtls_internal.h
+ * @brief Internal CoAP DTLS support
+ */
+
 #ifndef COAP_DTLS_INTERNAL_H_
 #define COAP_DTLS_INTERNAL_H_
 
 #include "coap_internal.h"
 
 /**
- * @defgroup dtls_internal DTLS Support (Internal)
- * CoAP DTLS Structures, Enums and Functions that are not exposed to
- * applications
+ * @ingroup internal_api
+ * @defgroup dtls_internal DTLS Support
+ * Internal API for DTLS Support
  * @{
  */
 

--- a/include/coap3/coap_event.h
+++ b/include/coap3/coap_event.h
@@ -9,14 +9,20 @@
  * of use.
  */
 
+/**
+ * @file coap_event.h
+ * @brief Event handling
+ */
+
 #ifndef COAP_EVENT_H_
 #define COAP_EVENT_H_
 
 #include "libcoap.h"
 
 /**
- * @defgroup events Event API
- * API functions for event delivery from lower-layer library functions.
+ * @ingroup application_api
+ * @defgroup events Event Handling
+ * API for event delivery from lower-layer library functions.
  * @{
  */
 

--- a/include/coap3/coap_forward_decls.h
+++ b/include/coap3/coap_forward_decls.h
@@ -12,7 +12,7 @@
 
 /**
  * @file coap_forward_decls.h
- * @brief COAP forward definitions
+ * @brief CoAP forward definitions
  */
 
 #ifndef COAP_FORWARD_DECLS_H_

--- a/include/coap3/coap_hashkey.h
+++ b/include/coap3/coap_hashkey.h
@@ -11,7 +11,7 @@
 
 /**
  * @file coap_hashkey.h
- * @brief definition of hash key type and helper functions
+ * @brief Definition of hash key type and helper functions
  */
 
 #ifndef COAP_HASHKEY_H_

--- a/include/coap3/coap_io.h
+++ b/include/coap3/coap_io.h
@@ -9,6 +9,11 @@
  * of use.
  */
 
+/**
+ * @file coap_io.h
+ * @brief Default network I/O functions
+ */
+
 #ifndef COAP_IO_H_
 #define COAP_IO_H_
 

--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -9,6 +9,11 @@
  * of use.
  */
 
+/**
+ * @file coap_io_internal.h
+ * @brief Internal network I/O functions
+ */
+
 #ifndef COAP_IO_INTERNAL_H_
 #define COAP_IO_INTERNAL_H_
 

--- a/include/coap3/coap_mutex.h
+++ b/include/coap3/coap_mutex.h
@@ -12,7 +12,7 @@
 
 /**
  * @file coap_mutex.h
- * @brief COAP mutex mechanism wrapper
+ * @brief CoAP mutex mechanism wrapper
  */
 
 #ifndef COAP_MUTEX_H_

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -1,5 +1,5 @@
 /*
- * coap_context_internal.h -- Structures, Enums & Functions that are not
+ * coap_net_internal.h -- CoAP context internal information
  * exposed to application programming
  *
  * Copyright (C) 2010-2021 Olaf Bergmann <bergmann@tzi.org>
@@ -12,7 +12,7 @@
 
 /**
  * @file coap_net_internal.h
- * @brief COAP net internal information
+ * @brief CoAP context internal information
  */
 
 #ifndef COAP_NET_INTERNAL_H_
@@ -21,9 +21,9 @@
 #include "coap_internal.h"
 
 /**
- * @defgroup context_internal Context Handling (Internal)
- * CoAP Context Structures, Enums and Functions that are not exposed to
- * applications
+ * @ingroup internal_api
+ * @defgroup context_internal Context Handling
+ * Internal API for Context Handling
  * @{
  */
 

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -26,9 +26,9 @@
 #include <stdint.h>
 
 /**
- * @defgroup pdu_internal PDU (Internal)
- * CoAP PDU Structures, Enums and Functions that are not exposed to
- * applications
+ * @ingroup internal_api
+ * @defgroup pdu_internal PDU
+ * Internal API for PDUs
  * @{
  */
 

--- a/include/coap3/coap_prng.h
+++ b/include/coap3/coap_prng.h
@@ -18,8 +18,9 @@
 #define COAP_PRNG_H_
 
 /**
+ * @ingroup application_api
  * @defgroup coap_prng Pseudo Random Numbers
- * API functions for gerating pseudo random numbers
+ * API for generating pseudo random numbers
  * @{
  */
 

--- a/include/coap3/coap_resource_internal.h
+++ b/include/coap3/coap_resource_internal.h
@@ -22,8 +22,9 @@
 
 #if COAP_SERVER_SUPPORT
 /**
- * @defgroup coap_resource_internal Resources (Internal)
- * Structures, Enums and Functions that are not exposed to applications
+ * @ingroup internal_api
+ * @defgroup coap_resource_internal Resources
+ * Internal API for handling resources
  * @{
  */
 

--- a/include/coap3/coap_riot.h
+++ b/include/coap3/coap_riot.h
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file coap_riot.h
+ * @brief RIOT-specific definitions for libcoap
+ */
+
 #ifndef COAP_RIOT_H_
 #define COAP_RIOT_H_
 

--- a/include/coap3/coap_session.h
+++ b/include/coap3/coap_session.h
@@ -17,8 +17,9 @@
 #define COAP_SESSION_H_
 
 /**
+ * @ingroup application_api
  * @defgroup session Sessions
- * API functions for CoAP Sessions
+ * API for CoAP Session access
  * @{
  */
 
@@ -386,7 +387,9 @@ coap_session_t *coap_session_get_by_peer(const coap_context_t *ctx,
   const coap_address_t *remote_addr, int ifindex);
 
  /**
+  * @ingroup application_api
   * @defgroup cc Rate Control
+  * API for updating transmission parameters for CoAP rate control.
   * The transmission parameters for CoAP rate control ("Congestion
   * Control" in stream-oriented protocols) are defined in
   * https://tools.ietf.org/html/rfc7252#section-4.8

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -12,7 +12,7 @@
 
 /**
  * @file coap_session_internal.h
- * @brief COAP session internal information
+ * @brief CoAP session internal information
  */
 
 #ifndef COAP_SESSION_INTERNAL_H_
@@ -26,9 +26,9 @@
 #define COAP_DEFAULT_MAX_HANDSHAKE_SESSIONS 100
 
 /**
- * @defgroup session_internal Sessions (Internal)
- * CoAP Session Structures, Enums and Functions that are not exposed to
- * applications
+ * @ingroup internal_api
+ * @defgroup session_internal Sessions
+ * Internal API for handling Sessions
  * @{
  */
 

--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -12,7 +12,7 @@
 
 /**
  * @file coap_subscribe_internal.h
- * @brief COAP subscribe internal information
+ * @brief CoAP subscribe internal information
  */
 
 #ifndef COAP_SUBSCRIBE_INTERNAL_H_
@@ -23,9 +23,9 @@
 #if COAP_SERVER_SUPPORT
 
 /**
- * @defgroup subscribe_internal Observe Subscription (Internal)
- * CoAP Observe Subscription Structures, Enums and Functions that are not
- * exposed to applications
+ * @ingroup internal_api
+ * @defgroup subscribe_internal Observe Subscription
+ * Internal API for handling CoAP Observe Subscriptions (RFC7641)
  * @{
  */
 

--- a/include/coap3/coap_tcp_internal.h
+++ b/include/coap3/coap_tcp_internal.h
@@ -11,7 +11,7 @@
 
 /**
  * @file coap_tcp_internal.h
- * @brief COAP tcp internal information
+ * @brief CoAP TCP internal information
  */
 
 #ifndef COAP_TCP_INTERNAL_H_
@@ -21,9 +21,9 @@
 #include "coap_io.h"
 
 /**
- * @defgroup tcp TCP Support (Internal)
- * CoAP TCP Structures, Enums and Functions that are not exposed to
- * applications
+ * @ingroup internal_api
+ * @defgroup tcp TCP Support
+ * Internal API for handling CoAP TCP (RFC8283)
  * @{
  */
 

--- a/include/coap3/coap_time.h
+++ b/include/coap3/coap_time.h
@@ -18,8 +18,9 @@
 #define COAP_TIME_H_
 
 /**
+ * @ingroup application_api
  * @defgroup clock Clock Handling
- * Default implementation of internal clock.
+ * API for internal clock assess
  * @{
  */
 

--- a/include/coap3/encode.h
+++ b/include/coap3/encode.h
@@ -9,6 +9,11 @@
  * of use.
  */
 
+/**
+ * @file encode.h
+ * @brief Encoding and decoding of CoAP data types
+ */
+
 #ifndef COAP_ENCODE_H_
 #define COAP_ENCODE_H_
 
@@ -35,8 +40,9 @@ extern int coap_flsll(long long i);
 #endif
 
 /**
+ * @ingroup application_api
  * @defgroup encode Encode / Decode API
- * API functions for endoding/decoding CoAP options.
+ * API for endoding/decoding CoAP options.
  * @{
  */
 

--- a/include/coap3/libcoap.h
+++ b/include/coap3/libcoap.h
@@ -9,6 +9,11 @@
  * of use.
  */
 
+/**
+ * @file libcoap.h
+ * @brief Platform specific header file for CoAP stack
+ */
+
 #ifndef COAP_LIBCOAP_H_
 #define COAP_LIBCOAP_H_
 

--- a/include/coap3/mem.h
+++ b/include/coap3/mem.h
@@ -9,6 +9,11 @@
  * of use.
  */
 
+/**
+ * @file mem.h
+ * @brief CoAP memory handling
+ */
+
 #ifndef COAP_MEM_H_
 #define COAP_MEM_H_
 

--- a/include/coap3/net.h
+++ b/include/coap3/net.h
@@ -1,5 +1,5 @@
 /*
- * net.h -- CoAP network interface
+ * net.h -- CoAP context interface
  *
  * Copyright (C) 2010-2021 Olaf Bergmann <bergmann@tzi.org>
  *
@@ -7,6 +7,11 @@
  *
  * This file is part of the CoAP library libcoap. Please see README for terms
  * of use.
+ */
+
+/**
+ * @file net.h
+ * @brief CoAP context interface
  */
 
 #ifndef COAP_NET_H_
@@ -31,8 +36,9 @@
 #include "coap_session.h"
 
 /**
+ * @ingroup application_api
  * @defgroup context Context Handling
- * API functions for handling PDUs using CoAP Contexts
+ * API for handling PDUs using CoAP Contexts
  * @{
  */
 
@@ -534,8 +540,9 @@ coap_mcast_set_hops(coap_session_t *session, size_t hops);
 /**@}*/
 
 /**
+ * @ingroup application_api
  * @defgroup app_io Application I/O Handling
- * API functions for Application Input / Output
+ * API for Application Input / Output checking
  * @{
  */
 
@@ -608,8 +615,9 @@ int coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
 /**@}*/
 
 /**
- * @defgroup app_io_internal Application I/O Handling (Internal)
- * Internal API functions for Application Input / Output
+ * @ingroup internal_api
+ * @defgroup app_io_internal Application I/O Handling
+ * Internal API for Application Input / Output checking
  * @{
  */
 

--- a/include/coap3/option.h
+++ b/include/coap3/option.h
@@ -63,8 +63,9 @@ size_t coap_opt_parse(const coap_opt_t *opt,
 size_t coap_opt_size(const coap_opt_t *opt);
 
 /**
+ * @ingroup application_api
  * @defgroup opt_filter Option Filters
- * API functions for access option filters
+ * API for access option filters
  * @{
  */
 

--- a/include/coap3/pdu.h
+++ b/include/coap3/pdu.h
@@ -27,8 +27,9 @@
 #include <stdint.h>
 
 /**
+ * @ingroup application_api
  * @defgroup pdu PDU
- * API functions for PDUs
+ * API for PDUs
  * @{
  */
 

--- a/include/coap3/resource.h
+++ b/include/coap3/resource.h
@@ -30,8 +30,9 @@
 #include "subscribe.h"
 
 /**
+ * @ingroup application_api
  * @defgroup coap_resource Resource Configuraton
- * API functions for setting up resources
+ * API for setting up resources
  * @{
  */
 

--- a/include/coap3/str.h
+++ b/include/coap3/str.h
@@ -9,6 +9,11 @@
  * of use.
  */
 
+/**
+ * @file str.h
+ * @brief Strings to be used in the CoAP library
+ */
+
 #ifndef COAP_STR_H_
 #define COAP_STR_H_
 
@@ -16,8 +21,9 @@
 
 
 /**
+ * @ingroup application_api
  * @defgroup string String handling support
- * API functions for handling strings and binary data
+ * API for handling strings and binary data
  * @{
  */
 

--- a/include/coap3/subscribe.h
+++ b/include/coap3/subscribe.h
@@ -19,8 +19,9 @@
 #define COAP_SUBSCRIBE_H_
 
 /**
+ * @ingroup application_api
  * @defgroup observe Resource Observation
- * API functions for interfacing with the observe handling (RFC7641)
+ * API for interfacing with the observe handling (RFC7641)
  * @{
  */
 

--- a/include/coap3/uri.h
+++ b/include/coap3/uri.h
@@ -9,6 +9,11 @@
  * of use.
  */
 
+/**
+ * @file uri.h
+ * @brief Helper functions for URI treatment
+ */
+
 #ifndef COAP_URI_H_
 #define COAP_URI_H_
 
@@ -72,8 +77,9 @@ coap_uri_t *coap_new_uri(const uint8_t *uri, unsigned int length);
 coap_uri_t *coap_clone_uri(const coap_uri_t *uri);
 
 /**
+ * @ingroup application_api
  * @defgroup uri_parse URI Parsing Functions
- *
+ * API for parsing URIs.
  * CoAP PDUs contain normalized URIs with their path and query split into
  * multiple segments. The functions in this module help splitting strings.
  * @{

--- a/src/address.c
+++ b/src/address.c
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file address.c
+ * @brief Handling of network addresses
+ */
+
 #include "coap3/coap_internal.h"
 
 #if !defined(WITH_CONTIKI) && !defined(WITH_LWIP)

--- a/src/async.c
+++ b/src/async.c
@@ -10,7 +10,7 @@
 
 /**
  * @file async.c
- * @brief state management for asynchronous messages
+ * @brief State handling for asynchronous messages
  */
 
 #include "coap3/coap_internal.h"

--- a/src/block.c
+++ b/src/block.c
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file block.c
+ * @brief CoAP Block handling
+ */
+
 #include "coap3/coap_internal.h"
 
 #ifndef min

--- a/src/coap_asn1.c
+++ b/src/coap_asn1.c
@@ -8,6 +8,11 @@
 * README for terms of use.
 */
 
+/**
+ * @file coap_asn1.c
+ * @brief CoAP specific ASN.1 handling
+ */
+
 #include "coap3/coap_internal.h"
 
 size_t

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -8,6 +8,11 @@
 * README for terms of use.
 */
 
+/**
+ * @file coap_cache.c
+ * @brief CoAP Cache handling
+ */
+
 #include "coap3/coap_internal.h"
 
 #if COAP_SERVER_SUPPORT

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -1,4 +1,4 @@
-/* debug.c -- debug utilities
+/* coap_debug.c -- debug utilities
  *
  * Copyright (C) 2010--2012,2014--2019 Olaf Bergmann <bergmann@tzi.org> and others
  *
@@ -6,6 +6,11 @@
  *
  * This file is part of the CoAP library libcoap. Please see
  * README for terms of use.
+ */
+
+/**
+ * @file coap_debug.c
+ * @brief Debug utilities
  */
 
 #include "coap3/coap_internal.h"

--- a/src/coap_event.c
+++ b/src/coap_event.c
@@ -9,6 +9,11 @@
  * of use.
  */
 
+/**
+ * @file coap_event.c
+ * @brief Event handling
+ */
+
 #include "coap3/coap_internal.h"
 
 /*

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -10,6 +10,11 @@
  * of use.
  */
 
+/**
+ * @file coap_gnutls.c
+ * @brief GndTLS interafe functions
+ */
+
 /*
  * Naming used to prevent confusion between coap sessions, gnutls sessions etc.
  * when reading the code.

--- a/src/coap_hashkey.c
+++ b/src/coap_hashkey.c
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file coap_hashkey.c
+ * @brief Hashkey functions
+ */
+
 #include "coap3/coap_internal.h"
 
 void

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file coap_io.c
+ * @brief Network I/O functions
+ */
+
 #include "coap3/coap_internal.h"
 
 #ifdef HAVE_STDIO_H

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -1,4 +1,4 @@
-/* coap_io_lwip.h -- Network I/O functions for libcoap on lwIP
+/* coap_io_lwip.c -- Network I/O functions for libcoap on lwIP
  *
  * Copyright (C) 2012,2014 Olaf Bergmann <bergmann@tzi.org>
  *               2014 chrysn <chrysn@fsfe.org>
@@ -7,6 +7,11 @@
  *
  * This file is part of the CoAP library libcoap. Please see
  * README for terms of use.
+ */
+
+/**
+ * @file coap_io_lwip.c
+ * @brief LwIP specific functions
  */
 
 #include "coap3/coap_internal.h"

--- a/src/coap_io_riot.c
+++ b/src/coap_io_riot.c
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file coap_io_riot.c
+ * @brief RIOT specific I/O functions
+ */
+
 #include "coap3/coap_internal.h"
 
 #ifdef HAVE_STDIO_H

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -1,14 +1,19 @@
 /*
-* coap_mbedtls.c -- Mbed TLS Datagram Transport Layer Support for libcoap
-*
-* Copyright (C) 2019-2021 Jon Shallow <supjps-libcoap@jpshallow.com>
-*               2019 Jitin George <jitin@espressif.com>
-*
+ * coap_mbedtls.c -- Mbed TLS Datagram Transport Layer Support for libcoap
+ *
+ * Copyright (C) 2019-2021 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *               2019 Jitin George <jitin@espressif.com>
+ *
  * SPDX-License-Identifier: BSD-2-Clause
  *
-* This file is part of the CoAP library libcoap. Please see README for terms
-* of use.
-*/
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_mbedtls.c
+ * @brief Mbed TLS specific interface functions.
+ */
 
 /*
  * Naming used to prevent confusion between coap sessions, mbedtls sessions etc.

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -1,13 +1,18 @@
 /*
-* coap_notls.c -- Stub Datagram Transport Layer Support for libcoap
-*
-* Copyright (C) 2016 Olaf Bergmann <bergmann@tzi.org>
-*
+ * coap_notls.c -- Stub Datagram Transport Layer Support for libcoap
+ *
+ * Copyright (C) 2016 Olaf Bergmann <bergmann@tzi.org>
+ *
  * SPDX-License-Identifier: BSD-2-Clause
  *
-* This file is part of the CoAP library libcoap. Please see README for terms
-* of use.
-*/
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_notls.c
+ * @brief NoTLS specific interface functions
+ */
 
 #include "coap3/coap_internal.h"
 

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1,14 +1,19 @@
 /*
-* coap_openssl.c -- Datagram Transport Layer Support for libcoap with openssl
-*
-* Copyright (C) 2017 Jean-Claude Michelou <jcm@spinetix.com>
-* Copyright (C) 2018 Jon Shallow <supjps-libcoap@jpshallow.com>
-*
+ * coap_openssl.c -- Datagram Transport Layer Support for libcoap with openssl
+ *
+ * Copyright (C) 2017 Jean-Claude Michelou <jcm@spinetix.com>
+ * Copyright (C) 2018 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
  * SPDX-License-Identifier: BSD-2-Clause
  *
-* This file is part of the CoAP library libcoap. Please see README for terms
-* of use.
-*/
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_openssl.c
+ * @brief OpenSSL specific interface functions.
+ */
 
 #include "coap3/coap_internal.h"
 

--- a/src/coap_prng.c
+++ b/src/coap_prng.c
@@ -9,6 +9,11 @@
  * for terms of use.
  */
 
+/**
+ * @file coap_prng.c
+ * @brief Pseudo Random Number functions
+ */
+
 #include "coap3/coap_internal.h"
 
 #ifdef HAVE_GETRANDOM

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1,12 +1,17 @@
 /* coap_session.c -- Session management for libcoap
-*
-* Copyright (C) 2017 Jean-Claue Michelou <jcm@spinetix.com>
-*
+ *
+ * Copyright (C) 2017 Jean-Claue Michelou <jcm@spinetix.com>
+ *
  * SPDX-License-Identifier: BSD-2-Clause
  *
-* This file is part of the CoAP library libcoap. Please see
-* README for terms of use.
-*/
+ * This file is part of the CoAP library libcoap. Please see
+ * README for terms of use.
+ */
+
+/**
+ * @file coap_session.c
+ * @brief Session handling functions
+ */
 
 #include "coap3/coap_internal.h"
 

--- a/src/coap_tcp.c
+++ b/src/coap_tcp.c
@@ -9,6 +9,11 @@
  * of use.
  */
 
+/**
+ * @file coap_tcp.c
+ * @brief CoAP TCP handling functions
+ */
+
 #include "coap3/coap_internal.h"
 
 #include <errno.h>

--- a/src/coap_time.c
+++ b/src/coap_time.c
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file coap_time.c
+ * @brief Clock handling functions
+ */
+
 #include "coap3/coap_internal.h"
 
 #ifdef HAVE_TIME_H

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -10,6 +10,11 @@
  * of use.
  */
 
+/**
+ * @file coap_tinydtls.c
+ * @brief TinyDTLS specific handling functions
+ */
+
 #include "coap3/coap_internal.h"
 
 #ifdef HAVE_LIBTINYDTLS

--- a/src/encode.c
+++ b/src/encode.c
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file encode.c
+ * @brief Encoding and decoding Coap data types functions
+ */
+
 #include "coap3/coap_internal.h"
 
 /* Carsten suggested this when fls() is not available: */

--- a/src/mem.c
+++ b/src/mem.c
@@ -8,6 +8,10 @@
  * README for terms of use.
  */
 
+/**
+ * @file mem.c
+ * @brief Memory handling functions
+ */
 
 #include "coap3/coap_internal.h"
 

--- a/src/net.c
+++ b/src/net.c
@@ -1,4 +1,4 @@
-/* net.c -- CoAP network interface
+/* net.c -- CoAP context inteface
  *
  * Copyright (C) 2010--2019 Olaf Bergmann <bergmann@tzi.org> and others
  *
@@ -6,6 +6,11 @@
  *
  * This file is part of the CoAP library libcoap. Please see
  * README for terms of use.
+ */
+
+/**
+ * @file net.c
+ * @brief CoAP context functions
  */
 
 #include "coap3/coap_internal.h"

--- a/src/option.c
+++ b/src/option.c
@@ -9,6 +9,10 @@
  * README for terms of use.
  */
 
+/**
+ * @file option.c
+ * @brief CoAP option handling functions
+ */
 
 #include "coap3/coap_internal.h"
 

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -1,4 +1,4 @@
-/* pdu.c -- CoAP message structure
+/* pdu.c -- CoAP PDU handling
  *
  * Copyright (C) 2010--2016 Olaf Bergmann <bergmann@tzi.org>
  *
@@ -6,6 +6,11 @@
  *
  * This file is part of the CoAP library libcoap. Please see
  * README for terms of use.
+ */
+
+/**
+ * @file pdu.c
+ * @brief CoAP PDU handling
  */
 
 #include "coap3/coap_internal.h"

--- a/src/resource.c
+++ b/src/resource.c
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file resource.c
+ * @brief Server resource handling functions
+ */
+
 #include "coap3/coap_internal.h"
 
 #if COAP_SERVER_SUPPORT

--- a/src/str.c
+++ b/src/str.c
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file str.c
+ * @brief String handling functions
+ */
+
 #include "coap3/coap_internal.h"
 
 #include <stdio.h>

--- a/src/subscribe.c
+++ b/src/subscribe.c
@@ -9,6 +9,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file subscribe.c
+ * @brief Subscription handling functions
+ */
+
 #include "coap3/coap_internal.h"
 
 #if COAP_SERVER_SUPPORT

--- a/src/uri.c
+++ b/src/uri.c
@@ -8,6 +8,11 @@
  * README for terms of use.
  */
 
+/**
+ * @file uri.c
+ * @brief URI handling functions
+ */
+
 #include "coap3/coap_internal.h"
 
 #if defined(HAVE_LIMITS_H)


### PR DESCRIPTION
doc/module_api_wrap.h: New

Used to split modules into Application and Internal only.

include/coap/*.h:

Module (@defgroup) description put into group application_api or internal_api
as appropriate.

Add in @file information if missing.

src/*.c

Add in @file information.