### PR TITLE
request_handler: Report only when app's request handler is actually called

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -1408,6 +1408,9 @@ coap_handle_request_put_block(coap_context_t *context,
         pdu->body_total = p->total_len;
         coap_log(LOG_DEBUG, "Server app version of updated PDU\n");
         coap_show_pdu(LOG_DEBUG, pdu);
+        coap_log(LOG_DEBUG, "call custom handler for resource '%*.*s'\n",
+                 (int)resource->uri_path->length,
+                 (int)resource->uri_path->length, resource->uri_path->s);
         /* Need to do this here as we need to free off p */
         h(resource, session, pdu, query, response);
         /* Check if lg_xmit generated and update PDU code if so */
@@ -1433,6 +1436,9 @@ coap_handle_request_put_block(coap_context_t *context,
                              (block.m << 3) |
                              block.szx),
                            buf);
+          coap_log(LOG_DEBUG, "call custom handler for resource '%*.*s'\n",
+                   (int)resource->uri_path->length,
+                   (int)resource->uri_path->length, resource->uri_path->s);
           h(resource, session, pdu, query, response);
           /* Check if lg_xmit generated and update PDU code if so */
           coap_check_code_lg_xmit(session, response, resource, query,

--- a/src/net.c
+++ b/src/net.c
@@ -2750,9 +2750,6 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
     h = resource->handler[pdu->code - 1];
 
   if (h) {
-     coap_log(LOG_DEBUG, "call custom handler for resource '%*.*s'\n",
-              (int)resource->uri_path->length, (int)resource->uri_path->length,
-              resource->uri_path->s);
     response = coap_pdu_init(pdu->type == COAP_MESSAGE_CON
       ? COAP_MESSAGE_ACK
       : COAP_MESSAGE_NON,
@@ -2823,6 +2820,9 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
       /*
        * Call the request handler with everything set up
        */
+      coap_log(LOG_DEBUG, "call custom handler for resource '%*.*s'\n",
+               (int)resource->uri_path->length, (int)resource->uri_path->length,
+               resource->uri_path->s);
       h(resource, session, pdu, query, response);
 
       /* Check if lg_xmit generated and update PDU code if so */

--- a/src/resource.c
+++ b/src/resource.c
@@ -967,6 +967,9 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         query = coap_get_query(obs->pdu);
         coap_log(LOG_DEBUG, "Observe PDU presented to app.\n");
         coap_show_pdu(LOG_DEBUG, obs->pdu);
+        coap_log(LOG_DEBUG, "call custom handler for resource '%*.*s'\n",
+                 (int)r->uri_path->length, (int)r->uri_path->length,
+                 r->uri_path->s);
         h(r, obs->session, obs->pdu, query, response);
         /* Check if lg_xmit generated and update PDU code if so */
         coap_check_code_lg_xmit(obs->session, response, r, query,


### PR DESCRIPTION
Aids tracking issues with the libcoap block handling logic to easily
differentiate when libcoap sends a response and when app handler is called
to send a response.