### PR TITLE
mcast support: Support multicast granular to the resource level

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -136,7 +136,6 @@ uint16_t last_block1_mid = 0;
 
 unsigned int wait_seconds = DEFAULT_WAIT_TIME; /* default timeout in seconds */
 unsigned int wait_ms = 0;
-int wait_ms_reset = 0;
 int obs_started = 0;
 unsigned int obs_seconds = 30;          /* default observe time */
 unsigned int obs_ms = 0;                /* timeout for current subscription */
@@ -458,8 +457,6 @@ message_handler(coap_session_t *session COAP_UNUSED,
                                   COAP_OPTION_OBSERVE, &opt_iter) == NULL : 1;
       }
       if(COAP_OPT_BLOCK_MORE(block_opt)) {
-        wait_ms = wait_seconds * 1000;
-        wait_ms_reset = 1;
         doing_getting_block = 1;
       }
       else {
@@ -1819,7 +1816,7 @@ main(int argc, char **argv) {
 
   if (is_mcast && wait_seconds == DEFAULT_WAIT_TIME)
     /* Allow for other servers to respond within DEFAULT_LEISURE RFC7252 8.2 */
-    wait_seconds = coap_session_get_default_leisure(session).integer_part;
+    wait_seconds = coap_session_get_default_leisure(session).integer_part + 1;
 
   wait_ms = wait_seconds * 1000;
   coap_log(LOG_DEBUG, "timeout is set to %u seconds\n", wait_seconds);
@@ -1856,7 +1853,7 @@ main(int argc, char **argv) {
     result = coap_io_process(ctx, timeout_ms);
 
     if ( result >= 0 ) {
-      if ( wait_ms > 0 && !wait_ms_reset ) {
+      if (wait_ms > 0) {
         if ( (unsigned)result >= wait_ms ) {
           coap_log(LOG_INFO, "timeout\n");
           break;
@@ -1913,7 +1910,6 @@ main(int argc, char **argv) {
           repeat_count--;
         }
       }
-      wait_ms_reset = 0;
       obs_ms_reset = 0;
     }
   }

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -146,6 +146,8 @@ struct coap_context_t {
 #endif /* COAP_EPOLL_SUPPORT */
 #if COAP_SERVER_SUPPORT
   uint8_t observe_pending;         /**< Observe response pending */
+  uint8_t mcast_per_resource;      /**< Mcast controlled on a per resource
+                                        basis */
 #endif /* COAP_SERVER_SUPPORT */
   uint8_t block_mode;              /**< Zero or more COAP_BLOCK_ or'd options */
 };

--- a/include/coap3/net.h
+++ b/include/coap3/net.h
@@ -548,7 +548,7 @@ coap_join_mcast_group_intf(coap_context_t *ctx, const char *groupname,
  * Function interface for defining the hop count (ttl) for sending
  * multicast traffic
  *
- * @param session The current contexsion.
+ * @param session The current session.
  * @param hops    The number of hops (ttl) to use before the multicast
  *                packet expires.
  *
@@ -556,6 +556,16 @@ coap_join_mcast_group_intf(coap_context_t *ctx, const char *groupname,
  */
 int
 coap_mcast_set_hops(coap_session_t *session, size_t hops);
+
+/**
+ * Function interface to enable processing mcast requests on a per resource
+ * basis.  This then enables a set of configuration flags set up when
+ * configuring the resources (coap_resource_init()).
+ *
+ * @param context The current context.
+ */
+void
+coap_mcast_per_resource(coap_context_t *context);
 
 /**@}*/
 

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -107,6 +107,7 @@ global:
   coap_log_impl;
   coap_make_str_const;
   coap_malloc_type;
+  coap_mcast_per_resource;
   coap_mcast_set_hops;
   coap_memory_init;
   coap_new_binary;
@@ -172,12 +173,14 @@ global:
   coap_resource_init;
   coap_resource_notify_observers;
   coap_resource_proxy_uri_init;
+  coap_resource_proxy_uri_init2;
   coap_resource_release_userdata_handler;
   coap_resource_set_dirty;
   coap_resource_set_get_observable;
   coap_resource_set_mode;
   coap_resource_set_userdata;
   coap_resource_unknown_init;
+  coap_resource_unknown_init2;
   coap_response_phrase;
   coap_send;
   coap_send_ack;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -105,6 +105,7 @@ coap_join_mcast_group_intf
 coap_log_impl
 coap_make_str_const
 coap_malloc_type
+coap_mcast_per_resource
 coap_mcast_set_hops
 coap_memory_init
 coap_new_binary
@@ -170,12 +171,14 @@ coap_resource_get_userdata
 coap_resource_init
 coap_resource_notify_observers
 coap_resource_proxy_uri_init
+coap_resource_proxy_uri_init2
 coap_resource_release_userdata_handler
 coap_resource_set_dirty
 coap_resource_set_get_observable
 coap_resource_set_mode
 coap_resource_set_userdata
 coap_resource_unknown_init
+coap_resource_unknown_init2
 coap_response_phrase
 coap_send
 coap_send_ack

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -122,6 +122,8 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_recovery.3" > coap_session_set_probing_wait.3
 	@echo ".so man3/coap_recovery.3" > coap_session_get_probing_wait.3
 	@echo ".so man3/coap_recovery.3" > coap_debug_set_packet_loss.3
+	@echo ".so man3/coap_resource.3" > coap_resource_set_mode.3
+	@echo ".so man3/coap_resource.3" > coap_resource_set_userdata.3
 	@echo ".so man3/coap_resource.3" > coap_resource_get_userdata.3
 	@echo ".so man3/coap_resource.3" > coap_resource_release_userdata_handler.3
 	@echo ".so man3/coap_resource.3" > coap_resource_get_uri_path.3

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -20,7 +20,7 @@ coap-server-notls
 SYNOPSIS
 --------
 *coap-server* [*-d* max] [*-e*] [*-g* group] [*-G* group_if] [*-l* loss]
-              [*-p* port] [*-v* num] [*-A* address] [*-L* value] [*-N*]
+              [*-p* port] [-r] [*-v* num] [*-A* address] [*-L* value] [*-N*]
               [*-P* scheme://addr[:port],[name1[,name2..]]] [*-X* size]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
               [*-s* match_psk_sni_file] [*-u* user]]
@@ -69,6 +69,11 @@ OPTIONS - General
    If (D)TLS is supported, then 'port' + 1 will also be listened on for
    (D)TLS connections.
    The default port is 5683 if not given any other value.
+
+*-r* ::
+   Enable multicast per resource support.  If enabled, only '/', '/async'
+   and '/.well-known/core' are enabled for multicast requests support,
+   otherwise all resources are enabled.
 
 *-v* num::
    The verbosity level to use (default 3, maximum is 9). Above 7, there is

--- a/man/coap_endpoint_server.txt.in
+++ b/man/coap_endpoint_server.txt.in
@@ -17,7 +17,8 @@ coap_context_set_psk2,
 coap_new_endpoint,
 coap_free_endpoint,
 coap_endpoint_set_default_mtu,
-coap_join_mcast_group_intf
+coap_join_mcast_group_intf,
+coap_mcast_per_resource
 - Work with CoAP server endpoints
 
 SYNOPSIS
@@ -43,6 +44,8 @@ unsigned _mtu_);*
 
 *int coap_join_mcast_group_intf(coap_context_t *_context_,
 const char *_groupname_, const char *_ifname_);*
+
+*void coap_mcast_per_resource(coap_context_t *_context_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -154,6 +157,11 @@ first appropriate interface. When the endpoint is freed off, the associated
 multicast group will be removed. The registered multicast addresses for CoAP
 are 224.0.1.187, ff0x::fd (Variable-Scope) - i.e. ff02::fd (Link-Local) and
 ff05::fd (Site-Local).
+
+The *coap_mcast_per_resource*() function enables mcast to be controlled on a
+per resource basis giving the server application flexibility in how to respond
+to mcast requests. With this enabled, this is done through additional flag
+definitions when setting up each resource.
 
 RETURN VALUES
 -------------

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -90,7 +90,7 @@ _incoming_pdu_'s data must not be used if calling
 taken.
 
 *NOTE:* A request callback handler can be called with a generic resource (i.e.
-set up using *coap_resource_unknown_init*(3)), so
+set up using *coap_resource_unknown_init2*(3)), so
 *coap_resource_get_uri_path*(3) can be used to determine the URI in this case.
 
 The *coap_register_response_handler*() is a client side function that registers

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -13,7 +13,9 @@ NAME
 coap_resource,
 coap_resource_init,
 coap_resource_unknown_init,
+coap_resource_unknown_init2,
 coap_resource_proxy_uri_init,
+coap_resource_proxy_uri_init2,
 coap_add_resource,
 coap_delete_resource,
 coap_resource_set_mode,
@@ -33,8 +35,15 @@ int _flags_);*
 *coap_resource_t *coap_resource_unknown_init(coap_method_handler_t
 _put_handler_);*
 
+*coap_resource_t *coap_resource_unknown_init2(coap_method_handler_t
+_put_handler_, int _flags_);*
+
 *coap_resource_t *coap_resource_proxy_uri_init(coap_method_handler_t
 _proxy_handler_, size_t _host_name_count_, const char *_host_name_list_[]);*
+
+*coap_resource_t *coap_resource_proxy_uri_init2(coap_method_handler_t
+_proxy_handler_, size_t _host_name_count_, const char *_host_name_list_[],
+int flags);*
 
 *void coap_add_resource(coap_context_t *_context_,
 coap_resource_t *_resource_);*
@@ -69,18 +78,19 @@ When resources are configured on the CoAP server, the URI to match against
 in the request packet is specified.
 
 Callback Handlers are then added to the resource to handle the different
-request methods.
+request methods. See *coap_register_request_handler*(3) for further information.
 
 Adding Attributes allows textual information to be added to the resource
 which can then be reported back to any client doing a "GET .well-known/core"
-request.
+request. See *coap_add_attr*(3) for further information.
 
 If an incoming packet request matches a resource's URI and Method, then
 the appropriate callback resource handler is invoked to process the packet
-which then should update a suitable response packet for sending back to the
+which should then update a suitable response packet for returning back to the
 requester.
 
-There is support for handling incoming packets where the URI is unknown.
+There is support for handling incoming packets where the URI is unknown (no
+specific resource has been created).
 This could, for example, happen when a PUT request is trying to create a new
 resource. It is the responsibility of the unknown resource callback handler
 to either create a new resource for the URI or just manage things separately.
@@ -89,13 +99,21 @@ CoAP Observe (RFC 7641) is not supported for unknown resources, so a new
 resource with GET handler must be created by the unknown resource callback
 handle matching the URI which then can be Observable.
 
+There is support for handling incoming proxy based requests using the Proxy-Uri
+or Proxy-Scheme options.
+
+FUNCTIONS
+---------
+
+*Function: coap_resource_init()*
+
 The *coap_resource_init*() function returns a newly created _resource_ of
 type _coap_resource_t_ * .  _uri_path_ specifies the uri string path to match
 against.  Normally there is no need for the leading '/' - e.g. just
 "full/path/for/resource".  _flags_ is used to define whether the
 _resource_ is of type Confirmable Message or Non-Confirmable Message for
 any "observe" responses.  See *coap_observe*(3).
-_flags_ can be one of the following definitions or'ed together.
+_flags_ can be one of the following definitions ored together.
 
 [horizontal]
 *COAP_RESOURCE_FLAGS_NOTIFY_NON*::
@@ -115,22 +133,81 @@ Set the notification message type to confirmable for any trigggered
 *COAP_RESOURCE_FLAGS_RELEASE_URI*::
 Free off the coap_str_const_t for _uri_path_ when the _resource_ is deleted.
 
+*NOTE:* The following flags are only tested against if
+*coap_mcast_per_resource*() has been called.  If *coap_mcast_per_resource*()
+has not been called, then all resources have multicast support, libcoap adds
+in random delays to the responses, and 4.xx / 5.xx responses are dropped.
+
+[horizontal]
+*COAP_RESOURCE_FLAGS_HAS_MCAST_SUPPORT*::
+This resource has support for multicast requests.
+
+*COAP_RESOURCE_FLAGS_LIB_DIS_MCAST_DELAYS*::
+Disable libcoap library from adding in delays to multicast requests before
+releasing the response back to the client.  It is then the responsibility of
+the app to delay the responses for multicast requests. See
+https://datatracker.ietf.org/doc/html/rfc7252#section-8.2.  However, the
+pseudo resource for ".well-known/core" always has multicast support enabled.
+
+*COAP_RESOURCE_FLAGS_LIB_ENA_MCAST_SUPPRESS_2_05*::
+Enable libcoap library suppression of 205 multicast responses that are empty
+(overridden by RFC7969 No-Response option) for multicast requests.
+
+*COAP_RESOURCE_FLAGS_LIB_ENA_MCAST_SUPPRESS_2_XX*::
+Enable libcoap library suppressing 2.xx multicast responses (overridden by
+RFC7969 No-Response option) for multicast requests.
+
+*COAP_RESOURCE_FLAGS_LIB_DIS_MCAST_SUPPRESS_4_XX*::
+Disable libcoap library suppressing 4.xx multicast responses (overridden by
+RFC7969 No-Response option) for multicast requests.
+
+*COAP_RESOURCE_FLAGS_LIB_DIS_MCAST_SUPPRESS_5_XX*::
+Disable libcoap library suppressing 5.xx multicast responses (overridden by
+RFC7969 No-Response option) for multicast requests.
+
 *NOTE:* _uri_path_, if not 7 bit readable ASCII, binary bytes must be hex
 encoded according to the rules defined in RFC3968 Section 2.1.
+
+*Function: coap_resource_unknown_init()*
 
 The *coap_resource_unknown_init*() function returns a newly created _resource_
 of type _coap_resource_t_ *. _put_handler_ is automatically added to the
 _resource_ to handle PUT requests to resources that are unknown. Additional
 handlers can be added to this resource if required.
 
+*Function: coap_resource_unknown_init2()*
+
+The *coap_resource_unknown_init2*() function returns a newly created _resource_
+of type _coap_resource_t_ *. _put_handler_ is automatically added to the
+_resource_ to handle PUT requests to resources that are unknown. Additional
+handlers can be added to this resource if required. _flags_ can be zero or
+more COAP_RESOURCE_FLAGS MCAST definitions.
+
+*Function: coap_resource_proxy_uri_init()*
+
 The *coap_resource_proxy_uri_init*() function returns a newly created
 _resource_ of type _coap_resource_t_ *. _proxy_handler_ is automatically added
-to the _resource_ to handle PUT/POST/GET etc. requests that use the Proxy-Uri:
+to the _resource_ to handle PUT/POST/GET etc. requests that use the Proxy-Uri
 option.  There is no need to add explicit request type handlers. One or more
 names by which the proxy is known by (IP address, DNS name etc.) must be
 supplied in the array defined by _host_name_list_[] which has a count of
 _host_name_count_.  This is used to check whether the current endpoint is
-the proxy target address.
+the proxy target address, or the request has to be passed on to an upstream
+server.
+
+*Function: coap_resource_proxy_uri_init2()*
+
+The *coap_resource_proxy_uri_init2*() function returns a newly created
+_resource_ of type _coap_resource_t_ *. _proxy_handler_ is automatically added
+to the _resource_ to handle PUT/POST/GET etc. requests that use the Proxy-Uri
+option.  There is no need to add explicit request type handlers. One or more
+names by which the proxy is known by (IP address, DNS name etc.) must be
+supplied in the array defined by _host_name_list_[] which has a count of
+_host_name_count_.  This is used to check whether the current endpoint is
+the proxy target address, or the request has to be passed on to an upstream
+server. _flags_ can be zero or more COAP_RESOURCE_FLAGS MCAST definitions.
+
+*Function: coap_add_resource()*
 
 The *coap_add_resource*() function registers the given _resource_ with the
 _context_. The _resource_ must have been created by *coap_resource_init*(),
@@ -142,14 +219,20 @@ associated with a _context_, *coap_add_resource*() (or
 *coap_add_resource_release*()) will delete any previous
 _resource_ with the same _uri_path_ before adding in the new _resource_.
 
+*Function: coap_delete_resource()*
+
 The *coap_delete_resource*() function deletes a resource identified by
 _resource_. The _context_ parameter is ignored. The storage allocated for that
 _resource_ is freed, along with any attributes associated with the _resource_.
+
+*Function: coap_resource_set_mode()*
 
 The *coap_resource_set_mode*() changes the notification message type of
 _resource_ to the given _mode_ which must be one of
 COAP_RESOURCE_FLAGS_NOTIFY_NON, COAP_RESOURCE_FLAGS_NOTIFY_NON_ALWAYS or
 COAP_RESOURCE_FLAGS_NOTIFY_CON.
+
+*Function: coap_resource_set_userdata()*
 
 The *coap_resource_set_userdata*() function allows a pointer to user _data_
 to be associated with a _resource_ that can accessed in any callback that
@@ -157,9 +240,13 @@ includes _resource_ as a parameter.
 
 *NOTE:* _data_ must point to a static, or allocated, block of memory.
 
+*Function: coap_resource_get_userdata()*
+
 The *coap_resource_get_userdata*() function obtains the user data pointer
 from the _resource_ that had previously been set up by
 *coap_resource_set_userdata*().
+
+*Function: coap_resource_release_userdata_handler()*
 
 The *coap_resource_release_userdata_handler*() function defines the _context_
 wide _callback_ handler to call to release the allocated user data that has
@@ -167,13 +254,16 @@ been added to the resource using *coap_resource_set_userdata*() when the
 resource is deleted. _callback_ can be NULL (which is the default) if nothing
 needs to be freed off.
 
+*Function: coap_resource_get_uri_path()*
+
 The *coap_resource_get_uri_path*() function is used to obtain the UriPath of
 the _resource_ definion.
 
 RETURN VALUES
 -------------
-The *coap_resource_init*(), *coap_resource_unknown_init*() and
-*coap_resource_proxy_uri_init*() functions return a newly created resource
+The *coap_resource_init*(), *coap_resource_unknown_init*(),
+*coap_resource_unknown_init2*(), *coap_resource_proxy_uri_init*() and
+*coap_resource_proxy_uri_init2*() functions return a newly created resource
 or NULL if there is a malloc failure.
 
 The *coap_delete_resource*() function return 0 on failure (_resource_ not
@@ -461,7 +551,7 @@ init_resources(coap_context_t *ctx) {
   coap_resource_t *r;
 
   /* Create a resource to handle PUTs to unknown URIs */
-  r = coap_resource_unknown_init(hnd_put_unknown);
+  r = coap_resource_unknown_init2(hnd_put_unknown, 0);
   /*
    * Additional handlers can be added - for example
    *  coap_register_request_handler(r, COAP_REQUEST_POST, hnd_post_unknown);
@@ -475,7 +565,7 @@ init_resources(coap_context_t *ctx) {
 
 SEE ALSO
 --------
-*coap_attribute*(3), *coap_context*(3), *coap_observe*(3) and *coap_handler*(3)
+*coap_attribute*(3), *coap_context*(3), *coap_handler*(3) and *coap_observe*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/src/resource.c
+++ b/src/resource.c
@@ -341,7 +341,7 @@ static const uint8_t coap_unknown_resource_uri[] =
                        "- Unknown -";
 
 coap_resource_t *
-coap_resource_unknown_init(coap_method_handler_t put_handler) {
+coap_resource_unknown_init2(coap_method_handler_t put_handler, int flags) {
   coap_resource_t *r;
 
   r = (coap_resource_t *)coap_malloc_type(COAP_RESOURCE, sizeof(coap_resource_t));
@@ -350,6 +350,7 @@ coap_resource_unknown_init(coap_method_handler_t put_handler) {
     r->is_unknown = 1;
     /* Something unlikely to be used, but it shows up in the logs */
     r->uri_path = coap_new_str_const(coap_unknown_resource_uri, sizeof(coap_unknown_resource_uri)-1);
+    r->flags = flags & COAP_RESOURCE_FLAGS_MCAST_LIST;
     coap_register_handler(r, COAP_REQUEST_PUT, put_handler);
   } else {
     coap_log(LOG_DEBUG, "coap_resource_unknown_init: no memory left\n");
@@ -358,12 +359,18 @@ coap_resource_unknown_init(coap_method_handler_t put_handler) {
   return r;
 }
 
+coap_resource_t *
+coap_resource_unknown_init(coap_method_handler_t put_handler) {
+  return coap_resource_unknown_init2(put_handler, 0);
+}
+
 static const uint8_t coap_proxy_resource_uri[] =
                        "- Proxy URI -";
 
 coap_resource_t *
-coap_resource_proxy_uri_init(coap_method_handler_t handler,
-                      size_t host_name_count, const char *host_name_list[]) {
+coap_resource_proxy_uri_init2(coap_method_handler_t handler,
+                              size_t host_name_count,
+                              const char *host_name_list[], int flags) {
   coap_resource_t *r;
 
   if (host_name_count == 0) {
@@ -403,11 +410,19 @@ coap_resource_proxy_uri_init(coap_method_handler_t handler,
         r->proxy_name_count = i;
       }
     }
+    r->flags = flags & COAP_RESOURCE_FLAGS_MCAST_LIST;
   } else {
-    coap_log(LOG_DEBUG, "coap_resource_proxy_uri_init: no memory left\n");
+    coap_log(LOG_DEBUG, "coap_resource_proxy_uri_init2: no memory left\n");
   }
 
   return r;
+}
+
+coap_resource_t *
+coap_resource_proxy_uri_init(coap_method_handler_t handler,
+                      size_t host_name_count, const char *host_name_list[]) {
+  return coap_resource_proxy_uri_init2(handler, host_name_count,
+                                       host_name_list, 0);
 }
 
 coap_attr_t *


### PR DESCRIPTION
Add in new function coap_mcast_per_resource() to enable granularity of
handling multicast requests differently at the resource level.

The granularity is handled by how the flags variable is set up in
coap_resource_init().  These additional flags are ignored if
function coap_mcast_per_resource() has not been invoked.

Added 2 functions coap_resource_unknown_init2() and 
coap_resource_proxy_uri_init2() that support defining the mcast flags as 
per coap_resource_init().

Responses are now delayed rather than the request being delayed before being
passed to the request handler.

Update coap-server with the -r option to enable multicast on specific
resources.

Requires #858 to support multicast delays for .well-known/core requests.

Fixes #854.