### PR TITLE
resource.c: Support deleting resources that have not yet been added

### DIFF
--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -228,7 +228,7 @@ hnd_delete_resource(coap_resource_t *resource,
   }
   /* FIXME: link attributes for resource have been created dynamically
    * using coap_malloc() and must be released. */
-  coap_delete_resource(coap_session_get_context(session), resource);
+  coap_delete_resource(NULL, resource);
 
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_DELETED);
 }

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1275,7 +1275,7 @@ hnd_delete(coap_resource_t *resource,
   }
 
   /* Dynamic resource no longer required - delete it */
-  coap_delete_resource(coap_session_get_context(session), resource);
+  coap_delete_resource(NULL, resource);
   coap_delete_string(uri_path);
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_DELETED);
 }

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -151,7 +151,7 @@ hnd_delete_resource(coap_resource_t *resource,
   if (payload)
     coap_delete_payload(resource);
 
-  coap_delete_resource(coap_session_get_context(session), resource);
+  coap_delete_resource(NULL, resource);
 
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_DELETED);
 }

--- a/include/coap3/resource.h
+++ b/include/coap3/resource.h
@@ -238,7 +238,8 @@ void coap_add_resource(coap_context_t *context, coap_resource_t *resource);
  * Deletes a resource identified by @p resource. The storage allocated for that
  * resource is freed, and removed from the context.
  *
- * @param context  The context where the resources are stored.
+ * @param context  This parameter is ignored, but kept for backward
+ *                 compatability.
  * @param resource The resource to delete.
  *
  * @return         @c 1 if the resource was found (and destroyed),

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -142,9 +142,9 @@ associated with a _context_, *coap_add_resource*() (or
 *coap_add_resource_release*()) will delete any previous
 _resource_ with the same _uri_path_ before adding in the new _resource_.
 
-The *coap_delete_resource*() function deletes a _resource_ identified by
-_resource_ from _context_. The storage allocated for that _resource_ is freed,
-along with any attrigutes associated with the _resource_.
+The *coap_delete_resource*() function deletes a resource identified by
+_resource_. The _context_ parameter is ignored. The storage allocated for that
+_resource_ is freed, along with any attributes associated with the _resource_.
 
 The *coap_resource_set_mode*() changes the notification message type of
 _resource_ to the given _mode_ which must be one of
@@ -325,7 +325,7 @@ const coap_pdu_t *request, const coap_string_t *query, coap_pdu_t *response) {
   /* .. code .. */
 
   /* Dynamic resource no longer required - delete it */
-  coap_delete_resource(coap_session_get_context(session), resource);
+  coap_delete_resource(NULL, resource);
 
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_DELETED);
 }

--- a/src/resource.c
+++ b/src/resource.c
@@ -568,24 +568,28 @@ coap_add_resource(coap_context_t *context, coap_resource_t *resource) {
   resource->context = context;
 }
 
+/*
+ * Input context is ignored, but param left there to keep API consistent
+ */
 int
 coap_delete_resource(coap_context_t *context, coap_resource_t *resource) {
-  if (!context || !resource)
+  if (!resource)
     return 0;
 
-  if (resource->is_unknown && (context->unknown_resource == resource)) {
-    coap_free_resource(context->unknown_resource);
-    context->unknown_resource = NULL;
-    return 1;
-  }
-  if (resource->is_proxy_uri && (context->proxy_uri_resource == resource)) {
-    coap_free_resource(context->proxy_uri_resource);
-    context->proxy_uri_resource = NULL;
-    return 1;
-  }
+  context = resource->context;
 
-  /* remove resource from list */
-  RESOURCES_DELETE(context->resources, resource);
+  if (resource->is_unknown) {
+    if (context && context->unknown_resource == resource) {
+      context->unknown_resource = NULL;
+    }
+  } else if (resource->is_proxy_uri) {
+    if (context && context->proxy_uri_resource == resource) {
+      context->proxy_uri_resource = NULL;
+    }
+  } else if (context) {
+    /* remove resource from list */
+    RESOURCES_DELETE(context->resources, resource);
+  }
 
   /* and free its allocated memory */
   coap_free_resource(resource);


### PR DESCRIPTION
Support deleting a resource both before and after calling
coap_delete_resource().

Make the coap_delete_resource() usage in examples less complex.

Resolves #788 
Replaces #787 