### PR TITLE
coap_session.c: Fix adding NULL pointer on error in coap_new_server_s…

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1383,8 +1383,10 @@ error:
    * Need to add in the session as coap_session_release()
    * will call SESSIONS_DELETE in coap_session_free().
    */
-  SESSIONS_ADD(ep->sessions, session);
-  coap_session_free(session);
+  if (session) {
+    SESSIONS_ADD(ep->sessions, session);
+    coap_session_free(session);
+  }
   return NULL;
 }
 #endif /* COAP_SERVER_SUPPORT */


### PR DESCRIPTION
…ession()

When coap_make_session() fails, the local variable session will be
NULL, and the program continues at the error label. Because of
session == NULL, coap_session_free() will return immediately, leaving
a NULL entry in ep->sessions.

This fix is related to CID 1520613.