### PR TITLE
versioning: Make current git describe available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMakeLists.txt for libcoap
 #
 # Copyright (C) 2020 Carlos Gomes Martinho <carlos.gomes_martinho@siemens.com>
-# Copyright (C) 2020-2021 Jon Shallow <supjps-libcoap@jpshallow.com>
+# Copyright (C) 2020-2022 Jon Shallow <supjps-libcoap@jpshallow.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
@@ -379,6 +379,31 @@ if(ENABLE_DTLS)
 
 endif()
 
+execute_process(COMMAND git describe --tags --dirty --always
+                RESULT_VARIABLE USING_GIT
+                OUTPUT_VARIABLE LIBCOAP_PACKAGE_BUILD
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET)
+if(NOT ${USING_GIT} EQUAL 0)
+  set(LIBCOAP_PACKAGE_BUILD ${PROJECT_VERSION})
+else()
+  set(LIBCOAP_PACKAGE_BUILD "${LIBCOAP_PACKAGE_BUILD}")
+endif()
+
+set(PACKAGE_URL "https://libcoap.net/")
+set(PACKAGE_NAME "${PROJECT_NAME}")
+set(PACKAGE_TARNAME "${PROJECT_NAME}")
+set(PACKAGE_STRING "${PROJECT_NAME} ${PROJECT_VERSION}")
+set(PACKAGE_VERSION "${PROJECT_VERSION}")
+set(PACKAGE_BUGREPORT "libcoap-developers@lists.sourceforge.net")
+set(LIBCOAP_PACKAGE_VERSION "${PACKAGE_VERSION}")
+set(LIBCOAP_PACKAGE_URL "${PACKAGE_URL}")
+set(LIBCOAP_PACKAGE_NAME "${PACKAGE_NAME}")
+set(LIBCOAP_PACKAGE_STRING "${PACKAGE_STRING}")
+set(LIBCOAP_PACKAGE_BUGREPORT "${PACKAGE_BUGREPORT}")
+
+message(STATUS "PACKAGE VERSION..................${PACKAGE_VERSION}")
+message(STATUS "PACKAGE BUILD....................${LIBCOAP_PACKAGE_BUILD}")
 message(STATUS "ENABLE_DTLS:.....................${ENABLE_DTLS}")
 message(STATUS "ENABLE_TCP:......................${ENABLE_TCP}")
 message(STATUS "ENABLE_CLIENT_MODE:..............${ENABLE_CLIENT_MODE}")
@@ -400,17 +425,6 @@ message(STATUS "BUILD_SHARED_LIBS:...............${BUILD_SHARED_LIBS}")
 message(STATUS "CMAKE_BUILD_TYPE:................${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_SYSTEM_PROCESSOR:..........${CMAKE_SYSTEM_PROCESSOR}")
 
-set(PACKAGE_URL "https://libcoap.net/")
-set(PACKAGE_NAME "${PROJECT_NAME}")
-set(PACKAGE_TARNAME "${PROJECT_NAME}")
-set(PACKAGE_STRING "${PROJECT_NAME} ${PROJECT_VERSION}")
-set(PACKAGE_VERSION "${PROJECT_VERSION}")
-set(LIBCOAP_PACKAGE_VERSION "${PROJECT_VERSION}")
-set(LIBCOAP_PACKAGE_URL "${PACKAGE_URL}")
-set(LIBCOAP_PACKAGE_NAME "${PROJECT_NAME}")
-set(LIBCOAP_PACKAGE_STRING "TODO")
-set(LIBCOAP_PACKAGE_BUGREPORT "libcoap-developers@lists.sourceforge.net")
-set(PACKAGE_BUGREPORT "libcoap-developers@lists.sourceforge.net")
 set(top_srcdir "${CMAKE_CURRENT_LIST_DIR}")
 set(top_builddir "${CMAKE_CURRENT_BINARY_DIR}")
 if(ENABLE_TCP)
@@ -517,6 +531,10 @@ target_link_libraries(
          $<$<BOOL:${HAVE_MBEDTLS}>:${MBEDTLS_LIBRARY}>
          $<$<BOOL:${HAVE_MBEDTLS}>:${MBEDX509_LIBRARY}>
          $<$<BOOL:${HAVE_MBEDTLS}>:${MBEDCRYPTO_LIBRARY}>)
+
+target_compile_options(
+  ${COAP_LIBRARY_NAME}
+  PUBLIC -DLIBCOAP_PACKAGE_BUILD="${LIBCOAP_PACKAGE_BUILD}")
 
 add_library(
   ${PROJECT_NAME}::${COAP_LIBRARY_NAME}

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,8 @@
 # Makefile.am for libcoap
 #
-# Copyright (C) 2010-2021,2021 Olaf Bergmann <bergmann@tzi.org>
+# Copyright (C) 2010-2022 Olaf Bergmann <bergmann@tzi.org>
 # Copyright (C) 2015-2017 Carsten Schoenert <c.schoenert@t-online.de>
-# Copyright (C) 2018-2021 Jon Shallow <supjps-libcoap@jpshallow.com>
+# Copyright (C) 2018-2022 Jon Shallow <supjps-libcoap@jpshallow.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
@@ -14,6 +14,8 @@
 AUTOMAKE_OPTIONS = subdir-objects
 
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
+
+LIBCOAP_PACKAGE_BUILD = @DOLLAR_SIGN@(shell git describe --tags --dirty --always 2>/dev/null || echo @PACKAGE_VERSION@)
 
 ## Additional files for the distribution archive
 EXTRA_DIST = \
@@ -77,7 +79,9 @@ EXTRA_DIST = \
   win32/testdriver/testdriver.vcxproj.filters \
   win32/testdriver/testdriver.vcxproj.user
 
-AM_CFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include $(WARNING_CFLAGS) $(DTLS_CFLAGS) -std=c99 $(EXTRA_CFLAGS)
+AM_CFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include $(WARNING_CFLAGS) \
+            $(DTLS_CFLAGS) -std=c99 $(EXTRA_CFLAGS) \
+            -DLIBCOAP_PACKAGE_BUILD='"$(LIBCOAP_PACKAGE_BUILD)"'
 
 SUBDIRS = $(subdirs) . man doc tests examples
 

--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -2,7 +2,7 @@
 
 /* coap-client -- simple CoAP client
  *
- * Copyright (C) 2010--2019 Olaf Bergmann <bergmann@tzi.org> and others
+ * Copyright (C) 2010--2022 Olaf Bergmann <bergmann@tzi.org> and others
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -489,17 +489,17 @@ static void
 usage( const char *program, const char *version) {
   const char *p;
   char buffer[72];
-  const char *lib_version = coap_package_version();
+  const char *lib_build = coap_package_build();
 
   p = strrchr( program, '/' );
   if ( p )
     program = ++p;
 
   fprintf( stderr, "%s v%s -- a small CoAP implementation\n"
-     "Copyright (C) 2010-2021 Olaf Bergmann <bergmann@tzi.org> and others\n\n"
+     "Copyright (C) 2010-2022 Olaf Bergmann <bergmann@tzi.org> and others\n\n"
+     "Build: %s\n"
      "%s\n"
-     "%s\n"
-    , program, version, lib_version,
+    , program, version, lib_build,
     coap_string_tls_version(buffer, sizeof(buffer)));
   fprintf(stderr, "%s\n", coap_string_tls_support(buffer, sizeof(buffer)));
   fprintf(stderr, "\n"

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -3,7 +3,7 @@
 /* coap -- simple implementation of the Constrained Application Protocol (CoAP)
  *         as defined in RFC 7252
  *
- * Copyright (C) 2010--2015 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2010--2015,2022 Olaf Bergmann <bergmann@tzi.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -568,17 +568,17 @@ static void
 usage( const char *program, const char *version) {
   const char *p;
   char buffer[72];
-  const char *lib_version = coap_package_version();
+  const char *lib_build = coap_package_build();
 
   p = strrchr( program, '/' );
   if ( p )
     program = ++p;
 
   fprintf( stderr, "%s v%s -- CoRE Resource Directory implementation\n"
-     "(c) 2011-2012,2019-2021 Olaf Bergmann <bergmann@tzi.org> and others\n\n"
+     "(c) 2011-2012,2019-2022 Olaf Bergmann <bergmann@tzi.org> and others\n\n"
+     "Build: %s\n"
      "%s\n"
-     "%s\n"
-    , program, version, lib_version,
+    , program, version, lib_build,
     coap_string_tls_version(buffer, sizeof(buffer)));
   fprintf(stderr, "%s\n", coap_string_tls_support(buffer, sizeof(buffer)));
   fprintf(stderr, "\n"

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -3,7 +3,7 @@
 /* coap -- simple implementation of the Constrained Application Protocol (CoAP)
  *         as defined in RFC 7252
  *
- * Copyright (C) 2010--2021 Olaf Bergmann <bergmann@tzi.org> and others
+ * Copyright (C) 2010--2022 Olaf Bergmann <bergmann@tzi.org> and others
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -2154,17 +2154,17 @@ static void
 usage( const char *program, const char *version) {
   const char *p;
   char buffer[72];
-  const char *lib_version = coap_package_version();
+  const char *lib_build = coap_package_build();
 
   p = strrchr( program, '/' );
   if ( p )
     program = ++p;
 
   fprintf( stderr, "%s v%s -- a small CoAP implementation\n"
-     "(c) 2010,2011,2015-2021 Olaf Bergmann <bergmann@tzi.org> and others\n\n"
+     "(c) 2010,2011,2015-2022 Olaf Bergmann <bergmann@tzi.org> and others\n\n"
+     "Build: %s\n"
      "%s\n"
-     "%s\n"
-    , program, version, lib_version,
+    , program, version, lib_build,
     coap_string_tls_version(buffer, sizeof(buffer)));
   fprintf(stderr, "%s\n", coap_string_tls_support(buffer, sizeof(buffer)));
   fprintf(stderr, "\n"

--- a/include/coap3/coap_debug.h
+++ b/include/coap3/coap_debug.h
@@ -1,7 +1,7 @@
 /*
  * coap_debug.h -- debug utilities
  *
- * Copyright (C) 2010-2011,2014 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2010-2011,2014-2022 Olaf Bergmann <bergmann@tzi.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -128,6 +128,13 @@ const char *coap_package_name(void);
  * @return Zero-terminated string with the library version.
  */
 const char *coap_package_version(void);
+
+/**
+ * Get the library package build.
+ *
+ * @return Zero-terminated string with the library build.
+ */
+const char *coap_package_build(void);
 
 /**
  * Writes the given text to @c COAP_ERR_FD (for @p level <= @c LOG_CRIT) or @c

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -134,6 +134,7 @@ global:
   coap_opt_setheader;
   coap_opt_size;
   coap_opt_value;
+  coap_package_build;
   coap_package_name;
   coap_package_version;
   coap_pdu_duplicate;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -132,6 +132,7 @@ coap_opt_parse
 coap_opt_setheader
 coap_opt_size
 coap_opt_value
+coap_package_build
 coap_package_name
 coap_package_version
 coap_pdu_duplicate

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -92,6 +92,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_get_session_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_set_csm_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_get_csm_timeout.3
+	@echo ".so man3/coap_logging.3" > coap_show_pdu.3
 	@echo ".so man3/coap_logging.3" > coap_endpoint_str.3
 	@echo ".so man3/coap_logging.3" > coap_session_str.3
 	@echo ".so man3/coap_pdu_access.3" > coap_option_filter_set.3

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -17,6 +17,7 @@ coap_set_log_level,
 coap_set_log_handler,
 coap_package_name,
 coap_package_version,
+coap_package_build,
 coap_set_show_pdu_output,
 coap_show_pdu,
 coap_endpoint_str,
@@ -42,6 +43,8 @@ SYNOPSIS
 *const char *coap_package_name(void);*
 
 *const char *coap_package_version(void);*
+
+*const char *coap_package_build(void);*
 
 *void coap_set_show_pdu_output(int _use_fprintf_);*
 
@@ -125,6 +128,10 @@ The *coap_package_name*() function returns the name of this library.
 
 The *coap_package_version*() function returns the version of this library.
 
+The *coap_package_build*() function returns the git information (as in
+"git describe --tags") for the build of this library or version of this
+library if git is not used.
+
 The *coap_set_show_pdu_output*() function defines whether the output from
 *coap_show_pdu*() is to be either sent to stdout/stderr, or output using
 *coap_log*().  _use_fprintf_ is set to 1 for stdout/stderr (the default), and
@@ -143,8 +150,9 @@ information about the _session_.
 RETURN VALUES
 -------------
 
-The *coap_package_name*() and *coap_package_version*() return the appropriate
-zero-terminated character string.
+The *coap_package_name*(), *coap_package_version*() and
+*coap_package_build*() return the appropriate zero-terminated character
+string.
 
 The *coap_get_log_level*() function returns the current logging level.
 

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -1,6 +1,6 @@
 /* coap_debug.c -- debug utilities
  *
- * Copyright (C) 2010--2012,2014--2019 Olaf Bergmann <bergmann@tzi.org> and others
+ * Copyright (C) 2010--2012,2014--2022 Olaf Bergmann <bergmann@tzi.org> and others
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -57,6 +57,14 @@ const char *coap_package_name(void) {
 
 const char *coap_package_version(void) {
   return PACKAGE_STRING;
+}
+
+const char *coap_package_build(void) {
+#ifdef LIBCOAP_PACKAGE_BUILD
+  return LIBCOAP_PACKAGE_BUILD;
+#else /* !LIBCOAP_PACKAGE_BUILD */
+  return PACKAGE_STRING;
+#endif /* !LIBCOAP_PACKAGE_BUILD */
 }
 
 void


### PR DESCRIPTION
Add new function coap_package_build() which returns "git describe --tags"
if available at library build time, else standard package version.

The value of "git describe --tags" is created at run time and passed in as
a compiler -D definition rather than let autotools update a file with
the value which may become stale in moving through git commits as well as
have the wrong value in the git repository after a commit or merge.
The alternative of Makefile updating a coap_build.h file always causes
coap_debug.o to get rebuilt even if coap_build.h is not actually changed.

Update copyright end dates for updated files.

See #798 