### PR TITLE
TLS SIGPIPE: Stop programs exiting with code 141 (128 + 13:SIGPIPE)

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2786,6 +2786,20 @@ main(int argc, char **argv) {
     }
   }
 
+#ifdef _WIN32
+  signal(SIGINT, handle_sigint);
+#else
+  memset (&sa, 0, sizeof(sa));
+  sigemptyset(&sa.sa_mask);
+  sa.sa_handler = handle_sigint;
+  sa.sa_flags = 0;
+  sigaction (SIGINT, &sa, NULL);
+  sigaction (SIGTERM, &sa, NULL);
+  /* So we do not exit on a SIGPIPE */
+  sa.sa_handler = SIG_IGN;
+  sigaction (SIGPIPE, &sa, NULL);
+#endif
+
   coap_startup();
   coap_dtls_set_log_level(log_level);
   coap_set_log_level(log_level);
@@ -2813,20 +2827,6 @@ main(int argc, char **argv) {
     FD_SET(coap_fd, &m_readfds);
     nfds = coap_fd + 1;
   }
-
-#ifdef _WIN32
-  signal(SIGINT, handle_sigint);
-#else
-  memset (&sa, 0, sizeof(sa));
-  sigemptyset(&sa.sa_mask);
-  sa.sa_handler = handle_sigint;
-  sa.sa_flags = 0;
-  sigaction (SIGINT, &sa, NULL);
-  sigaction (SIGTERM, &sa, NULL);
-  /* So we do not exit on a SIGPIPE */
-  sa.sa_handler = SIG_IGN;
-  sigaction (SIGPIPE, &sa, NULL);
-#endif
 
   wait_ms = COAP_RESOURCE_CHECK_TIME * 1000;
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -487,7 +487,10 @@ coap_socket_write(coap_socket_t *sock, const uint8_t *data, size_t data_len) {
 #ifdef _WIN32
   r = send(sock->fd, (const char *)data, (int)data_len, 0);
 #else
-  r = send(sock->fd, data, data_len, 0);
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif /* MSG_NOSIGNAL */
+  r = send(sock->fd, data, data_len, MSG_NOSIGNAL);
 #endif
   if (r == COAP_SOCKET_ERROR) {
 #ifdef _WIN32

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -2272,7 +2272,7 @@ ssize_t coap_tls_write(coap_session_t *c_session,
         break;
       }
       if (ret == -1) {
-        coap_log(LOG_WARNING, "coap_dtls_send: cannot send PDU\n");
+        coap_log(LOG_WARNING, "coap_tls_write: cannot send PDU\n");
       }
     }
   } else {


### PR DESCRIPTION
The example coap-client application was setting the SIGPIPE signal to
SIG_IGN too late.
 
For applications that do not handle SIGPIPE, set MSG_NOSIGNAL in send() flags 
to stop SIGPIPE being generated (but send() still returns EPIPE).

Drop the logging level when a client session cannot be extablished.

Can be reproduced when server requires certificates, but client does not
provide any certificate when using coaps+tcp:// and Mbed TLS.

````
Window 1
$ coap-server -c server.pem -C ca.pem
Window 2
$ coap-client coaps+tcp://127.0.0.1
$ echo $
````