### PR TITLE
net.c: Handle multiple same token request/responses

### DIFF
--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -144,8 +144,9 @@ struct coap_session_t {
   uint8_t block_mode;             /**< Zero or more COAP_BLOCK_ or'd options */
   uint8_t doing_first;            /**< Set if doing client's first request */
   uint8_t proxy_session;        /**< Set if this is an ongoing proxy session */
-  uint8_t delay_recursive;        /**< Set if in coap_client_delay_first() */  
+  uint8_t delay_recursive;        /**< Set if in coap_client_delay_first() */
   uint64_t tx_token;              /**< Next token number to use */
+  coap_bin_const_t *last_token;   /** last token used to make a request */
 };
 
 #if COAP_SERVER_SUPPORT


### PR DESCRIPTION
Sending off multiple CON requests with the same token without waiting for
any responses, causes the first one to be sent with the remainder ending
up in the delayqueue.

On receipt of ACK, coap_remove_from_queue() called in coap_dispatch(),
which returns the MID matching entry that was in the send queue, and then
the next entry on the delayqueue is removed from delayqueue and then sent
which puts the request on the sendqueue for any required re-transmissions.

coap_cancel_all_messages() should not be called in handle_response()
following the logic above if response is type ACK. If
coap_cancel_all_messages() is subsequently called with the same (possibly
empty) token as the next request that is being sent, then the next sendqueue
entry is inadvertantly deleted.

As there is now no sendqueue entry on receipt of the next ACK, the next
delayqueue entry is not sent off.

Only call coap_cancel_all_messages() if response is not of type ACK
(i.e. a separate response).

Report on tokens being the same as the previous one to encourage application
coders to use different tokens.

Fixes #846 