### PR TITLE
Manual pages: Update NAME section to contain all of the alternative names

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -59,7 +59,14 @@ man7_MANS = $(MAN7)
 
 .txt.3:
 	$(A2X) --doctype manpage --format manpage $<
+	@NEWLIST=`${SED} -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $< | ${SED} 's/^- /\\\\\\\- /g' | egrep -v 'NAME|----|SYNOPSIS|^\$$' | tr '\n' ' '` ;\
+	NAME=`echo $< | ${SED} -ne 's/^\(coap_[a-zA-Z_0-9]\+\).*$$/\1.3/p'` ;\
+	${SED} -i '/.SH "NAME"/{n;d;}' $${NAME} ;\
+	${SED} -i "/\.SH \"NAME\"/a $${NEWLIST}" $${NAME}
 	$(A2X) --doctype manpage --format xhtml $<
+	@NEWLIST=`${SED} -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $< | ${SED} 's^/^\\\\/^g' | egrep -v 'NAME|----|SYNOPSIS|^\$$' | tr '\n' ' '` ;\
+	NAME=`echo $< | ${SED} -ne 's/^\(coap_[a-zA-Z_0-9]\+\).*$$/\1.html/p'` ;\
+	${SED} -i "s^Name</h2><p>.*</p></div>^Name</h2><p>$${NEWLIST}</p></div>^" $${NAME}
 
 .txt.5:
 	$(A2X) --doctype manpage --format manpage $<


### PR DESCRIPTION
Update the NAME section with all of the alternative names.  All the different
files are already built.

Addresses and fixes #785.  Not all the versions of asciidoc output the warning limit.