### PR TITLE
sessions: Prevent multiple client session confusion

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -1477,6 +1477,16 @@ get_session(
       }
     }
     freeaddrinfo( result );
+  } else if (local_port) {
+    coap_address_t bind_addr;
+
+    coap_address_init(&bind_addr);
+    bind_addr.size = dst->size;
+    bind_addr.addr.sa.sa_family = dst->addr.sa.sa_family;
+    /* port is in same place for IPv4 and IPv6 */
+    bind_addr.addr.sin.sin_port = ntohs(atoi(local_port));
+    session = open_session(ctx, proto, &bind_addr, dst,
+                               identity, identity_len, key, key_len);
   } else {
     session = open_session(ctx, proto, NULL, dst,
                                identity, identity_len, key, key_len);

--- a/man/coap_endpoint_client.txt.in
+++ b/man/coap_endpoint_client.txt.in
@@ -48,7 +48,9 @@ DESCRIPTION
 -----------
 This man page focuses on the setting up of a CoAP client endpoint and hence
 creation of a CoAP Session used to connect to a server.  For a CoAP server
-endpoint, see *coap_endpoint_server*(3).
+endpoint, see *coap_endpoint_server*(3). There is no need to call
+*coap_new_endpoint*(3) for a client as well as one of the
+*coap_new_client_server**() functions.
 
 The CoAP stack's global state is stored in a coap_context_t Context object.
 Resources, Endpoints and Sessions are associated with this context object.

--- a/src/net.c
+++ b/src/net.c
@@ -1944,7 +1944,7 @@ coap_remove_from_queue(coap_queue_t **queue, coap_session_t *session, coap_mid_t
       (*queue)->t += (*node)->t;
     }
     (*node)->next = NULL;
-    coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed\n",
+    coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed 1\n",
              coap_session_str(session), id);
     return 1;
   }
@@ -1963,7 +1963,7 @@ coap_remove_from_queue(coap_queue_t **queue, coap_session_t *session, coap_mid_t
     }
     q->next = NULL;
     *node = q;
-    coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed\n",
+    coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed 2\n",
              coap_session_str(session), id);
     return 1;
   }
@@ -1980,7 +1980,7 @@ coap_cancel_session_messages(coap_context_t *context, coap_session_t *session,
   while (context->sendqueue && context->sendqueue->session == session) {
     q = context->sendqueue;
     context->sendqueue = q->next;
-    coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed\n",
+    coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed 3\n",
              coap_session_str(session), q->id);
     if (q->pdu->type == COAP_MESSAGE_CON && context->nack_handler)
       context->nack_handler(session, q->pdu, reason, q->id);
@@ -1996,7 +1996,7 @@ coap_cancel_session_messages(coap_context_t *context, coap_session_t *session,
   while (q) {
     if (q->session == session) {
       p->next = q->next;
-      coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed\n",
+      coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed 4\n",
                coap_session_str(session), q->id);
       if (q->pdu->type == COAP_MESSAGE_CON && context->nack_handler)
         context->nack_handler(session, q->pdu, reason, q->id);
@@ -2022,7 +2022,7 @@ coap_cancel_all_messages(coap_context_t *context, coap_session_t *session,
       context->sendqueue->pdu->token_length)) {
     q = context->sendqueue;
     context->sendqueue = q->next;
-    coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed\n",
+    coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed 5\n",
              coap_session_str(session), q->id);
     coap_delete_node(q);
   }
@@ -2039,7 +2039,7 @@ coap_cancel_all_messages(coap_context_t *context, coap_session_t *session,
       token_match(token, token_length,
         q->pdu->token, q->pdu->token_length)) {
       p->next = q->next;
-      coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed\n",
+      coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed 6\n",
                coap_session_str(session), q->id);
       coap_delete_node(q);
       q = p->next;
@@ -2925,7 +2925,8 @@ handle_response(coap_context_t *context, coap_session_t *session,
    * been lost, so we need to stop retransmitting requests with the
    * same token.
    */
-  coap_cancel_all_messages(context, session, rcvd->token, rcvd->token_length);
+  if (rcvd->type == COAP_MESSAGE_ACK)
+    coap_cancel_all_messages(context, session, rcvd->token, rcvd->token_length);
 
   if (session->block_mode & COAP_BLOCK_USE_LIBCOAP) {
     /* See if need to send next block to server */


### PR DESCRIPTION
Prevent multiple coap_new_client_session*() calls that are connecting to
the same server/port being bound to the same local ip/port.

Update logging for session creation / removal to easily differentiate between
sessions that have the same 4-tuple.

Document that coap_new_endpoint() is not required in client based code.

If coap-client '-p port' but not '-a addr' is provided, fix code so that
the port is bound to.

Only remove outstanding CON requests with token matches if there is an
ACK response.

Update the logging to differentiate between the 6 occurrences where the mid
is removed.

Addresses issues raised in Issue #810.