### PR TITLE
coap_send: Make error checks for coap_send() more rigorous

### DIFF
--- a/include/coap3/net.h
+++ b/include/coap3/net.h
@@ -483,7 +483,7 @@ coap_send_rst(coap_session_t *session, const coap_pdu_t *request) {
 /**
 * Sends a CoAP message to given peer. The memory that is
 * allocated for the pdu will be released by coap_send().
-* The caller must not use the pdu after calling coap_send().
+* The caller must not use or delete the pdu after calling coap_send().
 *
 * @param session         The CoAP session.
 * @param pdu             The CoAP PDU to send.

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -496,11 +496,12 @@ PDU TRANSMIT
 *Function: coap_send()*
 
 The *coap_send*() function is used to initiate the transmission of the _pdu_
-associated with the _session_.
+associated with the _session_. The caller must not access or delete _pdu_
+after calling *coap_send*() - even if there is a return error.
 
-*NOTE:* This is automatically done, based on the PDU code on the return from
-the calling of a request handler, and so the usage of *coap_send*() is not
-required there for transmission.
+*NOTE:* For request handlers, returning from the request handler will cause
+the response PDU to be transmitted as appropriate and there is no need to call
+*coap_send*() to do this.
 
 RETURN VALUES
 -------------

--- a/src/net.c
+++ b/src/net.c
@@ -1128,6 +1128,12 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
 
   assert(pdu);
 
+  if (session->type == COAP_SESSION_TYPE_CLIENT &&
+      session->sock.flags == COAP_SOCKET_EMPTY) {
+    coap_log(LOG_DEBUG, "coap_send: Socket closed\n");
+    coap_delete_pdu(pdu);
+    return COAP_INVALID_MID;
+  }
 #if COAP_CLIENT_SUPPORT
   coap_lg_crcv_t *lg_crcv = NULL;
   coap_opt_iterator_t opt_iter;
@@ -1208,8 +1214,10 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
       }
     }
     lg_crcv = coap_block_new_lg_crcv(session, pdu);
-    if (lg_crcv == NULL)
+    if (lg_crcv == NULL) {
+      coap_delete_pdu(pdu);
       return COAP_INVALID_MID;
+    }
     if (lg_xmit) {
       /* Need to update the token as set up in the session->lg_xmit */
       lg_xmit->b.b1.state_token = lg_crcv->state_token;
@@ -1965,7 +1973,8 @@ coap_io_do_epoll(coap_context_t *ctx, struct epoll_event *events, size_t nevents
             (events[j].events & (EPOLLOUT|EPOLLERR|EPOLLHUP|EPOLLRDHUP))) {
           sock->flags |= COAP_SOCKET_CAN_CONNECT;
           coap_connect_session(session->context, session, now);
-          if (!(sock->flags & COAP_SOCKET_WANT_WRITE)) {
+          if (sock->flags != COAP_SOCKET_EMPTY &&
+              !(sock->flags & COAP_SOCKET_WANT_WRITE)) {
             coap_epoll_ctl_mod(sock, EPOLLIN, __func__);
           }
         }


### PR DESCRIPTION
Always delete PDUs on error before return from coap_send() (aligning with
previous documentation).

Check that the socket is still available before continuing with the PDU
transmission in coap_send().

Update documentation to be clearer on non-usage of PDU on return from
coap_send().

Trap coap_send() errors in coap-client.

Move event handlers setup code to earlier in coap-client to trap events
early on in the CoAP setup process.