### PR TITLE
CSM: Move coap_client_delay_first() to later in code processing

### DIFF
--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -138,6 +138,7 @@ struct coap_session_t {
   uint8_t block_mode;             /**< Zero or more COAP_BLOCK_ or'd options */
   uint8_t doing_first;            /**< Set if doing client's first request */
   uint8_t proxy_session;        /**< Set if this is an ongoing proxy session */
+  uint8_t delay_recursive;        /**< Set if in coap_client_delay_first() */  
   uint64_t tx_token;              /**< Next token number to use */
 };
 

--- a/src/block.c
+++ b/src/block.c
@@ -745,6 +745,15 @@ coap_add_data_large_request(coap_session_t *session,
                             const uint8_t *data,
                             coap_release_large_data_t release_func,
                             void *app_ptr) {
+  /*
+   * Delay if session->doing_first is set.
+   * E.g. Reliable and CSM not in yet for checking block support
+   */
+  if (coap_client_delay_first(session) == 0) {
+    if (release_func)
+      release_func(session, app_ptr);
+    return 0;
+  }
   return coap_add_data_large_internal(session, pdu, NULL, NULL, -1, 0, length,
                                       data, release_func, app_ptr, 0);
 }


### PR DESCRIPTION
Commit 069a0786ce85ea9b847160cc93529c06bd737079 (#833) introduced the concept
of delaying PDU building until the CSM message had been received from server
so that PDUs could be correctly sized.

However, this meant that the functions coap_new_client_session*() would not
complete until the CSM was in for reliable protocols.  Some applications need
the returned session to handle / differentiate between different events.

CSM can update
session->mtu
session->csm_block_supported
session->csm_bert_rem_support

coap_client_delay_first() is now called in coap_add_data_large_request()
and coap_session_max_pdu_size() (not coap_session_max_pdu_rcv_size() as
this is for receiving PDUs).

coap_client_delay_first() has been updated to catch recursive requests as well
as using more of the common code for the LwIP specifics.