### PR TITLE
LwIP: Support receiving ethernet MTU sized packets

### DIFF
--- a/examples/lwip/config/lwipopts.h
+++ b/examples/lwip/config/lwipopts.h
@@ -28,6 +28,8 @@
 
 #define MEMP_USE_CUSTOM_POOLS 1
 #define MEM_SIZE (4 * 1024)
+/* Support a 1500 MTU packet */
+#define PBUF_POOL_BUFSIZE LWIP_MEM_ALIGN_SIZE(2*6 + 2 + 1500)
 
 /* Set if space is to be reserved for a response PDU */
 #define MEMP_STATS                      1

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -76,7 +76,7 @@ coap_pdu_from_pbuf( struct pbuf *pbuf )
 
   if (pbuf == NULL) return NULL;
 
-  LWIP_ASSERT("Can only deal with contiguous PBUFs", pbuf->tot_len == pbuf->len);
+  LWIP_ASSERT("Can only deal with contiguous PBUFs (increase PBUF_POOL_BUFSIZE)", pbuf->tot_len == pbuf->len);
   LWIP_ASSERT("coap_io_do_io needs to receive an exclusive copy of the incoming pbuf", pbuf->ref == 1);
 
   pdu = coap_malloc_type(COAP_PDU, sizeof(coap_pdu_t) );


### PR DESCRIPTION
Define PBUF_POOL_BUFSIZE appropriately in lwipopts.h