### PR TITLE
pdu building: Enforce the application order of building a PDU

### DIFF
--- a/include/coap3/block.h
+++ b/include/coap3/block.h
@@ -206,6 +206,8 @@ typedef void (*coap_release_large_data_t)(coap_session_t *session,
 /**
  * Associates given data with the @p pdu that is passed as second parameter.
  *
+ * This function will fail if data has aready been added to the @p pdu.
+ *
  * If all the data can be transmitted in a single PDU, this is functionally
  * the same as coap_add_data() except @p release_func (if not NULL) will get
  * invoked after data transmission.
@@ -254,6 +256,8 @@ int coap_add_data_large_request(coap_session_t *session,
  * Associates given data with the @p response pdu that is passed as fourth
  * parameter.
  *
+ * This function will fail if data has aready been added to the @p pdu.
+ *
  * If all the data can be transmitted in a single PDU, this is functionally
  * the same as coap_add_data() except @p release_func (if not NULL) will get
  * invoked after data transmission. The MEDIA_TYPE, MAXAGE and ETAG options may
@@ -273,7 +277,7 @@ int coap_add_data_large_request(coap_session_t *session,
  * There is no need for the application to include the BLOCK2 option in the
  * @p pdu.
  *
- * coap_add_data_large_response() (or the alternative coap_add_data_large*()
+ * coap_add_data_large_response() (or the alternative coap_add_data_large_*()
  * functions) must be called only once per PDU and must be the last PDU update
  * before returning from the request handler function.
  *

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -213,6 +213,30 @@ int coap_pdu_parse_opt(coap_pdu_t *pdu);
 void coap_pdu_clear(coap_pdu_t *pdu, size_t size);
 
 /**
+ * Adds option of given @p number to @p pdu that is passed as first
+ * parameter.
+ *
+ * The internal version of coap_add_option() may cause an @p option to be
+ * inserted, even if there is any data in the @p pdu.
+ *
+ * Note: Where possible, the option @p data needs to be stripped of leading
+ * zeros (big endian) to reduce the amount of data needed in the PDU, as well
+ * as in some cases the maximum data size of an option can be exceeded if not
+ * stripped and hence be illegal. This is done by using coap_encode_var_safe()
+ * or coap_encode_var_safe8().
+ *
+ * @param pdu    The PDU where the option is to be added.
+ * @param number The number of the new option.
+ * @param len    The length of the new option.
+ * @param data   The data of the new option.
+ *
+ * @return The overall length of the option or @c 0 on failure.
+ */
+size_t coap_add_option_internal(coap_pdu_t *pdu,
+                                coap_option_num_t number,
+                                size_t len,
+                                const uint8_t *data);
+/**
  * Removes (first) option of given number from the @p pdu.
  *
  * @param pdu   The PDU to remove the option from.

--- a/include/coap3/pdu.h
+++ b/include/coap3/pdu.h
@@ -416,10 +416,11 @@ int coap_pdu_parse(coap_proto_t proto,
 
 /**
  * Adds token of length @p len to @p pdu.
- * Adding the token destroys any following contents of the pdu. Hence options
- * and data must be added after coap_add_token() has been called. In @p pdu,
- * length is set to @p len + @c 4, and max_delta is set to @c 0. This function
- * returns @c 0 on error or a value greater than zero on success.
+ *
+ * This function will fail if a token has already been added to the @p pdu.
+ *
+ * Hence options and data must be added after optional coap_add_token() has
+ * been called.
  *
  * @param pdu  The PDU where the token is to be added.
  * @param len  The length of the new token.
@@ -432,12 +433,12 @@ int coap_add_token(coap_pdu_t *pdu,
                   const uint8_t *data);
 
 /**
- * Adds option of given number to pdu that is passed as first
+ * Adds option of given @p number to @p pdu that is passed as first
  * parameter.
- * coap_add_option() destroys the PDU's data, so coap_add_data() must be called
- * after all options have been added. As coap_add_token() destroys the options
- * following the token, the token must be added before coap_add_option() is
- * called. This function returns the number of bytes written or @c 0 on error.
+ *
+ * This function will fail if data has aready been added to the @p pdu.
+ *
+ * Hence data must be added after optional coap_add_option() has been called.
  *
  * Note: Where possible, the option data needs to be stripped of leading zeros
  * (big endian) to reduce the amount of data needed in the PDU, as well as in
@@ -458,9 +459,9 @@ size_t coap_add_option(coap_pdu_t *pdu,
                        const uint8_t *data);
 
 /**
- * Adds given data to the pdu that is passed as first parameter. Note that the
- * PDU's data is destroyed by coap_add_option(). coap_add_data() must be called
- * only once per PDU, otherwise the result is undefined.
+ * Adds given data to the pdu that is passed as first parameter.
+ *
+ * This function will fail if data has aready been added to the @p pdu.
  *
  * @param pdu    The PDU where the data is to be added.
  * @param len    The length of the data.
@@ -474,9 +475,9 @@ int coap_add_data(coap_pdu_t *pdu,
 
 /**
  * Adds given data to the pdu that is passed as first parameter but does not
- * copy it. Note that the PDU's data is destroyed by coap_add_option().
- * coap_add_data() must be have been called once for this PDU, otherwise the
- * result is undefined.
+ *
+ * This function will fail if data has aready been added to the @p pdu.
+ *
  * The actual data must be copied at the returned location.
  *
  * @param pdu    The PDU where the data is to be added.

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -386,10 +386,10 @@ void coap_session_send_csm(coap_session_t *session) {
     session->mtu = COAP_DEFAULT_MTU;  /* base value */
   pdu = coap_pdu_init(COAP_MESSAGE_CON, COAP_SIGNALING_CODE_CSM, 0, 20);
   if ( pdu == NULL
-    || coap_add_option(pdu, COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE,
+    || coap_add_option_internal(pdu, COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE,
          coap_encode_var_safe(buf, sizeof(buf),
                                 COAP_DEFAULT_MAX_PDU_RX_SIZE), buf) == 0
-    || coap_add_option(pdu, COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER,
+    || coap_add_option_internal(pdu, COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER,
          coap_encode_var_safe(buf, sizeof(buf),
                                 0), buf) == 0
     || coap_pdu_encode_header(pdu, session->proto) == 0

--- a/src/net.c
+++ b/src/net.c
@@ -2144,9 +2144,9 @@ coap_new_error_response(const coap_pdu_t *request, coap_pdu_code_t code,
     /* copy all options */
     coap_option_iterator_init(request, &opt_iter, opts);
     while ((option = coap_option_next(&opt_iter))) {
-      coap_add_option(response, opt_iter.number,
-        coap_opt_length(option),
-        coap_opt_value(option));
+      coap_add_option_internal(response, opt_iter.number,
+                               coap_opt_length(option),
+                               coap_opt_value(option));
     }
 
 #if COAP_ERROR_PHRASE_LENGTH > 0
@@ -2271,19 +2271,19 @@ coap_wellknown_response(coap_context_t *context, coap_session_t *session,
   if (need_block2) {
     /* Add in a pseudo etag (use wkc_len) in case .well-known/core
        changes over time */
-    coap_add_option(resp,
-                    COAP_OPTION_ETAG,
-                    coap_encode_var_safe8(buf, sizeof(buf), wkc_len),
-                    buf);
+    coap_add_option_internal(resp,
+                             COAP_OPTION_ETAG,
+                             coap_encode_var_safe8(buf, sizeof(buf), wkc_len),
+                             buf);
   }
 
   /* Add Content-Format. As we have checked for available storage,
    * nothing should go wrong here. */
   assert(coap_encode_var_safe(buf, sizeof(buf),
     COAP_MEDIATYPE_APPLICATION_LINK_FORMAT) == 1);
-  coap_add_option(resp, COAP_OPTION_CONTENT_FORMAT,
-    coap_encode_var_safe(buf, sizeof(buf),
-      COAP_MEDIATYPE_APPLICATION_LINK_FORMAT), buf);
+  coap_add_option_internal(resp, COAP_OPTION_CONTENT_FORMAT,
+                           coap_encode_var_safe(buf, sizeof(buf),
+                           COAP_MEDIATYPE_APPLICATION_LINK_FORMAT), buf);
 
 
   /* write Block2 option if necessary */
@@ -2295,10 +2295,10 @@ coap_wellknown_response(coap_context_t *context, coap_session_t *session,
     }
   }
 
-  coap_add_option(resp,
-                  COAP_OPTION_SIZE2,
-                  coap_encode_var_safe8(buf, sizeof(buf), wkc_len),
-                  buf);
+  coap_add_option_internal(resp,
+                           COAP_OPTION_SIZE2,
+                           coap_encode_var_safe8(buf, sizeof(buf), wkc_len),
+                           buf);
 
   len = need_block2 ?
         min(SZX_TO_BYTES(block.szx), wkc_len - (block.num << (block.szx + 4))) :
@@ -2800,10 +2800,10 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
               uint8_t buf[4];
 
               coap_touch_observer(context, session, &token);
-              coap_add_option(response, COAP_OPTION_OBSERVE,
-                              coap_encode_var_safe(buf, sizeof (buf),
-                                                   resource->observe),
-                              buf);
+              coap_add_option_internal(response, COAP_OPTION_OBSERVE,
+                                       coap_encode_var_safe(buf, sizeof (buf),
+                                                            resource->observe),
+                                       buf);
             }
           }
           else if (observe_action == COAP_OBSERVE_CANCEL) {
@@ -2985,7 +2985,7 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
       context->ping_handler(session, pdu, pdu->mid);
     }
     if (pong) {
-      coap_add_option(pong, COAP_SIGNALING_OPTION_CUSTODY, 0, NULL);
+      coap_add_option_internal(pong, COAP_SIGNALING_OPTION_CUSTODY, 0, NULL);
       coap_send_internal(session, pong);
     }
   } else if (pdu->code == COAP_SIGNALING_CODE_PONG) {

--- a/src/option.c
+++ b/src/option.c
@@ -554,11 +554,16 @@ coap_add_optlist_pdu(coap_pdu_t *pdu, coap_optlist_t** options) {
   coap_optlist_t *opt;
 
   if (options && *options) {
+    if (pdu->data) {
+      coap_log(LOG_WARNING,
+               "coap_add_optlist_pdu: PDU already contains data\n");
+      return 0;
+    }
     /* sort options for delta encoding */
     LL_SORT((*options), order_opts);
 
     LL_FOREACH((*options), opt) {
-      coap_add_option(pdu, opt->number, opt->length, opt->data);
+      coap_add_option_internal(pdu, opt->number, opt->length, opt->data);
     }
     return 1;
   }

--- a/src/resource.c
+++ b/src/resource.c
@@ -951,18 +951,18 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
       switch (deleting) {
       case COAP_NOT_DELETING_RESOURCE:
         /* fill with observer-specific data */
-        coap_add_option(response, COAP_OPTION_OBSERVE,
-                        coap_encode_var_safe(buf, sizeof (buf),
-                                             r->observe),
-                        buf);
+        coap_add_option_internal(response, COAP_OPTION_OBSERVE,
+                                 coap_encode_var_safe(buf, sizeof (buf),
+                                                      r->observe),
+                                 buf);
         if (coap_get_block(obs->pdu, COAP_OPTION_BLOCK2, &block)) {
           /* Will get updated later (e.g. M bit) if appropriate */
-          coap_add_option(response, COAP_OPTION_BLOCK2,
-                          coap_encode_var_safe(buf, sizeof(buf),
-                                               ((0 << 4) |
-                                                (0 << 3) |
-                                                block.szx)),
-                          buf);
+          coap_add_option_internal(response, COAP_OPTION_BLOCK2,
+                                   coap_encode_var_safe(buf, sizeof(buf),
+                                                        ((0 << 4) |
+                                                         (0 << 3) |
+                                                         block.szx)),
+                                   buf);
         }
 
         h = r->handler[obs->pdu->code - 1];


### PR DESCRIPTION
Make coap_add_option() invalid after calling a coap_add_data*() function.
Add in internal support for adding options to PDUs that contain data with
a replacement coap_add_option_internal() function.  Call this new function
in the appropriate places in the libcoap src.

Add coap_log warnings when the application tries to build a PDU in the wrong
order and then return failure.

Update documentation re-inforcing the PDU building order.

Prevents the issue raised in Issue #811 happening without warnings. 