### PR TITLE
coap_event.h: Make coap_event_t an enum

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -280,6 +280,14 @@ event_handler(coap_session_t *session COAP_UNUSED,
   case COAP_EVENT_SESSION_CLOSED:
     quit = 1;
     break;
+  case COAP_EVENT_DTLS_CONNECTED:
+  case COAP_EVENT_DTLS_RENEGOTIATE:
+  case COAP_EVENT_DTLS_ERROR:
+  case COAP_EVENT_TCP_CONNECTED:
+  case COAP_EVENT_TCP_FAILED:
+  case COAP_EVENT_SESSION_CONNECTED:
+  case COAP_EVENT_SESSION_FAILED:
+  case COAP_EVENT_PARTIAL_BLOCK:
   default:
     break;
   }

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1585,6 +1585,14 @@ proxy_event_handler(coap_session_t *session,
     /* Need to remove any proxy associations */
     remove_proxy_association(session, 0);
     break;
+  case COAP_EVENT_DTLS_CONNECTED:
+  case COAP_EVENT_DTLS_RENEGOTIATE:
+  case COAP_EVENT_DTLS_ERROR:
+  case COAP_EVENT_TCP_CONNECTED:
+  case COAP_EVENT_TCP_FAILED:
+  case COAP_EVENT_SESSION_CONNECTED:
+  case COAP_EVENT_SESSION_FAILED:
+  case COAP_EVENT_PARTIAL_BLOCK:
   default:
     break;
   }

--- a/include/coap3/coap_event.h
+++ b/include/coap3/coap_event.h
@@ -24,34 +24,34 @@
  * Scalar type to represent different events, e.g. DTLS events or
  * retransmission timeouts.
  */
- typedef unsigned int coap_event_t;
-
+typedef enum coap_event_t {
 /**
  * (D)TLS events for COAP_PROTO_DTLS and COAP_PROTO_TLS
  */
-#define COAP_EVENT_DTLS_CLOSED        0x0000
-#define COAP_EVENT_DTLS_CONNECTED     0x01DE
-#define COAP_EVENT_DTLS_RENEGOTIATE   0x01DF
-#define COAP_EVENT_DTLS_ERROR         0x0200
+  COAP_EVENT_DTLS_CLOSED       = 0x0000,
+  COAP_EVENT_DTLS_CONNECTED    = 0x01DE,
+  COAP_EVENT_DTLS_RENEGOTIATE  = 0x01DF,
+  COAP_EVENT_DTLS_ERROR        = 0x0200,
 
 /**
  * TCP events for COAP_PROTO_TCP and COAP_PROTO_TLS
  */
-#define COAP_EVENT_TCP_CONNECTED      0x1001
-#define COAP_EVENT_TCP_CLOSED         0x1002
-#define COAP_EVENT_TCP_FAILED         0x1003
+  COAP_EVENT_TCP_CONNECTED     = 0x1001,
+  COAP_EVENT_TCP_CLOSED        = 0x1002,
+  COAP_EVENT_TCP_FAILED        = 0x1003,
 
 /**
  * CSM exchange events for reliable protocols only
  */
-#define COAP_EVENT_SESSION_CONNECTED  0x2001
-#define COAP_EVENT_SESSION_CLOSED     0x2002
-#define COAP_EVENT_SESSION_FAILED     0x2003
+  COAP_EVENT_SESSION_CONNECTED = 0x2001,
+  COAP_EVENT_SESSION_CLOSED    = 0x2002,
+  COAP_EVENT_SESSION_FAILED    = 0x2003,
 
 /**
- * BLOCK2 receive errors
+ * (Q-)BLOCK receive errors
  */
-#define COAP_EVENT_PARTIAL_BLOCK      0x3001
+  COAP_EVENT_PARTIAL_BLOCK     = 0x3001
+} coap_event_t;
 
 /**
  * Type for event handler functions that can be registered with a CoAP


### PR DESCRIPTION
examples/coap-client.c:
examples/coap-server.c:

Explicitly define each enum case to remove complier warnings.

Abstracted out of #611.