### PR TITLE
lwip: Fix minor issues

### DIFF
--- a/include/coap3/lwippools.h
+++ b/include/coap3/lwippools.h
@@ -66,7 +66,7 @@
 #endif
 
 #ifndef MEMP_LEN_COAPSTRING
-#define MEMP_LEN_COAPSTRING 32
+#define MEMP_LEN_COAPSTRING 40
 #endif
 
 #ifndef MEMP_NUM_COAPCACHE_KEYS

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -110,7 +110,8 @@ error:
    * https://tools.ietf.org/html/rfc7252#section-4.2 MUST send RST
    * https://tools.ietf.org/html/rfc7252#section-4.3 MAY send RST
    */
-  coap_send_rst(session, pdu);
+  if (session)
+    coap_send_rst(session, pdu);
   coap_delete_pdu(pdu);
   if (packet) {
     packet->pbuf = NULL;


### PR DESCRIPTION
Increase MEMP_LEN_COAPSTRING to handle example server .wellknown/core request.

If session cannot be generated, check for NULL pointer.