### PR TITLE
Observe: Support disabling observe cancellation on session close

### DIFF
--- a/include/coap3/coap_session.h
+++ b/include/coap3/coap_session.h
@@ -614,4 +614,11 @@ uint32_t coap_session_get_probing_rate(const coap_session_t *session);
  */
 coap_mid_t coap_session_send_ping(coap_session_t *session);
 
+/**
+ * Disable client automatically sending observe cancel on session close
+ *
+ * @param session The CoAP session.
+ */
+void coap_session_set_no_observe_cancel(coap_session_t *session);
+
 #endif  /* COAP_SESSION_H */

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -145,6 +145,8 @@ struct coap_session_t {
   uint8_t doing_first;            /**< Set if doing client's first request */
   uint8_t proxy_session;        /**< Set if this is an ongoing proxy session */
   uint8_t delay_recursive;        /**< Set if in coap_client_delay_first() */
+  uint8_t no_observe_cancel;      /**< Set if do not cancel observe on session
+                                       close */
   uint32_t tx_rtag;               /**< Next Request-Tag number to use */
   uint64_t tx_token;              /**< Next token number to use */
   coap_bin_const_t *last_token;   /** last token used to make a request */

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -218,6 +218,7 @@ global:
   coap_session_set_default_leisure;
   coap_session_set_max_retransmit;
   coap_session_set_mtu;
+  coap_session_set_no_observe_cancel;
   coap_session_set_nstart;
   coap_session_set_probing_rate;
   coap_session_set_type_client;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -216,6 +216,7 @@ coap_session_set_app_data
 coap_session_set_default_leisure
 coap_session_set_max_retransmit
 coap_session_set_mtu
+coap_session_set_no_observe_cancel
 coap_session_set_nstart
 coap_session_set_probing_rate
 coap_session_set_type_client

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -13,7 +13,8 @@ NAME
 coap_observe,
 coap_resource_set_get_observable,
 coap_resource_notify_observers,
-coap_cancel_observe
+coap_cancel_observe,
+coap_session_set_no_observe_cancel
 - work with CoAP observe
 
 SYNOPSIS
@@ -28,6 +29,8 @@ const coap_string_t *_query_);*
 
 *int coap_cancel_observe(coap_session_t *_session_, coap_binary_t *_token_,
 coap_pdu_type_t _message_type_);*
+
+*void coap_session_set_no_observe_cancel(coap_session_t *_session_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -116,6 +119,11 @@ observe request that is being tracked. This will cause the
 appropriate PDU to be sent to the server to cancel the observation, based on
 the _session_ and _token_ used to set up the observe and the PDU is of type
 _message_type_ (use COAP_MESSAGE_NON or COAP_MESSAGE_CON).
+
+The *coap_session_set_no_observe_cancel*() function can be called by the
+client to disable calling *coap_cancel_observe*() when the _session_ is being
+closed down / freed off. *coap_cancel_observe*() can still be called directly
+by the client application.
 
 RETURN VALUES
 -------------
@@ -375,8 +383,8 @@ error:
 
 SEE ALSO
 --------
-*coap_attribute*(3), *coap_block*(3), *coap_context*(3), *coap_handler*(3),
-*coap_pdu_setup*(3) and *coap_resource*(3)
+*coap_block*(3), *coap_context*(3), *coap_handler*(3),
+*coap_pdu_setup*(3), *coap_resource*(3) and *coap_session*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -234,7 +234,7 @@ void coap_session_mfree(coap_session_t *session) {
 
   /* Need to do this before (D)TLS and socket is closed down */
   LL_FOREACH_SAFE(session->lg_crcv, cq, etmp) {
-    if (cq->observe_set) {
+    if (cq->observe_set && session->no_observe_cancel == 0) {
       /* Need to close down observe */
       if (coap_cancel_observe(session, cq->app_token, COAP_MESSAGE_NON)) {
         /* Need to delete node we set up for NON */
@@ -1697,5 +1697,11 @@ const char *coap_endpoint_str(const coap_endpoint_t *endpoint) {
 
   return szEndpoint;
 }
-#endif /* ! COAP_SERVER_SUPPORT */
+#endif /* COAP_SERVER_SUPPORT */
+#ifdef COAP_CLIENT_SUPPORT
+void
+coap_session_set_no_observe_cancel(coap_session_t *session) {
+  session->no_observe_cancel = 1;
+}
+#endif /* COAP_CLIENT_SUPPORT */
 #endif  /* COAP_SESSION_C_ */


### PR DESCRIPTION
Add in a new function coap_session_set_no_observe_cancel() to support this.

Fixes issues raised in #810 and #887 