### PR TITLE
Corrects return value in net.c#coap_send_internal

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1281,8 +1281,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
   }
 
   if (bytes_written < 0) {
-    coap_delete_pdu(pdu);
-    return (coap_mid_t)bytes_written;
+    goto error;
   }
 
 #if !COAP_DISABLE_TCP


### PR DESCRIPTION
The interface description of coap_send_internal says that COAP_INVALID_MID is returned  in the case of errors. Presently, it, however, returns `(coap_mid_t)bytes_written` in a special case. Accidentally, bytes_written == -1 == COAP_INVALID_MID in this specific case, which is why no problems occur in practice due to this. As a cosmetic fix, this PR changes the return value to COAP_INVALID_MID.