### PR TITLE
Allow usage of a non-vendored TinyDTLS version when using autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -318,6 +318,7 @@ AM_CONDITIONAL(BUILD_MANPAGES, [test "x$build_manpages" = "xyes"])
 gnutls_version_required=3.3.0
 openssl_version_required=1.1.0
 mbedtls_version_required=2.7.10
+tinydtls_version_required=0.8.6
 
 AC_ARG_ENABLE([dtls],
               [AS_HELP_STRING([--enable-dtls],
@@ -349,11 +350,23 @@ AC_ARG_WITH([tinydtls],
            [with_tinydtls="$withval"],
            [with_tinydtls="no"])
 
+AC_ARG_WITH([submodule-tinydtls],
+           [AS_HELP_STRING([--with-submodule-tinydtls],
+                           [Use the TinyDTLS provided in the git submodule over the system-provided version [default=fallback to submodule if --with-tinydtls is explicitly set and no system-provided version was found])])],
+           [with_submodule_tinydtls="$withval"],
+           [with_submodule_tinydtls="explicit_fallback"])
+
 if test "x$with_gnutls" = "xyes" -o "x$with_openssl" = "xyes" -o "x$with_mbedtls" = "xyes" -o "x$with_tinydtls" = "xyes"; then
-    if test "x$build_dtls" = "x"; then
+    if test "x$build_dtls" = "xno"; then
         # Give an advice that '--with_gnutls', '--with_openssl', '--with-mbedtls' or '--with-tinydtls' was used but
         # DTLS support isn't configured.
-        AC_MSG_NOTICE([==> Using the configure options '--with-gnutls', '--with-openssl', '--with-mbedtls' or '--with-tinydtls' without '--enable-dtls' is useles and will be ignored.])
+        AC_MSG_WARN([==> Using the configure options '--with-gnutls', '--with-openssl', '--with-mbedtls' or '--with-tinydtls' without '--enable-dtls' is useless and will be ignored.])
+    fi
+fi
+if test "x$with_submodule_tinydtls" = "xyes"; then
+    if test "x$with_tinydtls" = "xno"; then
+        # Give an advice that '--with-submodule-tinydtls' is useless if tinydtls is not also enabled.
+        AC_MSG_WARN([==> Using the configure option '--with-submodule-tinydtls' without '--with-tinydtls' is useless and it will be ignored.])
     fi
 fi
 
@@ -422,7 +435,18 @@ if test "x$build_dtls" = "xyes"; then
         fi
     fi
 
-    # TinyDTLS ?
+    if test "${TinyDTLS_CFLAGS+set}" = "set"; then
+        tinydtls_cflags_overridden="yes"
+    fi
+    if test "${TinyDTLS_LIBS+set}" = "set"; then
+        tinydtls_libs_overridden="yes"
+    fi
+    # TinyDTLS
+    PKG_CHECK_MODULES([TinyDTLS],
+                      [tinydtls],
+                      [have_tinydtls="yes"],
+                      [have_tinydtls="no"])
+
     # TBD ?
 
     # The user wants to use explicit GnuTLS if '--with-gnutls' was set.
@@ -481,15 +505,53 @@ if test "x$build_dtls" = "xyes"; then
 
     # The user wants to use explicit TinyDTLS if '--with-tinydtls was set'.
     if test "x$with_tinydtls" = "xyes" ; then
-        if test -d "$srcdir/ext/tinydtls"; then
-           AC_CONFIG_SUBDIRS([ext/tinydtls])
-           have_tinydtls="yes"
-         else
-           have_tinydtls="no" # don't confuse AC_MSG_RESULT at the end of the script
-         fi
-         have_gnutls="no" # don't confuse AC_MSG_RESULT at the end of the script
-         have_openssl="no" # don't confuse AC_MSG_RESULT at the end of the script
-         have_mbedtls="no" # don't confuse AC_MSG_RESULT at the end of the script
+        AC_MSG_NOTICE([The use of TinyDTLS was explicitly requested with configure option '--with-tinydtls'!])
+        if [ test "x$have_tinydtls" = "xno" ] && [ test "x$with_submodule_tinydtls" = "xexplicit_fallback" ]  || [ test "x$with_submodule_tinydtls" = "xyes" ]; then
+            AC_MSG_NOTICE([Using TinyDTLS submodule over system-provided version because either "--with-submodule-tinydtls" was set or no system-provided TinyDTLS was found.])
+            if test -e "$srcdir/ext/tinydtls/dtls.h"; then
+               AC_CONFIG_SUBDIRS([ext/tinydtls])
+               if test "x$enable_shared" = "xyes"; then
+                   auto_TinyDTLS_LIBS="-L\$(top_builddir)/ext/tinydtls -ltinydtls"
+               else
+                   # Needed as TinyDTLS compiling does not recognize --disable-shared
+                   # and still builds libtinydtls.so which gets linked in otherwise
+                   auto_TinyDTLS_LIBS="-L\$(top_builddir)/ext/tinydtls -l:libtinydtls.a"
+               fi
+               have_submodule_tinydtls="yes"
+
+               auto_TinyDTLS_CFLAGS="-I \$(top_srcdir)/ext -I \$(top_srcdir)/ext/tinydtls"
+
+               if test "x$tinydtls_cflags_overridden" != "xyes";  then
+                   TinyDTLS_CFLAGS="$auto_TinyDTLS_CFLAGS"
+               fi
+               if test "x$tinydtls_libs_overridden" != "xyes";  then
+                   TinyDTLS_LIBS="$auto_TinyDTLS_LIBS"
+               fi
+            else
+                AC_MSG_ERROR([==> You want to build libcoap with DTLS support using the TinyDTLS submodule library but no suitable version could be found!
+                            Check whether you have updated the TinyDTLS git submodule, use the system-provided version if available (set '--with-submodule-tinydtls=no'),
+                            select a different TLS library or disable the DTLS support using '--disable-dtls'.])
+                have_tinydtls="no" # don't confuse AC_MSG_RESULT at the end of the script
+                have_submodule_tinydtls="no" # don't confuse AC_MSG_RESULT at the end of the script
+            fi
+        elif test "x$have_tinydtls" = "xyes"; then
+            AC_MSG_NOTICE([Using system-provided TinyDTLS])
+            tinydtls_version=`$PKG_CONFIG --modversion tinydtls`
+            AX_CHECK_TINYDTLS_VERSION
+            have_gnutls="no" # don't confuse AC_MSG_RESULT at the end of the script
+            have_mbedtls="no" # don't confuse AC_MSG_RESULT at the end of the script
+            have_openssl="no" # don't confuse AC_MSG_RESULT at the end of the script
+        else
+            AC_MSG_ERROR([==> You want to build libcoap with DTLS support using the TinyDTLS library but no suitable version could be found!
+                        Use the submodule TinyDTLS version (set '--with-submodule-tinydtls=yes' and update the git submodule),
+                        ensure that you have a system-provided version of TinyDTLS that can be found using pkg-config (older versions can not),
+                        select a different TLS library or disable the DTLS support using '--disable-dtls'.])
+            have_tinydtls="no" # don't confuse AC_MSG_RESULT at the end of the script
+        fi
+
+        have_gnutls="no" # don't confuse AC_MSG_RESULT at the end of the script
+        have_openssl="no" # don't confuse AC_MSG_RESULT at the end of the script
+        have_mbedtls="no" # don't confuse AC_MSG_RESULT at the end of the script
     fi
 
     if test "$TLSCOUNT" -eq 0; then
@@ -525,11 +587,21 @@ if test "x$build_dtls" = "xyes"; then
           have_openssl="no" # don't confuse AC_MSG_RESULT at the end of the script
           have_tinydtls="no" # don't confuse AC_MSG_RESULT at the end of the script
 
-      # Note that tinyDTLS is used only when explicitly requested.
+      elif [ test "x$with_tinydtls" = "xyes" ] && [ test "x$have_tinydtls" = "xyes" ]; then
+        AC_MSG_NOTICE([Using auto selected library TinyDTLS for DTLS support!])
+        tinydtls_version=`$PKG_CONFIG --modversion tinydtls`
+        AX_CHECK_TINYDTLS_VERSION
+        with_tinydtls_auto="yes"
+        have_gnutls="no" # don't confuse AC_MSG_RESULT at the end of the script
+        have_mbedtls="no" # don't confuse AC_MSG_RESULT at the end of the script
+        have_openssl="no" # don't confuse AC_MSG_RESULT at the end of the script
+
+
+      # Note that the TinyDTLS submodule is used only when explicitly requested.
       # Giving out an error message if we haven't found at least one crypto library.
       else
-          AC_MSG_ERROR([==> Option '--enable-dtls' is set but none of the needed cryptography libraries GnuTLS, OpenSSL or Mbed TLS could be found!
-                        Install at least one of the package(s) that contains the development files for GnuTLS (>= $gnutls_version_required), OpenSSL(>= $openssl_version_required), or Mbed TLS(>= $mbedtls_version_required)
+          AC_MSG_ERROR([==> Option '--enable-dtls' is set but none of the needed cryptography libraries GnuTLS, OpenSSL, Mbed TLS or TinyDTLS could be found!
+                        Install at least one of the package(s) that contains the development files for GnuTLS (>= $gnutls_version_required), OpenSSL(>= $openssl_version_required), Mbed TLS(>= $mbedtls_version_required), or TinyDTLS(>= $tinydtls_version_required)
                         or disable the DTLS support using '--disable-dtls'.])
       fi
     fi
@@ -550,15 +622,9 @@ if test "x$build_dtls" = "xyes"; then
         DTLS_LIBS="$MbedTLS_LIBS"
         AC_DEFINE(HAVE_MBEDTLS, [1], [Define if the system has libmbedtls2.7.10])
     fi
-    if test "x$with_tinydtls" = "xyes"; then
-        DTLS_CFLAGS="-I \$(top_srcdir)/ext/tinydtls"
-        if test "x$enable_shared" = "xyes"; then
-            DTLS_LIBS="-L\$(top_builddir)/ext/tinydtls -ltinydtls"
-        else
-            # Needed as TinyDTLS compiling does not recognize --disable-shared
-            # and still builds libtinydtls.so which gets linked in otherwise
-            DTLS_LIBS="-L\$(top_builddir)/ext/tinydtls -l:libtinydtls.a"
-        fi
+    if test "x$with_tinydtls" = "xyes" -o "x$with_tinydtls_auto" = "xyes"; then
+        DTLS_CFLAGS="$TinyDTLS_CFLAGS"
+        DTLS_LIBS="$TinyDTLS_LIBS"
         AC_DEFINE(HAVE_LIBTINYDTLS, [1], [Define if the system has libtinydtls])
     fi
     AC_SUBST(DTLS_CFLAGS)
@@ -965,9 +1031,13 @@ if test "x$with_mbedtls" = "xyes" -o "x$with_mbedtls_auto" = "xyes"; then
 fi
 if test "x$with_tinydtls" = "xyes"; then
     AC_MSG_RESULT([      build DTLS support       : "yes"])
-    AC_MSG_RESULT([         -->  tinyDTLS around  : "yes"])
-    AC_MSG_RESULT([              TINYDTLS_CFLAGS  : "$DTLS_CFLAGS"])
-    AC_MSG_RESULT([              TINYDTLS_LIBS    : "$DTLS_LIBS"])
+    if test "x$have_submodule_tinydtls" = "xyes"; then
+        AC_MSG_RESULT([         -->  TinyDTLS around  : "yes" (submodule)])
+    else
+        AC_MSG_RESULT([         -->  TinyDTLS around  : "yes (found TinyDTLS $tinydtls_version)"])
+    fi
+    AC_MSG_RESULT([              TinyDTLS_CFLAGS  : "$DTLS_CFLAGS"])
+    AC_MSG_RESULT([              TinyDTLS_LIBS    : "$DTLS_LIBS"])
 fi
 if test "x$build_dtls" != "xyes"; then
     AC_MSG_RESULT([      build DTLS support       : "no"])

--- a/m4/ac_check_cryptolibs.m4
+++ b/m4/ac_check_cryptolibs.m4
@@ -69,3 +69,16 @@ AC_DEFUN([AX_CHECK_MBEDTLS_VERSION],
           fi
 ]) dnl AX_CHECK_MBEDTLS_VERSION
 
+AC_DEFUN([AX_CHECK_TINYDTLS_VERSION],
+    [AC_MSG_CHECKING([for compatible TinyDTLS version (>= $tinydtls_version_required)])
+    AS_VERSION_COMPARE([$tinydtls_version], [$tinydtls_version_required],
+        [AC_MSG_RESULT([no])
+        TINYDTLSV=""],
+        [AC_MSG_RESULT([yes $tinydtls_version])
+        TINYDTLSV="$tinydtls_version"],
+        [AC_MSG_RESULT([yes $tinydtls_version])
+        TINYDTLSV="$tinydtls_version"])
+    if test "x$TINYDTLSV" = "x"; then
+        AC_MSG_ERROR([==> TinyDTLS $tinydtls_version too old. TinyDTLS >= $tinydtls_version_required required for suitable DTLS support build.])
+    fi
+]) dnl AX_CHECK_TINYDTLS_VERSION

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -27,9 +27,9 @@
 #undef PACKAGE_URL
 #undef PACKAGE_VERSION
 
-#include <tinydtls.h>
-#include <dtls.h>
-#include <dtls_debug.h>
+#include <tinydtls/tinydtls.h>
+#include <tinydtls/dtls.h>
+#include <tinydtls/dtls_debug.h>
 
 typedef struct coap_tiny_context_t {
   struct dtls_context_t *dtls_context;


### PR DESCRIPTION
This PR modifies the autotools scripts (mostly `configure.ac`) to allow using a tinydtls version that is different from the one provided in the submodule.

To do so, set the `--with-system-tinydtls` (as well as the `--with-tinydtls`) configure script option when building.
It is also possible to override the linker and compiler flags using the `TinyDTLS_LIBS` and `TinyDTLS_CFLAGS` environment variables, analogously to the `(OpenSSL|GnuTLS)_(LIBS|CFLAGS)` environment variable for the other TLS backends.