### PR TITLE
block.c: Do not match large response if no Block2 option in request

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -992,9 +992,9 @@ coap_handle_request_send_block(coap_session_t *session,
   uint32_t out_blocks[1];
   const char *error_phrase;
 
-  if (coap_get_block(pdu, COAP_OPTION_BLOCK2, &block)) {
-    block_opt = COAP_OPTION_BLOCK2;
-  }
+  if (!coap_get_block(pdu, COAP_OPTION_BLOCK2, &block))
+    return 0;
+  block_opt = COAP_OPTION_BLOCK2;
   LL_FOREACH(session->lg_xmit, p) {
     size_t chunk;
     coap_opt_iterator_t opt_iter;


### PR DESCRIPTION
Allows a following request not to match cached multi-payload large response.

Fixes #793 for requests that are not specifying Block2 to define return blocking and reponses that are not all multi-payload.