### PR TITLE
block.c: Fix possible null-pointer dereference

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -698,25 +698,15 @@ coap_add_data_large_response(coap_resource_t *resource,
     default:                        /* everything is good */
         ;
     }
-
-    if (!coap_add_data_large_internal(session, response, resource, query,
-                                      maxage, etag, length, data,
-                                      release_func, app_ptr,
-                                      request->code)) {
-      response->code = COAP_RESPONSE_CODE(500);
-      goto error;
-    }
-
-    return 1;
   }
 
-  /*
-   * BLOCK2 not requested
-   */
-  if (!coap_add_data_large_internal(session, response, resource, query, maxage,
-                                    etag, length, data, release_func,
-                                    app_ptr, request->code)) {
-    response->code = COAP_RESPONSE_CODE(400);
+  /* add data body */
+  if (request &&
+      !coap_add_data_large_internal(session, response, resource, query,
+                                    maxage, etag, length, data,
+                                    release_func, app_ptr,
+                                    request->code)) {
+    response->code = COAP_RESPONSE_CODE(500);
     goto error;
   }
 


### PR DESCRIPTION
Commit 9cb2f62a3 [1] has introduced library-internal handling of
Block1 and Block2 requests. To add the data to the response body the
function coap_add_data_large_internal() is used.

This change calls the function independent of a Block2 request unless
request is NULL. The response code is set to 500 if
coap_add_data_large_internal() failed.

Fixes Coverity-Id 1514379

[1] https://github.com/obgm/libcoap/commit/9cb2f62a3eef2e0aeb682615b785d4734b473bd4