### PR TITLE
RFC7959: Handle both client and server initiating requests

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1041,6 +1041,7 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
 #if COAP_CLIENT_SUPPORT
   coap_lg_crcv_t *lg_crcv = NULL;
   coap_opt_iterator_t opt_iter;
+  coap_block_t block = {0, 0, 0};
   int observe_action = -1;
   int have_block1 = 0;
   coap_opt_t *opt;
@@ -1050,8 +1051,6 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
   }
 
   if (COAP_PDU_IS_REQUEST(pdu)) {
-    coap_block_t block;
-
     opt = coap_check_option(pdu, COAP_OPTION_OBSERVE, &opt_iter);
 
     if (opt) {
@@ -1071,18 +1070,25 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
   if (observe_action != -1 || have_block1 ||
       ((pdu->type == COAP_MESSAGE_NON || COAP_PROTO_RELIABLE(session->proto)) &&
        COAP_PDU_IS_REQUEST(pdu) && pdu->code != COAP_REQUEST_CODE_DELETE)) {
+    coap_lg_xmit_t *lg_xmit = NULL;
+
+    if (!session->lg_xmit) {
+      coap_log(LOG_DEBUG, "PDU presented by app\n");
+      coap_show_pdu(LOG_DEBUG, pdu);
+    }
     /* See if this token is already in use for large body responses */
     LL_FOREACH(session->lg_crcv, lg_crcv) {
       if (token_match(pdu->token, pdu->token_length,
                       lg_crcv->app_token->s, lg_crcv->app_token->length)) {
 
         if (observe_action == COAP_OBSERVE_CANCEL) {
+          uint8_t buf[8];
+          size_t len;
+
           /* Need to update token to server's version */
-          coap_update_token(pdu, lg_crcv->base_token_length,
-                            lg_crcv->base_token);
-          memcpy(lg_crcv->token, lg_crcv->base_token,
-                 lg_crcv->base_token_length);
-          lg_crcv->token_length = lg_crcv->base_token_length;
+          len = coap_encode_var_safe8(buf, sizeof(lg_crcv->state_token),
+                                      lg_crcv->state_token);
+          coap_update_token(pdu, len, buf);
           lg_crcv->initial = 1;
           lg_crcv->observe_set = 0;
           /* de-reference lg_crcv as potentially linking in later */
@@ -1097,24 +1103,23 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
       }
     }
 
-    lg_crcv = coap_block_new_lg_crcv(session, pdu);
-    if (lg_crcv == NULL)
-      return COAP_INVALID_MID;
     if (have_block1 && session->lg_xmit) {
-      coap_lg_xmit_t *lg_xmit;
-
       LL_FOREACH(session->lg_xmit, lg_xmit) {
         if (COAP_PDU_IS_REQUEST(&lg_xmit->pdu) &&
             lg_xmit->b.b1.app_token &&
             token_match(pdu->token, pdu->token_length,
                         lg_xmit->b.b1.app_token->s,
                         lg_xmit->b.b1.app_token->length)) {
-          /* Need to update the token as set up in the session->lg_xmit */
-          coap_update_token(pdu, session->lg_xmit->b.b1.token_length,
-                            session->lg_xmit->b.b1.token);
           break;
         }
       }
+    }
+    lg_crcv = coap_block_new_lg_crcv(session, pdu);
+    if (lg_crcv == NULL)
+      return COAP_INVALID_MID;
+    if (lg_xmit) {
+      /* Need to update the token as set up in the session->lg_xmit */
+      lg_xmit->b.b1.state_token = lg_crcv->state_token;
     }
   }
 
@@ -2819,7 +2824,7 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
       h(resource, session, pdu, query, response);
 
       /* Check if lg_xmit generated and update PDU code if so */
-      coap_check_code_lg_xmit(session, response, resource, query);
+      coap_check_code_lg_xmit(session, response, resource, query, pdu->code);
 
 skip_handler:
       respond = no_response(pdu, response, session);
@@ -3040,7 +3045,6 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
       /* We have sent something the receiver disliked, so we remove
        * not only the message id but also the subscriptions we might
        * have. */
-
       is_ping_rst = 0;
       if (pdu->mid == session->last_ping_mid &&
           context->ping_timeout && session->last_ping > 0)

--- a/src/resource.c
+++ b/src/resource.c
@@ -961,7 +961,8 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         coap_show_pdu(LOG_DEBUG, obs->pdu);
         h(r, obs->session, obs->pdu, query, response);
         /* Check if lg_xmit generated and update PDU code if so */
-        coap_check_code_lg_xmit(obs->session, response, r, query);
+        coap_check_code_lg_xmit(obs->session, response, r, query,
+                                obs->pdu->code);
         coap_delete_string(query);
         if (COAP_RESPONSE_CLASS(response->code) != 2) {
           coap_remove_option(response, COAP_OPTION_OBSERVE);


### PR DESCRIPTION
Simplify token handling by having a state token for Block1 requests where the
top 16 bits are an incrementing request counter and the bottom 48 bits are the
base token.

Re-order struct coap_lg_crcv_t to reduce data space usage.

Track request method for Block2 requests.

Make coap_add_data_large_internal() a static function.

Abstracted from PR #611