### PR TITLE
BERT: Support block BERT szx of 7 for reliable protocols

### DIFF
--- a/include/coap3/block.h
+++ b/include/coap3/block.h
@@ -44,6 +44,19 @@ typedef struct {
   unsigned int szx:3;     /**< block size */
 } coap_block_t;
 
+/**
+ * Structure of Block options with BERT support.
+ */
+typedef struct {
+  unsigned int num;       /**< block number */
+  unsigned int m:1;       /**< 1 if more blocks follow, 0 otherwise */
+  unsigned int szx:3;     /**< block size (0-6) */
+  unsigned int aszx:3;    /**< block size (0-7 including BERT */
+  unsigned int defined:1; /**< Set if block found */
+  unsigned int bert:1;    /**< Operating as BERT */
+  uint32_t chunk_size;    /**< > 1024 if BERT */
+} coap_block_b_t;
+
 #define COAP_BLOCK_USE_LIBCOAP  0x01 /* Use libcoap to do block requests */
 #define COAP_BLOCK_SINGLE_BODY  0x02 /* Deliver the data as a single body */
 
@@ -97,12 +110,31 @@ coap_opt_block_set_m(coap_opt_t *block_opt, int m) {
  * @param pdu    The pdu to search for option @p number.
  * @param number The option number to search for (must be COAP_OPTION_BLOCK1 or
  *               COAP_OPTION_BLOCK2).
- * @param block  The block structure to initilize.
+ * @param block  The block structure to initialize.
  *
  * @return       @c 1 on success, @c 0 otherwise.
  */
 int coap_get_block(const coap_pdu_t *pdu, coap_option_num_t number,
                    coap_block_t *block);
+
+
+/**
+ * Initializes @p block from @p pdu. @p number must be either COAP_OPTION_BLOCK1
+ * or COAP_OPTION_BLOCK2. When option @p number was found in @p pdu, @p block is
+ * initialized with values from this option and the function returns the value
+ * @c 1. Otherwise, @c 0 is returned. BERT information is abstracted as
+ * appropriate.
+ *
+ * @param session THe session that the pdu is associated with,
+ * @param pdu    The pdu to search for option @p number.
+ * @param number The option number to search for (must be COAP_OPTION_BLOCK1 or
+ *               COAP_OPTION_BLOCK2).
+ * @param block  The block structure to initialize.
+ *
+ * @return       @c 1 on success, @c 0 otherwise.
+ */
+int coap_get_block_b(const coap_session_t *session, const coap_pdu_t *pdu,
+                     coap_option_num_t number, coap_block_b_t *block);
 
 /**
  * Writes a block option of type @p number to message @p pdu. If the requested
@@ -128,6 +160,33 @@ int coap_write_block_opt(coap_block_t *block,
                          coap_option_num_t number,
                          coap_pdu_t *pdu,
                          size_t data_length);
+/**
+ * Writes a block option of type @p number to message @p pdu. If the requested
+ * block size is too large to fit in @p pdu, it is reduced accordingly. An
+ * exception is made for the final block when less space is required. The actual
+ * length of the resource is specified in @p data_length.
+ *
+ * This function may change *block to reflect the values written to @p pdu. As
+ * the function takes into consideration the remaining space @p pdu, no more
+ * options should be added after coap_write_block_opt() has returned.
+ *
+ * @param session     The CoAP session.
+ * @param block       The block structure to use. On return, this object is
+ *                    updated according to the values that have been written to
+ *                    @p pdu.
+ * @param number      COAP_OPTION_BLOCK1 or COAP_OPTION_BLOCK2.
+ * @param pdu         The message where the block option should be written.
+ * @param data_length The length of the actual data that will be added the @p
+ *                    pdu by calling coap_add_block().
+ *
+ * @return            @c 1 on success, or a negative value on error.
+ */
+int coap_write_block_b_opt(coap_session_t *session,
+                           coap_block_b_t *block,
+                           coap_option_num_t number,
+                           coap_pdu_t *pdu,
+                           size_t data_length);
+
 
 /**
  * Adds the @p block_num block of size 1 << (@p block_szx + 4) from source @p
@@ -146,6 +205,19 @@ int coap_add_block(coap_pdu_t *pdu,
                    const uint8_t *data,
                    unsigned int block_num,
                    unsigned char block_szx);
+
+/**
+ * Adds the appropriate payload data of the body to the @p pdu.
+ *
+ * @param pdu       The message to add the block.
+ * @param len       The length of @p data.
+ * @param data      The source data to fill the block with.
+ * @param block     The block information (including potentially BERT)
+ *
+ * @return          @c 1 on success, @c 0 otherwise.
+ */
+int coap_add_block_b_data(coap_pdu_t *pdu, size_t len, const uint8_t *data,
+                          coap_block_b_t *block);
 
 /**
  * Re-assemble payloads into a body

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -58,6 +58,7 @@ typedef struct coap_rblock_t {
 typedef struct coap_l_block1_t {
   coap_binary_t *app_token; /**< original PDU token */
   uint64_t state_token;  /**< state token */
+  size_t bert_size;      /**< size of last BERT block */
   uint32_t count;        /**< the number of packets sent for payload */
 } coap_l_block1_t;
 

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -133,9 +133,11 @@ struct coap_session_t {
   unsigned int dtls_timeout_count;      /**< dtls setup retry counter */
   int dtls_event;                       /**< Tracking any (D)TLS events on this
                                              sesison */
+  uint8_t csm_bert_rem_support;  /**< CSM TCP BERT blocks supported (remote) */
+  uint8_t csm_bert_loc_support;  /**< CSM TCP BERT blocks supported (local) */
   uint8_t block_mode;             /**< Zero or more COAP_BLOCK_ or'd options */
   uint8_t doing_first;            /**< Set if doing client's first request */
-  uint8_t proxy_session;          /**< Set if this is an ongoing proxy session */
+  uint8_t proxy_session;        /**< Set if this is an ongoing proxy session */
   uint64_t tx_token;              /**< Next token number to use */
 };
 

--- a/include/coap3/pdu.h
+++ b/include/coap3/pdu.h
@@ -40,6 +40,8 @@
 #define COAP_DEFAULT_MTU       1152
 #endif /* COAP_DEFAULT_MTU */
 
+#define COAP_BERT_BASE 1152
+
 #ifndef COAP_DEFAULT_HOP_LIMIT
 #define COAP_DEFAULT_HOP_LIMIT       16
 #endif /* COAP_DEFAULT_HOP_LIMIT */

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -2,6 +2,7 @@ VER_3 {
 global:
   coap_add_attr;
   coap_add_block;
+  coap_add_block_b_data;
   coap_add_data;
   coap_add_data_after;
   coap_add_data_blocked_response;
@@ -84,6 +85,7 @@ global:
   coap_free_type;
   coap_get_app_data;
   coap_get_block;
+  coap_get_block_b;
   coap_get_data;
   coap_get_data_large;
   coap_get_log_level;
@@ -233,6 +235,7 @@ global:
   coap_ticks_to_rt;
   coap_ticks_to_rt_us;
   coap_tls_is_supported;
+  coap_write_block_b_opt;
   coap_write_block_opt;
 local:
   *;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -1,5 +1,6 @@
 coap_add_attr
 coap_add_block
+coap_add_block_b_data
 coap_add_data
 coap_add_data_after
 coap_add_data_blocked_response
@@ -82,6 +83,7 @@ coap_free_endpoint
 coap_free_type
 coap_get_app_data
 coap_get_block
+coap_get_block_b
 coap_get_data
 coap_get_data_large
 coap_get_log_level
@@ -231,4 +233,5 @@ coap_ticks_from_rt_us
 coap_ticks_to_rt
 coap_ticks_to_rt_us
 coap_tls_is_supported
+coap_write_block_b_opt
 coap_write_block_opt

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -420,10 +420,15 @@ void coap_session_send_csm(coap_session_t *session) {
     coap_session_disconnected(session, COAP_NACK_NOT_DELIVERABLE);
   } else {
     ssize_t bytes_written = coap_session_send_pdu(session, pdu);
-    if (bytes_written != (ssize_t)pdu->used_size + pdu->hdr_size)
+    if (bytes_written != (ssize_t)pdu->used_size + pdu->hdr_size) {
       coap_session_disconnected(session, COAP_NACK_NOT_DELIVERABLE);
-    else
+    } else {
       session->csm_rcv_mtu = session->context->csm_max_message_size;
+      if (session->csm_rcv_mtu > COAP_BERT_BASE)
+        session->csm_bert_loc_support = 1;
+      else
+        session->csm_bert_loc_support = 0;
+    }
   }
   if (pdu)
     coap_delete_pdu(pdu);

--- a/src/net.c
+++ b/src/net.c
@@ -1131,7 +1131,7 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
 #if COAP_CLIENT_SUPPORT
   coap_lg_crcv_t *lg_crcv = NULL;
   coap_opt_iterator_t opt_iter;
-  coap_block_t block = {0, 0, 0};
+  coap_block_b_t block;
   int observe_action = -1;
   int have_block1 = 0;
   coap_opt_t *opt;
@@ -1148,8 +1148,11 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
                                                      coap_opt_length(opt));
     }
 
-    if (coap_get_block(pdu, COAP_OPTION_BLOCK1, &block) && block.m == 1)
+    if (coap_get_block_b(session, pdu, COAP_OPTION_BLOCK1, &block) &&
+        (block.m == 1 || block.bert == 1))
       have_block1 = 1;
+  } else {
+    memset(&block, 0, sizeof(block));
   }
 
   /*
@@ -1344,21 +1347,36 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
 
 #if !COAP_DISABLE_TCP
   if (COAP_PROTO_RELIABLE(session->proto) &&
-      session->state == COAP_SESSION_STATE_ESTABLISHED &&
-      !session->csm_block_supported) {
-    /*
-     * Need to check that this instance is not sending any block options as the
-     * remote end via CSM has not informed us that there is support
-     * https://tools.ietf.org/html/rfc8323#section-5.3.2
-     * Note that this also includes BERT which is application specific.
-     */
-    if (coap_check_option(pdu, COAP_OPTION_BLOCK1, &opt_iter) != NULL) {
-      coap_log(LOG_DEBUG,
-               "Remote end did not indicate CSM support for BLOCK1 enabled\n");
+      session->state == COAP_SESSION_STATE_ESTABLISHED) {
+    if (!session->csm_block_supported) {
+      /*
+       * Need to check that this instance is not sending any block options as
+       * the remote end via CSM has not informed us that there is support
+       * https://tools.ietf.org/html/rfc8323#section-5.3.2
+       * This includes potential BERT blocks.
+       */
+      if (coap_check_option(pdu, COAP_OPTION_BLOCK1, &opt_iter) != NULL) {
+        coap_log(LOG_DEBUG,
+                 "Remote end did not indicate CSM support for Block1 enabled\n");
+      }
+      if (coap_check_option(pdu, COAP_OPTION_BLOCK2, &opt_iter) != NULL) {
+        coap_log(LOG_DEBUG,
+                 "Remote end did not indicate CSM support for Block2 enabled\n");
+      }
     }
-    if (coap_check_option(pdu, COAP_OPTION_BLOCK2, &opt_iter) != NULL) {
-      coap_log(LOG_DEBUG,
-               "Remote end did not indicate CSM support for BLOCK2 enabled\n");
+    else if (!session->csm_bert_rem_support) {
+      coap_opt_t *opt;
+
+      opt = coap_check_option(pdu, COAP_OPTION_BLOCK1, &opt_iter);
+      if (opt && COAP_OPT_BLOCK_SZX(opt) == 7) {
+        coap_log(LOG_DEBUG,
+               "Remote end did not indicate CSM support for BERT Block1\n");
+      }
+      opt = coap_check_option(pdu, COAP_OPTION_BLOCK2, &opt_iter);
+      if (opt && COAP_OPT_BLOCK_SZX(opt) == 7) {
+        coap_log(LOG_DEBUG,
+               "Remote end did not indicate CSM support for BERT Block2\n");
+      }
     }
   }
 #endif /* !COAP_DISABLE_TCP */
@@ -2295,7 +2313,7 @@ coap_wellknown_response(coap_context_t *context, coap_session_t *session,
   uint8_t buf[4];
   int result = 0;
   int need_block2 = 0;           /* set to 1 if Block2 option is required */
-  coap_block_t block;
+  coap_block_b_t block;
   coap_opt_t *query_filter;
   size_t offset = 0;
   uint8_t *data;
@@ -2328,7 +2346,7 @@ coap_wellknown_response(coap_context_t *context, coap_session_t *session,
   }
 
   /* check whether the request contains the Block2 option */
-  if (coap_get_block(request, COAP_OPTION_BLOCK2, &block)) {
+  if (coap_get_block_b(session, request, COAP_OPTION_BLOCK2, &block)) {
     coap_log(LOG_DEBUG, "create block\n");
     offset = block.num << (block.szx + 4);
     if (block.szx > 6) {  /* invalid, MUST lead to 4.00 Bad Request */
@@ -2392,7 +2410,8 @@ coap_wellknown_response(coap_context_t *context, coap_session_t *session,
 
   /* write Block2 option if necessary */
   if (need_block2) {
-    if (coap_write_block_opt(&block, COAP_OPTION_BLOCK2, resp, wkc_len) < 0) {
+    if (coap_write_block_b_opt(session, &block, COAP_OPTION_BLOCK2, resp,
+        wkc_len) < 0) {
       coap_log(LOG_DEBUG,
                "coap_wellknown_response: cannot add Block2 option\n");
       goto error;
@@ -2887,7 +2906,7 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
       coap_opt_t *observe = NULL;
       int observe_action = COAP_OBSERVE_CANCEL;
       coap_string_t *query = coap_get_query(pdu);
-      coap_block_t block;
+      coap_block_b_t block;
       int added_block = 0;
 
       /* check for Observe option RFC7641 and RFC8132 */
@@ -2903,7 +2922,7 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
           if (observe_action == COAP_OBSERVE_ESTABLISH) {
             coap_subscription_t *subscription;
 
-            if (coap_get_block(pdu, COAP_OPTION_BLOCK2, &block)) {
+            if (coap_get_block_b(session, pdu, COAP_OPTION_BLOCK2, &block)) {
               if (block.num != 0) {
                 response->code = COAP_RESPONSE_CODE(400);
                 goto skip_handler;
@@ -3080,7 +3099,7 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
   coap_pdu_t *pdu) {
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
-  (void)context;
+  int set_mtu = 0;
 
   coap_option_iterator_init(pdu, &opt_iter, COAP_OPT_ALL);
 
@@ -3089,9 +3108,16 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
       if (opt_iter.number == COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE) {
         coap_session_set_mtu(session, coap_decode_var_bytes(coap_opt_value(option),
           coap_opt_length(option)));
+        set_mtu = 1;
       } else if (opt_iter.number == COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER) {
         session->csm_block_supported = 1;
       }
+    }
+    if (set_mtu) {
+      if (session->mtu > COAP_BERT_BASE && session->csm_block_supported)
+        session->csm_bert_rem_support = 1;
+      else
+        session->csm_bert_rem_support = 0;
     }
     if (session->state == COAP_SESSION_STATE_CSM)
       coap_session_connected(session);

--- a/src/resource.c
+++ b/src/resource.c
@@ -889,7 +889,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
   coap_pdu_t *response;
   uint8_t buf[4];
   coap_string_t *query;
-  coap_block_t block;
+  coap_block_b_t block;
 
   if (r->observable && (r->dirty || r->partiallydirty)) {
     r->partiallydirty = 0;
@@ -955,13 +955,14 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
                                  coap_encode_var_safe(buf, sizeof (buf),
                                                       r->observe),
                                  buf);
-        if (coap_get_block(obs->pdu, COAP_OPTION_BLOCK2, &block)) {
+        if (coap_get_block_b(obs->session, obs->pdu, COAP_OPTION_BLOCK2,
+                             &block)) {
           /* Will get updated later (e.g. M bit) if appropriate */
           coap_add_option_internal(response, COAP_OPTION_BLOCK2,
                                    coap_encode_var_safe(buf, sizeof(buf),
                                                         ((0 << 4) |
                                                          (0 << 3) |
-                                                         block.szx)),
+                                                         block.aszx)),
                                    buf);
         }
 


### PR DESCRIPTION
Add in new coap_block_b_t structure that tracks BERT usage, and
use new functions coap_*block_b_* that are in addition to the old
coap_*block_* functions that use coap_block_b_t.

Addresses issue in #774