### PR TITLE
Large Observes: Prevent server sending new response if active response

### DIFF
--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -91,7 +91,8 @@ struct coap_lg_xmit_t {
   } b;
   coap_pdu_t pdu;        /**< skeletal PDU */
   coap_tick_t last_payload; /**< Last time MAX_PAYLOAD was sent or 0 */
-  coap_tick_t last_used; /**< Last time all data sent or 0 */
+  coap_tick_t last_all_sent; /**< Last time all data sent or 0 */
+  coap_tick_t last_obs; /**< Last time used (Observe tracking) or 0 */
   coap_release_large_data_t release_func; /**< large data de-alloc function */
   void *app_ptr;         /**< applicaton provided ptr for de-alloc function */
 };

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -571,6 +571,27 @@ coap_add_option_internal(coap_pdu_t *pdu, coap_option_num_t number, size_t len,
     case COAP_OPTION_URI_QUERY:
     case COAP_OPTION_LOCATION_QUERY:
       break;
+    /* Protest at the known non-repeatable options and ignore them */
+    case COAP_OPTION_URI_HOST:
+    case COAP_OPTION_IF_NONE_MATCH:
+    case COAP_OPTION_OBSERVE:
+    case COAP_OPTION_URI_PORT:
+    case COAP_OPTION_OSCORE:
+    case COAP_OPTION_CONTENT_FORMAT:
+    case COAP_OPTION_MAXAGE:
+    case COAP_OPTION_HOP_LIMIT:
+    case COAP_OPTION_ACCEPT:
+    case COAP_OPTION_BLOCK2:
+    case COAP_OPTION_BLOCK1:
+    case COAP_OPTION_SIZE2:
+    case COAP_OPTION_PROXY_URI:
+    case COAP_OPTION_PROXY_SCHEME:
+    case COAP_OPTION_SIZE1:
+    case COAP_OPTION_NORESPONSE:
+      coap_log(LOG_INFO,
+               "Option number %d is not defined as repeatable - dropped\n",
+               number);
+      return 0;
     default:
       coap_log(LOG_INFO, "Option number %d is not defined as repeatable\n",
                number);


### PR DESCRIPTION
If the response is large, it can take time to transfer over the body.  If
the server then initiates a new unsolicited response during the existing
transfer, then overflow / retry issues start to occur, compounded if multiple
unsolicited responses are triggerred during an existing transfer.

Hold back the notify of the new unsolicited response(s) until the
existing response has completed (or failed for another reason).

Other code has been tightened up incase the server or client are
not libcoap based and also exhibit this behavior, so to have a better chance
of recovery.

Fixes #758.  #740 may help here as well.