### PR TITLE
DTLS/TLS: Support TLS when DTLS is not enabled

### DIFF
--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -845,30 +845,46 @@ char *coap_string_tls_version(char *buffer, size_t bufsize)
 char *coap_string_tls_support(char *buffer, size_t bufsize)
 {
   coap_tls_version_t *tls_version = coap_get_tls_library_version();
+  const int have_tls = coap_tls_is_supported();
+  const int have_dtls = coap_dtls_is_supported();
 
+  if (have_dtls == 0 && have_tls == 0) {
+    snprintf(buffer, bufsize, "(No DTLS or TLS support)");
+    return buffer;
+  } 
   switch (tls_version->type) {
   case COAP_TLS_LIBRARY_NOTLS:
     snprintf(buffer, bufsize, "(No DTLS or TLS support)");
     break;
   case COAP_TLS_LIBRARY_TINYDTLS:
     snprintf(buffer, bufsize,
-             "(DTLS and no TLS support; PSK and RPK support)");
+             "(%sDTLS and%s TLS support; PSK, no PKI, no PKCS11, and RPK support)",
+             have_dtls ? "" : " no",
+             have_tls ? "" : " no");
     break;
   case COAP_TLS_LIBRARY_OPENSSL:
     snprintf(buffer, bufsize,
-             "(DTLS and TLS support; PSK, PKI, PKCS11 and no RPK support)");
+             "(%sDTLS and%s TLS support; PSK, PKI, PKCS11, and no RPK support)",
+             have_dtls ? "" : " no",
+             have_tls ? "" : " no");
     break;
   case COAP_TLS_LIBRARY_GNUTLS:
     if (tls_version->version >= 0x030606)
       snprintf(buffer, bufsize,
-               "(DTLS and TLS support; PSK, PKI, PKCS11 and RPK support)");
+               "(%sDTLS and%s TLS support; PSK, PKI, PKCS11, and RPK support)",
+               have_dtls ? "" : " no",
+               have_tls ? "" : " no");
     else
       snprintf(buffer, bufsize,
-               "(DTLS and TLS support; PSK, PKI, PKCS11 and no RPK support)");
+               "(%sDTLS and%s TLS support; PSK, PKI, PKCS11, and no RPK support)",
+               have_dtls ? "" : " no",
+               have_tls ? "" : " no");
     break;
   case COAP_TLS_LIBRARY_MBEDTLS:
     snprintf(buffer, bufsize,
-             "(DTLS and no TLS support; PSK, PKI and no RPK support)");
+             "(%sDTLS and%s TLS support; PSK, PKI, no PKCS11, and no RPK support)",
+             have_dtls ? "" : " no",
+             have_tls ? "" : " no");
     break;
   default:
     buffer[0] = '\000';

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -961,7 +961,7 @@ coap_session_t *coap_new_client_session_psk2(
       return NULL;
     }
   }
-  else if (coap_dtls_is_supported()) {
+  else if (coap_dtls_is_supported() || coap_tls_is_supported()) {
     coap_log(LOG_WARNING, "Identity (PSK) not defined\n");
     coap_session_release(session);
     return NULL;
@@ -976,13 +976,13 @@ coap_session_t *coap_new_client_session_psk2(
       return NULL;
     }
   }
-  else if (coap_dtls_is_supported()) {
+  else if (coap_dtls_is_supported() || coap_tls_is_supported()) {
     coap_log(LOG_WARNING, "Pre-shared key (PSK) not defined\n");
     coap_session_release(session);
     return NULL;
   }
 
-  if (coap_dtls_is_supported()) {
+  if (coap_dtls_is_supported() || coap_tls_is_supported()) {
     if (!coap_dtls_context_set_cpsk(ctx, setup_data)) {
       coap_session_release(session);
       return NULL;
@@ -1073,7 +1073,7 @@ coap_session_t *coap_new_client_session_pki(
 ) {
   coap_session_t *session;
 
-  if (coap_dtls_is_supported()) {
+  if (coap_dtls_is_supported() || coap_tls_is_supported()) {
     if (!setup_data) {
       return NULL;
     } else {
@@ -1091,7 +1091,7 @@ coap_session_t *coap_new_client_session_pki(
     return NULL;
   }
 
-  if (coap_dtls_is_supported()) {
+  if (coap_dtls_is_supported() || coap_tls_is_supported()) {
     /* we know that setup_data is not NULL */
     if (!coap_dtls_context_set_pki(ctx, setup_data, COAP_DTLS_ROLE_CLIENT)) {
       coap_session_release(session);

--- a/src/net.c
+++ b/src/net.c
@@ -413,7 +413,7 @@ int coap_context_set_psk2(coap_context_t *ctx,
 
   ctx->spsk_setup_data = *setup_data;
 
-  if (coap_dtls_is_supported()) {
+  if (coap_dtls_is_supported() || coap_tls_is_supported()) {
     return coap_dtls_context_set_spsk(ctx, setup_data);
   }
   return 0;
@@ -428,7 +428,7 @@ int coap_context_set_pki(coap_context_t *ctx,
     coap_log(LOG_ERR, "coap_context_set_pki: Wrong version of setup_data\n");
     return 0;
   }
-  if (coap_dtls_is_supported()) {
+  if (coap_dtls_is_supported() || coap_tls_is_supported()) {
     return coap_dtls_context_set_pki(ctx, setup_data, COAP_DTLS_ROLE_SERVER);
   }
   return 0;
@@ -438,7 +438,7 @@ int coap_context_set_pki_root_cas(coap_context_t *ctx,
   const char *ca_file,
   const char *ca_dir
 ) {
-  if (coap_dtls_is_supported()) {
+  if (coap_dtls_is_supported() || coap_tls_is_supported()) {
     return coap_dtls_context_set_pki_root_cas(ctx, ca_file, ca_dir);
   }
   return 0;
@@ -570,7 +570,7 @@ coap_new_context(
   }
 #endif /* COAP_EPOLL_SUPPORT */
 
-  if (coap_dtls_is_supported()) {
+  if (coap_dtls_is_supported() || coap_tls_is_supported()) {
     c->dtls_context = coap_dtls_new_context(c);
     if (!c->dtls_context) {
       coap_log(LOG_EMERG, "coap_init: no DTLS context available\n");


### PR DESCRIPTION
Add in support for when TLS is enabled, but DTLS is not enabled, specific
to Mbed TLS configurations (ESP-IDF).