### PR TITLE
CMakeLists.txt: Correctly determine cmsghdr support for determining a…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ if(WIN32)
   set(HAVE_STRUCT_CMSGHDR 1)
 else()
   check_symbol_exists(
-    cmsghdr
+    CMSG_FIRSTHDR
     sys/socket.h
     HAVE_STRUCT_CMSGHDR)
 endif()

--- a/cmake_coap_config.h.in
+++ b/cmake_coap_config.h.in
@@ -13,6 +13,10 @@
 #ifndef COAP_CONFIG_H_
 #define COAP_CONFIG_H_
 
+#if ! defined(_WIN32)
+#define _GNU_SOURCE
+#endif
+
 /* Define to 1 if you have <ws2tcpip.h> header file. */
 #cmakedefine HAVE_WS2TCPIP_H @HAVE_WS2TCPIP_H@
 


### PR DESCRIPTION
…ddresses

check_symbol_exists() only works for defines etc., not struct, so look for
CMSG_FIRSTHDR instead.

Make sure _GNU_SOURCE is defined to pick up the in6_pktinfo definition needed
for the logic using cmsghdr.

Fixes #849.