### PR TITLE
coap_gnutls.c: Handle another error in do_gnutls_handshake()

### DIFF
--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -2165,6 +2165,7 @@ do_gnutls_handshake(coap_session_t *c_session, coap_gnutls_env_t *g_env) {
     log_last_alert(c_session, g_env->g_session);
     /* Fall through */
   case GNUTLS_E_UNEXPECTED_HANDSHAKE_PACKET:
+  case GNUTLS_E_UNEXPECTED_PACKET:
     c_session->dtls_event = COAP_EVENT_DTLS_CLOSED;
     ret = -1;
     break;


### PR DESCRIPTION
Treat GNUTLS_E_UNEXPECTED_PACKET as a reason for DTLS closure.

To test, gnutls server and client with different PSK keys and coaps://

GNUTLS_E_UNEXPECTED_PACKET raised if alert sent by server in the
middle of the setup handshaking.