### PR TITLE
CMake: Force all Warnings to Errors when doing github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,16 +86,32 @@ jobs:
         if: matrix.TLS == 'no'
         run: |
           cd $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
-          cmake $GITHUB_WORKSPACE -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -DENABLE_DTLS=OFF -DENABLE_DOCS=OFF
+          cmake $GITHUB_WORKSPACE -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -DENABLE_DTLS=OFF -DENABLE_DOCS=OFF -DWARNING_TO_ERROR=ON
       - name: configure TLS
         if: matrix.TLS != 'no'
         run: |
           cd $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
-          cmake $GITHUB_WORKSPACE -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -DENABLE_DTLS=ON -DENABLE_DOCS=OFF -DDTLS_BACKEND=${{matrix.TLS}}
+          cmake $GITHUB_WORKSPACE -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -DENABLE_DTLS=ON -DENABLE_DOCS=OFF -DDTLS_BACKEND=${{matrix.TLS}} -DWARNING_TO_ERROR=ON
       - name: build
         run: |
           cd $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
           cmake --build .
+  cmake-macos:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: macOS CMake setup
+      run: |
+        cmake -E make_directory build_test
+    - name: macOS CMake configure
+      run: |
+        cd build_test
+        cmake .. -DWARNING_TO_ERROR=ON -DENABLE_TESTS=NO -DENABLE_DTLS=NO
+    - name: macOS CMake build
+      run: |
+        cd build_test
+        cmake --build .
   other-build:
     runs-on: ubuntu-latest
     strategy:
@@ -129,6 +145,27 @@ jobs:
       - name: Build sln
         shell: cmd
         run: call .\scripts\msbuild.sln.cmd
+  ms-cmake:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install OpenSSL on Windows (choco)
+      run: |
+        choco install openssl
+      shell: cmd
+
+    - name: MS CMake setup
+      run: |
+        cmake -E make_directory build_test
+    - name: MS CMake configure
+      run: |
+        cd build_test
+        cmake .. -DWARNING_TO_ERROR=ON -DWITH_OPENSSL=YES
+    - name: MS CMake build
+      run: |
+        cd build_test
+        cmake --build .
 
   additional-tests:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,10 @@ option(
   ENABLE_DOCS
   "build also doxygen documentation"
   ON)
+option(
+  WARNING_TO_ERROR
+  "force all compiler warnings to be errors"
+  OFF)
 
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 11)
@@ -424,6 +428,7 @@ message(STATUS "CMAKE_C_COMPILER:................${CMAKE_C_COMPILER}")
 message(STATUS "BUILD_SHARED_LIBS:...............${BUILD_SHARED_LIBS}")
 message(STATUS "CMAKE_BUILD_TYPE:................${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_SYSTEM_PROCESSOR:..........${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "WARNING_TO_ERROR:................${WARNING_TO_ERROR}")
 
 set(top_srcdir "${CMAKE_CURRENT_LIST_DIR}")
 set(top_builddir "${CMAKE_CURRENT_BINARY_DIR}")
@@ -554,6 +559,19 @@ add_compile_options(
   $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wswitch-enum>
   $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wunused>
   $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wwrite-strings>)
+
+if(${WARNING_TO_ERROR})
+add_compile_options(
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Werror>)
+endif()
+
+if(CMAKE_GENERATOR MATCHES "Visual Studio")
+  option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols when compiling to a .dll" ON)
+  # add_compile_options(-Wall -wd4100)
+  if(${WARNING_TO_ERROR})
+    add_compile_options(-WX)
+  endif()
+endif()
 
 #
 # tests

--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -1399,10 +1399,6 @@ setup_psk(
   return &dtls_psk;
 }
 
-#ifdef _WIN32
-#define S_ISDIR(x) (((x) & S_IFMT) == S_IFDIR)
-#endif
-
 static coap_session_t*
 open_session(
   coap_context_t *ctx,


### PR DESCRIPTION
Add new option WARNING_TO_ERROR for CMakeLists.txt

Includes cmake builds for Windows and macOS
[Fix coap-client S_ISDIR() duplication bug]