### PR TITLE
RFC8974: Add in support for Extended Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The following RFCs are supported
 
 * RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option
 
+* RFC8974: Extended Tokens and Stateless Clients in the Constrained Application Protocol (CoAP)
+
 * RFC9175: CoAP: Echo, Request-Tag, and Token Processing
 
 There is (D)TLS support for the following libraries

--- a/doc/main.md
+++ b/doc/main.md
@@ -42,6 +42,8 @@ The following RFCs are supported
 
 * RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option
 
+* RFC8974: Extended Tokens and Stateless Clients in the Constrained Application Protocol (CoAP)
+
 * RFC9175: CoAP: Echo, Request-Tag, and Token Processing
 
 There is (D)TLS support for the following libraries

--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -51,8 +51,8 @@ strndup(const char* s1, size_t n) {
 
 int flags = 0;
 
-static unsigned char _token_data[8];
-coap_binary_t base_token = { 0, _token_data };
+static unsigned char _token_data[24]; /* With support for RFC8974 */
+coap_binary_t the_token = { 0, _token_data };
 
 typedef struct {
   coap_binary_t *token;
@@ -271,11 +271,19 @@ coap_new_request(coap_context_t *ctx,
 
   /*
    * Create unique token for this request for handling unsolicited /
-   * delayed responses
+   * delayed responses.
+   * Note that only up to 8 bytes are returned
    */
-  coap_session_new_token(session, &tokenlen, token);
-  track_new_token(tokenlen, token);
-  if (!coap_add_token(pdu, tokenlen, token)) {
+  if (the_token.length > COAP_TOKEN_DEFAULT_MAX) {
+    coap_session_new_token(session, &tokenlen, token);
+    /* Update the last part 8 bytes of the large token */
+    memcpy(&the_token.s[the_token.length - tokenlen], token, tokenlen);
+  }
+  else {
+    coap_session_new_token(session, &the_token.length, the_token.s);
+  }
+  track_new_token(the_token.length, the_token.s);
+  if (!coap_add_token(pdu, the_token.length, the_token.s)) {
     coap_log_debug("cannot add token to request\n");
   }
 
@@ -537,7 +545,7 @@ usage(const char *program, const char *version) {
      "\t       \t\tconnect to a CoAP proxy (automatically adds Proxy-Uri\n"
      "\t       \t\toption to request) to forward the request to.\n"
      "\t       \t\tScheme is one of coap, coaps, coap+tcp and coaps+tcp\n"
-     "\t-T token\tDefine the initial starting token\n"
+     "\t-T token\tDefine the initial starting token (up to 24 characters)\n"
      "\t-U     \t\tNever include Uri-Host or Uri-Port options\n"
      "\t-V num \t\tVerbosity level (default 3, maximum is 7) for (D)TLS\n"
      "\t       \t\tlibrary logging\n"
@@ -936,9 +944,9 @@ cmdline_proxy(char *arg) {
 
 static inline void
 cmdline_token(char *arg) {
-  base_token.length = min(sizeof(_token_data), strlen(arg));
-  if (base_token.length > 0) {
-    memcpy((char *)base_token.s, arg, base_token.length);
+  the_token.length = min(sizeof(_token_data), strlen(arg));
+  if (the_token.length > 0) {
+    memcpy((char *)the_token.s, arg, the_token.length);
   }
 }
 
@@ -1812,6 +1820,8 @@ main(int argc, char **argv) {
   coap_register_response_handler(ctx, message_handler);
   coap_register_event_handler(ctx, event_handler);
   coap_register_nack_handler(ctx, nack_handler);
+  if (the_token.length > COAP_TOKEN_DEFAULT_MAX)
+    coap_context_set_max_token_size(ctx, the_token.length);
 
   session = get_session(ctx,
                         node_str[0] ? node_str : NULL,
@@ -1832,8 +1842,9 @@ main(int argc, char **argv) {
    * Prime the base token value, which coap_session_new_token() will increment
    * every time it is called to get an unique token.
    * [Option '-T token' is used to seed a different value]
+   * Note that only the first 8 bytes of the token are used as the prime.
    */
-  coap_session_init_token(session, base_token.length, base_token.s);
+  coap_session_init_token(session, the_token.length, the_token.s);
 
   /* add Uri-Host if server address differs from uri.host */
 

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -122,7 +122,7 @@ struct coap_lg_crcv_t {
   size_t total_len;      /**< Length as indicated by SIZE2 option */
   coap_binary_t *body_data; /**< Used for re-assembling entire body */
   coap_binary_t *app_token; /**< app requesting PDU token */
-  coap_binary_t **obs_token; /**< Tokens used in setting up Observe
+  coap_bin_const_t **obs_token; /**< Tokens used in setting up Observe
                                   (to handle large FETCH) */
   size_t obs_token_cnt; /**< number of tokens used to set up Observe */
   uint64_t state_token; /**< state token */
@@ -153,8 +153,6 @@ struct coap_lg_srcv_t {
   coap_resource_t *resource; /**< associated resource */
   coap_str_const_t *uri_path; /** set to uri_path if unknown resource */
   coap_rblock_t rec_blocks; /** < list of received blocks */
-  uint8_t last_token[8]; /**< last used token */
-  size_t last_token_length; /**< length of token */
   coap_mid_t last_mid;   /**< Last received mid for this set of packets */
   coap_tick_t last_used; /**< Last time data sent or 0 */
   uint16_t block_option; /**< Block option in use */

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -145,6 +145,7 @@ struct coap_context_t {
                                         when creating a cache-key */
 #endif /* COAP_SERVER_SUPPORT */
   void *app;                       /**< application-specific data */
+  uint32_t max_token_size;         /**< Largest token size supported RFC8974 */
 #ifdef COAP_EPOLL_SUPPORT
   int epfd;                        /**< External FD for epoll */
   int eptimerfd;                   /**< Internal FD for timeout */
@@ -274,12 +275,10 @@ coap_wait_ack( coap_context_t *context, coap_session_t *session,
  * @param context      The context in use.
  * @param session      Session of the messages to remove.
  * @param token        Message token.
- * @param token_length Actual length of @p token.
  */
 void coap_cancel_all_messages(coap_context_t *context,
                               coap_session_t *session,
-                              const uint8_t *token,
-                              size_t token_length);
+                              coap_bin_const_t *token);
 
 /**
 * Cancels all outstanding messages for session @p session.

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -50,6 +50,12 @@
 #define OSCORE_CRYPTO_BUFFER_SIZE (COAP_MAX_CHUNK_SIZE+16)
 #endif /* HAVE_OSCORE  */
 
+/* Extended Token constants */
+#define COAP_TOKEN_EXT_1B_TKL 13
+#define COAP_TOKEN_EXT_2B_TKL 14
+#define COAP_TOKEN_EXT_1B_BIAS 13
+#define COAP_TOKEN_EXT_2B_BIAS 269 /* 13 + 256 */
+
 #ifndef COAP_DEBUG_BUF_SIZE
 #if defined(WITH_CONTIKI) || defined(WITH_LWIP)
 #define COAP_DEBUG_BUF_SIZE 128
@@ -102,7 +108,7 @@
  *
  * allocated buffer always starts max_hdr_size before token.
  *
- * options starts at token + token_length.
+ * options starts at token + e_token_length.
  * payload starts at data, its length is used_size - (data - token).
  *
  * alloc_size, used_size and max_size are the offsets from token.
@@ -117,16 +123,19 @@ struct coap_pdu_t {
   uint8_t max_hdr_size;     /**< space reserved for protocol-specific header */
   uint8_t hdr_size;         /**< actual size used for protocol-specific
                                  header (0 until header is encoded) */
-  uint8_t token_length;     /**< length of Token */
   uint8_t crit_opt;         /**< Set if unknown critical option for proxy */
   uint16_t max_opt;         /**< highest option number in PDU */
+  uint32_t e_token_length;  /**< length of Token space (includes leading
+                                 extended bytes */
+  coap_bin_const_t actual_token; /**< Actual token in pdu */
   size_t alloc_size;        /**< allocated storage for token, options and
                                  payload */
   size_t used_size;         /**< used bytes of storage for token, options and
                                  payload */
   size_t max_size;          /**< maximum size for token, options and payload,
                                  or zero for variable size pdu */
-  uint8_t *token;           /**< first byte of token, if any, or options */
+  uint8_t *token;           /**< first byte of token (or extended length bytes
+                                 prefix), if any, or options */
   uint8_t *data;            /**< first byte of payload, if any */
 #ifdef WITH_LWIP
   struct pbuf *pbuf;        /**< lwIP PBUF. The package data will always reside

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -52,6 +52,15 @@ typedef enum {
 } COAP_OSCORE_B_2_STEP;
 
 /**
+ * coap_ext_token_check_t values
+ */
+typedef enum coap_ext_token_check_t {
+  COAP_EXT_T_NOT_CHECKED = 0, /**< Not checked */
+  COAP_EXT_T_CHECKED,         /**< Token size valid */
+  COAP_EXT_T_CHECKING,        /**< Token size check request sent */
+} coap_ext_token_check_t;
+
+/**
  * Abstraction of virtual session that can be attached to coap_context_t
  * (client) or coap_endpoint_t (server).
  */
@@ -166,6 +175,11 @@ struct coap_session_t {
                                            associations */
   uint64_t oscore_r2;             /**< R2 for RFC8613 Appendix B.2 */
 #endif /* HAVE_OSCORE */
+  volatile uint8_t max_token_checked; /**< Check for max token size
+                                           coap_ext_token_check_t */
+  uint16_t max_token_mid;         /**< mid used for checking ext token
+                                       support */
+  uint32_t max_token_size;        /**< Largest token size supported RFC8974 */
   uint64_t tx_token;              /**< Next token number to use */
   coap_bin_const_t *last_token;   /** last token used to make a request */
   coap_bin_const_t *echo;         /**< Echo value to send with next request */

--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -79,7 +79,7 @@ void coap_subscription_init(coap_subscription_t *);
 void
 coap_handle_failed_notify(coap_context_t *context,
                           coap_session_t *session,
-                          const coap_binary_t *token);
+                          const coap_bin_const_t *token);
 
 /**
  * Checks all known resources to see if they are dirty and then notifies
@@ -105,7 +105,7 @@ void coap_check_notify(coap_context_t *context);
  */
 coap_subscription_t *coap_add_observer(coap_resource_t *resource,
                                        coap_session_t *session,
-                                       const coap_binary_t *token,
+                                       const coap_bin_const_t *token,
                                        const coap_pdu_t *pdu);
 
 /**
@@ -119,7 +119,7 @@ coap_subscription_t *coap_add_observer(coap_resource_t *resource,
  */
 coap_subscription_t *coap_find_observer(coap_resource_t *resource,
                                         coap_session_t *session,
-                                        const coap_binary_t *token);
+                                        const coap_bin_const_t *token);
 
 /**
  * Flags that data is ready to be sent to observers.
@@ -131,7 +131,7 @@ coap_subscription_t *coap_find_observer(coap_resource_t *resource,
  */
 void coap_touch_observer(coap_context_t *context,
                          coap_session_t *session,
-                         const coap_binary_t *token);
+                         const coap_bin_const_t *token);
 
 /**
  * Removes any subscription for @p observer from @p resource and releases the
@@ -146,7 +146,7 @@ void coap_touch_observer(coap_context_t *context,
  */
 int coap_delete_observer(coap_resource_t *resource,
                          coap_session_t *session,
-                         const coap_binary_t *token);
+                         const coap_bin_const_t *token);
 
 /**
  * Removes any subscription for @p session and releases the allocated storage.

--- a/include/coap3/net.h
+++ b/include/coap3/net.h
@@ -234,6 +234,16 @@ coap_context_set_pki_root_cas(coap_context_t *context,
 void coap_context_set_keepalive(coap_context_t *context, unsigned int seconds);
 
 /**
+ * Set the maximum token size (RFC8974).
+ *
+ * @param context        The coap_context_t object.
+ * @param max_token_size The maximum token size.  A value between 8 and 65804
+ *                       inclusive.
+ */
+void coap_context_set_max_token_size(coap_context_t *context,
+                                     size_t max_token_size);
+
+/**
  * Get the libcoap internal file descriptor for using in an application's
  * select() or returned as an event in an application's epoll_wait() call.
  *

--- a/include/coap3/pdu.h
+++ b/include/coap3/pdu.h
@@ -52,6 +52,10 @@
 /** well-known resources URI */
 #define COAP_DEFAULT_URI_WELLKNOWN ".well-known/core"
 
+/* Extended Token constants */
+#define COAP_TOKEN_DEFAULT_MAX 8
+#define COAP_TOKEN_EXT_MAX 65804 /* 13 + 256 + 65535 */
+
 /* CoAP message types */
 
 /**
@@ -182,11 +186,15 @@ typedef enum coap_pdu_signaling_proto_t {
 /* Applies to COAP_SIGNALING_CSM */
 #define COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE 2
 #define COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER 4
+#define COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH 6
+
 /* Applies to COAP_SIGNALING_PING / COAP_SIGNALING_PONG */
 #define COAP_SIGNALING_OPTION_CUSTODY 2
+
 /* Applies to COAP_SIGNALING_RELEASE */
 #define COAP_SIGNALING_OPTION_ALTERNATIVE_ADDRESS 2
 #define COAP_SIGNALING_OPTION_HOLD_OFF 4
+
 /* Applies to COAP_SIGNALING_ABORT */
 #define COAP_SIGNALING_OPTION_BAD_CSM_OPTION 2
 

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -51,6 +51,7 @@ global:
   coap_context_set_keepalive;
   coap_context_set_max_handshake_sessions;
   coap_context_set_max_idle_sessions;
+  coap_context_set_max_token_size;
   coap_context_set_pki;
   coap_context_set_pki_root_cas;
   coap_context_set_psk;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -49,6 +49,7 @@ coap_context_set_csm_timeout
 coap_context_set_keepalive
 coap_context_set_max_handshake_sessions
 coap_context_set_max_idle_sessions
+coap_context_set_max_token_size
 coap_context_set_pki
 coap_context_set_pki_root_cas
 coap_context_set_psk

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -104,6 +104,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_get_session_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_set_csm_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_get_csm_timeout.3
+	@echo ".so man3/coap_context.3" > coap_context_set_max_token_size.3
 	@echo ".so man3/coap_io.3" > coap_can_exit.3
 	@echo ".so man3/coap_logging.3" > coap_log_info.3
 	@echo ".so man3/coap_logging.3" > coap_log_debug.3

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -170,7 +170,7 @@ OPTIONS - General
    Scheme is one of coap, coaps, coap+tcp and coaps+tcp.
 
 *-T* token::
-   Define the initial starting 'token' for the request.
+   Define the initial starting 'token' for the request (up to 24 characters).
 
 *-U* ::
    Never include Uri-Host or Uri-Port options.

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -20,7 +20,7 @@ coap-rd-notls
 SYNOPSIS
 --------
 *coap-rd* [*-g* group] [*-G* group_if] [*-p* port] [*-v* num] [*-A* address]
-          [*-V* num]
+          [*-T* max_token_size] [*-V* num]
           [[*-h* hint] [*-k* key]]
           [[*-c* certfile] [*-n*] [*-C* cafile] [*-R* trusted_casfile]]
 
@@ -56,6 +56,9 @@ OPTIONS
 
 *-A* address::
    The local address of the interface which the server has to listen on.
+
+*-T* max_token_size::
+   Set the maximum token length (8-65804).
 
 *-V* num::
    The verbosity level to use (default 3, maximum is 7) for (D)TLS

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -22,8 +22,8 @@ SYNOPSIS
 *coap-server* [*-d* max] [*-e*] [*-g* group] [*-l* loss] [*-p* port] [-r]
               [*-v* num] [*-A* address] [*-E* oscore_conf_file[,seq_file]]
               [*-G* group_if] [*-L* value] [*-N*]
-              [*-P* scheme://addr[:port],[name1[,name2..]]] [*-V* num]
-              [*-X* size]
+              [*-P* scheme://addr[:port],[name1[,name2..]]]
+              [*-T* max_token_size] [*-V* num] [*-X* size]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
               [*-s* match_psk_sni_file] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
@@ -113,6 +113,9 @@ OPTIONS - General
    scheme://address[:port] is not defined before the leading , (comma) of the
    first name, then the ongoing connection will be a direct connection.
    Scheme is one of coap, coaps, coap+tcp and coaps+tcp.
+
+*-T* max_token_size::
+   Set the maximum token length (8-65804).
 
 *-V* num::
    The verbosity level to use (default 3, maximum is 7) for (D)TLS

--- a/man/coap.txt.in
+++ b/man/coap.txt.in
@@ -73,6 +73,8 @@ See
 
 "https://rfc-editor.org/rfc/rfc8768[RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option]"
 
+"https://rfc-editor.org/rfc/rfc8974[RFC8974: Extended Tokens and Stateless Clients in the Constrained Application Protocol (CoAP)]"
+
 "https://rfc-editor.org/rfc/rfc9175[RFC9175: CoAP: Echo, Request-Tag, and Token Processing]"
 
 for further information.

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -20,7 +20,8 @@ coap_context_get_max_handshake_sessions,
 coap_context_set_session_timeout,
 coap_context_get_session_timeout,
 coap_context_set_csm_timeout,
-coap_context_get_csm_timeout
+coap_context_get_csm_timeout,
+coap_context_set_max_token_size
 - Work with CoAP contexts
 
 SYNOPSIS
@@ -53,6 +54,9 @@ const coap_context_t *_context_);*
 unsigned int _csm_timeout_);*
 
 *unsigned int coap_context_get_csm_timeout(const coap_context_t *_context_);*
+
+*void coap_context_set_max_token_size(coap_context_t *_context_,
+size_t _max_token_size_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -135,6 +139,18 @@ _context_.  0 (the default) means wait forever.
 The *coap_context_get_csm_timeout*() function returns the seconds to wait for
 a (TCP) CSM negotiation response from the peer for _context_,
 
+*Function: coap_context_set_max_token_size()*
+
+The *coap_context_set_max_token_size*() function sets the _max_token_size_
+for _context_.  _max_token_size_ must be greater than 8 to indicate
+support for https://rfc-editor.org/rfc/rfc8974[RFC8974] up to _max_token_size_
+bytes, else 8 to disable https://rfc-editor.org/rfc/rfc8974[RFC8974]
+(if previously set).
+
+*NOTE:* For the client, it will send an initial PDU to test the server
+supports the requested extended token size as per
+"https://rfc-editor.org/rfc/rfc8974.html#section-2.2.2[RFC8794 Section 2.2.2]"
+
 RETURN VALUES
 -------------
 *coap_new_context*() function returns a newly created context or
@@ -161,6 +177,8 @@ FURTHER INFORMATION
 See
 
 "https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+"https://rfc-editor.org/rfc/rfc8974[RFC8974: Extended Tokens and Stateless Clients in the Constrained Application Protocol (CoAP)]"
 
 for further information.
 

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -258,6 +258,9 @@ PDU TOKEN FUNCTIONS
 The *coap_session_init_token*() function is used to initialize the starting
 _token_ of _length_ for the _session_.
 
+*NOTE:* this only takes the first 8 bytes of the token if extended tokens
+are being used (https://rfc-editor.org/rfc/rfc8974[RFC8974]).
+
 *Function: coap_session_new_token()*
 
 The *coap_session_new_token*() function is used to obtain the next available
@@ -266,13 +269,18 @@ for doing an observe cancellation that was used for doing the observe
 registration.  Otherwise tokens should be unique for each request/response so
 that they can be correctly matched.
 
+*NOTE:* Only a token of up to 8 bytes is returned.
+
 *Function: coap_add_token()*
 
 The *coap_add_token*() function adds in the specified token's _data_ of length
-_length_ to the PDU _pdu_.  The maximum length of the token is 8 bytes.
+_length_ to the PDU _pdu_.  The maximum (but impractical due to PDU sizes)
+length of the token is 65804 bytes.  If anything more than 8, the remote peer
+needs to support extended tokens for this to work.
 Adding the token must be done before any options or data are added.
 This function must only be called once per _pdu_, and must not be called
-in the appropriate request handler.
+in the appropriate request handler as the token has already been added into
+the skeletal response PDU.
 
 If a token is not added, then the token in the PDU is zero length, but still a
 valid token which is used for matching.  The exception is an empty ACK packet.
@@ -724,6 +732,8 @@ See
 "https://rfc-editor.org/rfc/rfc7959[RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)]"
 
 "https://rfc-editor.org/rfc/rfc8613[RFC8613: Object Security for Constrained RESTful Environments (OSCORE)]"
+
+"https://rfc-editor.org/rfc/rfc8974[RFC8974: Extended Tokens and Stateless Clients in the Constrained Application Protocol (CoAP)]"
 
 for further information.
 

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -436,7 +436,8 @@ msg_option_string(uint8_t code, uint16_t option_type) {
 
   static struct option_desc_t options_csm[] = {
     { COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE, "Max-Message-Size" },
-    { COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER, "Block-Wise-Transfer" }
+    { COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER, "Block-Wise-Transfer" },
+    { COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH, "Extended-Token-Length" }
   };
 
   static struct option_desc_t options_pingpong[] = {
@@ -599,7 +600,8 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
   char outbuf[COAP_DEBUG_BUF_SIZE];
 #endif /* ! COAP_CONSTRAINED_STACK */
   size_t buf_len = 0; /* takes the number of bytes written to buf */
-  int encode = 0, have_options = 0, i;
+  int encode = 0, have_options = 0;
+  uint32_t i;
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
   int content_format = -1;
@@ -622,10 +624,10 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
           COAP_DEFAULT_VERSION, msg_type_string(pdu->type),
           msg_code_string(pdu->code), pdu->mid);
 
-  for (i = 0; i < pdu->token_length; i++) {
+  for (i = 0; i < pdu->actual_token.length; i++) {
     outbuflen = strlen(outbuf);
     snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
-              "%02x", pdu->token[i]);
+              "%02x", pdu->actual_token.s[i]);
   }
   outbuflen = strlen(outbuf);
   snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  "}");
@@ -645,6 +647,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
     }
 
     if (pdu->code == COAP_SIGNALING_CODE_CSM) switch(opt_iter.number) {
+    case COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH:
     case COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE:
       buf_len = snprintf((char *)buf, sizeof(buf), "%u",
                          coap_decode_var_bytes(coap_opt_value(option),

--- a/src/coap_option.c
+++ b/src/coap_option.c
@@ -121,13 +121,13 @@ coap_option_iterator_init(const coap_pdu_t *pdu, coap_opt_iterator_t *oi,
 
   memset(oi, 0, sizeof(coap_opt_iterator_t));
 
-  oi->next_option = pdu->token + pdu->token_length;
+  oi->next_option = pdu->token + pdu->e_token_length;
   if (pdu->token + pdu->used_size <= oi->next_option) {
     oi->bad = 1;
     return NULL;
   }
 
-  oi->length = pdu->used_size - pdu->token_length;
+  oi->length = pdu->used_size - pdu->e_token_length;
 
   if (filter) {
     memcpy(&oi->filter, filter, sizeof(coap_opt_filter_t));

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -1306,7 +1306,8 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
   }
 
   /* Account for 1 byte 'code' used as token */
-  plain_pdu->token_length = 1;
+  plain_pdu->e_token_length = 1;
+  plain_pdu->actual_token.length = 1;
   /* Account for the decrypted data */
   plain_pdu->used_size = encrypt_len - tag_len;
 
@@ -1396,8 +1397,7 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
 
     coap_cancel_all_messages(session->context,
                              session,
-                             pdu->token,
-                             pdu->token_length);
+                             &pdu->actual_token);
     if (session->con_active)
       session->con_active--;
     coap_send_ack(session, pdu);
@@ -1546,8 +1546,7 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
     /* Server is requesting Echo refresh check */
     coap_cancel_all_messages(session->context,
                              session,
-                             pdu->token,
-                             pdu->token_length);
+                             &pdu->actual_token);
     if (session->con_active)
       session->con_active--;
     if (sent_pdu) {

--- a/src/encode.c
+++ b/src/encode.c
@@ -65,7 +65,7 @@ uint64_t
 coap_decode_var_bytes8(const uint8_t *buf, size_t len) {
   unsigned int i;
   uint64_t n = 0;
-  for (i = 0; i < len; ++i)
+  for (i = 0; i < len && i < sizeof(uint64_t); ++i)
     n = (n << 8) + buf[i];
 
   return n;

--- a/src/net.c
+++ b/src/net.c
@@ -397,6 +397,14 @@ void coap_context_set_keepalive(coap_context_t *context, unsigned int seconds) {
 }
 
 void
+coap_context_set_max_token_size(coap_context_t *context,
+                                size_t max_token_size) {
+  assert(max_token_size >= COAP_TOKEN_DEFAULT_MAX &&
+         max_token_size <= COAP_TOKEN_EXT_MAX);
+  context->max_token_size = (uint32_t)max_token_size;
+}
+
+void
 coap_context_set_max_idle_sessions(coap_context_t *context,
                                    unsigned int max_idle_sessions) {
   context->max_idle_sessions = max_idle_sessions;
@@ -567,6 +575,7 @@ coap_new_context(
   etimer_set(&the_coap_context.retransmit_timer, 0xFFFF);
   PROCESS_CONTEXT_END(&coap_retransmit_process);
 #endif /* WITH_CONTIKI */
+  c->max_token_size = COAP_TOKEN_DEFAULT_MAX; /* RFC8974 */
 
   return c;
 
@@ -800,6 +809,7 @@ ssize_t
 coap_session_send_pdu(coap_session_t *session, coap_pdu_t *pdu) {
   ssize_t bytes_written = -1;
   assert(pdu->hdr_size > 0);
+
   switch(session->proto) {
     case COAP_PROTO_UDP:
       bytes_written = coap_session_send(session, pdu->token - pdu->hdr_size,
@@ -1039,11 +1049,45 @@ coap_wait_ack(coap_context_t *context, coap_session_t *session,
   return node->id;
 }
 
-COAP_STATIC_INLINE int
-token_match(const uint8_t *a, size_t alen,
-  const uint8_t *b, size_t blen) {
-  return alen == blen && (alen == 0 || memcmp(a, b, alen) == 0);
+#if COAP_CLIENT_SUPPORT
+/*
+ * Sent out a test PDU for Extended Token
+ */
+static coap_mid_t
+coap_send_test_extended_token(coap_session_t *session) {
+  coap_pdu_t *pdu;
+  coap_mid_t mid = COAP_INVALID_MID;
+  size_t i;
+  coap_binary_t *token;
+
+  coap_log_debug("Testing for Extended Token support\n");
+  /* https://rfc-editor.org/rfc/rfc8974#section-2.2.2 */
+  pdu = coap_pdu_init(COAP_MESSAGE_CON, COAP_REQUEST_CODE_GET,
+                      coap_new_message_id(session),
+                      coap_session_max_pdu_size(session));
+  if (!pdu)
+    return COAP_INVALID_MID;
+
+  token = coap_new_binary(session->max_token_size);
+  if (token == NULL) {
+    coap_delete_pdu(pdu);
+    return COAP_INVALID_MID;
+  }
+  for (i = 0; i < session->max_token_size; i++) {
+    token->s[i] = (uint8_t)(i + 1);
+  }
+  coap_add_token(pdu, session->max_token_size, token->s);
+  coap_delete_binary(token);
+
+  coap_insert_option(pdu, COAP_OPTION_IF_NONE_MATCH, 0 , NULL);
+
+  session->max_token_checked = COAP_EXT_T_CHECKING; /* Checking out this one */
+  if ((mid = coap_send_internal(session, pdu)) == COAP_INVALID_MID)
+    return COAP_INVALID_MID;
+  session->max_token_mid = mid;
+  return mid;
 }
+#endif /* COAP_CLIENT_SUPPORT */
 
 int
 coap_client_delay_first(coap_session_t *session)
@@ -1095,6 +1139,14 @@ coap_client_delay_first(coap_session_t *session)
 coap_mid_t
 coap_send(coap_session_t *session, coap_pdu_t *pdu) {
   coap_mid_t mid = COAP_INVALID_MID;
+#if COAP_CLIENT_SUPPORT
+  coap_lg_crcv_t *lg_crcv = NULL;
+  coap_opt_iterator_t opt_iter;
+  coap_block_b_t block;
+  int observe_action = -1;
+  int have_block1 = 0;
+  coap_opt_t *opt;
+#endif /* COAP_CLIENT_SUPPORT */
 
   assert(pdu);
 
@@ -1104,13 +1156,54 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
     coap_delete_pdu(pdu);
     return COAP_INVALID_MID;
   }
+  /*
+   * If this is not the first client request and are waiting for a response
+   * to the first client request, then delay sending out this next request
+   * untill all is properly established.
+   */
+  if (!coap_client_delay_first(session))
+    return COAP_INVALID_MID;
+
 #if COAP_CLIENT_SUPPORT
-  coap_lg_crcv_t *lg_crcv = NULL;
-  coap_opt_iterator_t opt_iter;
-  coap_block_b_t block;
-  int observe_action = -1;
-  int have_block1 = 0;
-  coap_opt_t *opt;
+  assert(pdu);
+
+  /* Indicate support for Extended Tokens if appropriate */
+  if (session->max_token_checked == COAP_EXT_T_NOT_CHECKED &&
+      session->max_token_size > COAP_TOKEN_DEFAULT_MAX &&
+      session->type == COAP_SESSION_TYPE_CLIENT &&
+      COAP_PDU_IS_REQUEST(pdu)) {
+    if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
+      /*
+       * When the pass / fail response for Extended Token is received, this PDU
+       * will get transmitted.
+       */
+      if (coap_send_test_extended_token(session) == COAP_INVALID_MID) {
+        coap_delete_pdu(pdu);
+        return COAP_INVALID_MID;
+      }
+    }
+    /*
+     * For reliable protocols, this will get cleared after CSM exchanged
+     * in coap_session_connected()
+     */
+    session->doing_first = 1;
+  }
+
+  if (coap_client_delay_first(session) == 0) {
+    return COAP_INVALID_MID;
+  }
+
+  /*
+   * Check validity of token length
+   */
+  if (COAP_PDU_IS_REQUEST(pdu) &&
+      pdu->actual_token.length > session->max_token_size) {
+    coap_log_warn(
+             "coap_send: PDU dropped as token too long (%ld > %d)\n",
+             pdu->actual_token.length, session->max_token_size);
+    coap_delete_pdu(pdu);
+    return COAP_INVALID_MID;
+  }
 
   /* A lot of the reliable code assumes type is CON */
   if (COAP_PROTO_RELIABLE(session->proto) && pdu->type == COAP_MESSAGE_NON)
@@ -1159,14 +1252,13 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
       have_block1 = 1;
     if (observe_action != COAP_OBSERVE_CANCEL) {
       /* Warn about re-use of tokens */
-      coap_bin_const_t token = coap_pdu_get_token(pdu);
-
       if (session->last_token &&
-          coap_binary_equal(&token, session->last_token)) {
+          coap_binary_equal(&pdu->actual_token, session->last_token)) {
         coap_log_debug("Token reused - see https://rfc-editor.org/rfc/rfc9175.html#section-4.2\n");
       }
       coap_delete_bin_const(session->last_token);
-      session->last_token = coap_new_bin_const(token.s, token.length);
+      session->last_token = coap_new_bin_const(pdu->actual_token.s,
+                                               pdu->actual_token.length);
     }
     if (!coap_check_option(pdu, COAP_OPTION_RTAG, &opt_iter) &&
         (session->block_mode & COAP_BLOCK_NO_PREEMPTIVE_RTAG) == 0 &&
@@ -1194,14 +1286,13 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
        COAP_PDU_IS_REQUEST(pdu) && pdu->code != COAP_REQUEST_CODE_DELETE)) {
     coap_lg_xmit_t *lg_xmit = NULL;
 
-    if (!session->lg_xmit) {
+    if (!session->lg_xmit && have_block1) {
       coap_log_debug("PDU presented by app\n");
       coap_show_pdu(COAP_LOG_DEBUG, pdu);
     }
     /* See if this token is already in use for large body responses */
     LL_FOREACH(session->lg_crcv, lg_crcv) {
-      if (token_match(pdu->token, pdu->token_length,
-                      lg_crcv->app_token->s, lg_crcv->app_token->length)) {
+      if (coap_binary_equal(&pdu->actual_token, lg_crcv->app_token)) {
 
         if (observe_action == COAP_OBSERVE_CANCEL) {
           uint8_t buf[8];
@@ -1234,9 +1325,7 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
       LL_FOREACH(session->lg_xmit, lg_xmit) {
         if (COAP_PDU_IS_REQUEST(&lg_xmit->pdu) &&
             lg_xmit->b.b1.app_token &&
-            token_match(pdu->token, pdu->token_length,
-                        lg_xmit->b.b1.app_token->s,
-                        lg_xmit->b.b1.app_token->length)) {
+            coap_binary_equal(&pdu->actual_token, lg_xmit->b.b1.app_token)) {
           break;
         }
       }
@@ -1558,12 +1647,7 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
   /* Check if subscriptions exist that should be canceled after
      COAP_OBS_MAX_FAIL */
   if (COAP_RESPONSE_CLASS(node->pdu->code) >= 2) {
-    coap_binary_t token = { 0, NULL };
-
-    token.length = node->pdu->token_length;
-    token.s = node->pdu->token;
-
-    coap_handle_failed_notify(context, node->session, &token);
+    coap_handle_failed_notify(context, node->session, &node->pdu->actual_token);
   }
 #endif /* COAP_SERVER_SUPPORT */
   if (node->session->con_active) {
@@ -1787,14 +1871,17 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
         } else if (session->partial_read > 0) {
           size_t hdr_size = coap_pdu_parse_header_size(session->proto,
             session->read_header);
-          size_t len = hdr_size - session->partial_read;
+          size_t tkl = session->read_header[0] & 0x0f;
+          size_t tok_ext_bytes = tkl == COAP_TOKEN_EXT_1B_TKL ? 1 :
+                                 tkl == COAP_TOKEN_EXT_2B_TKL ? 2 : 0;
+          size_t len = hdr_size + tok_ext_bytes - session->partial_read;
           size_t n = min(len, (size_t)bytes_read);
           memcpy(session->read_header + session->partial_read, p, n);
           p += n;
           bytes_read -= n;
           if (n == len) {
             size_t size = coap_pdu_parse_size(session->proto, session->read_header,
-              hdr_size);
+              hdr_size + tok_ext_bytes);
             if (size > COAP_DEFAULT_MAX_PDU_RX_SIZE) {
               coap_log_warn(
                        "** %s: incoming PDU length too large (%zu > %lu)\n",
@@ -1816,8 +1903,8 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
             }
             session->partial_pdu->hdr_size = (uint8_t)hdr_size;
             session->partial_pdu->used_size = size;
-            memcpy(session->partial_pdu->token - hdr_size, session->read_header, hdr_size);
-            session->partial_read = hdr_size;
+            memcpy(session->partial_pdu->token - hdr_size, session->read_header, hdr_size + tok_ext_bytes);
+            session->partial_read = hdr_size + tok_ext_bytes;
             if (size == 0) {
               if (coap_pdu_parse_header(session->partial_pdu, session->proto)) {
 #if COAP_CONSTRAINED_STACK
@@ -2202,7 +2289,7 @@ coap_cancel_session_messages(coap_context_t *context, coap_session_t *session,
 
 void
 coap_cancel_all_messages(coap_context_t *context, coap_session_t *session,
-  const uint8_t *token, size_t token_length) {
+                         coap_bin_const_t *token) {
   /* cancel all messages in sendqueue that belong to session
    * and use the specified token */
   coap_queue_t **p, *q;
@@ -2215,8 +2302,7 @@ coap_cancel_all_messages(coap_context_t *context, coap_session_t *session,
 
   while (q) {
     if (q->session == session &&
-      token_match(token, token_length,
-        q->pdu->token, q->pdu->token_length)) {
+        coap_binary_equal(&q->pdu->actual_token, token)) {
       *p = q->next;
       coap_log_debug("** %s: mid=0x%x: removed (6)\n",
                coap_session_str(session), q->id);
@@ -2239,7 +2325,7 @@ coap_new_error_response(const coap_pdu_t *request, coap_pdu_code_t code,
                         coap_opt_filter_t *opts) {
   coap_opt_iterator_t opt_iter;
   coap_pdu_t *response;
-  size_t size = request->token_length;
+  size_t size = request->e_token_length;
   unsigned char type;
   coap_opt_t *option;
   coap_option_num_t opt_num = 0;        /* used for calculating delta-storage */
@@ -2320,8 +2406,8 @@ coap_new_error_response(const coap_pdu_t *request, coap_pdu_code_t code,
   response = coap_pdu_init(type, code, request->mid, size);
   if (response) {
     /* copy token */
-    if (!coap_add_token(response, request->token_length,
-      request->token)) {
+    if (!coap_add_token(response, request->actual_token.length,
+                        request->actual_token.s)) {
       coap_log_debug("cannot add token to error response\n");
       coap_delete_pdu(response);
       return NULL;
@@ -2440,7 +2526,7 @@ error_released:
   if (response->code == 0) {
     /* set error code 5.03 and remove all options and data from response */
     response->code = COAP_RESPONSE_CODE(503);
-    response->used_size = response->token_length;
+    response->used_size = response->e_token_length;
     response->data = NULL;
   }
 }
@@ -2458,20 +2544,20 @@ error_released:
  */
 static int
 coap_cancel(coap_context_t *context, const coap_queue_t *sent) {
-  coap_binary_t token = { 0, NULL };
   int num_cancelled = 0;    /* the number of observers cancelled */
 
+#ifndef COAP_SERVER_SUPPORT
+  (void)sent;
+#endif /* ! COAP_SERVER_SUPPORT */
   (void)context;
-  /* remove observer for this resource, if any
-   * get token from sent and try to find a matching resource. Uh!
-   */
-
-  COAP_SET_STR(&token, sent->pdu->token_length, sent->pdu->token);
 
 #if COAP_SERVER_SUPPORT
+  /* remove observer for this resource, if any
+   * Use token from sent and try to find a matching resource. Uh!
+   */
   RESOURCES_ITER(context->resources, r) {
-    coap_cancel_all_messages(context, sent->session, token.s, token.length);
-    num_cancelled += coap_delete_observer(r, sent->session, &token);
+    coap_cancel_all_messages(context, sent->session, &sent->pdu->actual_token);
+    num_cancelled += coap_delete_observer(r, sent->session, &sent->pdu->actual_token);
   }
 #endif /* COAP_SERVER_SUPPORT */
 
@@ -2558,7 +2644,8 @@ no_response(coap_pdu_t *request, coap_pdu_t *response,
           /* Still need to ACK the request */
           response->code = 0;
           /* Remove token/data from piggybacked acknowledgment PDU */
-          response->token_length = 0;
+          response->actual_token.length = 0;
+          response->e_token_length = 0;
           response->used_size = 0;
           return RESPONSE_SEND;
         }
@@ -2645,7 +2732,6 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
   int skip_hop_limit_check = 0;
   int resp;
   int send_early_empty_ack = 0;
-  coap_binary_t token = { pdu->token_length, pdu->token };
   coap_string_t *query = NULL;
   coap_opt_t *observe = NULL;
   coap_string_t *uri_path = NULL;
@@ -2654,7 +2740,6 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
   int added_block = 0;
   coap_lg_srcv_t *free_lg_srcv = NULL;
 #ifndef WITHOUT_ASYNC
-  coap_bin_const_t tokenc = { pdu->token_length, pdu->token };
   coap_async_t *async;
 #endif /* WITHOUT_ASYNC */
 
@@ -2665,7 +2750,7 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
     }
   }
 #ifndef WITHOUT_ASYNC
-  async = coap_find_async(session, tokenc);
+  async = coap_find_async(session, pdu->actual_token);
   if (async) {
     coap_tick_t now;
 
@@ -2936,7 +3021,8 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
     response->type = COAP_MESSAGE_CON;
 #endif /* WITHOUT_ASYNC */
 
-  if (!coap_add_token(response, pdu->token_length, pdu->token)) {
+  if (!coap_add_token(response, pdu->actual_token.length,
+                      pdu->actual_token.s)) {
     resp = 500;
     goto fail_response;
   }
@@ -2988,12 +3074,12 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
           goto skip_handler;
         }
       }
-      subscription = coap_add_observer(resource, session, &token,
+      subscription = coap_add_observer(resource, session, &pdu->actual_token,
                                        pdu);
       if (subscription) {
         uint8_t buf[4];
 
-        coap_touch_observer(context, session, &token);
+        coap_touch_observer(context, session, &pdu->actual_token);
         coap_add_option_internal(response, COAP_OPTION_OBSERVE,
                                  coap_encode_var_safe(buf, sizeof (buf),
                                                       resource->observe),
@@ -3001,7 +3087,7 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
       }
     }
     else if (observe_action == COAP_OBSERVE_CANCEL) {
-      coap_delete_observer(resource, session, &token);
+      coap_delete_observer(resource, session, &pdu->actual_token);
     }
     else {
       coap_log_info("observe: unexpected action %d\n", observe_action);
@@ -3073,7 +3159,7 @@ skip_handler:
     }
     if (COAP_RESPONSE_CLASS(response->code) > 2) {
       if (observe)
-        coap_delete_observer(resource, session, &token);
+        coap_delete_observer(resource, session, &pdu->actual_token);
       if (added_block)
         coap_remove_option(response, COAP_OPTION_BLOCK1);
     }
@@ -3085,7 +3171,8 @@ skip_handler:
     if ((response->type == COAP_MESSAGE_ACK)
       && (response->code == 0)) {
       /* Remove token from otherwise-empty acknowledgment PDU */
-      response->token_length = 0;
+      response->actual_token.length = 0;
+      response->e_token_length = 0;
       response->used_size = 0;
     }
 
@@ -3156,12 +3243,13 @@ fail_response:
 static void
 handle_response(coap_context_t *context, coap_session_t *session,
                 coap_pdu_t *sent, coap_pdu_t *rcvd) {
+
   /* In a lossy context, the ACK of a separate response may have
    * been lost, so we need to stop retransmitting requests with the
-   * same token.
+   * same token. Matching on token potentially containing ext length bytes.
    */
   if (rcvd->type != COAP_MESSAGE_ACK)
-    coap_cancel_all_messages(context, session, rcvd->token, rcvd->token_length);
+    coap_cancel_all_messages(context, session, &rcvd->actual_token);
 
   /* Check for message duplication */
   if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
@@ -3178,6 +3266,23 @@ handle_response(coap_context_t *context, coap_session_t *session,
       }
       session->last_ack_mid = rcvd->mid;
     }
+  }
+  /* Check to see if checking out extended token support */
+  if (session->max_token_checked == COAP_EXT_T_CHECKING &&
+      session->max_token_mid == rcvd->mid) {
+
+    if (rcvd->actual_token.length != session->max_token_size ||
+        rcvd->code == COAP_RESPONSE_CODE(400) ||
+        rcvd->code == COAP_RESPONSE_CODE(503)) {
+      coap_log_debug("Extended Token requested size support not available\n");
+      session->max_token_size = COAP_TOKEN_DEFAULT_MAX;
+    }
+    else {
+      coap_log_debug("Extended Token support available\n");
+    }
+    session->max_token_checked = COAP_EXT_T_CHECKED;
+    session->doing_first = 0;
+    return;
   }
 
   if (session->block_mode & COAP_BLOCK_USE_LIBCOAP) {
@@ -3223,6 +3328,9 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
   coap_option_iterator_init(pdu, &opt_iter, COAP_OPT_ALL);
 
   if (pdu->code == COAP_SIGNALING_CODE_CSM) {
+    if (session->max_token_checked == COAP_EXT_T_NOT_CHECKED) {
+      session->max_token_size = COAP_TOKEN_DEFAULT_MAX;
+    }
     while ((option = coap_option_next(&opt_iter))) {
       if (opt_iter.number == COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE) {
         coap_session_set_mtu(session, coap_decode_var_bytes(coap_opt_value(option),
@@ -3230,6 +3338,16 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
         set_mtu = 1;
       } else if (opt_iter.number == COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER) {
         session->csm_block_supported = 1;
+      }
+      else if (opt_iter.number == COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH) {
+        session->max_token_size =
+                               coap_decode_var_bytes(coap_opt_value(option),
+                                                     coap_opt_length(option));
+        if (session->max_token_size < COAP_TOKEN_DEFAULT_MAX)
+          session->max_token_size = COAP_TOKEN_DEFAULT_MAX;
+        else if (session->max_token_size > COAP_TOKEN_EXT_MAX)
+          session->max_token_size = COAP_TOKEN_EXT_MAX;
+        session->max_token_checked = COAP_EXT_T_CHECKED;
       }
     }
     if (set_mtu) {
@@ -3261,6 +3379,42 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
 }
 #endif /* !COAP_DISABLE_TCP */
 
+static int
+check_token_size(coap_session_t *session, const coap_pdu_t *pdu) {
+  if (COAP_PDU_IS_REQUEST(pdu) &&
+      pdu->actual_token.length >
+       (session->type == COAP_SESSION_TYPE_CLIENT ?
+                session->max_token_size : session->context->max_token_size)) {
+    /* https://rfc-editor.org/rfc/rfc8974#section-2.2.2 */
+    if (session->max_token_size > COAP_TOKEN_DEFAULT_MAX) {
+      coap_opt_filter_t opt_filter;
+      coap_pdu_t *response;
+
+      memset(&opt_filter, 0, sizeof(coap_opt_filter_t));
+      response = coap_new_error_response(pdu, COAP_RESPONSE_CODE(400),
+                                         &opt_filter);
+      if (!response) {
+        coap_log_warn(
+                 "coap_dispatch: cannot create error response\n");
+      }
+      else {
+        /*
+         * Note - have to leave in oversize token as per
+         * https://rfc-editor.org/rfc/rfc7252#section-5.3.1
+         */
+        if (coap_send_internal(session, response) == COAP_INVALID_MID)
+          coap_log_warn("coap_dispatch: error sending response\n");
+      }
+    }
+    else {
+      /* Indicate no extended token support */
+      coap_send_rst(session, pdu);
+    }
+    return 0;
+  }
+  return 1;
+}
+
 void
 coap_dispatch(coap_context_t *context, coap_session_t *session,
               coap_pdu_t *pdu) {
@@ -3273,6 +3427,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
   coap_opt_iterator_t opt_iter;
   coap_pdu_t *dec_pdu = NULL;
 #endif /* HAVE_OSCORE */
+  int is_ext_token_rst;
 
   coap_show_pdu(COAP_LOG_DEBUG, pdu);
 
@@ -3379,9 +3534,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
        * notification. Then, we must flag the observer to be alive
        * by setting obs->fail_cnt = 0. */
       if (sent && COAP_RESPONSE_CLASS(sent->pdu->code) == 2) {
-        const coap_binary_t token =
-        { sent->pdu->token_length, sent->pdu->token };
-        coap_touch_observer(context, sent->session, &token);
+        coap_touch_observer(context, sent->session, &sent->pdu->actual_token);
       }
 #endif /* COAP_SERVER_SUPPORT */
 
@@ -3401,7 +3554,17 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
           context->ping_timeout && session->last_ping > 0)
         is_ping_rst = 1;
 
-      if (!is_ping_rst)
+      /* Check to see if checking out extended token support */
+      is_ext_token_rst = 0;
+      if (session->max_token_checked == COAP_EXT_T_CHECKING &&
+          session->max_token_mid == pdu->mid) {
+        coap_log_debug("Extended Token support not available\n");
+        session->max_token_size = COAP_TOKEN_DEFAULT_MAX;
+        session->max_token_checked = COAP_EXT_T_CHECKED;
+        session->doing_first = 0;
+        is_ext_token_rst = 1;
+      }
+      if (!is_ping_rst && !is_ext_token_rst)
         coap_log_alert("got RST for mid=0x%x\n", pdu->mid);
 
       if (session->con_active) {
@@ -3417,14 +3580,14 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
       if (sent) {
         coap_cancel(context, sent);
 
-        if (!is_ping_rst) {
+        if (!is_ping_rst && !is_ext_token_rst) {
           if(sent->pdu->type==COAP_MESSAGE_CON && context->nack_handler) {
             coap_check_update_token(sent->session, sent->pdu);
             context->nack_handler(sent->session, sent->pdu,
                                   COAP_NACK_RST, sent->id);
           }
         }
-        else {
+        else if (is_ping_rst) {
           if (context->pong_handler) {
             context->pong_handler(session, pdu, pdu->mid);
           }
@@ -3439,9 +3602,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
           coap_subscription_t *obs, *tmp;
           LL_FOREACH_SAFE(r->subscribers, obs, tmp) {
             if (obs->pdu->mid == pdu->mid && obs->session == session) {
-              coap_binary_t token = { 0, NULL };
-              COAP_SET_STR(&token, obs->pdu->token_length, obs->pdu->token);
-              coap_delete_observer(r, session, &token);
+              coap_delete_observer(r, session, &obs->pdu->actual_token);
               goto cleanup;
             }
           }
@@ -3457,6 +3618,9 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
       if (coap_option_check_critical(session, pdu, &opt_filter) == 0) {
         packet_is_bad = 1;
         coap_send_rst(session, pdu);
+        goto cleanup;
+      }
+      if (!check_token_size(session, pdu)) {
         goto cleanup;
       }
       break;
@@ -3481,6 +3645,10 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
         }
         goto cleanup;
       }
+      if (!check_token_size(session, pdu)) {
+        goto cleanup;
+      }
+      break;
     default: break;
   }
 

--- a/tests/test_error_response.c
+++ b/tests/test_error_response.c
@@ -45,7 +45,7 @@ t_error_response1(void) {
 
   CU_ASSERT(response->used_size == sizeof(teststr) - 4);
   CU_ASSERT(response->type == COAP_MESSAGE_ACK);
-  CU_ASSERT(response->token_length == 0);
+  CU_ASSERT(response->e_token_length == 0);
   CU_ASSERT(response->code == 0x80);
   CU_ASSERT(response->mid == 0x1234);
   CU_ASSERT(coap_pdu_encode_header(response, COAP_PROTO_UDP) == 4);
@@ -75,7 +75,7 @@ t_error_response2(void) {
 
   CU_ASSERT(response->used_size == sizeof(teststr) - 4);
   CU_ASSERT(response->type == COAP_MESSAGE_NON);
-  CU_ASSERT(response->token_length == 5);
+  CU_ASSERT(response->e_token_length == 5);
   CU_ASSERT(response->code == 0x84);
   CU_ASSERT(coap_pdu_encode_header(response, COAP_PROTO_UDP) == 4);
   CU_ASSERT(memcmp(response->token - 4, teststr, sizeof(teststr)) == 0);
@@ -108,7 +108,7 @@ t_error_response3(void) {
 
   CU_ASSERT(response->used_size == sizeof(teststr) - 4);
   CU_ASSERT(response->type == COAP_MESSAGE_ACK);
-  CU_ASSERT(response->token_length == 5);
+  CU_ASSERT(response->e_token_length == 5);
   CU_ASSERT(response->code == code);
   CU_ASSERT(coap_pdu_encode_header(response, COAP_PROTO_UDP) == 4);
   CU_ASSERT(memcmp(response->token - 4, teststr, sizeof(teststr)) == 0);
@@ -147,7 +147,7 @@ t_error_response4(void) {
 
   CU_ASSERT(response->used_size == sizeof(teststr) - 4);
   CU_ASSERT(response->type == COAP_MESSAGE_ACK);
-  CU_ASSERT(response->token_length == 5);
+  CU_ASSERT(response->e_token_length == 5);
   CU_ASSERT(response->code == code);
   CU_ASSERT(coap_pdu_encode_header(response, COAP_PROTO_UDP) == 4);
   CU_ASSERT(memcmp(response->token - 4, teststr, sizeof(teststr)) == 0);
@@ -188,7 +188,7 @@ t_error_response5(void) {
 
   CU_ASSERT(response->used_size == sizeof(teststr) - 4);
   CU_ASSERT(response->type == COAP_MESSAGE_ACK);
-  CU_ASSERT(response->token_length == 5);
+  CU_ASSERT(response->e_token_length == 5);
   CU_ASSERT(response->code == code);
   CU_ASSERT(coap_pdu_encode_header(response, COAP_PROTO_UDP) == 4);
   CU_ASSERT(memcmp(response->token - 4, teststr, sizeof(teststr)) == 0);
@@ -229,7 +229,7 @@ t_error_response6(void) {
 
   CU_ASSERT(response->used_size == sizeof(teststr) - 4);
   CU_ASSERT(response->type == COAP_MESSAGE_ACK);
-  CU_ASSERT(response->token_length == 5);
+  CU_ASSERT(response->e_token_length == 5);
   CU_ASSERT(response->code == code);
   CU_ASSERT(coap_pdu_encode_header(response, COAP_PROTO_UDP) == 4);
   CU_ASSERT(memcmp(response->token - 4, teststr, sizeof(teststr)) == 0);
@@ -271,7 +271,7 @@ t_error_response7(void) {
 
   CU_ASSERT(response->used_size == sizeof(teststr) - 4);
   CU_ASSERT(response->type == COAP_MESSAGE_ACK);
-  CU_ASSERT(response->token_length == 5);
+  CU_ASSERT(response->e_token_length == 5);
   CU_ASSERT(response->code == code);
   CU_ASSERT(coap_pdu_encode_header(response, COAP_PROTO_UDP) == 4);
   CU_ASSERT(memcmp(response->token - 4, teststr, sizeof(teststr)) == 0);
@@ -312,7 +312,7 @@ t_error_response8(void) {
 
   CU_ASSERT(response->used_size == sizeof(teststr) - 4);
   CU_ASSERT(response->type == COAP_MESSAGE_ACK);
-  CU_ASSERT(response->token_length == 5);
+  CU_ASSERT(response->e_token_length == 5);
   CU_ASSERT(response->code == code);
   CU_ASSERT(coap_pdu_encode_header(response, COAP_PROTO_UDP) == 4);
   CU_ASSERT(memcmp(response->token - 4, teststr, sizeof(teststr)) == 0);

--- a/tests/test_options.c
+++ b/tests/test_options.c
@@ -497,7 +497,7 @@ t_iterate_option2(void) {
 
   coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
-    .token_length = 3,
+    .e_token_length = 3,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -524,7 +524,7 @@ t_iterate_option3(void) {
 
   coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
-    .token_length = 3,
+    .e_token_length = 3,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -567,7 +567,7 @@ t_iterate_option4(void) {
 
   coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
-    .token_length = 3,
+    .e_token_length = 3,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -609,7 +609,7 @@ t_iterate_option5(void) {
 
   coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -642,7 +642,7 @@ t_iterate_option6(void) {
 
   coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -687,7 +687,7 @@ t_iterate_option7(void) {
 
   coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -734,7 +734,7 @@ t_iterate_option8(void) {
 
   coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -765,7 +765,7 @@ t_iterate_option9(void) {
 
   coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -796,7 +796,7 @@ t_iterate_option10(void) {
 
   coap_pdu_t pdu = {
     .max_size = TEST_MAX_SIZE,
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };

--- a/tests/test_pdu.c
+++ b/tests/test_pdu.c
@@ -32,7 +32,7 @@ t_parse_pdu1(void) {
 
   CU_ASSERT(pdu->used_size == sizeof(teststr) - 4);
   CU_ASSERT(pdu->type == COAP_MESSAGE_CON);
-  CU_ASSERT(pdu->token_length == 0);
+  CU_ASSERT(pdu->e_token_length == 0);
   CU_ASSERT(pdu->code == COAP_REQUEST_CODE_GET);
   CU_ASSERT(pdu->mid == 0x9334);
   CU_ASSERT_PTR_NULL(pdu->data);
@@ -48,7 +48,7 @@ t_parse_pdu2(void) {
 
   CU_ASSERT(pdu->used_size == sizeof(teststr) - 4);
   CU_ASSERT(pdu->type == COAP_MESSAGE_NON);
-  CU_ASSERT(pdu->token_length == 5);
+  CU_ASSERT(pdu->e_token_length == 5);
   CU_ASSERT(pdu->code == 0x69);
   CU_ASSERT(pdu->mid == 0x1234);
   CU_ASSERT(memcmp(pdu->token, teststr + 4, 5) == 0);
@@ -66,14 +66,15 @@ t_parse_pdu3(void) {
 
 static void
 t_parse_pdu4(void) {
-  /* illegal token length */
+  /* illegal token length (token only 8 bytes) */
   uint8_t teststr[] = {  0x59, 0x69, 0x12, 0x34,
-                      't', 'o', 'k', 'e', 'n', '1', '2', '3', '4' };
+                      't', 'o', 'k', 'e', 'n', '1', '2', '3' };
   int result;
 
   result = coap_pdu_parse(COAP_PROTO_UDP, teststr, sizeof(teststr), pdu);
   CU_ASSERT(result == 0);
 
+  /* illegal token length */
   teststr[0] = 0x5f;
 
   result = coap_pdu_parse(COAP_PROTO_UDP, teststr, sizeof(teststr), pdu);
@@ -93,7 +94,7 @@ t_parse_pdu5(void) {
 
   CU_ASSERT(pdu->used_size == sizeof(teststr) - 4);
   CU_ASSERT(pdu->type == COAP_MESSAGE_NON);
-  CU_ASSERT(pdu->token_length == 5);
+  CU_ASSERT(pdu->e_token_length == 5);
   CU_ASSERT(pdu->code == 0x73);
   CU_ASSERT(pdu->mid == 0x1234);
   CU_ASSERT(memcmp(pdu->token, teststr + 4, 5) == 0);
@@ -128,7 +129,7 @@ t_parse_pdu7(void) {
 
   CU_ASSERT(pdu->used_size == sizeof(teststr) - 4);
   CU_ASSERT(pdu->type == COAP_MESSAGE_NON);
-  CU_ASSERT(pdu->token_length == 5);
+  CU_ASSERT(pdu->e_token_length == 5);
   CU_ASSERT(pdu->code == 0x73);
   CU_ASSERT(pdu->mid == 0x1234);
   CU_ASSERT(memcmp(pdu->token, teststr + 4, 5) == 0);
@@ -153,7 +154,7 @@ t_parse_pdu8(void) {
 
   CU_ASSERT(pdu->used_size == sizeof(teststr) - 4);
   CU_ASSERT(pdu->type == COAP_MESSAGE_NON);
-  CU_ASSERT(pdu->token_length == 0);
+  CU_ASSERT(pdu->e_token_length == 0);
   CU_ASSERT(pdu->code == 0x73);
   CU_ASSERT(pdu->mid == 0x1234);
 
@@ -195,7 +196,7 @@ t_parse_pdu11(void) {
 
   CU_ASSERT(pdu->used_size == sizeof(teststr) - 4);
   CU_ASSERT(pdu->type == COAP_MESSAGE_ACK);
-  CU_ASSERT(pdu->token_length == 0);
+  CU_ASSERT(pdu->e_token_length == 0);
   CU_ASSERT(pdu->code == 0);
   CU_ASSERT(pdu->mid == 0x1234);
 }
@@ -211,7 +212,7 @@ t_parse_pdu12(void) {
 
   CU_ASSERT(pdu->used_size == sizeof(teststr) - 4);
   CU_ASSERT(pdu->type == COAP_MESSAGE_RST);
-  CU_ASSERT(pdu->token_length == 0);
+  CU_ASSERT(pdu->e_token_length == 0);
   CU_ASSERT(pdu->code == 0);
   CU_ASSERT(pdu->mid == 0x1234);
 }
@@ -350,6 +351,7 @@ t_encode_pdu1(void) {
 
 static void
 t_encode_pdu2(void) {
+  coap_log_t level = coap_get_log_level();
   size_t old_max = pdu->max_size;
   int result;
 
@@ -359,7 +361,9 @@ t_encode_pdu2(void) {
   pdu->code = COAP_REQUEST_CODE_GET;
   pdu->mid = 0x1234;
 
+  coap_set_log_level(COAP_LOG_CRIT);
   result = coap_add_token(pdu, 5, (const uint8_t *)"token");
+  coap_set_log_level(level);
 
   CU_ASSERT(result == 0);
 
@@ -369,10 +373,16 @@ t_encode_pdu2(void) {
 static void
 t_encode_pdu3(void) {
   int result;
+  coap_bin_const_t check_token;
 
-  result = coap_add_token(pdu, 9, (const uint8_t *)"123456789");
+  result = coap_add_token(pdu, 15, (const uint8_t *)"123456789012345");
 
-  CU_ASSERT(result == 0);
+  /* length of 15 triggers extension */
+  CU_ASSERT(result == 1 && pdu->actual_token.length == 15 &&
+            pdu->e_token_length == 16 && pdu->token[0] == 2);
+
+  check_token = coap_pdu_get_token(pdu);
+  CU_ASSERT(check_token.length == 15);
 }
 
 static void

--- a/tests/test_uri.c
+++ b/tests/test_uri.c
@@ -333,7 +333,7 @@ t_parse_uri13(void) {
 
   coap_pdu_t pdu = {
     .max_size = sizeof(teststr),
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -434,7 +434,7 @@ t_parse_uri18(void) {
   uint8_t token[1] = "";
   coap_pdu_t pdu = {
     .max_size = 0,
-    .token_length = 0,
+    .e_token_length = 0,
     .token = token,
     .used_size = 0
   };
@@ -459,7 +459,7 @@ t_parse_uri19(void) {
 
   coap_pdu_t pdu = {
     .max_size = sizeof(teststr),
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -479,7 +479,7 @@ t_parse_uri20(void) {
 
   coap_pdu_t pdu = {
     .max_size = sizeof(teststr),
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -500,7 +500,7 @@ t_parse_uri21(void) {
 
   coap_pdu_t pdu = {
     .max_size = sizeof(teststr),
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -523,7 +523,7 @@ t_parse_uri22(void) {
 
   coap_pdu_t pdu = {
     .max_size = sizeof(teststr),
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };
@@ -544,7 +544,7 @@ t_parse_uri23(void) {
 
   coap_pdu_t pdu = {
     .max_size = sizeof(teststr),
-    .token_length = 0,
+    .e_token_length = 0,
     .token = teststr,
     .used_size = sizeof(teststr)
   };


### PR DESCRIPTION
Add in new function coap_context_set_max_token_size() to define the maximum supported token size.

Track changes to PDU to support extended tokens.

Update documentation.

Closes #937