### PR TITLE
coap_write_session: Account correctly for partial TCP writes

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -325,7 +325,7 @@ ssize_t coap_session_write(coap_session_t *session, const uint8_t *data, size_t 
   if (bytes_written > 0) {
     coap_ticks(&session->last_rx_tx);
     coap_log(LOG_DEBUG, "*  %s: sent %zd bytes\n",
-             coap_session_str(session), datalen);
+             coap_session_str(session), bytes_written);
   } else if (bytes_written < 0) {
     coap_log(LOG_DEBUG,  "*   %s: failed to send %zd bytes\n",
              coap_session_str(session), datalen );

--- a/src/net.c
+++ b/src/net.c
@@ -1487,7 +1487,7 @@ coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now
 #if !COAP_DISABLE_TCP
         bytes_written = coap_session_write(
           session,
-          q->pdu->token - q->pdu->hdr_size - session->partial_write,
+          q->pdu->token - q->pdu->hdr_size + session->partial_write,
           q->pdu->used_size + q->pdu->hdr_size - session->partial_write
         );
 #endif /* !COAP_DISABLE_TCP */


### PR DESCRIPTION
Fix the buffer start offset when writing the next part of the PDU.

Also correctly report the number of bytes actually written,

See #774 