### PR TITLE
block.c: Correct size of allocated PDU buffer

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -676,8 +676,7 @@ coap_add_data_large_internal(coap_session_t *session,
     if (!lg_xmit->pdu.token)
       goto fail;
 
-    lg_xmit->pdu.alloc_size = lg_xmit->pdu.used_size +
-                              lg_xmit->pdu.max_hdr_size;
+    lg_xmit->pdu.alloc_size = lg_xmit->pdu.used_size;
     lg_xmit->pdu.token += lg_xmit->pdu.max_hdr_size;
     memcpy(lg_xmit->pdu.token, pdu->token, lg_xmit->pdu.used_size);
     if (pdu->data)


### PR DESCRIPTION
Fix potential buffer overrun corruptions.