### PR TITLE
github workflow: Support windows-2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           make -C examples/${{matrix.OS}}
   ms-build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v2

--- a/scripts/msbuild.sln.cmd
+++ b/scripts/msbuild.sln.cmd
@@ -8,7 +8,7 @@ if exist NoTLS rd /s /q NoTLS
 
 cd ..
 
-"%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" ./win32/libcoap.sln /p:Configuration=NoTLS /p:Platform=x64 /warnaserror
+"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe" ./win32/libcoap.sln /p:Configuration=NoTLS /p:Platform=x64 /warnaserror
 
 :exit
 popd


### PR DESCRIPTION
The provided host for windows-latest is migrating across from
windows-2019 to windows-2022 on github.  This allows things to be built on
a windows-2022 system.