### PR TITLE
coap_io_prepare_io: Re-order function code for correctly updating sockets[]

### DIFF
--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -228,8 +228,10 @@ coap_tick_t coap_dtls_get_timeout(coap_session_t *coap_session,
  * Handle a DTLS timeout expiration.
  *
  * @param coap_session The CoAP session.
+ *
+ * @return @c 1 timed out or @c 0 still timing out
  */
-void coap_dtls_handle_timeout(coap_session_t *coap_session);
+int coap_dtls_handle_timeout(coap_session_t *coap_session);
 
 /**
  * Handling incoming data from a DTLS peer.

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -17,7 +17,8 @@ coap_context_get_coap_fd,
 coap_io_prepare_io,
 coap_io_do_io,
 coap_io_prepare_epoll,
-coap_io_do_epoll
+coap_io_do_epoll,
+coap_io_can_exit
 - Work with CoAP I/O to do the packet send and receives
 
 SYNOPSIS

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -2,7 +2,7 @@
  * coap_gnutls.c -- GnuTLS Datagram Transport Layer Support for libcoap
  *
  * Copyright (C) 2017 Dag Bjorklund <dag.bjorklund@comsel.fi>
- * Copyright (C) 2018-2021 Jon Shallow <supjps-libcoap@jpshallow.com>
+ * Copyright (C) 2018-2022 Jon Shallow <supjps-libcoap@jpshallow.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -2374,7 +2374,12 @@ coap_tick_t coap_dtls_get_timeout(coap_session_t *c_session, coap_tick_t now) {
   return 0;
 }
 
-void coap_dtls_handle_timeout(coap_session_t *c_session) {
+/*
+ * return 1 timed out
+ *        0 still timing out
+ */
+int
+coap_dtls_handle_timeout(coap_session_t *c_session) {
   coap_gnutls_env_t *g_env = (coap_gnutls_env_t *)c_session->tls;
 
   assert(g_env != NULL && c_session->state == COAP_SESSION_STATE_HANDSHAKE);
@@ -2384,9 +2389,11 @@ void coap_dtls_handle_timeout(coap_session_t *c_session) {
     /* Too many retries */
     g_env->doing_dtls_timeout = 0;
     coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
+    return 1;
   }
   else {
     g_env->doing_dtls_timeout = 0;
+    return 0;
   }
 }
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -832,10 +832,15 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
       if (errno == ECONNREFUSED) {
 #endif
         /* client-side ICMP destination unreachable, ignore it */
-        coap_log(LOG_WARNING, "coap_network_read: unreachable\n");
+        coap_log(LOG_WARNING, "** %s: coap_network_read: unreachable\n",
+                               sock->session ?
+                                  coap_session_str(sock->session) : "");
         return -2;
       }
-      coap_log(LOG_WARNING, "coap_network_read: %s\n", coap_socket_strerror());
+      coap_log(LOG_WARNING, "** %s: coap_network_read: %s\n",
+                             sock->session ?
+                                coap_session_str(sock->session) : "",
+                             coap_socket_strerror());
       goto error;
     } else if (len > 0) {
       packet->length = (size_t)len;
@@ -1122,6 +1127,7 @@ coap_io_prepare_io(coap_context_t *ctx,
   coap_session_t *s, *rtmp;
   coap_tick_t timeout = 0;
   coap_tick_t s_timeout;
+  int check_dtls_timeouts = 0;
 #ifdef COAP_EPOLL_SUPPORT
   (void)sockets;
   (void)max_sockets;
@@ -1139,6 +1145,33 @@ coap_io_prepare_io(coap_context_t *ctx,
   timeout = coap_check_async(ctx, now);
 #endif /* WITHOUT_ASYNC */
 
+  /* Check to see if we need to send off any retransmit request */
+  nextpdu = coap_peek_next(ctx);
+  while (nextpdu && now >= ctx->sendqueue_basetime &&
+         nextpdu->t <= now - ctx->sendqueue_basetime) {
+    coap_retransmit(ctx, coap_pop_next(ctx));
+    nextpdu = coap_peek_next(ctx);
+  }
+  if (nextpdu && (timeout == 0 ||
+      nextpdu->t - (now - ctx->sendqueue_basetime) < timeout))
+    timeout = nextpdu->t - (now - ctx->sendqueue_basetime);
+
+  /* Check for DTLS timeouts */
+  if (ctx->dtls_context) {
+    if (coap_dtls_is_context_timeout()) {
+      coap_tick_t tls_timeout = coap_dtls_get_context_timeout(ctx->dtls_context);
+      if (tls_timeout > 0) {
+        if (tls_timeout < now + COAP_TICKS_PER_SECOND / 10)
+          tls_timeout = now + COAP_TICKS_PER_SECOND / 10;
+        coap_log(LOG_DEBUG, "** DTLS global timeout set to %dms\n",
+                 (int)((tls_timeout - now) * 1000 / COAP_TICKS_PER_SECOND));
+        if (timeout == 0 || tls_timeout - now < timeout)
+          timeout = tls_timeout - now;
+      }
+    } else {
+      check_dtls_timeouts = 1;
+    }
+  }
 #if COAP_SERVER_SUPPORT
   coap_endpoint_t *ep;
   coap_tick_t session_timeout;
@@ -1156,6 +1189,7 @@ coap_io_prepare_io(coap_context_t *ctx,
     }
 #endif /* ! COAP_EPOLL_SUPPORT */
     SESSIONS_ITER_SAFE(ep->sessions, s, rtmp) {
+      /* Check whether any idle server sessions should be released */
       if (s->type == COAP_SESSION_TYPE_SERVER && s->ref == 0 &&
           s->delayqueue == NULL &&
           (s->last_rx_tx + session_timeout <= now ||
@@ -1163,10 +1197,33 @@ coap_io_prepare_io(coap_context_t *ctx,
         coap_handle_event(ctx, COAP_EVENT_SERVER_SESSION_DEL, s);
         coap_session_free(s);
       } else {
-        if (s->type == COAP_SESSION_TYPE_SERVER && s->ref == 0 && s->delayqueue == NULL) {
+        if (s->type == COAP_SESSION_TYPE_SERVER && s->ref == 0 &&
+            s->delayqueue == NULL) {
           s_timeout = (s->last_rx_tx + session_timeout) - now;
           if (timeout == 0 || s_timeout < timeout)
             timeout = s_timeout;
+        }
+        /* Make sure the session object is not deleted in any callbacks */
+        coap_session_reference(s);
+        /* Check any DTLS timeouts and expire if appropriate */
+        if (check_dtls_timeouts && s->state == COAP_SESSION_STATE_HANDSHAKE &&
+            s->proto == COAP_PROTO_DTLS && s->tls) {
+          coap_tick_t tls_timeout = coap_dtls_get_timeout(s, now);
+          while (tls_timeout > 0 && tls_timeout <= now) {
+            coap_log(LOG_DEBUG, "** %s: DTLS retransmit timeout\n",
+                     coap_session_str(s));
+            if (coap_dtls_handle_timeout(s))
+              goto release_1;
+
+            if (s->tls)
+              tls_timeout = coap_dtls_get_timeout(s, now);
+            else {
+              tls_timeout = 0;
+              timeout = 1;
+            }
+          }
+          if (tls_timeout > 0 && (timeout == 0 || tls_timeout - now < timeout))
+            timeout = tls_timeout - now;
         }
         /* Check if any server large receives have timed out */
         if (s->lg_srcv) {
@@ -1181,25 +1238,25 @@ coap_io_prepare_io(coap_context_t *ctx,
             timeout = s_timeout;
         }
 #ifndef COAP_EPOLL_SUPPORT
-        if (s->sock.flags & (COAP_SOCKET_WANT_READ | COAP_SOCKET_WANT_WRITE)) {
+        if (s->sock.flags & (COAP_SOCKET_WANT_READ|COAP_SOCKET_WANT_WRITE)) {
           if (*num_sockets < max_sockets)
             sockets[(*num_sockets)++] = &s->sock;
         }
 #endif /* ! COAP_EPOLL_SUPPORT */
+release_1:
+        coap_session_release(s);
       }
     }
   }
 #endif /* COAP_SERVER_SUPPORT */
 #if COAP_CLIENT_SUPPORT
   SESSIONS_ITER_SAFE(ctx->sessions, s, rtmp) {
-    if (!COAP_DISABLE_TCP
-     && s->type == COAP_SESSION_TYPE_CLIENT
-     && s->state == COAP_SESSION_STATE_ESTABLISHED
-     && ctx->ping_timeout > 0
-    ) {
+    if (s->type == COAP_SESSION_TYPE_CLIENT &&
+        s->state == COAP_SESSION_STATE_ESTABLISHED &&
+        ctx->ping_timeout > 0) {
       if (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND <= now) {
-        if ((s->last_ping > 0 && s->last_pong < s->last_ping)
-          || ((s->last_ping_mid = coap_session_send_ping(s)) == COAP_INVALID_MID))
+        if ((s->last_ping > 0 && s->last_pong < s->last_ping) ||
+            ((s->last_ping_mid = coap_session_send_ping(s)) == COAP_INVALID_MID))
         {
           /* Make sure the session object is not deleted in the callback */
           coap_session_reference(s);
@@ -1215,12 +1272,9 @@ coap_io_prepare_io(coap_context_t *ctx,
         timeout = s_timeout;
     }
 
-    if (!COAP_DISABLE_TCP
-     && s->type == COAP_SESSION_TYPE_CLIENT
-     && COAP_PROTO_RELIABLE(s->proto)
-     && s->state == COAP_SESSION_STATE_CSM
-     && ctx->csm_timeout > 0
-    ) {
+#if !COAP_DISABLE_TCP
+    if (s->type == COAP_SESSION_TYPE_CLIENT && COAP_PROTO_RELIABLE(s->proto) &&
+        s->state == COAP_SESSION_STATE_CSM && ctx->csm_timeout > 0) {
       if (s->csm_tx == 0) {
         s->csm_tx = now;
       } else if (s->csm_tx + ctx->csm_timeout * COAP_TICKS_PER_SECOND <= now) {
@@ -1234,6 +1288,29 @@ coap_io_prepare_io(coap_context_t *ctx,
       if (timeout == 0 || s_timeout < timeout)
         timeout = s_timeout;
     }
+#endif /* !COAP_DISABLE_TCP */
+
+    /* Make sure the session object is not deleted in any callbacks */
+    coap_session_reference(s);
+    /* Check any DTLS timeouts and expire if appropriate */
+    if (s->state == COAP_SESSION_STATE_HANDSHAKE &&
+        s->proto == COAP_PROTO_DTLS && s->tls) {
+      coap_tick_t tls_timeout = coap_dtls_get_timeout(s, now);
+      while (tls_timeout > 0 && tls_timeout <= now) {
+        coap_log(LOG_DEBUG, "** %s: DTLS retransmit timeout\n", coap_session_str(s));
+        if (coap_dtls_handle_timeout(s))
+          goto release_2;
+
+        if (s->tls)
+          tls_timeout = coap_dtls_get_timeout(s, now);
+        else {
+          tls_timeout = 0;
+          timeout = 1;
+        }
+      }
+      if (tls_timeout > 0 && (timeout == 0 || tls_timeout - now < timeout))
+        timeout = tls_timeout - now;
+    }
 
     /* Check if any client large receives have timed out */
     if (s->lg_crcv) {
@@ -1243,89 +1320,18 @@ coap_io_prepare_io(coap_context_t *ctx,
     }
 
 #ifndef COAP_EPOLL_SUPPORT
-    if (s->sock.flags & (COAP_SOCKET_WANT_READ | COAP_SOCKET_WANT_WRITE | COAP_SOCKET_WANT_CONNECT)) {
+    assert(s->ref > 1);
+    if (s->sock.flags & (COAP_SOCKET_WANT_READ |
+                         COAP_SOCKET_WANT_WRITE |
+                         COAP_SOCKET_WANT_CONNECT)) {
       if (*num_sockets < max_sockets)
         sockets[(*num_sockets)++] = &s->sock;
     }
 #endif /* ! COAP_EPOLL_SUPPORT */
+release_2:
+    coap_session_release(s);
   }
 #endif /* COAP_CLIENT_SUPPORT */
-
-  nextpdu = coap_peek_next(ctx);
-
-  while (nextpdu && now >= ctx->sendqueue_basetime && nextpdu->t <= now - ctx->sendqueue_basetime) {
-    coap_retransmit(ctx, coap_pop_next(ctx));
-    nextpdu = coap_peek_next(ctx);
-  }
-
-  if (nextpdu && (timeout == 0 || nextpdu->t - ( now - ctx->sendqueue_basetime ) < timeout))
-    timeout = nextpdu->t - (now - ctx->sendqueue_basetime);
-
-  if (ctx->dtls_context) {
-    if (coap_dtls_is_context_timeout()) {
-      coap_tick_t tls_timeout = coap_dtls_get_context_timeout(ctx->dtls_context);
-      if (tls_timeout > 0) {
-        if (tls_timeout < now + COAP_TICKS_PER_SECOND / 10)
-          tls_timeout = now + COAP_TICKS_PER_SECOND / 10;
-        coap_log(LOG_DEBUG, "** DTLS global timeout set to %dms\n",
-                 (int)((tls_timeout - now) * 1000 / COAP_TICKS_PER_SECOND));
-        if (timeout == 0 || tls_timeout - now < timeout)
-          timeout = tls_timeout - now;
-      }
-    } else {
-#if COAP_SERVER_SUPPORT
-      LL_FOREACH(ctx->endpoint, ep) {
-        if (ep->proto == COAP_PROTO_DTLS) {
-          SESSIONS_ITER(ep->sessions, s, rtmp) {
-            if (s->state == COAP_SESSION_STATE_HANDSHAKE &&
-                s->proto == COAP_PROTO_DTLS && s->tls) {
-              coap_tick_t tls_timeout = coap_dtls_get_timeout(s, now);
-              while (tls_timeout > 0 && tls_timeout <= now) {
-                coap_log(LOG_DEBUG, "** %s: DTLS retransmit timeout\n",
-                         coap_session_str(s));
-                /* Make sure the session object is not deleted in any callbacks */
-                coap_session_reference(s);
-                coap_dtls_handle_timeout(s);
-                if (s->tls)
-                  tls_timeout = coap_dtls_get_timeout(s, now);
-                else {
-                  tls_timeout = 0;
-                  timeout = 1;
-                }
-                coap_session_release(s);
-              }
-              if (tls_timeout > 0 && (timeout == 0 || tls_timeout - now < timeout))
-                timeout = tls_timeout - now;
-            }
-          }
-        }
-      }
-#endif /* COAP_SERVER_SUPPORT */
-#if COAP_CLIENT_SUPPORT
-      SESSIONS_ITER(ctx->sessions, s, rtmp) {
-        if (s->state == COAP_SESSION_STATE_HANDSHAKE &&
-            s->proto == COAP_PROTO_DTLS && s->tls) {
-          coap_tick_t tls_timeout = coap_dtls_get_timeout(s, now);
-          while (tls_timeout > 0 && tls_timeout <= now) {
-            coap_log(LOG_DEBUG, "** %s: DTLS retransmit timeout\n", coap_session_str(s));
-            /* Make sure the session object is not deleted in any callbacks */
-            coap_session_reference(s);
-            coap_dtls_handle_timeout(s);
-            if (s->tls)
-              tls_timeout = coap_dtls_get_timeout(s, now);
-            else {
-              tls_timeout = 0;
-              timeout = 1;
-            }
-            coap_session_release(s);
-          }
-          if (tls_timeout > 0 && (timeout == 0 || tls_timeout - now < timeout))
-            timeout = tls_timeout - now;
-        }
-      }
-#endif /* COAP_CLIENT_SUPPORT */
-    }
-  }
 
   return (unsigned int)((timeout * 1000 + COAP_TICKS_PER_SECOND - 1) / COAP_TICKS_PER_SECOND);
 }

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -1947,7 +1947,12 @@ coap_tick_t coap_dtls_get_timeout(coap_session_t *c_session, coap_tick_t now)
   return 0;
 }
 
-void coap_dtls_handle_timeout(coap_session_t *c_session)
+/*
+ * return 1 timed out
+ *        0 still timing out
+ */
+int
+coap_dtls_handle_timeout(coap_session_t *c_session)
 {
   coap_mbedtls_env_t *m_env = (coap_mbedtls_env_t *)c_session->tls;
 
@@ -1957,8 +1962,9 @@ void coap_dtls_handle_timeout(coap_session_t *c_session)
       (do_mbedtls_handshake(c_session, m_env) < 0)) {
     /* Too many retries */
     coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
+    return 1;
   }
-  return;
+  return 0;
 }
 
 /*

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -1,7 +1,8 @@
 /*
  * coap_notls.c -- Stub Datagram Transport Layer Support for libcoap
  *
- * Copyright (C) 2016 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2016      Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2021-2022 Jon Shallow <supjps-libcoap@jpshallow.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -150,7 +151,13 @@ coap_dtls_get_timeout(coap_session_t *session COAP_UNUSED, coap_tick_t now COAP_
   return 0;
 }
 
-void coap_dtls_handle_timeout(coap_session_t *session COAP_UNUSED) {
+/*
+ * return 1 timed out
+ *        0 still timing out
+ */
+int
+coap_dtls_handle_timeout(coap_session_t *session COAP_UNUSED) {
+  return 0;
 }
 
 int

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1,8 +1,8 @@
 /*
  * coap_openssl.c -- Datagram Transport Layer Support for libcoap with openssl
  *
- * Copyright (C) 2017 Jean-Claude Michelou <jcm@spinetix.com>
- * Copyright (C) 2018 Jon Shallow <supjps-libcoap@jpshallow.com>
+ * Copyright (C) 2017      Jean-Claude Michelou <jcm@spinetix.com>
+ * Copyright (C) 2018-2022 Jon Shallow <supjps-libcoap@jpshallow.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -3036,7 +3036,12 @@ coap_tick_t coap_dtls_get_timeout(coap_session_t *session, coap_tick_t now COAP_
   return ssl_data->timeout;
 }
 
-void coap_dtls_handle_timeout(coap_session_t *session) {
+/*
+ * return 1 timed out
+ *        0 still timing out
+ */
+int
+coap_dtls_handle_timeout(coap_session_t *session) {
   SSL *ssl = (SSL *)session->tls;
 
   assert(ssl != NULL && session->state == COAP_SESSION_STATE_HANDSHAKE);
@@ -3044,7 +3049,9 @@ void coap_dtls_handle_timeout(coap_session_t *session) {
       (DTLSv1_handle_timeout(ssl) < 0)) {
     /* Too many retries */
     coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
+    return 1;
   }
+  return 0;
 }
 
 #if COAP_SERVER_SUPPORT

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -2,7 +2,7 @@
  * coap_tinydtls.c -- Datagram Transport Layer Support for libcoap with tinydtls
  *
  * Copyright (C) 2016-2020 Olaf Bergmann <bergmann@tzi.org>
- * Copyright (C) 2020 Jon Shallow <supjps-libcoap@jpshallow.com>
+ * Copyright (C) 2020-2022 Jon Shallow <supjps-libcoap@jpshallow.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -654,9 +654,14 @@ coap_tick_t coap_dtls_get_timeout(coap_session_t *session, coap_tick_t now) {
   return 0;
 }
 
-void coap_dtls_handle_timeout(coap_session_t *session) {
+/*
+ * return 1 timed out
+ *        0 still timing out
+ */
+int
+coap_dtls_handle_timeout(coap_session_t *session) {
   (void)session;
-  return;
+  return 0;
 }
 
 int


### PR DESCRIPTION
Two cases for not updating active sockets[] with file descriptors from a
session (non epoll code)

-   coap_retransmit() can release a session
-   coap_dtls_handle_timeout() can disconnect a session

Move the restransmit test code to before any updates to socket[].

Update coap_dtls_handle_timeout() to return a value indicating a DTLS timeout
has occurred.  At the same time move the coap_dtls_handle_timeout() checks
into the first sessions iteration loop, removing having to iterate through the
sessions twice if DTLS.