### PR TITLE
Logging: Make logging consistent across (D)TLS libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -527,6 +527,8 @@ if test "x$build_dtls" = "xyes"; then
                if test "x$tinydtls_libs_overridden" != "xyes";  then
                    TinyDTLS_LIBS="$auto_TinyDTLS_LIBS"
                fi
+               # 'git submodule update' may be required
+               AC_DEFINE(HAVE_DTLS_SET_LOG_HANDLER, [1], [Define if TinyDTLS has dtls_set_log_handler])
             else
                 AC_MSG_ERROR([==> You want to build libcoap with DTLS support using the TinyDTLS submodule library but no suitable version could be found!
                             Check whether you have updated the TinyDTLS git submodule, use the system-provided version if available (set '--with-submodule-tinydtls=no'),
@@ -538,9 +540,7 @@ if test "x$build_dtls" = "xyes"; then
             AC_MSG_NOTICE([Using system-provided TinyDTLS])
             tinydtls_version=`$PKG_CONFIG --modversion tinydtls`
             AX_CHECK_TINYDTLS_VERSION
-            have_gnutls="no" # don't confuse AC_MSG_RESULT at the end of the script
-            have_mbedtls="no" # don't confuse AC_MSG_RESULT at the end of the script
-            have_openssl="no" # don't confuse AC_MSG_RESULT at the end of the script
+            AC_CHECK_LIB(tinydtls,dtls_set_log_handler,AC_DEFINE(HAVE_DTLS_SET_LOG_HANDLER, [1], [Define if TinyDTLS has dtls_set_log_handler]))
         else
             AC_MSG_ERROR([==> You want to build libcoap with DTLS support using the TinyDTLS library but no suitable version could be found!
                         Use the submodule TinyDTLS version (set '--with-submodule-tinydtls=yes' and update the git submodule),

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -583,6 +583,7 @@ usage(const char *program, const char *version) {
   fprintf(stderr, "%s\n", coap_string_tls_support(buffer, sizeof(buffer)));
   fprintf(stderr, "\n"
      "Usage: %s [-g group] [-G group_if] [-p port] [-v num] [-A address]\n"
+     "\t       [-V num]\n"
      "\t       [[-h hint] [-k key]]\n"
      "\t       [[-c certfile] [-C cafile] [-n] [-R trust_casfile]]\n"
      "General Options\n"
@@ -592,9 +593,11 @@ usage(const char *program, const char *version) {
      "\t       \t\tgroup. This can be different from the implied interface\n"
      "\t       \t\tif the -A option is used\n"
      "\t-p port\t\tListen on specified port\n"
-     "\t-v num \t\tVerbosity level (default 3, maximum is 9). Above 7,\n"
-     "\t       \t\tthere is increased verbosity in GnuTLS and OpenSSL logging\n"
+     "\t-v num \t\tVerbosity level (default 4, maximum is 8) for general\n"
+     "\t       \t\tCoAP logging\n"
      "\t-A address\tInterface address to bind to\n"
+     "\t-V num \t\tVerbosity level (default 3, maximum is 7) for (D)TLS\n"
+     "\t       \t\tlibrary logging\n"
      "PSK Options (if supported by underlying (D)TLS library)\n"
      "\t-h hint\t\tIdentity Hint. Default is CoAP. Zero length is no hint\n"
      "\t-k key \t\tPre-Shared Key. This argument requires (D)TLS with PSK\n"
@@ -781,12 +784,13 @@ main(int argc, char **argv) {
   char *group = NULL;
   char *group_if = NULL;
   int opt;
-  coap_log_t log_level = LOG_WARNING;
+  coap_log_t log_level = COAP_LOG_WARN;
+  coap_log_t dtls_log_level = COAP_LOG_ERR;
 #ifndef _WIN32
   struct sigaction sa;
 #endif
 
-  while ((opt = getopt(argc, argv, "A:c:C:g:G:h:k:n:R:p:v:")) != -1) {
+  while ((opt = getopt(argc, argv, "A:c:C:g:G:h:k:n:R:p:v:V:")) != -1) {
     switch (opt) {
     case 'A' :
       strncpy(addr_str, optarg, NI_MAXHOST-1);
@@ -832,6 +836,9 @@ main(int argc, char **argv) {
     case 'v' :
       log_level = strtol(optarg, NULL, 10);
       break;
+    case 'V':
+      dtls_log_level = strtol(optarg, NULL, 10);
+      break;
     default:
       usage( argv[0], LIBCOAP_PACKAGE_VERSION );
       exit( 1 );
@@ -839,8 +846,8 @@ main(int argc, char **argv) {
   }
 
   coap_startup();
-  coap_dtls_set_log_level(log_level);
   coap_set_log_level(log_level);
+  coap_dtls_set_log_level(dtls_log_level);
 
   ctx = get_context(addr_str, port_str);
   if (!ctx)

--- a/include/coap3/coap_dtls.h
+++ b/include/coap3/coap_dtls.h
@@ -498,22 +498,4 @@ typedef struct coap_dtls_spsk_t {
 
 /** @} */
 
-/**
- * @ingroup logging
- * Sets the (D)TLS logging level to the specified @p level.
- * Note: coap_log_level() will influence output if at a specified level.
- *
- * @param level The logging level to use - LOG_*
- */
-void coap_dtls_set_log_level(int level);
-
-/**
- * @ingroup logging
- * Get the current (D)TLS logging.
- *
- * @return The current log level (one of LOG_*).
- */
-int coap_dtls_get_log_level(void);
-
-
 #endif /* COAP_DTLS_H */

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -101,6 +101,20 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_get_session_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_set_csm_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_get_csm_timeout.3
+	@echo ".so man3/coap_logging.3" > coap_log_info.3
+	@echo ".so man3/coap_logging.3" > coap_log_debug.3
+	@echo ".so man3/coap_logging.3" > coap_log_oscore.3
+	@echo ".so man3/coap_logging.3" > coap_log_dtls.3
+	@echo ".so man3/coap_logging.3" > coap_get_log_level.3
+	@echo ".so man3/coap_logging.3" > coap_set_log_level.3
+	@echo ".so man3/coap_logging.3" > coap_set_log_handler.3
+	@echo ".so man3/coap_logging.3" > coap_dtls_log.3
+	@echo ".so man3/coap_logging.3" > coap_dtls_get_log_level.3
+	@echo ".so man3/coap_logging.3" > coap_dtls_set_log_level.3
+	@echo ".so man3/coap_logging.3" > coap_package_name.3
+	@echo ".so man3/coap_logging.3" > coap_package_version.3
+	@echo ".so man3/coap_logging.3" > coap_package_build.3
+	@echo ".so man3/coap_logging.3" > coap_set_show_pdu_output.3
 	@echo ".so man3/coap_logging.3" > coap_show_pdu.3
 	@echo ".so man3/coap_logging.3" > coap_endpoint_str.3
 	@echo ".so man3/coap_logging.3" > coap_session_str.3

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -24,7 +24,7 @@ SYNOPSIS
               [*-t* type] [*-v* num] [*-w*] [*-A* type] [*-B* seconds]
               [*-G* count] [*-H* hoplimit] [*-K* interval] [*-L* value] [*-N*]
               [*-O* num,text] [*-P* scheme://addr[:port]] [*-T* token] [*-U*]
-              [*-X* size]
+              [*-V* num] [*-X* size]
               [[*-h* match_hint_file] [*-k* key] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [-n] [*-C* cafile]
               [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* trust_casfile]] URI
@@ -113,8 +113,8 @@ OPTIONS - General
      application/cbor (cbor)
 
 *-v* num::
-   The verbosity level to use (default 3, maximum is 9). Above 7, there is
-   increased verbosity in GnuTLS and OpenSSL logging.
+   The verbosity level to use (default 4, maximum is 8) for general
+   CoAP logging.
 
 *-w*::
    Append a newline to received data.
@@ -165,6 +165,10 @@ OPTIONS - General
 
 *-U* ::
    Never include Uri-Host or Uri-Port options.
+
+*-V* num::
+   The verbosity level to use (default 3, maximum is 7) for (D)TLS
+   library logging.
 
 *-X* size::
    Maximum message size to use for TCP based connections (default is 8388864).

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -20,6 +20,7 @@ coap-rd-notls
 SYNOPSIS
 --------
 *coap-rd* [*-g* group] [*-G* group_if] [*-p* port] [*-v* num] [*-A* address]
+          [*-V* num]
           [[*-h* hint] [*-k* key]]
           [[*-c* certfile] [*-n*] [*-C* cafile] [*-R* trusted_casfile]]
 
@@ -50,11 +51,15 @@ OPTIONS
    The default port is 5683 if not given any other value.
 
 *-v* num::
-   The verbosity level to use (default: 3, maximum is 9). Above 7, there is
-   increased verbosity in GnuTLS and OpenSSL logging.
+   The verbosity level to use (default 4, maximum is 8) for general
+   CoAP logging.
 
 *-A* address::
    The local address of the interface which the server has to listen on.
+
+*-V* num::
+   The verbosity level to use (default 3, maximum is 7) for (D)TLS
+   library logging.
 
 OPTIONS - PSK
 -------------

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -21,7 +21,7 @@ SYNOPSIS
 --------
 *coap-server* [*-d* max] [*-e*] [*-g* group] [*-G* group_if] [*-l* loss]
               [*-p* port] [-r] [*-v* num] [*-A* address] [*-L* value] [*-N*]
-              [*-P* scheme://addr[:port],[name1[,name2..]]] [*-X* size]
+              [*-P* scheme://addr[:port],[name1[,name2..]]] [*-V* num] [*-X* size]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
               [*-s* match_psk_sni_file] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
@@ -76,8 +76,8 @@ OPTIONS - General
    otherwise all resources are enabled.
 
 *-v* num::
-   The verbosity level to use (default 3, maximum is 9). Above 7, there is
-   increased verbosity in GnuTLS and OpenSSL logging.
+   The verbosity level to use (default 4, maximum is 8) for general
+   CoAP logging.
 
 *-A* address::
    The local address of the interface which the server has to listen on.
@@ -104,6 +104,10 @@ OPTIONS - General
    scheme://address[:port] is not defined before the leading , (comma) of the
    first name, then the ongoing connection will be a direct connection.
    Scheme is one of coap, coaps, coap+tcp and coaps+tcp.
+
+*-V* num::
+   The verbosity level to use (default 3, maximum is 7) for (D)TLS
+   library logging.
 
 *-X* size::
    Maximum message size to use for TCP based connections (default is 8388864).

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -12,8 +12,20 @@ NAME
 ----
 coap_logging,
 coap_log,
+coap_log_emerg,
+coap_log_alert,
+coap_log_crit,
+coap_logi_err,
+coap_log_warn,
+coap_log_info,
+coap_log_notice,
+coap_log_debug,
+coap_log_oscore,
 coap_get_log_level,
 coap_set_log_level,
+coap_dtls_log,
+coap_dtls_get_log_level,
+coap_dtls_set_log_level,
 coap_set_log_handler,
 coap_package_name,
 coap_package_version,
@@ -28,15 +40,35 @@ SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
 
-*void coap_log(coap_log_t _level_, const char *_format_, ...);*
+*void coap_log(coap_log_t _level_, const char *_format_, _..._);*
+
+*void coap_log_emerg(const char *_format_, _..._);*
+
+*void coap_log_alert(const char *_format_, _..._);*
+
+*void coap_log_crit(const char *_format_, _..._);*
+
+*void coap_log_err(const char *_format_, _..._);*
+
+*void coap_log_warn(const char *_format_, _..._);*
+
+*void coap_log_info(const char *_format_, _..._);*
+
+*void coap_log_notice(const char *_format_, _..._);*
+
+*void coap_log_debug(const char *_format_, _..._);*
+
+*void coap_log_oscore(const char *_format_, _..._);*
 
 *void coap_set_log_level(coap_log_t _level_);*
 
 *coap_log_t coap_get_log_level(void);*
 
-*void coap_dtls_set_log_level(int _level_);*
+*void coap_dtls_log(coap_log_t _level_, const char *_format_, _..._);*
 
-*int coap_dtls_get_log_level(void);*
+*void coap_dtls_set_log_level(coap_log_t _level_);*
+
+*coap_log_t coap_dtls_get_log_level(void);*
 
 *void coap_set_log_handler(coap_log_handler_t _handler_);*
 
@@ -69,54 +101,133 @@ Logging by default is to stderr or stdout depending on the logging level of
 the log entry.  It ia possible to send the logging information to an
 application logging callback handler for processing by the application.
 
+Logging levels (*coap_log_t*) are defined by (initially the same as for
+*syslog*()), which are numerically incrementing in value:
+
+*COAP_LOG_EMERG*::
+Emergency level (0).
+
+*COAP_LOG_ALERT*::
+Alert level (1).
+
+*COAP_LOG_CRIT*::
+Critical level (2).
+
+*COAP_LOG_ERR*::
+Error level (3).
+
+*COAP_LOG_WARN*::
+Warning level (the default) (4).
+
+*COAP_LOG_NOTICE*::
+Notice level (5).
+
+*COAP_LOG_INFO*::
+Information level (6).
+
+*COAP_LOG_DEBUG*::
+Debug level (7).
+
+With an additional level:
+
+*COAP_LOG_OSCORE*::
+Debug OSCORE information (8).
+
+FUNCTIONS
+---------
+
+*Function: coap_log()*
+
 The *coap_log*() function is used to log information at the appropriate _level_.
 The rest of the parameters follow the standard *printf*() function format.
 
-Logging levels (*coap_log_t*) are defined by (the same as for *syslog*()), which
-are numerically incrementing in value:
+*Function: coap_log_emerg()*
 
-*LOG_EMERG*::
-Emergency level (0).
+The *coap_log_emerg*() function provides a wrapper to the *coap_log*() function
+with _level_ set to COAP_LOG_EMERG.
+The parameters follow the standard *printf*() function format.
 
-*LOG_ALERT*::
-Alert level (1).
+*Function: coap_log_alert()*
 
-*LOG_CRIT*::
-Critical level (2).
+The *coap_log_alert*() function provides a wrapper to the *coap_log*() function
+with _level_ set to COAP_LOG_ALERT.
+The parameters follow the standard *printf*() function format.
 
-*LOG_ERR*::
-Error level (3).
+*Function: coap_log_crit()*
 
-*LOG_WARNING*::
-Warning level (the default) (4).
+The *coap_log_crit*() function provides a wrapper to the *coap_log*() function
+with _level_ set to COAP_LOG_CRIT.
+The parameters follow the standard *printf*() function format.
 
-*LOG_NOTICE*::
-Notice level (5).
+*Function: coap_log_err()*
 
-*LOG_INFO*::
-Information level (6).
+The *coap_log_err*() function provides a wrapper to the *coap_log*() function
+with _level_ set to COAP_LOG_ERR.
+The parameters follow the standard *printf*() function format.
 
-*LOG_DEBUG*::
-Debug level (7).
+*Function: coap_log_warn()*
+
+The *coap_log_warn*() function provides a wrapper to the *coap_log*() function
+with _level_ set to COAP_LOG_WARN.
+The parameters follow the standard *printf*() function format.
+
+*Function: coap_log_notice()*
+
+The *coap_log_notice*() function provides a wrapper to the *coap_log*() function
+with _level_ set to COAP_LOG_NOTICE.
+The parameters follow the standard *printf*() function format.
+
+*Function: coap_log_info()*
+
+The *coap_log_info*() function provides a wrapper to the *coap_log*() function
+with _level_ set to COAP_LOG_INFO.
+The parameters follow the standard *printf*() function format.
+
+*Function: coap_log_debug()*
+
+The *coap_log_debug*() function provides a wrapper to the *coap_log*() function
+with _level_ set to COAP_LOG_DEBUG.
+The parameters follow the standard *printf*() function format.
+
+*Function: coap_log_oscore()*
+
+The *coap_log_oscore*() function provides a wrapper to the *coap_log*() function
+with _level_ set to COAP_LOG_OSCORE.
+The parameters follow the standard *printf*() function format.
+
+*Function: coap_set_log_level()*
 
 The *coap_set_log_level*() function is used to set the current logging _level_
 for output by any subsequent *coap_log*() calls.  Output is only logged if the
 *coap_log*() _level_ definition is smaller than or equal to the current logging
 _level_.
 
+*Function: coap_get_log_level()*
+
 The *coap_get_log_level*() function is used to get the current logging level.
 
-The *coap_dtls_set_log_level*() function is used to set the logging _level_
-for output by the DTLS library for specific DTLS information. Usually, both
-*coap_set_log_level*() and *coap_dtls_set_log_level*() would be set to the
-same _level_ value. If the logging level is set to greater than LOG_DEBUG,
-the underlying TLS library may get more verbose in its output.
+*Function: coap_dtls_log()*
+
+The *coap_dtls_log*() function is used to log (D)TLS library information at the
+appropriate _level_.  The rest of the parameters follow the standard *printf*()
+function format.
+
+*Function: coap_dtls_set_log_level()*
+
+The *coap_dtls_set_log_level*() function is used to set the current logging
+_level_ for output by any subsequent *coap_dtls_log*() calls.  Output is only
+logged if the *coap_dtls_log*() _level_ definition is smaller than or equal to
+the current DTLS logging _level_.
+
+*Function: coap_dtls_get_log_level()*
 
 The *coap_dtls_get_log_level*() function is used to get the current logging
 level for the DTLS library.
 
+*Function: coap_set_log_handler()*
+
 The *coap_set_log_handler*()* function can be used to define an alternative
-logging handler for processing the logging messages.  The logging handler
+logging handler for processing any logging messages.  The logging handler
 prototype is defined as:
 
 [source, c]
@@ -124,25 +235,39 @@ prototype is defined as:
 typedef void (*coap_log_handler_t) (coap_log_t level, const char *message);
 ----
 
+*Function: coap_package_name()*
+
 The *coap_package_name*() function returns the name of this library.
 
+*Function: coap_package_version()*
+
 The *coap_package_version*() function returns the version of this library.
+
+*Function: coap_package_build()*
 
 The *coap_package_build*() function returns the git information (as in
 "git describe --tags") for the build of this library or version of this
 library if git is not used.
+
+*Function: coap_set_show_pdu_output()*
 
 The *coap_set_show_pdu_output*() function defines whether the output from
 *coap_show_pdu*() is to be either sent to stdout/stderr, or output using
 *coap_log*().  _use_fprintf_ is set to 1 for stdout/stderr (the default), and
 _use_fprintf_ is set to 0 for *coap_log*().
 
+*Function: coap_show_pdu()*
+
 The *coap_show_pdu*() function is used to decode the _pdu_, outputting as
 appropriate for logging _level_.  Where the output goes is dependent on
 *coap_set_show_pdu_output*().
 
+*Function: coap_endpoint_str()*
+
 The *coap_endpoint_str*() function returns a description string of the
 _endpoint_.
+
+*Function: coap_session_str()*
 
 The *coap_session_str*() function is used to get a string containing the
 information about the _session_.
@@ -171,8 +296,11 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -59,6 +59,16 @@ const char *define_list[] = {
   "coap_string_equal(",
   "coap_binary_equal(",
   "coap_log(",
+  "coap_log_emerg(",
+  "coap_log_alert(",
+  "coap_log_crit(",
+  "coap_log_err(",
+  "coap_log_warn(",
+  "coap_log_info(",
+  "coap_log_notice(",
+  "coap_log_debug(",
+  "coap_log_oscore(",
+  "coap_dtls_log(",
 };
 
 const char *struct_list[] = {

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -165,7 +165,7 @@ typedef enum coap_free_bye_t {
   G_CHECK(xx, func); \
 } while 0
 
-static int dtls_log_level = 0;
+static coap_log_t dtls_log_level = 0;
 
 #if COAP_SERVER_SUPPORT
 static int post_client_hello_gnutls_pki(gnutls_session_t g_session);
@@ -278,10 +278,12 @@ coap_gnutls_audit_log_func(gnutls_session_t g_session, const char* text)
 static void
 coap_gnutls_log_func(int level, const char* text)
 {
-  /* debug logging in gnutls starts at 2 */
-  if (level > 2)
-    level = 2;
-  coap_log(LOG_DEBUG + level - 2, "%s", text);
+  /* Things get noisy, even at level 1 */
+  if (level > 0)
+    level += COAP_LOG_WARN;
+  if (level > COAP_LOG_DEBUG)
+    level = COAP_LOG_DEBUG;
+  coap_dtls_log(level, "%s", text);
 }
 
 /*
@@ -451,21 +453,15 @@ coap_dtls_get_tls(const coap_session_t *c_session,
 }
 
 void
-coap_dtls_set_log_level(int level) {
+coap_dtls_set_log_level(coap_log_t level) {
   dtls_log_level = level;
-  if (level - LOG_DEBUG >= -2) {
-    /* debug logging in gnutls starts at 2 */
-    gnutls_global_set_log_level(2 + level - LOG_DEBUG);
-  }
-  else {
-    gnutls_global_set_log_level(0);
-  }
+  gnutls_global_set_log_level(dtls_log_level);
 }
 
 /*
  * return current logging level
  */
-int
+coap_log_t
 coap_dtls_get_log_level(void) {
   return dtls_log_level;
 }

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -113,7 +113,7 @@ coap_dtls_context_check_keys_enabled(coap_context_t *ctx COAP_UNUSED)
   return 0;
 }
 
-static int dtls_log_level = 0;
+static coap_log_t dtls_log_level = COAP_LOG_EMERG;
 
 void coap_dtls_startup(void) {
 }
@@ -130,11 +130,11 @@ void coap_dtls_shutdown(void) {
 }
 
 void
-coap_dtls_set_log_level(int level) {
+coap_dtls_set_log_level(coap_log_t level) {
   dtls_log_level = level;
 }
 
-int
+coap_log_t
 coap_dtls_get_log_level(void) {
   return dtls_log_level;
 }


### PR DESCRIPTION
Set up coap_log_t as an enum, using syslog variable names prefixed by
COAP_.

Add function coap_dtls_log() for logging information from (D)TLS libraries.

Update the log output to have a prefix of DTLS- for the logging levels to
indicate that output is from the (D)TLS library instead of the CoAP library.

(D)TLS libraries updated to be consistent in the usage of
coap_dtls_set_log_level()/coap_dtls_get_log_level().

Add in coap_log_emerg(), coap_log_alert() etc. as wrappers to reduce the line
length required for log entries.  Updating all the coap_log() functions to
no longer use syslog variants will be a part of a separate PR.

Added in the "-V" option to the examples, with an initial default of
COAP_LOG_WARN, separating out the CoAP and (D)TLS logging levels.

Note: TinyDTLS log output will be consistent when built against a TinyDTLS
version that contains support for an external logging handler.

Closes #871