### PR TITLE
Observe: Clean up server timing out after observe failures

### DIFF
--- a/coap_config.h.contiki
+++ b/coap_config.h.contiki
@@ -101,22 +101,28 @@
 #endif /* COAP_MAX_LG_SRCV */
 
 /**
- * Number of notifications that may be sent non-confirmable before a
- * confirmable message is sent to detect if observers are alive. The
- * maximum allowed value here is @c 15.
+ * Number of notifications that may be sent non-confirmable before a confirmable
+ * message is sent to detect if observers are alive. The maximum allowed value
+ * here is @c 255.
  */
 #ifndef COAP_OBS_MAX_NON
 #define COAP_OBS_MAX_NON   5
 #endif /* COAP_OBS_MAX_NON */
+#if COAP_OBS_MAX_NON > 255
+#error COAP_OBS_MAX_NON is too large
+#endif /* COAP_OBS_MAX_NON > 255 */
 
 /**
- * Number of confirmable notifications that may fail (i.e. time out
- * without being ACKed) before an observer is removed. The maximum
- * value for COAP_OBS_MAX_FAIL is @c 3.
+ * Number of different confirmable notifications that may fail (i.e. those
+ * that have hit MAX_RETRANSMIT multiple times) before an observer is removed. 
+ * The maximum value for COAP_OBS_MAX_FAIL is @c 255.
  */
 #ifndef COAP_OBS_MAX_FAIL
-#define COAP_OBS_MAX_FAIL  3
+#define COAP_OBS_MAX_FAIL  1
 #endif /* COAP_OBS_MAX_FAIL */
+#if COAP_OBS_MAX_FAIL > 255
+#error COAP_OBS_MAX_FAIL is too large
+#endif /* COAP_OBS_MAX_FAIL > 255 */
 
 #ifndef DEBUG
 # define DEBUG DEBUG_PRINT

--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -29,34 +29,40 @@
  * @{
  */
 
-#ifndef COAP_OBS_MAX_NON
 /**
  * Number of notifications that may be sent non-confirmable before a confirmable
  * message is sent to detect if observers are alive. The maximum allowed value
- * here is @c 15.
+ * here is @c 255.
  */
+#ifndef COAP_OBS_MAX_NON
 #define COAP_OBS_MAX_NON   5
 #endif /* COAP_OBS_MAX_NON */
+#if COAP_OBS_MAX_NON > 255
+#error COAP_OBS_MAX_NON is too large
+#endif /* COAP_OBS_MAX_NON > 255 */
 
-#ifndef COAP_OBS_MAX_FAIL
 /**
- * Number of confirmable notifications that may fail (i.e. time out without
- * being ACKed) before an observer is removed. The maximum value for
- * COAP_OBS_MAX_FAIL is @c 3.
+ * Number of different confirmable notifications that may fail (i.e. those
+ * that have hit MAX_RETRANSMIT multiple times) before an observer is removed.
+ * The maximum value for COAP_OBS_MAX_FAIL is @c 255.
  */
-#define COAP_OBS_MAX_FAIL  3
+#ifndef COAP_OBS_MAX_FAIL
+#define COAP_OBS_MAX_FAIL  1
 #endif /* COAP_OBS_MAX_FAIL */
+#if COAP_OBS_MAX_FAIL > 255
+#error COAP_OBS_MAX_FAIL is too large
+#endif /* COAP_OBS_MAX_FAIL > 255 */
 
 /** Subscriber information */
 struct coap_subscription_t {
   struct coap_subscription_t *next; /**< next element in linked list */
   struct coap_session_t *session;   /**< subscriber session */
 
-  unsigned int non_cnt:4;  /**< up to 15 non-confirmable notifies allowed */
-  unsigned int fail_cnt:2; /**< up to 3 confirmable notifies can fail */
-  unsigned int dirty:1;    /**< set if the notification temporarily could not be
-                            *   sent (in that case, the resource's partially
-                            *   dirty flag is set too) */
+  uint8_t non_cnt;  /**< up to 255 non-confirmable notifies allowed */
+  uint8_t fail_cnt; /**< up to 255 confirmable notifies can fail */
+  uint8_t dirty;    /**< set if the notification temporarily could not be
+                     *   sent (in that case, the resource's partially
+                     *   dirty flag is set too) */
   coap_cache_key_t *cache_key; /** cache_key to identify requester */
   coap_pdu_t *pdu;         /**< PDU to use for additional requests */
 };

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -469,7 +469,7 @@ coap_update_epoll_timer(coap_context_t *context, coap_tick_t delay)
       }
 #ifdef COAP_DEBUG_WAKEUP_TIMES
       else {
-        coap_log(LOG_INFO, "****** Next wakeup time %ld.%09ld\n",
+        coap_log(LOG_INFO, "****** Next wakeup time %3ld.%09ld\n",
                  new_value.it_value.tv_sec, new_value.it_value.tv_nsec);
       }
 #endif /* COAP_DEBUG_WAKEUP_TIMES */
@@ -1101,7 +1101,7 @@ coap_io_prepare_epoll(coap_context_t *ctx, coap_tick_t now) {
                                    1000000;
     }
 #ifdef COAP_DEBUG_WAKEUP_TIMES
-    coap_log(LOG_INFO, "****** Next wakeup time %ld.%09ld\n",
+    coap_log(LOG_INFO, "****** Next wakeup time %3ld.%09ld\n",
              new_value.it_value.tv_sec, new_value.it_value.tv_nsec);
 #endif /* COAP_DEBUG_WAKEUP_TIMES */
     /* reset, or specify a future time for eptimerfd to trigger */

--- a/src/net.c
+++ b/src/net.c
@@ -1506,8 +1506,8 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
 
 #if COAP_SERVER_SUPPORT
   /* Check if subscriptions exist that should be canceled after
-     COAP_MAX_NOTIFY_FAILURES */
-  if (node->pdu->code >= 64) {
+     COAP_OBS_MAX_FAIL */
+  if (COAP_RESPONSE_CLASS(node->pdu->code) >= 2) {
     coap_binary_t token = { 0, NULL };
 
     token.length = node->pdu->token_length;


### PR DESCRIPTION
Support for larger COAP_OBS_MAX_NON and COAP_OBS_MAX_FAIL definitions.

Change default for COAP_OBS_MAX_FAIL to 1 as there will already have
been MAX_RETRANSMIT(4) of the notification over a period of 93 seconds if
defaults are used.

Code and documentation clean up