### PR TITLE
handlers: Clarify which handlers are client only, server only or both

### DIFF
--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -472,9 +472,9 @@ hnd_post_rd(coap_resource_t *resource COAP_UNUSED,
   resource_val.s = loc;
   resource_val.length = loc_size;
   r = coap_resource_init(&resource_val, 0);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_resource);
-  coap_register_handler(r, COAP_REQUEST_PUT, hnd_put_resource);
-  coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_resource);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_resource);
+  coap_register_request_handler(r, COAP_REQUEST_PUT, hnd_put_resource);
+  coap_register_request_handler(r, COAP_REQUEST_DELETE, hnd_delete_resource);
 
   if (ins.s) {
     buf = (unsigned char *)coap_malloc(ins.length + 2);
@@ -552,8 +552,8 @@ init_resources(coap_context_t *ctx) {
   coap_resource_t *r;
 
   r = coap_resource_init(coap_make_str_const(RD_ROOT_STR), 0);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_rd);
-  coap_register_handler(r, COAP_REQUEST_POST, hnd_post_rd);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_rd);
+  coap_register_request_handler(r, COAP_REQUEST_POST, hnd_post_rd);
 
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("40"), 0);
   coap_add_attr(r, coap_make_str_const("rt"), coap_make_str_const("\"core.rd\""), 0);

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1566,11 +1566,11 @@ hnd_unknown_put(coap_resource_t *resource COAP_UNUSED,
   r = coap_resource_init((coap_str_const_t*)uri_path,
         COAP_RESOURCE_FLAGS_RELEASE_URI | resource_flags);
   coap_add_attr(r, coap_make_str_const("title"), coap_make_str_const("\"Dynamic\""), 0);
-  coap_register_handler(r, COAP_REQUEST_PUT, hnd_put);
-  coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete);
+  coap_register_request_handler(r, COAP_REQUEST_PUT, hnd_put);
+  coap_register_request_handler(r, COAP_REQUEST_DELETE, hnd_delete);
   /* We possibly want to Observe the GETs */
   coap_resource_set_get_observable(r, 1);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get);
   coap_add_resource(coap_session_get_context(session), r);
 
   /* Do the PUT for this first call */
@@ -1753,7 +1753,7 @@ init_resources(coap_context_t *ctx) {
   coap_resource_t *r;
 
   r = coap_resource_init(NULL, 0);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_index);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_index);
 
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
   coap_add_attr(r, coap_make_str_const("title"), coap_make_str_const("\"General Info\""), 0);
@@ -1763,10 +1763,10 @@ init_resources(coap_context_t *ctx) {
   my_clock_base = clock_offset;
 
   r = coap_resource_init(coap_make_str_const("time"), resource_flags);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_fetch_time);
-  coap_register_handler(r, COAP_REQUEST_FETCH, hnd_get_fetch_time);
-  coap_register_handler(r, COAP_REQUEST_PUT, hnd_put_time);
-  coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_time);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_fetch_time);
+  coap_register_request_handler(r, COAP_REQUEST_FETCH, hnd_get_fetch_time);
+  coap_register_request_handler(r, COAP_REQUEST_PUT, hnd_put_time);
+  coap_register_request_handler(r, COAP_REQUEST_DELETE, hnd_delete_time);
   coap_resource_set_get_observable(r, 1);
 
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
@@ -1785,15 +1785,15 @@ init_resources(coap_context_t *ctx) {
 
   if (coap_async_is_supported()) {
     r = coap_resource_init(coap_make_str_const("async"), 0);
-    coap_register_handler(r, COAP_REQUEST_GET, hnd_get_async);
+    coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_async);
 
     coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
     coap_add_resource(ctx, r);
   }
 
   r = coap_resource_init(coap_make_str_const("example_data"), 0);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_example_data);
-  coap_register_handler(r, COAP_REQUEST_PUT, hnd_put_example_data);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_example_data);
+  coap_register_request_handler(r, COAP_REQUEST_PUT, hnd_put_example_data);
   coap_resource_set_get_observable(r, 1);
 
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -194,8 +194,8 @@ hnd_post_test(coap_resource_t *resource COAP_UNUSED,
     memcpy(test_payload->data, data, len);
 
     r = coap_resource_init(uri, COAP_RESOURCE_FLAGS_RELEASE_URI);
-    coap_register_handler(r, COAP_REQUEST_GET, hnd_get_resource);
-    coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_resource);
+    coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_resource);
+    coap_register_request_handler(r, COAP_REQUEST_DELETE, hnd_delete_resource);
 
     /* set media_type if available */
     option = coap_check_option(request, COAP_OPTION_CONTENT_TYPE, &opt_iter);
@@ -445,10 +445,10 @@ init_resources(coap_context_t *ctx) {
     /* test_payload->media_type is 0 anyway */
 
     r = coap_resource_init(coap_make_str_const("test"), 0);
-    coap_register_handler(r, COAP_REQUEST_GET, hnd_get_resource);
-    coap_register_handler(r, COAP_REQUEST_POST, hnd_post_test);
-    coap_register_handler(r, COAP_REQUEST_PUT, hnd_put_test);
-    coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_test);
+    coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_resource);
+    coap_register_request_handler(r, COAP_REQUEST_POST, hnd_post_test);
+    coap_register_request_handler(r, COAP_REQUEST_PUT, hnd_put_test);
+    coap_register_request_handler(r, COAP_REQUEST_DELETE, hnd_delete_test);
 
     coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
     coap_add_attr(r, coap_make_str_const("rt"), coap_make_str_const("test"), 0);
@@ -468,7 +468,7 @@ init_resources(coap_context_t *ctx) {
     coap_log(LOG_CRIT, "cannot allocate resource /large\n");
   else {
     r = coap_resource_init(coap_make_str_const("large"), 0);
-    coap_register_handler(r, COAP_REQUEST_GET, hnd_get_resource);
+    coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_resource);
 
     coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("41"), 0);
     coap_add_attr(r, coap_make_str_const("rt"), coap_make_str_const("large"), 0);
@@ -489,7 +489,7 @@ init_resources(coap_context_t *ctx) {
     /* test_payload->media_type is 0 anyway */
 
     r = coap_resource_init(coap_make_str_const("seg1/seg2/seg3"), 0);
-    coap_register_handler(r, COAP_REQUEST_GET, hnd_get_resource);
+    coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_resource);
 
     coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
     coap_add_resource(ctx, r);
@@ -499,14 +499,14 @@ init_resources(coap_context_t *ctx) {
 
   /* For TD_COAP_CORE_13 */
   r = coap_resource_init(coap_make_str_const("query"), 0);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_query);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_query);
 
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
   coap_add_resource(ctx, r);
 
   /* For TD_COAP_CORE_16 */
   r = coap_resource_init(coap_make_str_const("separate"), 0);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_separate);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_separate);
 
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
   coap_add_attr(r, coap_make_str_const("rt"), coap_make_str_const("seperate"), 0);

--- a/include/coap3/resource.h
+++ b/include/coap3/resource.h
@@ -247,14 +247,26 @@ void coap_add_resource(coap_context_t *context, coap_resource_t *resource);
 int coap_delete_resource(coap_context_t *context, coap_resource_t *resource);
 
 /**
- * Registers the specified @p handler as message handler for the request type @p
- * method
+ * Registers the specified @p handler as message handler for the request type
+ * @p method
  *
  * @param resource The resource for which the handler shall be registered.
  * @param method   The CoAP request method to handle.
  * @param handler  The handler to register with @p resource.
  */
 void coap_register_handler(coap_resource_t *resource,
+                           coap_request_t method,
+                           coap_method_handler_t handler);
+
+/**
+ * Registers the specified @p handler as message handler for the request type
+ * @p method
+ *
+ * @param resource The resource for which the handler shall be registered.
+ * @param method   The CoAP request method to handle.
+ * @param handler  The handler to register with @p resource.
+ */
+void coap_register_request_handler(coap_resource_t *resource,
                            coap_request_t method,
                            coap_method_handler_t handler);
 

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -158,6 +158,7 @@ global:
   coap_register_option;
   coap_register_ping_handler;
   coap_register_pong_handler;
+  coap_register_request_handler;
   coap_register_response_handler;
   coap_resize_binary;
   coap_resource_get_uri_path;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -156,6 +156,7 @@ coap_register_nack_handler
 coap_register_option
 coap_register_ping_handler
 coap_register_pong_handler
+coap_register_request_handler
 coap_register_response_handler
 coap_resize_binary
 coap_resource_get_uri_path

--- a/man/coap_attribute.txt.in
+++ b/man/coap_attribute.txt.in
@@ -101,7 +101,7 @@ init_resources(coap_context_t *ctx) {
 
   /* Create a resource to return general information */
   r = coap_resource_init(NULL, 0);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_index);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_index);
 
   /* Document resource for '.well-known/core' request */
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
@@ -114,9 +114,9 @@ init_resources(coap_context_t *ctx) {
   r = coap_resource_init(coap_make_str_const("time"),
                          COAP_RESOURCE_FLAGS_NOTIFY_CON);
   coap_resource_set_get_observable(r, 1);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_time);
-  coap_register_handler(r, COAP_REQUEST_PUT, hnd_put_time);
-  coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_time);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_time);
+  coap_register_request_handler(r, COAP_REQUEST_PUT, hnd_put_time);
+  coap_register_request_handler(r, COAP_REQUEST_DELETE, hnd_delete_time);
 
   /* Document resource for 'time' request */
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -437,7 +437,7 @@ int main(int argc, char *argv[]) {
   r = coap_resource_init(coap_make_str_const("time"),
                          COAP_RESOURCE_FLAGS_NOTIFY_CON);
   coap_resource_set_get_observable(r, 1);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_time);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_time);
 
   /* Document resource for 'time' request */
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -11,7 +11,7 @@ coap_handler(3)
 NAME
 ----
 coap_handler,
-coap_register_handler,
+coap_register_request_handler,
 coap_register_response_handler,
 coap_register_nack_handler,
 coap_register_ping_handler,
@@ -23,8 +23,8 @@ SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
 
-*void coap_register_handler(coap_resource_t *_resource_, coap_request_t
-_method_, coap_method_handler_t _handler_);*
+*void coap_register_request_handler(coap_resource_t *_resource_,
+coap_request_t _method_, coap_method_handler_t _handler_);*
 
 *void coap_register_response_handler(coap_context_t *_context_,
 coap_response_handler_t _handler_)*;
@@ -50,9 +50,10 @@ or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
 DESCRIPTION
 -----------
 
-The *coap_register_handler*() function registers a callback handler _handler_
-that is called when there is a URI match against the _resource_ and there is
-a _method_ (e.g. PUT, POST etc.) match. _method_ can be one of the following.
+The *coap_register_request_handler*() is a server side function that registers
+a callback handler _handler_ that is called when there is an incoming request
+PDU and there is a URI match against the _resource_ and there is a _method_
+(e.g. PUT, POST etc.) match. _method_ can be one of the following.
 ----
 COAP_REQUEST_GET
 COAP_REQUEST_POST
@@ -73,21 +74,30 @@ typedef void (*coap_method_handler_t)(coap_resource_t *resource,
                                       coap_pdu_t *response_pdu);
 ----
 
-*NOTE:* _incoming_pdu_ will be NULL for the GET Handler if this is an
-internally generated Observe Response.  *coap_resource_get_uri_path*()
-can be used to determine the URI in this case.
+In _handler_, data from _incoming_pdu_ can be abstracted as described in
+*coap_pdu_access*(3) for analysis and then updates _response_pdu_ as
+appropriate as described in *coap_pdu_setup*(3).  _response_pdu_ is already
+pre-populated with the _incoming_pdu_'s token and the PDU type.  If this
+handler is called as a result of an unsolicited Observe trigger, then the
+option OBSERVE (and potentially option BLOCK2) are also added in.  The
+ _response_pdu_'s response code should always be updated.
 
 *NOTE:* Any data associated with _incoming_pdu_ is no longer be available after
-exiting this function as _incoming_pdu_ is deleted, unless *coap_add_data*()
-was used to update _response_pdu_ where a copy of the data is taken.  In
-particular _incoming_pdu_'s data must not be used if calling
-*coap_add_data_large_response*().
+exiting this function as _incoming_pdu_ is deleted.  In particular
+_incoming_pdu_'s data must not be used if calling
+*coap_add_data_large_response*(). However, it is safe to use the data if
+*coap_add_data*() is used to update _response_pdu_ where a copy of the data is
+taken.
 
-The *coap_register_response_handler*() function defines a request's response
-_handler_ for traffic associated with the _context_.  The application can use
-this for handling any response packets, including sending a RST packet if this
-response was unexpected.  If _handler_ is NULL, then the handler is
-de-registered.
+*NOTE:* A request callback handler can be called with a generic resource (i.e.
+set up using *coap_resource_unknown_init*(3)), so
+*coap_resource_get_uri_path*(3) can be used to determine the URI in this case.
+
+The *coap_register_response_handler*() is a client side function that registers
+a request's response callback _handler_ for traffic associated with the
+_context_.  The application can use this for handling any response packets,
+including sending a RST packet if this response was unexpected.  If _handler_
+is NULL, then the handler is de-registered.
 
 The response handler function prototype is defined as:
 [source, c]
@@ -103,18 +113,21 @@ typedef coap_response_t (*coap_response_handler_t)(coap_session_t *session,
                                                    const coap_mid_t id);
 ----
 
+In _handler_, data from _received_ (and optionally _sent_ if set) can be
+abstracted as described in *coap_pdu_access*(3) for analysis.
+
 *NOTE:* _sent_ will only be non NULL when the request PDU is Confirmable and
 this is an ACK or RST response to the request.  In general, matching of
-Requests and Responses whould be done by generating unique Tokens for each Request
-and then matching up based on the Token in _received_ Response.
+Requests and Responses whould be done by generating unique Tokens for each
+Request and then matching up based on the Token in _received_ Response.
 
-*NOTE:* If the returned value is COAP_RESPONSE_FAIL, then a CoAP RST packet will get
-sent to the server by libcoap.  The returned value of COAP_RESPONSE_OK indicates
-that all is OK.
+*NOTE:* If the returned value is COAP_RESPONSE_FAIL, then a CoAP RST packet
+will get sent to the server by libcoap.  The returned value of COAP_RESPONSE_OK
+indicates that all is OK.
 
-The *coap_register_nack_handler*() function defines a request's negative
-response _handler_ for traffic associated with the _context_.
-If _handler_ is NULL, then the handler is de-registered.
+The *coap_register_nack_handler*() is a client side function that registers a
+request's negative response callback _handler_ for traffic associated with the
+_context_.  If _handler_ is NULL, then the handler is de-registered.
 
 The nack handler function prototype is defined as:
 [source, c]
@@ -124,7 +137,7 @@ typedef void (*coap_nack_handler_t)(coap_session_t *session,
                                     const coap_nack_reason_t reason,
                                     const coap_mid_t mid);
 ----
-NACKs can be one of the following
+NACK _reason_ can be one of the following
 ----
 COAP_NACK_TOO_MANY_RETRIES
 COAP_NACK_NOT_DELIVERABLE
@@ -133,9 +146,13 @@ COAP_NACK_TLS_FAILED
 COAP_NACK_ICMP_ISSUE
 ----
 
-The *coap_register_ping_handler*() function defines a _handler_ for tracking
-receipt of CoAP ping traffic associated with the _context_. If _handler_ is
-NULL, then the handler is de-registered.
+_sent_ can be NULL.  _mid_ can be used for determing which is the transmitting
+request.
+
+The *coap_register_ping_handler*() function registers a callback _handler_ for
+tracking receipt of CoAP ping traffic associated with the _context_. If
+_handler_ is NULL, then the handler is de-registered. It can be used both
+client and server side.
 
 The ping handler function prototype is defined as:
 [source, c]
@@ -145,9 +162,10 @@ typedef void (*coap_ping_handler_t)(coap_session_t *session,
                                     const coap_mid_t mid);
 ----
 
-The *coap_register_pong_handler*() function defines a _handler_ for tracking
-receipt of CoAP ping response traffic associated with the _context_.
-If _handler_ is NULL, then the handler is de-registered.
+The *coap_register_pong_handler*() function registers a callback _handler_ for
+tracking receipt of CoAP ping response traffic associated with the _context_.
+If _handler_ is NULL, then the handler is de-registered. It can be used both
+client and server side.
 
 The pong handler function prototype is defined as:
 [source, c]
@@ -157,9 +175,10 @@ typedef void (*coap_pong_handler_t)(coap_session_t *session,
                                     const coap_mid_t mid);
 ----
 
-The *coap_register_event_handler*() function defines a _handler_ for tracking
-(D)TLS events associated with the _context_. If _handler_ is NULL, then
-the handler is de-registered.
+The *coap_register_event_handler*() function registers a callback _handler_
+for tracking network events associated with the _context_. If _handler_ is
+NULL, then the handler is de-registered. It can be used both client and server
+side.
 
 The event handler function prototype is defined as:
 [source, c]
@@ -300,7 +319,8 @@ coap_pdu_t *sent, coap_pdu_t *received, const coap_mid_t mid) {
 
 SEE ALSO
 --------
-*coap_block*(3), *coap_observe*(3) and *coap_resource*(3)
+*coap_block*(3), *coap_observe*(3), *coap_pdu_access*(3), *coap_pdu_setup*(3)
+and *coap_resource*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -228,7 +228,7 @@ init_resources(coap_context_t *ctx)
                          COAP_RESOURCE_FLAGS_NOTIFY_CON);
 
   /* We are using a generic GET handler here */
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_generic);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_generic);
 
   coap_resource_set_get_observable(r, 1);
 

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -273,7 +273,7 @@ init_resources(coap_context_t *ctx) {
 
   /* Create a resource to return general information */
   r = coap_resource_init(NULL, 0);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_index);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_index);
 
   /* Document resource for '.well-known/core' request */
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
@@ -286,9 +286,9 @@ init_resources(coap_context_t *ctx) {
   r = coap_resource_init(coap_make_str_const("time"),
                          COAP_RESOURCE_FLAGS_NOTIFY_CON);
   coap_resource_set_get_observable(r, 1);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_time);
-  coap_register_handler(r, COAP_REQUEST_PUT, hnd_put_time);
-  coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_time);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_time);
+  coap_register_request_handler(r, COAP_REQUEST_PUT, hnd_put_time);
+  coap_register_request_handler(r, COAP_REQUEST_DELETE, hnd_delete_time);
 
   /* Document resource for 'time' request */
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
@@ -439,11 +439,11 @@ const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
    */
   r = coap_resource_init((coap_str_const_t*)uri_path,
         COAP_RESOURCE_FLAGS_RELEASE_URI | COAP_RESOURCE_FLAGS_NOTIFY_NON);
-  coap_register_handler(r, COAP_REQUEST_PUT, hnd_put);
-  coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete);
+  coap_register_request_handler(r, COAP_REQUEST_PUT, hnd_put);
+  coap_register_request_handler(r, COAP_REQUEST_DELETE, hnd_delete);
   /* We possibly want to Observe the GETs */
   coap_resource_set_get_observable(r, 1);
-  coap_register_handler(r, COAP_REQUEST_GET, hnd_get);
+  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get);
   coap_add_resource(coap_session_get_context(session), r);
 
   /* Do the PUT for this first call */
@@ -464,9 +464,9 @@ init_resources(coap_context_t *ctx) {
   r = coap_resource_unknown_init(hnd_unknown_put);
   /*
    * Additional handlers can be added - for example
-   *  coap_register_handler(r, COAP_REQUEST_POST, hnd_post_unknown);
-   *  coap_register_handler(r, COAP_REQUEST_GET, hnd_get_unknown);
-   *  coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_unknown);
+   *  coap_register_request_handler(r, COAP_REQUEST_POST, hnd_post_unknown);
+   *  coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_unknown);
+   *  coap_register_request_handler(r, COAP_REQUEST_DELETE, hnd_delete_unknown);
    */
   coap_add_resource(ctx, r);
 

--- a/src/net.c
+++ b/src/net.c
@@ -2685,9 +2685,12 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
        * defined for it
        * Example set up code:-
        *   r = coap_resource_unknown_init(hnd_put_unknown);
-       *   coap_register_handler(r, COAP_REQUEST_POST, hnd_post_unknown);
-       *   coap_register_handler(r, COAP_REQUEST_GET, hnd_get_unknown);
-       *   coap_register_handler(r, COAP_REQUEST_DELETE, hnd_delete_unknown);
+       *   coap_register_request_handler(r, COAP_REQUEST_POST,
+       *                                 hnd_post_unknown);
+       *   coap_register_request_handler(r, COAP_REQUEST_GET,
+       *                                 hnd_get_unknown);
+       *   coap_register_request_handler(r, COAP_REQUEST_DELETE,
+       *                                 hnd_delete_unknown);
        *   coap_add_resource(ctx, r);
        *
        * Note: It is not possible to observe the unknown_resource, a separate

--- a/src/resource.c
+++ b/src/resource.c
@@ -684,8 +684,16 @@ void
 coap_register_handler(coap_resource_t *resource,
                       coap_request_t method,
                       coap_method_handler_t handler) {
+  coap_register_request_handler(resource, method, handler);
+}
+
+void
+coap_register_request_handler(coap_resource_t *resource,
+                              coap_request_t method,
+                              coap_method_handler_t handler) {
   assert(resource);
-  assert(method > 0 && (size_t)(method-1) < sizeof(resource->handler)/sizeof(coap_method_handler_t));
+  assert(method > 0 && (size_t)(method-1) <
+                       sizeof(resource->handler)/sizeof(coap_method_handler_t));
   resource->handler[method-1] = handler;
 }
 


### PR DESCRIPTION
Add in additional handler coap_register_request_handler() in addition to
coap_register_handler() but now only refer to and use
coap_register_request_handler() to aid readability.