### PR TITLE
PSK: Make PSK hint / key / identity retrieval simpler

### DIFF
--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -334,6 +334,46 @@ ssize_t coap_tls_read(coap_session_t *coap_session,
                       );
 
 /**
+ * Get the current client's PSK key.
+ *
+ * @param coap_session The CoAP session.
+ *
+ * @return          @c NULL if no key, else a pointer the current key.
+ */
+const coap_bin_const_t *coap_get_session_client_psk_key(
+                                           const coap_session_t *coap_session);
+
+/**
+ * Get the current client's PSK identity.
+ *
+ * @param coap_session The CoAP session.
+ *
+ * @return          @c NULL if no identity, else a pointer the current identity.
+ */
+const coap_bin_const_t *coap_get_session_client_psk_identity(
+                                           const coap_session_t *coap_session);
+
+/**
+ * Get the current server's PSK key.
+ *
+ * @param coap_session The CoAP session.
+ *
+ * @return          @c NULL if no key, else a pointer the current key.
+ */
+const coap_bin_const_t *coap_get_session_server_psk_key(
+                                           const coap_session_t *coap_session);
+
+/**
+ * Get the current server's PSK identity hint.
+ *
+ * @param coap_session The CoAP session.
+ *
+ * @return          @c NULL if no hint, else a pointer the current hint.
+ */
+const coap_bin_const_t *coap_get_session_server_psk_hint(
+                                           const coap_session_t *coap_session);
+
+/**
  * Initialize the underlying (D)TLS Library layer.
  *
  */

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -107,20 +107,6 @@ struct coap_context_t {
 
   ssize_t (*network_read)(coap_socket_t *sock, coap_packet_t *packet);
 
-#if COAP_CLIENT_SUPPORT
-  size_t(*get_client_psk)(const coap_session_t *session, const uint8_t *hint,
-                          size_t hint_len, uint8_t *identity,
-                          size_t *identity_len, size_t max_identity_len,
-                          uint8_t *psk, size_t max_psk_len);
-#endif /* COAP_CLIENT_SUPPORT */
-#if COAP_SERVER_SUPPORT
-  size_t(*get_server_psk)(const coap_session_t *session,
-                          const uint8_t *identity, size_t identity_len,
-                          uint8_t *psk, size_t max_psk_len);
-  size_t(*get_server_hint)(const coap_session_t *session, uint8_t *hint,
-                          size_t max_hint_len);
-#endif /* COAP_SERVER_SUPPORT */
-
   void *dtls_context;
 
 #if COAP_SERVER_SUPPORT

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -186,12 +186,25 @@ int coap_session_refresh_psk_hint(coap_session_t *session,
  *
  * @param session  The current coap_session_t object.
  * @param psk_key  If NULL, the pre-shared key will revert to the
- *                 initial pre-shared key used as session setup.
+ *                 initial pre-shared key used at session setup.
  *
  * @return @c 1 if successful, else @c 0.
  */
 int coap_session_refresh_psk_key(coap_session_t *session,
                                  const coap_bin_const_t *psk_key);
+
+/**
+ * Refresh the session's current pre-shared identity (PSK).
+ * Note: A copy of @p psk_identity is maintained in the session by libcoap.
+ *
+ * @param session  The current coap_session_t object.
+ * @param psk_identity  If NULL, the pre-shared identity will revert to the
+ *                 initial pre-shared key used as session setup.
+ *
+ * @return @c 1 if successful, else @c 0.
+ */
+int coap_session_refresh_psk_identity(coap_session_t *session,
+                                 const coap_bin_const_t *psk_identity);
 
 #if COAP_SERVER_SUPPORT
 /**


### PR DESCRIPTION
Make the retrieval of  PSK hint / key / identity items simpler, remove
duplicate coding, remove a set of memcpy() and handle all these internally 
as coap_bin_const_t.

This removes the need for libcoap internally to allocate (potentially
limited) holding space for these items on the stack.

The respective (D)TLS interface modules then convert these items into
the format required for the underlying (D)TLS libraries.

If the underlying (D)TLS library indicates that there is insufficient
space for an item (defined by a max_len type parameter), then the item
is truncated to that size and a warning issued about the provided item
being too large for the underlying (D)TLS library.

The item access functions are now standalone, not indexed through
coap_context_t.

Addresses #708.