### PR TITLE
Doxygen: Add in individual man pages for the ease of finding the functions

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -34,10 +34,22 @@ man-page-prepare: man-page-cleanup
 
 man-page-start: man-page-prepare
 	## Setup the man page tab
+	@echo '' > $(top_builddir)/doc/scratch_insert_file
 	@echo '    <tab type="usergroup" visible="yes" url="@ref manpage" title="Manual Pages">' > $(top_builddir)/doc/insert_file
+	@echo '     <tab  type="usergroup" visible="yes" url="@ref man_summary" title="Man Pages Summary">' >> $(top_builddir)/doc/insert_file
+	##
 	@echo '/** @page manpage Manual Pages' > $(top_builddir)/doc/man_tmp/manpage.dox
-	@echo '  Here is a list of libcoap API manual pages, some of which have code examples:' >> $(top_builddir)/doc/man_tmp/manpage.dox
-	@echo '   <table class="directory">' >> $(top_builddir)/doc/man_tmp/manpage.dox
+	@echo '  Here are the libcoap API and Example manual pages:' >> $(top_builddir)/doc/man_tmp/manpage.dox
+	@echo ' */' >> $(top_builddir)/doc/man_tmp/manpage.dox
+	##
+	@echo '/** @page man_summary Manual Pages Summary' > $(top_builddir)/doc/man_tmp/man_summary.dox
+	@echo '  Here are a list of libcoap API summary man pages, some of which have code examples, and Examples:' >> $(top_builddir)/doc/man_tmp/man_summary.dox
+	@echo '   <table class="directory">' >> $(top_builddir)/doc/man_tmp/man_summary.dox
+	##
+	@echo '/** @page man_individual Individual Manual Pages' > $(top_builddir)/doc/man_tmp/man_individual.dox
+	@echo '  Here are a list of libcoap API individual man pages, some of which have code examples:' >> $(top_builddir)/doc/man_tmp/man_individual.dox
+	@echo '   <table class="directory">' >> $(top_builddir)/doc/man_tmp/man_individual.dox
+	##
 	## Setup the upgrading tab
 	@echo '/** @page upgrading Upgrading' > $(top_builddir)/doc/man_tmp/upgrading.dox
 	@echo '  Upgrading between libcoap versions:' >> $(top_builddir)/doc/man_tmp/upgrading.dox
@@ -53,45 +65,110 @@ man-page-build: upg-page-build man-page-start
 	if [ "$${COUNT_MAN_FILES}" != "$${COUNT_HTML_FILES}" ]; then \
 		$(MAKE) -C ../man ;\
 	fi ;\
+	##
+	## Build the summary man pages
+	##
 	for FILE in $${MAN_FILES} ; do \
 		BASE=`basename $${FILE} | cut -d. -f 1` ;\
 		MANUAL=`egrep -B 1 "^====" $${FILE} | head -1` ;\
-		SUMMARY=`egrep -B 2 "^SYNOPSIS" $${FILE} | sed 's/coap-//g' | cut -d\- -f2 | cut -c2- | head -1` ;\
+		SUMMARY=`egrep -B 2 "^SYNOPSIS" $${FILE} | ${SED} 's/coap-//g' | cut -d\- -f2 | cut -c2- | head -1` ;\
+		##
+		## Fix and copy .html file across
+		##
+		if [ -f $(top_builddir)/man/$${BASE}.html ]; then \
+			## Correct case sensitive Name and Synopsis on master (used later)
+			$(SED) -i 's^<h2>Name</h2>^<h2>NAME</h2>^g' $(top_builddir)/man/$${BASE}.html ;\
+			$(SED) -i 's^<h2>Synopsis</h2>^<h2>SYNOPSIS</h2>^g' $(top_builddir)/man/$${BASE}.html ;\
+			cp -f $(top_builddir)/man/$${BASE}.html $(top_builddir)/doc/man_html/$${BASE}.html ;\
+		else \
+			echo "ERROR: $(top_builddir)/man/$${BASE}.html not found!";\
+			exit 1 ;\
+		fi ;\
 		## Build the manual insert page
 		echo "/// @page man_$${BASE} $${MANUAL}" > $(top_builddir)/doc/man_tmp/$${MANUAL}.dox ;\
 		echo "/// @htmlinclude $${BASE}.html $${MANUAL}" >> $(top_builddir)/doc/man_tmp/$${MANUAL}.dox ;\
-		## Update insert_file
+		## Update insert_file (the list is sorted appropriately)
 		echo "      <tab type=\"user\" visible=\"yes\" url=\"@ref man_$${BASE}\" title=\"$${MANUAL} - $${SUMMARY}\" intro=\"\"/>" >> $(top_builddir)/doc/insert_file ;\
 		## Update the summary man page
-		echo "   <tr id=\"row_$${ID}_\"$${ROW_EVEN}>" >> $(top_builddir)/doc/man_tmp/manpage.dox ;\
-		echo "   <td class=\"entry\" align=\"left\"> @ref man_$${BASE} </td><td class=\"desc\" align=\"left\">$${MANUAL} - $${SUMMARY}</td>" >> $(top_builddir)/doc/man_tmp/manpage.dox ;\
-		echo "   </tr>" >> $(top_builddir)/doc/man_tmp/manpage.dox ;\
+		echo "   <tr$${ROW_EVEN}>" >> $(top_builddir)/doc/man_tmp/man_summary.dox ;\
+		echo "   <td class=\"entry\" align=\"left\"> @ref man_$${BASE} </td><td class=\"desc\" align=\"left\">$${SUMMARY}</td>" >> $(top_builddir)/doc/man_tmp/man_summary.dox ;\
+		echo "   </tr>" >> $(top_builddir)/doc/man_tmp/man_summary.dox ;\
 		if [ -z $${ROW_EVEN} ] ; then \
 			ROW_EVEN=" class=\"even\"" ;\
 		else \
 			ROW_EVEN= ;\
 		fi \
 	done ;\
-	## Close off the man page file
-	echo '   </table>' >> $(top_builddir)/doc/man_tmp/manpage.dox ;\
-	echo ' */' >> $(top_builddir)/doc/man_tmp/manpage.dox ;\
+	##
+	## Close off the man page summary file
+	##
+	echo '   </table>' >> $(top_builddir)/doc/man_tmp/man_summary.dox ;\
+	echo ' */' >> $(top_builddir)/doc/man_tmp/man_summary.dox ;\
+	echo '     </tab>' >> $(top_builddir)/doc/insert_file ;\
+	##
+	## Build the individual man pages
+	##
+	echo '     <tab  type="usergroup" visible="yes" url="@ref man_individual" title="Individual Man Pages">' >> $(top_builddir)/doc/insert_file ;\
+	for FILE in $${MAN_FILES} ; do \
+		BASE=`basename $${FILE} | cut -d. -f 1` ;\
+		LIST=`${SED} -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $${FILE} | ${SED} -ne '/coap_/{ s/ *, *//g ; p }' | egrep -v "^$${BASE}$$"` ;\
+		for ENTRY in $${LIST} ; do \
+			MANUAL="$${ENTRY}(3)" ;\
+			## Build the manual insert page
+			echo "/// @page man_$${ENTRY} $${MANUAL}" > $(top_builddir)/doc/man_tmp/$${MANUAL}.dox ;\
+			echo "/// @htmlinclude $${ENTRY}.html $${MANUAL}" >> $(top_builddir)/doc/man_tmp/$${MANUAL}.dox ;\
+			## Create html file
+			cat $(top_builddir)/man/$${BASE}.html | ${SED} "s/Function: $${ENTRY}(/<a class=\"anchor\" id=\"$${ENTRY}\"><\/a>\0/" | ${SED} "s/\($${ENTRY}\)\([<(\*<]\)/<span class=\"man-highlight\">\1<\/span>\2/g" > $(top_builddir)/doc/man_html/$${ENTRY}.html ;\
+			## Update scratch_insert_file for sorting later
+			echo "$${ENTRY}" >> $(top_builddir)/doc/scratch_insert_file ;\
+		done ;\
+	done ;\
+	##
+	## Process the (sorted) list of individual man pages
+	##
+	for ENTRY in `cat $(top_builddir)/doc/scratch_insert_file | ALL=C sort -u` ; do \
+		## Update the individual man page
+		MANUAL="$${ENTRY}(3)" ;\
+		echo "      <tab type=\"user\" visible=\"yes\" url=\"@ref man_$${ENTRY}\" title=\"$${MANUAL}\" intro=\"\"/>" >> $(top_builddir)/doc/insert_file ;\
+		echo "   <tr$${ROW_EVEN}>" >> $(top_builddir)/doc/man_tmp/man_individual.dox ;\
+		echo "   <td class=\"entry\" align=\"left\"> @ref man_$${ENTRY} </td><td class=\"desc\" align=\"left\"></td>" >> $(top_builddir)/doc/man_tmp/man_individual.dox ;\
+		echo "   </tr>" >> $(top_builddir)/doc/man_tmp/man_individual.dox ;\
+		if [ -z $${ROW_EVEN} ] ; then \
+			ROW_EVEN=" class=\"even\"" ;\
+		else \
+			ROW_EVEN= ;\
+		fi \
+	done ;\
+	##
+	## Close off the individual man pages
+	##
+	echo '   </table>' >> $(top_builddir)/doc/man_tmp/man_individual.dox ;\
+	echo ' */' >> $(top_builddir)/doc/man_tmp/man_individual.dox ;\
+	echo '     </tab>' >> $(top_builddir)/doc/insert_file ;\
+	##
+	## Close off the man page top level
+	##
 	echo '    </tab>' >> $(top_builddir)/doc/insert_file ;\
+	##
 	## Add in the deprecated tab
+	##
 	echo '    <tab type="user" visible="yes" url="@ref deprecated" title="Deprecated Items" intro=""/>' >> $(top_builddir)/doc/insert_file ;\
+	##
 	## Start the upgrade tab
+	##
 	echo '    <tab type="usergroup" visible="yes" url="@ref upgrading" title="Upgrading">' >> $(top_builddir)/doc/insert_file ;\
 	for FILE in $${UPG_FILES} ; do \
 		BASE=`basename $${FILE} | $(SED) "s/\.txt$$//g"`; \
 		UPGRADE=`echo $${BASE} | $(SED) "s/^upgrade_//g"`; \
 		CUPGRADE=`echo $${UPGRADE} | $(SED) "s/\./-/g"`; \
-		SUMMARY=`head -1 $${FILE} | sed 's/^= //g'` ;\
+		SUMMARY=`head -1 $${FILE} | ${SED} 's/^= //g'` ;\
 		## Build the upgrade insert page
 		echo "/// @page upg_$${CUPGRADE} $${UPGRADE}" > $(top_builddir)/doc/man_tmp/$${UPGRADE}.dox ;\
 		echo "/// @htmlinclude $${BASE}.html $${UPGRADE}" >> $(top_builddir)/doc/man_tmp/$${UPGRADE}.dox ;\
 		## Update insert_file
 		echo "      <tab type=\"user\" visible=\"yes\" url=\"@ref upg_$${CUPGRADE}\" title=\"$${SUMMARY}\" intro=\"\"/>" >> $(top_builddir)/doc/insert_file ;\
 		## Update the upgrading page
-		echo "   <tr id=\"row_$${ID}_\"$${ROW_EVEN}>" >> $(top_builddir)/doc/man_tmp/upgrading.dox ;\
+		echo "   <tr$${ROW_EVEN}>" >> $(top_builddir)/doc/man_tmp/upgrading.dox ;\
 		echo "   <td class=\"entry\" align=\"left\"> @ref upg_$${CUPGRADE} </td><td class=\"desc\" align=\"left\">$${SUMMARY}</td>" >> $(top_builddir)/doc/man_tmp/upgrading.dox ;\
 		echo "   </tr>" >> $(top_builddir)/doc/man_tmp/upgrading.dox ;\
 		if [ -z $${ROW_EVEN} ] ; then \
@@ -108,33 +185,29 @@ man-page-build: upg-page-build man-page-start
 			exit 1 ;\
 		fi \
 	done ;\
+	##
 	## Close off the upgrading tab
+	##
 	echo '   </table>' >> $(top_builddir)/doc/man_tmp/upgrading.dox ;\
 	echo ' */' >> $(top_builddir)/doc/man_tmp/upgrading.dox ;\
+	##
+	## Close off the insert file list
+	##
 	echo '    </tab>' >> $(top_builddir)/doc/insert_file ;\
+	##
 	## Create and Update the DoxygenLayout.xml file
+	##
 	$(DOXYGEN) -l ;\
 	$(SED) -i 's/<tab type="pages" visible="yes" /<tab type="pages" visible="no" /g' $(top_builddir)/doc/DoxygenLayout.xml ;\
 	$(SED) -i '/<tab type="examples" visible=.*/r insert_file' $(top_builddir)/doc/DoxygenLayout.xml ;\
-	$(RM) $(top_builddir)/doc/insert_file ;\
+	##
 	## Fix up man html files, fixing links, UC Name and Synopsis
+	##
 	for FILE in $${MAN_FILES} ; do \
 		BASE=`basename $${FILE} | cut -d . -f1` ;\
-		if [ -f $(top_builddir)/man/$${BASE}.html ]; then \
-			cp -f $(top_builddir)/man/$${BASE}.html $(top_builddir)/doc/man_html/$${BASE}.html ;\
-			## Correct case sensitive Name and Synopsis
-			$(SED) -i 's^<h2>Name</h2>^<h2>NAME</h2>^g' $(top_builddir)/doc/man_html/$${BASE}.html ;\
-			$(SED) -i 's^<h2>Synopsis</h2>^<h2>SYNOPSIS</h2>^g' $(top_builddir)/doc/man_html/$${BASE}.html ;\
-		else \
-			echo "ERROR: $(top_builddir)/man/$${BASE}.html not found!";\
-			exit 1 ;\
-		fi ;\
-		for ENTRY in $${MAN_FILES} ; do \
-			EBASE=`basename $${ENTRY} | cut -d . -f1` ;\
-			MANUAL=`egrep -B 1 "^====" $${ENTRY} | head -1` ;\
-			SECTION=`echo $${MANUAL} | cut -d\( -f2 | cut -d\) -f1` ;\
-			$(SED) -i "s^<span class=\"strong\"><strong>$${EBASE}</strong></span>($${SECTION})^<a href=\"man_$${EBASE}.html\" target=\"_self\"><span class=\"strong\"><strong>$${EBASE}</strong></span>($${SECTION})</a>^g" $(top_builddir)/doc/man_html/$${BASE}.html ;\
-		done ;\
+		MANUAL=`egrep -B 1 "^====" $${FILE} | head -1` ;\
+		SECTION=`echo $${MANUAL} | cut -d\( -f2 | cut -d\) -f1` ;\
+		$(SED) -i "s^<span class=\"strong\"><strong>$${BASE}</strong></span>($${SECTION})^<a href=\"man_$${BASE}.html\" target=\"_self\"><span class=\"strong\"><strong>$${BASE}</strong></span>($${SECTION})</a>^g" $(top_builddir)/doc/man_html/$${BASE}.html ;\
 		echo "finalized addition $${BASE}.html" ;\
 	done
 
@@ -148,6 +221,13 @@ upg-page-build:
 
 all: man-page-build
 	$(DOXYGEN) Doxyfile
+	##
+	## Process the list of individual man pages to update html/navtree.js
+	##
+	@for ENTRY in `cat $(top_builddir)/doc/scratch_insert_file` ; do \
+		${SED} -i "s/man_$${ENTRY}.html/\0#$${ENTRY}/" $(top_builddir)/doc/html/navtree.js ;\
+	done
+	@$(RM) $(top_builddir)/doc/insert_file $(top_builddir)/doc/scratch_insert_file
 	@cp -f $(top_srcdir)/doc/docbook.local.css $(top_builddir)/doc/html/docbook-xsl.css
 
 else

--- a/doc/docbook.local.css
+++ b/doc/docbook.local.css
@@ -12,3 +12,4 @@ dt {
   margin-top: 0.1em;
 }
 
+span.man-highlight { background: yellow; }


### PR DESCRIPTION
Add in a new index tag for all the functions defined within the man pages.

Highlight the occurrence of that function name in the appropriate displayed
page.

For the man pages that have been restructured to break out the individual
functions, jump to the function definition.