### PR TITLE
PDU Data: Clean up internal usage of PDU data

### DIFF
--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -83,14 +83,24 @@
 
 /**
  * structure for CoAP PDUs
- * token, if any, follows the fixed size header, then options until
- * payload marker (0xff), then the payload if stored inline.
+ *
+ * Separate COAP_PDU_BUF is allocated with offsets held in coap_pdu_t.
+
+ * token, if any, follows the fixed size header, then optional options until
+ * payload marker (0xff) (if paylooad), then the optional payload.
+ *
  * Memory layout is:
  * <---header--->|<---token---><---options--->0xff<---payload--->
+ *
  * header is addressed with a negative offset to token, its maximum size is
  * max_hdr_size.
- * options starts at token + token_length
- * payload starts at data, its length is used_size - (data - token)
+ *
+ * allocated buffer always starts max_hdr_size before token.
+ *
+ * options starts at token + token_length.
+ * payload starts at data, its length is used_size - (data - token).
+ *
+ * alloc_size, used_size and max_size are the offsets from token.
  */
 
 struct coap_pdu_t {
@@ -101,7 +111,7 @@ struct coap_pdu_t {
                                  order */
   uint8_t max_hdr_size;     /**< space reserved for protocol-specific header */
   uint8_t hdr_size;         /**< actual size used for protocol-specific
-                                 header */
+                                 header (0 until header is encoded) */
   uint8_t token_length;     /**< length of Token */
   uint8_t crit_opt;         /**< Set if unknown critical option for proxy */
   uint16_t max_opt;         /**< highest option number in PDU */

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -185,7 +185,7 @@ coap_pdu_duplicate(const coap_pdu_t *old_pdu,
     size_t length = old_pdu->used_size - old_pdu->token_length -
           (old_pdu->data ?
                  old_pdu->used_size - (old_pdu->data - old_pdu->token) +1 : 0);
-    if (!coap_pdu_resize(pdu, length + old_pdu->hdr_size))
+    if (!coap_pdu_resize(pdu, length + pdu->token_length))
       goto fail;
     /* Copy the options but not any data across */
     memcpy(pdu->token + pdu->token_length,
@@ -215,6 +215,10 @@ fail:
   return NULL;
 }
 
+
+/*
+ * The new size does not include the coap header (max_hdr_size)
+ */
 int
 coap_pdu_resize(coap_pdu_t *pdu, size_t new_size) {
   if (new_size > pdu->alloc_size) {
@@ -233,7 +237,8 @@ coap_pdu_resize(coap_pdu_t *pdu, size_t new_size) {
     } else {
       offset = 0;
     }
-    new_hdr = (uint8_t*)realloc(pdu->token - pdu->max_hdr_size, new_size + pdu->max_hdr_size);
+    new_hdr = (uint8_t*)realloc(pdu->token - pdu->max_hdr_size,
+                                new_size + pdu->max_hdr_size);
     if (new_hdr == NULL) {
       coap_log(LOG_WARNING, "coap_pdu_resize: realloc failed\n");
       return 0;


### PR DESCRIPTION
Replace usage of hdr_size with max_hdr_size as appropriate as hdr_size
is not set until PDU is encoded. This should eliminate potential buffer
overruns.

Better checks for available space for the payload when using BlockX.

Clarify documentation.