### PR TITLE
FETCH Observe: Handle Observes when FETCH body is large

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1795,6 +1795,7 @@ init_resources(coap_context_t *ctx) {
   r = coap_resource_init(coap_make_str_const("example_data"), resource_flags);
   coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_example_data);
   coap_register_request_handler(r, COAP_REQUEST_PUT, hnd_put_example_data);
+  coap_register_request_handler(r, COAP_REQUEST_FETCH, hnd_get_example_data);
   coap_resource_set_get_observable(r, 1);
 
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -122,7 +122,9 @@ struct coap_lg_crcv_t {
   size_t total_len;      /**< Length as indicated by SIZE2 option */
   coap_binary_t *body_data; /**< Used for re-assembling entire body */
   coap_binary_t *app_token; /**< app requesting PDU token */
-  coap_binary_t *obs_token; /**< Initial Observe response PDU token */
+  coap_binary_t **obs_token; /**< Tokens used in setting up Observe
+                                  (to handle large FETCH) */
+  size_t obs_token_cnt; /**< number of tokens used to set up Observe */
   uint64_t state_token; /**< state token */
   coap_pdu_t pdu;        /**< skeletal PDU */
   coap_rblock_t rec_blocks; /** < list of received blocks */
@@ -161,7 +163,8 @@ struct coap_lg_srcv_t {
 
 #if COAP_CLIENT_SUPPORT
 coap_lg_crcv_t * coap_block_new_lg_crcv(coap_session_t *session,
-                                        coap_pdu_t *pdu);
+                                        coap_pdu_t *pdu,
+                                        coap_lg_xmit_t *lg_xmit);
 
 void coap_block_delete_lg_crcv(coap_session_t *session,
                                coap_lg_crcv_t *lg_crcv);
@@ -192,9 +195,8 @@ int coap_handle_request_put_block(coap_context_t *context,
                                   coap_resource_t *resource,
                                   coap_string_t *uri_path,
                                   coap_opt_t *observe,
-                                  coap_string_t *query,
-                                  coap_method_handler_t h,
-                                  int *added_block);
+                                  int *added_block,
+                                  coap_lg_srcv_t **free_lg_srcv);
 
 coap_lg_xmit_t * coap_find_lg_xmit_response(const coap_session_t *session,
                                             const coap_pdu_t *request,

--- a/include/coap3/mem.h
+++ b/include/coap3/mem.h
@@ -131,6 +131,10 @@ COAP_STATIC_INLINE void coap_memory_init(void) {}
                                          memp_malloc(MEMP_ ## type) : NULL)
 #define coap_free_type(type, p) memp_free(MEMP_ ## type, p)
 
+/* As these are fixed size, return value if already defined */
+#define coap_realloc_type(type, p, asize) \
+  ((p) ? ((asize) <= memp_pools[MEMP_ ## type]->size) ? (p) : NULL : coap_malloc_type(type, asize))
+
 /* Those are just here to make uri.c happy where string allocation has not been
  * made conditional.
  */

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -230,13 +230,13 @@ void coap_session_mfree(coap_session_t *session) {
   coap_lg_xmit_t *lq, *ltmp;
 
 #if COAP_CLIENT_SUPPORT
-  coap_lg_crcv_t *cq, *etmp;
+  coap_lg_crcv_t *lg_crcv, *etmp;
 
   /* Need to do this before (D)TLS and socket is closed down */
-  LL_FOREACH_SAFE(session->lg_crcv, cq, etmp) {
-    if (cq->observe_set && session->no_observe_cancel == 0) {
+  LL_FOREACH_SAFE(session->lg_crcv, lg_crcv, etmp) {
+    if (lg_crcv->observe_set && session->no_observe_cancel == 0) {
       /* Need to close down observe */
-      if (coap_cancel_observe(session, cq->app_token, COAP_MESSAGE_NON)) {
+      if (coap_cancel_observe(session, lg_crcv->app_token, COAP_MESSAGE_NON)) {
         /* Need to delete node we set up for NON */
         coap_queue_t *queue = session->context->sendqueue;
 
@@ -247,10 +247,12 @@ void coap_session_mfree(coap_session_t *session) {
           }
           queue = queue->next;
         }
+        /* lg_crcv will be deleted when coap_cancel_observe() completes */
+        continue;
       }
     }
-    LL_DELETE(session->lg_crcv, cq);
-    coap_block_delete_lg_crcv(session, cq);
+    LL_DELETE(session->lg_crcv, lg_crcv);
+    coap_block_delete_lg_crcv(session, lg_crcv);
   }
 #endif /* COAP_CLIENT_SUPPORT */
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -330,6 +330,29 @@ coap_free_type(coap_memory_tag_t type, void *object) {
   if (object != NULL)
     memarray_free(get_container(type), object);
 }
+
+void *
+coap_realloc_type(coap_memory_tag_t type, void *p, size_t size) {
+  memarray_t *container = get_container(type);
+
+  assert(container);
+  /* The fixed container is all we have to work with */
+  if (p) {
+    if (size > container->size) {
+      coap_log(LOG_WARNING,
+               "coap_realloc_type: Requested memory exceeds maximum object "
+               "size (type %d, size %zu, max %d)\n",
+               type, size, container->size);
+      return NULL;
+    }
+    if (size == 0) {
+      coap_free_type(type, p);
+      return NULL;
+    }
+    return p;
+  }
+  return coap_malloc_type(type, size);
+}
 #else /* ! RIOT_VERSION */
 
 #ifdef HAVE_MALLOC
@@ -469,6 +492,29 @@ coap_malloc_type(coap_memory_tag_t type, size_t size) {
 void
 coap_free_type(coap_memory_tag_t type, void *object) {
   memb_free(get_container(type), object);
+}
+
+void *
+coap_realloc_type(coap_memory_tag_t type, void *p, size_t size) {
+  struct memb *container = get_container(type);
+
+  assert(container);
+  /* The fixed container is all we have to work with */
+  if (p) {
+    if (size > container->size) {
+      coap_log(LOG_WARNING,
+               "coap_realloc_type: Requested memory exceeds maximum object "
+               "size (type %d, size %zu, max %d)\n",
+               type, size, container->size);
+      return NULL;
+    }
+    if (size == 0) {
+      coap_free_type(type, p);
+      return NULL;
+    }
+    return p;
+  }
+  return coap_malloc_type(type, size);
 }
 #endif /* WITH_CONTIKI */
 

--- a/src/resource.c
+++ b/src/resource.c
@@ -780,6 +780,8 @@ static const uint16_t cache_ignore_options[] = { COAP_OPTION_ETAG };
     return NULL;
   }
   if (coap_get_data(request, &len, &data)) {
+    /* This could be a large bodied FETCH */
+    s->pdu->max_size = 0;
     coap_add_data(s->pdu, len, data);
   }
   if (cache_key == NULL) {


### PR DESCRIPTION
Assemble all the blocks before checking for Observe registration
or de-registration.

Track all the tokens used for the large FETCH registration and
re-use them for the de-registration as the server can elect to use
any of them when re-assembling the body for the registration Token.