### PR TITLE
async: Handle changes to delay when using epoll

### DIFF
--- a/include/coap3/async.h
+++ b/include/coap3/async.h
@@ -1,7 +1,7 @@
 /*
  * async.h -- state management for asynchronous messages
  *
- * Copyright (C) 2010-2011 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2010-2022 Olaf Bergmann <bergmann@tzi.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -70,6 +70,17 @@ coap_register_async(coap_session_t *session,
  */
 void
 coap_async_set_delay(coap_async_t *async, coap_tick_t delay);
+
+/**
+ * Trigger the registered @p async.
+ *
+ * A copy of the original request will get sent to the appropriate request
+ * handler.
+ *
+ * @param async The async object to trigger.
+ */
+void
+coap_async_trigger(coap_async_t *async);
 
 /**
  * Releases the memory that was allocated by coap_register_async() for the

--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -1,7 +1,7 @@
 /*
  * coap_io.h -- Default network I/O functions for libcoap
  *
- * Copyright (C) 2012-2013 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2012-2022 Olaf Bergmann <bergmann@tzi.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -96,6 +96,14 @@ coap_socket_read(coap_socket_t *sock, uint8_t *data, size_t data_len);
 
 void
 coap_epoll_ctl_mod(coap_socket_t *sock, uint32_t events, const char *func);
+
+/**
+ * Update the epoll timer fd as to when it is to trigger.
+ *
+ * @param context The context to update the epoll timer on.
+ * @param delay The time to delay before the epoll timer fires.
+ */
+void coap_update_epoll_timer(coap_context_t *context, coap_tick_t delay);
 
 #ifdef WITH_LWIP
 ssize_t

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -19,6 +19,7 @@ global:
   coap_async_is_supported;
   coap_async_set_app_data;
   coap_async_set_delay;
+  coap_async_trigger;
   coap_attr_get_value;
   coap_block_build_body;
   coap_cache_derive_key;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -17,6 +17,7 @@ coap_async_get_app_data
 coap_async_is_supported
 coap_async_set_app_data
 coap_async_set_delay
+coap_async_trigger
 coap_attr_get_value
 coap_block_build_body
 coap_cache_derive_key

--- a/man/coap_async.txt.in
+++ b/man/coap_async.txt.in
@@ -13,6 +13,7 @@ NAME
 coap_async,
 coap_async_is_supported,
 coap_register_async,
+coap_async_trigger,
 coap_async_set_delay,
 coap_find_async,
 coap_free_async,
@@ -28,6 +29,8 @@ SYNOPSIS
 
 *coap_async_t *coap_register_async(coap_session_t *_session_,
 const coap_pdu_t *_request_, coap_tick_t _delay_);*
+
+*void coap_async_trigger(coap_async_t *_async_);*
 
 *void coap_async_set_delay(coap_async_t *_async_, coap_tick_t _delay_);*
 
@@ -68,7 +71,12 @@ The *coap_register_async*() function is used to set up an asynchronous delayed
 request for the _request_ PDU associated with the _session_. The
 application request handler will get called with a copy of _request_ after
 _delay_ ticks which will then cause a response to be sent.  If _delay_ is 0,
-then the application request handler will not get called.
+then the application request handler will not get called until
+*coap_async_trigger*() or *coap_async_set_delay*() is called.
+
+The *coap_async_trigger*() function is used to expire the delay for the
+_async_ definition, so the application request handler is almost
+immediately called.
 
 The *coap_async_set_delay*() function is used to update the remaining _delay_
 before the application request handler is called for the _async_ definition. If
@@ -76,7 +84,8 @@ _delay_ is set to 0, then the application request handler will not get called.
 
 An example of usage here is *coap_register_async*() sets _delay_ to 0, and
 then when the response is ready at an indeterminate point in the future,
-*coap_async_set_delay*() is called setting _delay_ to 1.
+*coap_async_set_delay*() is called setting _delay_ to 1. Alternatively,
+*coap_async_trigger*() can be called.
 
 The *coap_free_async*() function is used to delete an _async_ definition.
 

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -86,9 +86,9 @@ conditions (no input traffic) *coap_io_process*() will then get called every
 _timeout_ms_, but more frequently if there is input / retransmission traffic.
 
 2. Wait on the file descriptor returned by *coap_context_get_coap_fd*()
-using *select*() or an event returned by epoll_wait(). If 'read' is available on
-the file descriptor, call *coap_io_process*() with _timeout_ms_ set to
-COAP_IO_NO_WAIT. +
+using *select*(), *poll*() or an event returned by epoll_wait(). If 'read' is
+available on the CoAP file descriptor, call *coap_io_process*() with
+_timeout_ms_ set to COAP_IO_NO_WAIT. +
 *NOTE*: This second method is only available for environments that support epoll
 (mostly Linux) with libcoap compiled to use *epoll* (the default) as libcoap
 will then be using *epoll* internally to process all the file descriptors of

--- a/src/net.c
+++ b/src/net.c
@@ -1015,28 +1015,7 @@ coap_wait_ack(coap_context_t *context, coap_session_t *session,
     (unsigned)(node->t * 1000 / COAP_TICKS_PER_SECOND));
 
 #ifdef COAP_EPOLL_SUPPORT
-  if (context->eptimerfd != -1) {
-    coap_ticks(&now);
-    if (context->next_timeout == 0 ||
-        context->next_timeout > now + (node->t * 1000 / COAP_TICKS_PER_SECOND)) {
-      struct itimerspec new_value;
-      int ret;
-
-      context->next_timeout = now + (node->t * 1000 / COAP_TICKS_PER_SECOND);
-      memset(&new_value, 0, sizeof(new_value));
-      coap_tick_t rem_timeout = (node->t * 1000 / COAP_TICKS_PER_SECOND);
-      /* Need to trigger an event on context->epfd in the future */
-      new_value.it_value.tv_sec = rem_timeout / 1000;
-      new_value.it_value.tv_nsec = (rem_timeout % 1000) * 1000000;
-      ret = timerfd_settime(context->eptimerfd, 0, &new_value, NULL);
-      if (ret == -1) {
-        coap_log(LOG_ERR,
-                  "%s: timerfd_settime failed: %s (%d)\n",
-                  "coap_wait_ack",
-                  coap_socket_strerror(), errno);
-      }
-    }
-  }
+  coap_update_epoll_timer(context, node->t);
 #endif /* COAP_EPOLL_SUPPORT */
 
   return node->id;
@@ -1900,10 +1879,10 @@ coap_io_do_epoll(coap_context_t *ctx, struct epoll_event *events, size_t nevents
         /* do nothing */;
       }
     }
-    /* And update eptimerfd as to when to next trigger */
-    coap_ticks(&now);
-    coap_io_prepare_epoll(ctx, now);
   }
+  /* And update eptimerfd as to when to next trigger */
+  coap_ticks(&now);
+  coap_io_prepare_epoll(ctx, now);
 #endif /* COAP_EPOLL_SUPPORT */
 }
 
@@ -3264,7 +3243,7 @@ coap_check_async(coap_context_t *context, coap_tick_t now) {
   coap_async_t *async, *tmp;
 
   LL_FOREACH_SAFE(context->async_state, async, tmp) {
-    if (async->delay <= now) {
+    if (async->delay != 0 && async->delay <= now) {
       /* Send off the request to the application */
       handle_request(context, async->session, async->pdu);
 

--- a/src/resource.c
+++ b/src/resource.c
@@ -1,6 +1,6 @@
 /* resource.c -- generic resource handling
  *
- * Copyright (C) 2010--2021 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2010--2022 Olaf Bergmann <bergmann@tzi.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -1037,21 +1037,7 @@ coap_resource_notify_observers(coap_resource_t *r,
   assert(r->context);
   r->context->observe_pending = 1;
 #ifdef COAP_EPOLL_SUPPORT
-  if (r->context->eptimerfd != -1) {
-    /* Need to immediately trigger any epoll_wait() */
-    struct itimerspec new_value;
-    int ret;
-
-    memset(&new_value, 0, sizeof(new_value));
-    new_value.it_value.tv_nsec = 1; /* small that is not zero */
-    ret = timerfd_settime(r->context->eptimerfd, 0, &new_value, NULL);
-    if (ret == -1) {
-      coap_log(LOG_ERR,
-                "%s: timerfd_settime failed: %s (%d)\n",
-                "coap_resource_notify_observers",
-                coap_socket_strerror(), errno);
-    }
-  }
+  coap_update_epoll_timer(r->context, 0);
 #endif /* COAP_EPOLL_SUPPORT */
   return 1;
 }


### PR DESCRIPTION
Add in new function coap_async_trigger() to immediately release an async
session, rather than using coap_async_set_delay(async, 1)

Add new internal function coap_update_epoll_timer() to reduce code
duplication and use it for the async logic.

Move doing coap_io_prepare_epoll() for every epoll event to just doing it once
outside of the loop.

Fixes delay issue in #794
Update documentation.