### PR TITLE
Proxy: Support unknown Critical but Safe-To-Forward options

### DIFF
--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -297,7 +297,7 @@ void coap_dispatch(coap_context_t *context, coap_session_t *session,
   coap_opt_filter_t f = COAP_OPT_NONE;
   coap_opt_iterator_t opt_iter;
 
-  if (coap_option_check_critical(ctx, pdu, f) == 0) {
+  if (coap_option_check_critical(session, pdu, f) == 0) {
     coap_option_iterator_init(pdu, &opt_iter, f);
 
     while (coap_option_next(&opt_iter)) {
@@ -308,14 +308,14 @@ void coap_dispatch(coap_context_t *context, coap_session_t *session,
   }
    @endcode
  *
- * @param ctx      The context where all known options are registered.
+ * @param session  The current session.
  * @param pdu      The PDU to check.
  * @param unknown  The output filter that will be updated to indicate the
  *                 unknown critical options found in @p pdu.
  *
  * @return         @c 1 if everything was ok, @c 0 otherwise.
  */
-int coap_option_check_critical(coap_context_t *ctx,
+int coap_option_check_critical(coap_session_t *session,
                                coap_pdu_t *pdu,
                                coap_opt_filter_t *unknown);
 

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -103,6 +103,7 @@ struct coap_pdu_t {
   uint8_t hdr_size;         /**< actual size used for protocol-specific
                                  header */
   uint8_t token_length;     /**< length of Token */
+  uint8_t crit_opt;         /**< Set if unknown critical option for proxy */
   uint16_t max_opt;         /**< highest option number in PDU */
   size_t alloc_size;        /**< allocated storage for token, options and
                                  payload */

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -133,6 +133,7 @@ struct coap_session_t {
   int dtls_event;                       /**< Tracking any (D)TLS events on this
                                              sesison */
   uint8_t block_mode;             /**< Zero or more COAP_BLOCK_ or'd options */
+  uint8_t proxy_session;          /**< Set if this is an ongoing proxy session */
   uint64_t tx_token;              /**< Next token number to use */
 };
 

--- a/src/block.c
+++ b/src/block.c
@@ -668,10 +668,11 @@ coap_add_data_large_response(coap_resource_t *resource,
     }
   }
 
-  coap_insert_option(response, COAP_OPTION_CONTENT_TYPE,
-                     coap_encode_var_safe(buf, sizeof(buf),
-                                          media_type),
-                     buf);
+  if (media_type != 0)
+    coap_insert_option(response, COAP_OPTION_CONTENT_FORMAT,
+                       coap_encode_var_safe(buf, sizeof(buf),
+                                            media_type),
+                       buf);
 
   if (maxage >= 0) {
     coap_insert_option(response,

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -860,6 +860,10 @@ coap_session_create_client(
   if (local_if)
     session->sock.flags |= COAP_SOCKET_BOUND;
   SESSIONS_ADD(ctx->sessions, session);
+#if COAP_SERVER_SUPPORT
+  if (ctx->proxy_uri_resource)
+    session->proxy_session = 1;
+#endif /* COAP_SERVER_SUPPORT */
   return session;
 
 error:

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -49,6 +49,7 @@ coap_pdu_clear(coap_pdu_t *pdu, size_t size) {
   pdu->code = 0;
   pdu->hdr_size = 0;
   pdu->token_length = 0;
+  pdu->crit_opt = 0;
   pdu->mid = 0;
   pdu->max_opt = 0;
   pdu->max_size = size;

--- a/tests/test_error_response.c
+++ b/tests/test_error_response.c
@@ -87,7 +87,7 @@ t_error_response3(void) {
   const uint8_t code = COAP_RESPONSE_CODE(402);
   uint8_t teststr[] = {
     0x65, code, 0x00, 0x00, 't', 'o', 'k', 'e',
-    'n', 0x90, 0xff, 'B', 'a', 'd', ' ', 'O',
+    'n', 0xd0, 0x0c, 0xff, 'B', 'a', 'd', ' ', 'O',
     'p', 't', 'i', 'o', 'n'
   };
   coap_pdu_t *response;
@@ -97,11 +97,11 @@ t_error_response3(void) {
   coap_add_token(pdu, 5, (const uint8_t *)"token");
   /* coap_add_option(pdu, COAP_OPTION_URI_HOST, 4, (const uint8_t *)"time"); */
 
-  /* unknown critical option 9 */
-  coap_add_option(pdu, 9, 0, NULL);
+  /* unknown critical option 25 */
+  coap_add_option(pdu, 25, 0, NULL);
 
   coap_option_filter_clear(&opts);
-  coap_option_filter_set(&opts, 9);
+  coap_option_filter_set(&opts, 25);
   response = coap_new_error_response(pdu, code, &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);
@@ -124,7 +124,7 @@ t_error_response4(void) {
   };
   uint8_t teststr[] = {
     0x65, code, 0x00, 0x00,  't',  'o',  'k',  'e',
-     'n', 0x9c, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+     'n', 0xdc, 0x0c, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
     0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0xff,  'B',
      'a',  'd',  ' ',  'O',  'p',  't',  'i',  'o',
      'n'
@@ -136,11 +136,11 @@ t_error_response4(void) {
   coap_add_token(pdu, 5, (const uint8_t *)"token");
   /* coap_add_option(pdu, COAP_OPTION_URI_HOST, 4, (const uint8_t *)"time"); */
 
-  /* unknown critical option 9 */
-  coap_add_option(pdu, 9, sizeof(optval), optval);
+  /* unknown critical option 25 */
+  coap_add_option(pdu, 25, sizeof(optval), optval);
 
   coap_option_filter_clear(&opts);
-  coap_option_filter_set(&opts, 9);
+  coap_option_filter_set(&opts, 25);
   response = coap_new_error_response(pdu, code, &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);
@@ -164,7 +164,7 @@ t_error_response5(void) {
   };
   uint8_t teststr[] = {
     0x65, code, 0x00, 0x00,  't',  'o',  'k',  'e',
-     'n', 0x9d, 0x06, 0x00, 0x01, 0x02, 0x03, 0x04,
+     'n', 0xdd, 0x0c, 0x06, 0x00, 0x01, 0x02, 0x03, 0x04,
     0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
     0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0xff,  'B',
      'a',  'd',  ' ',  'O',  'p',  't',  'i',  'o',
@@ -177,11 +177,11 @@ t_error_response5(void) {
   coap_add_token(pdu, 5, (const uint8_t *)"token");
   /* coap_add_option(pdu, COAP_OPTION_URI_HOST, 4, (const uint8_t *)"time"); */
 
-  /* unknown critical option 9 */
-  coap_add_option(pdu, 9, sizeof(optval), optval);
+  /* unknown critical option 25 */
+  coap_add_option(pdu, 25, sizeof(optval), optval);
 
   coap_option_filter_clear(&opts);
-  coap_option_filter_set(&opts, 9);
+  coap_option_filter_set(&opts, 25);
   response = coap_new_error_response(pdu, code, &opts);
 
   CU_ASSERT_PTR_NOT_NULL(response);


### PR DESCRIPTION
The CoAP Proxy may not know how to handle a Critical option, but if it
is safe to forward it should be able to handle this.

RFRC7252 5.4.1
   Critical/elective rules apply to non-proxying endpoints.  A proxy
   processes options based on Unsafe/Safe-to-Forward classes as defined
   in Section 5.7.

If this is an incoming proxy type request special case any
critical options that are safe to forward.

Track ongoing sessions from an enabled proxy server so unknown critical
response options can be passed back to the originating requestor.

Update coap-server to handle Proxy-Scheme for proxying.

Update tests to use option 25 instead of 9.

Closes #825.