### PR TITLE
resource: change return type of coap_resource_delete

### DIFF
--- a/include/coap3/resource.h
+++ b/include/coap3/resource.h
@@ -240,11 +240,8 @@ void coap_add_resource(coap_context_t *context, coap_resource_t *resource);
  *
  * @param context  The context where the resources are stored.
  * @param resource The resource to delete.
- *
- * @return         @c 1 if the resource was found (and destroyed),
- *                 @c 0 otherwise.
  */
-int coap_delete_resource(coap_context_t *context, coap_resource_t *resource);
+void coap_delete_resource(coap_context_t *context, coap_resource_t *resource);
 
 /**
  * Registers the specified @p handler as message handler for the request type

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -39,7 +39,7 @@ _proxy_handler_, size_t _host_name_count_, const char *_host_name_list_[]);*
 *void coap_add_resource(coap_context_t *_context_,
 coap_resource_t *_resource_);*
 
-*int coap_delete_resource(coap_context_t *_context_,
+*void coap_delete_resource(coap_context_t *_context_,
 coap_resource_t *_resource_);*
 
 *void coap_resource_set_mode(coap_resource_t *_resource_, int _mode_);*
@@ -144,7 +144,7 @@ _resource_ with the same _uri_path_ before adding in the new _resource_.
 
 The *coap_delete_resource*() function deletes a _resource_ identified by
 _resource_ from _context_. The storage allocated for that _resource_ is freed,
-along with any attrigutes associated with the _resource_.
+along with any attributes associated with the _resource_.
 
 The *coap_resource_set_mode*() changes the notification message type of
 _resource_ to the given _mode_ which must be one of
@@ -175,9 +175,6 @@ RETURN VALUES
 The *coap_resource_init*(), *coap_resource_unknown_init*() and
 *coap_resource_proxy_uri_init*() functions return a newly created resource
 or NULL if there is a malloc failure.
-
-The *coap_delete_resource*() function return 0 on failure (_resource_ not
-found), 1 on success.
 
 The *coap_resource_get_userdata*() function returns the value previously set
 by the *coap_resource_set_userdata*() function or NULL.

--- a/src/resource.c
+++ b/src/resource.c
@@ -568,20 +568,20 @@ coap_add_resource(coap_context_t *context, coap_resource_t *resource) {
   resource->context = context;
 }
 
-int
+void
 coap_delete_resource(coap_context_t *context, coap_resource_t *resource) {
-  if (!context || !resource)
-    return 0;
+  assert(context);
+  assert(resource);
 
   if (resource->is_unknown && (context->unknown_resource == resource)) {
     coap_free_resource(context->unknown_resource);
     context->unknown_resource = NULL;
-    return 1;
+    return;
   }
   if (resource->is_proxy_uri && (context->proxy_uri_resource == resource)) {
     coap_free_resource(context->proxy_uri_resource);
     context->proxy_uri_resource = NULL;
-    return 1;
+    return;
   }
 
   /* remove resource from list */
@@ -589,8 +589,6 @@ coap_delete_resource(coap_context_t *context, coap_resource_t *resource) {
 
   /* and free its allocated memory */
   coap_free_resource(resource);
-
-  return 1;
 }
 
 void


### PR DESCRIPTION
Change return type of coap_delete_resource.

It never fails if used correctly.