### PR TITLE
LwIP: Add in TinyDTLS support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
           $GITHUB_WORKSPACE/configure --disable-documentation --disable-examples --disable-tests --disable-dtls
       - name: compile
         run: |
-          make -C examples/${{matrix.OS}}
+          make -C examples/${{matrix.OS}} EXTRA_CFLAGS=-Werror
   ms-build:
     runs-on: windows-latest
 

--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -22,8 +22,23 @@ WITH_LWIP_CONTRIB_BRANCH=STABLE-2_1_0_RELEASE
 LDLIBS := $(shell if [ -f $(libcoap_dir)/config.log ] ; then \
           grep ac_cv_search_clock_gettime=- $(libcoap_dir)/config.log|cut -d= -f2 ; fi)
 
-all: lib-server lib-client lwip lwip-contrib check-version \
-     $(coap_include_dir)/coap.h server client
+#
+# Remove the 4 -dtls checks from "all" if you do not want DTLS included in
+# some of the built objects.
+#
+all: lwip \
+     lwip-contrib \
+     check-version \
+     check-tinydtls \
+     $(coap_include_dir)/coap.h \
+     lib-server \
+     server \
+     lib-client \
+     client \
+     lib-server-dtls \
+     server-dtls \
+     lib-client-dtls \
+     client-dtls
 
 lwip:
 	git clone --depth 1 git://git.savannah.nongnu.org/lwip.git -b $(WITH_LWIP_BRANCH)
@@ -61,10 +76,36 @@ check-version:
 		fi ; \
 	fi)
 
+# base libcoap git has empty ext/tinydtls
+check-tinydtls:
+	@(if [ ! -d $(libcoap_dir)/ext/tinydtls ] ; then \
+		mkdir -p $(libcoap_dir)/ext ; \
+		(cd $(libcoap_dir)/ext ; git clone https://github.com/eclipse/tinydtls.git) ; \
+	fi ; \
+	if [ ! -f $(libcoap_dir)/ext/tinydtls/dtls.c ] ; then \
+		IN_GIT=`git rev-parse --is-inside-work-tree` ; \
+		if [ "$$IN_GIT" = "true" ] ; then \
+			(cd $(libcoap_dir) ; git submodule init ; git submodule update) ; \
+		else \
+			(cd $(libcoap_dir)/ext ; git clone https://github.com/eclipse/tinydtls.git) ; \
+		fi ; \
+		if [ ! -f $(libcoap_dir)/ext/tinydtls/dtls.c ] ; then \
+			exit 1 ; \
+		fi ; \
+	fi ; \
+	if [ ! -f $(libcoap_dir)/ext/tinydtls/dtls_config.h ] ; then \
+		(cd $(libcoap_dir)/ext/tinydtls ; ./autogen.sh ; ./configure) ; \
+		${MAKE} ; \
+	fi)
+
 # lwip and coap opts (include early to shadow the lwip-contrib/ports/unix/proj/minimal/ file and any ../../config.h)
-CFLAGS += -DWITH_LWIP -iquote./config
+CFLAGS += -DWITH_LWIP -iquote./config $(EXTRA_CFLAGS)
 
 # lwip library
+
+CFLAGS += -Ilwip/src/include/ -Ilwip/src/include/ipv4/ \
+	  -Ilwip-contrib/ports/unix/port/include/ \
+	  -Ilwip-contrib/ports/unix/proj/minimal/
 
 LWIP_SRC = def.c init.c tapif.c etharp.c netif.c timeouts.c stats.c udp.c \
 	   tcp.c pbuf.c ip4_addr.c ip4.c inet_chksum.c tcp_in.c tcp_out.c \
@@ -78,8 +119,11 @@ vpath %.c lwip/src/core/ lwip-contrib/ports/unix/proj/minimal/ \
 vpath %.c lwip/src/core/ipv6/
 LWIP_SRC += mld6.c ip6.c icmp6.c ethip6.c nd6.c ip6_addr.c ip6_frag.c
 
-C_LWIP_OBJ =$(patsubst %.c,lib-client/%.o,$(LWIP_SRC))
-S_LWIP_OBJ =$(patsubst %.c,lib-server/%.o,$(LWIP_SRC))
+CN_LWIP_OBJ =$(patsubst %.c,lib-client/%.o,$(LWIP_SRC))
+SN_LWIP_OBJ =$(patsubst %.c,lib-server/%.o,$(LWIP_SRC))
+CD_LWIP_OBJ =$(patsubst %.c,lib-client-dtls/%.o,$(LWIP_SRC))
+SD_LWIP_OBJ =$(patsubst %.c,lib-server-dtls/%.o,$(LWIP_SRC))
+
 # coap library
 
 CFLAGS += -std=gnu99
@@ -89,6 +133,7 @@ CFLAGS += -I$(libcoap_dir)/include
 vpath %.c $(libcoap_dir)/src
 
 COAP_SRC = coap_address.c \
+	   coap_asn1.c \
 	   coap_async.c \
 	   block.c \
 	   coap_cache.c \
@@ -104,34 +149,76 @@ COAP_SRC = coap_address.c \
 	   resource.c \
 	   coap_session.c \
 	   coap_subscribe.c \
+	   coap_tinydtls.c \
 	   str.c \
 	   coap_tcp.c \
 	   uri.c
 
-C_COAP_OBJ =$(patsubst %.c,lib-client/%.o,$(COAP_SRC))
-S_COAP_OBJ =$(patsubst %.c,lib-server/%.o,$(COAP_SRC))
+CN_COAP_OBJ =$(patsubst %.c,lib-client/%.o,$(COAP_SRC))
+SN_COAP_OBJ =$(patsubst %.c,lib-server/%.o,$(COAP_SRC))
+CD_COAP_OBJ =$(patsubst %.c,lib-client-dtls/%.o,$(COAP_SRC))
+SD_COAP_OBJ =$(patsubst %.c,lib-server-dtls/%.o,$(COAP_SRC))
+
+# tinydtls library
+
+vpath %.c $(libcoap_dir)/ext/tinydtls $(libcoap_dir)/ext/tinydtls/sha2 $(libcoap_dir)/ext/tinydtls/aes $(libcoap_dir)/ext/tinydtls/ecc
+
+TINYDTLS_CFLAGS = -I. -I$(libcoap_dir)/ext -I$(libcoap_dir)/ext/tinydtls -DDTLSv12 -DWITH_SHA256 -DSHA2_USE_INTTYPES_H -DDTLS_CHECK_CONTENTTYPE -DHAVE_LIBTINYDTLS -DHAVE_DTLS_SET_LOG_HANDLER=1
+
+DTLS_SRC = dtls.c \
+           dtls_debug.c \
+           crypto.c \
+           dtls_time.c \
+           hmac.c \
+           sha2.c \
+           session.c \
+           peer.c \
+           netq.c \
+           rijndael_wrap.c \
+           rijndael.c \
+           ecc.c \
+           ccm.c \
+           dtls_prng.c
+
+CN_DTLS_OBJ =$(patsubst %.c,lib-client/%.o,$(DTLS_SRC))
+SN_DTLS_OBJ =$(patsubst %.c,lib-server/%.o,$(DTLS_SRC))
+CD_DTLS_OBJ =$(patsubst %.c,lib-client-dtls/%.o,$(DTLS_SRC))
+SD_DTLS_OBJ =$(patsubst %.c,lib-server-dtls/%.o,$(DTLS_SRC))
 
 CFLAGS += -g3 -Wall -Wextra -pedantic -O0
 
-CFLAGS += -Ilwip/src/include/ -Ilwip/src/include/ipv4/ \
-	  -Ilwip-contrib/ports/unix/port/include/ \
-	  -Ilwip-contrib/ports/unix/proj/minimal/
+CN_APP_OBJ =$(patsubst %.c,lib-client/%.o,client.c client-coap.c)
+SN_APP_OBJ =$(patsubst %.c,lib-server/%.o,server.c server-coap.c)
+CD_APP_OBJ =$(patsubst %.c,lib-client-dtls/%.o,client.c client-coap.c)
+SD_APP_OBJ =$(patsubst %.c,lib-server-dtls/%.o,server.c server-coap.c)
 
-SOBJS = server.o server-coap.o ${S_LWIP_OBJ} ${S_COAP_OBJ}
 
-COBJS = client.o client-coap.o ${C_LWIP_OBJ} ${C_COAP_OBJ}
+CN_OBJS = ${CN_APP_OBJ} ${CN_LWIP_OBJ} ${CN_COAP_OBJ}
+SN_OBJS = ${SN_APP_OBJ} ${SN_LWIP_OBJ} ${SN_COAP_OBJ}
+CD_OBJS = ${CD_APP_OBJ} ${CD_LWIP_OBJ} ${CD_COAP_OBJ} ${CD_DTLS_OBJ}
+SD_OBJS = ${SD_APP_OBJ} ${SD_LWIP_OBJ} ${SD_COAP_OBJ} ${SD_DTLS_OBJ}
 
 $(coap_include_dir)/coap.h:
-	@echo "Error: $@ not present. Run the autotools chain (\`./autogen.sh && ./configure\`) in the project root directory to build the required coap.h file."
-	@exit 1
+	@(if [ ! -f $(coap_include_dir)/coap.h  ] ; then \
+		(cd $(libcoap_dir) ; ./autogen.sh ; ./configure --disable-dtls --disable-man) ; \
+		${MAKE}; \
+	fi)
 
-${SOBJS}: $(coap_include_dir)/coap.h server-coap.h
+${SN_OBJS} ${SD_OBJS}: $(coap_include_dir)/coap.h server-coap.h
 
-server: ${SOBJS}
+server: ${SN_OBJS}
+	$(CC) $(CFLAGS) ${SN_OBJS} -o server ${LDLIBS}
 
-${COBJS}: $(coap_include_dir)/coap.h client-coap.h
+server-dtls: ${SD_OBJS}
+	$(CC) $(CFLAGS) ${SD_OBJS} -o server-dtls ${LDLIBS}
 
-client: ${COBJS}
+${CN_OBJS} ${CD_OBJS}: $(coap_include_dir)/coap.h client-coap.h
+
+client: ${CN_OBJS}
+	$(CC) $(CFLAGS) ${CN_OBJS} -o client ${LDLIBS}
+
+client-dtls: ${CD_OBJS}
+	$(CC) $(CFLAGS) ${CD_OBJS} -o client-dtls ${LDLIBS}
 
 lib-server:
 	@mkdir -p $@
@@ -139,13 +226,27 @@ lib-server:
 lib-server/%.o: %.c config/lwipopts.h config/lwippools.h config/coap_config.h
 	$(CC) ${CFLAGS} -DCOAP_SERVER_SUPPORT -c $< -o $@
 
+lib-server-dtls:
+	@mkdir -p $@
+
+lib-server-dtls/%.o: %.c config/lwipopts.h config/lwippools.h config/coap_config.h
+	$(CC) ${CFLAGS} ${TINYDTLS_CFLAGS} -DCOAP_SERVER_SUPPORT -c $< -o $@
+
 lib-client:
 	@mkdir -p $@
 
 lib-client/%.o: %.c config/lwipopts.h config/lwippools.h config/coap_config.h
 	$(CC) ${CFLAGS} -DCOAP_CLIENT_SUPPORT -c $< -o $@
 
+lib-client-dtls:
+	@mkdir -p $@
+
+lib-client-dtls/%.o: %.c config/lwipopts.h config/lwippools.h config/coap_config.h
+	$(CC) ${CFLAGS} ${TINYDTLS_CFLAGS} -DCOAP_CLIENT_SUPPORT -c $< -o $@
+
 clean:
-	rm -rf server client ${COBJS} ${SOBJS} lib-server lib-client
+	rm -rf server server-dtls client client-dtls \
+	${CN_OBJS} ${SN_OBJS} ${CD_OBJS} ${SD_OBJS} \
+	lib-server lib-server-dtls lib-client lib-client-dtls
 
 .PHONY: all clean

--- a/examples/lwip/README
+++ b/examples/lwip/README
@@ -4,14 +4,17 @@ Example of libcoap running on lwIP
 To run the server example, do
 
     $ make
-    $ sudo ./server
+    $ sudo ./server                 # No TinyDTLS support
+       or
+    $ sudo ./server-dtls            # With TinyDTLS support
 
 (and in a second terminal)
 
     $ sudo ip a a dev tap0 192.168.113.1/24
 
 and query `coap://192.168.113.2/time?ticks` with any coap tool,
-or query `coap://192.168.113.2/.well-known/core`
+or query `coap://192.168.113.2/.well-known/core`.
+(If server-dtls is running, you can use coaps:// as appropriate.)
 
 This will
 
@@ -23,7 +26,12 @@ This will
 
 * return the appropriate response from the server to the client.
 
-The server supports the "-v level" option where logging "level" can be 0 to 7.
+The server supports the following options
+"-k PSK" option where PSK defines the DTLS PSK to use (default is "secretPSK").
+         (Only works for server-dtls.)
+"-v level" option where logging "level" can be 0 to 7 (default is 4).
+"-V level" option where DTLS logging "level" can be 0 to 7 (default is 3).
+           (Only works for server-dtls.)
 
 The server creates a resource for 'time' with a query 'ticks'.  This is
 reported for `.well-known/core`. The work flow for adding more resources does
@@ -34,12 +42,20 @@ in `config/lwippools.h`.
 To run the client example
 
     $ make
-    $ sudo ./client
+    $ sudo ./client                 # No TinyDTLS support
+       or
+    $ sudo ./client-dtls            # With TinyDTLS support
 
-As this tries to connect to coap://libcoap.net/, the tap0 interface will need IP
-forwarding enabled
+As client (or client-dtls) tries to connect to coap://libcoap.net/, the tap0
+interface will need IP forwarding enabled
 
     $ sudo sysctl -w net.ipv4.conf.default.forwarding=1
+
+Then you will need IP forwarding enabled on your public interface
+(where eth0 is replaced by your public facing interface name)
+for response packets
+
+    $ sudo sysctl -w net.eth0.conf.default.forwarding=1
 
 As well as the interface connecting to the internet will need a NAT rule to
 masquerade the internal IP address (192.168.114.2) to the IP of the outgoing
@@ -47,7 +63,17 @@ interface (where eth0 is replaced by your public facing interface name)
 
     $ iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 
-The client supports the "-v level" option where logging "level" can be 0 to 7.
+The client supports the following options
+"-k PSK" option where PSK defines the DTLS PSK to use (default is "secretPSK").
+         (Only works for client-dtls.)
+"-u id" option where id defines the DTLS id to use (default is "abc").
+         (Only works for client-dtls.)
+"-v level" option where logging "level" can be 0 to 7 (default is 4).
+"-V level" option where DTLS logging "level" can be 0 to 7 (default is 3).
+           (Only works for client-dtls.)
+
 The client supports an optional parameter which is the CoAP URI to connect to
 .e.g "coap://libcoap.net/.well-known/core".  The default
-is "coap://libcoap.net/".
+is "coap://libcoap.net/" for client and client-dtls.
+Using "coaps://libcoap.net" will establish a DTLS session if there is
+DTLS support compiled in (client-dtls).

--- a/examples/lwip/client-coap.h
+++ b/examples/lwip/client-coap.h
@@ -15,7 +15,7 @@
 
 /* Start up the CoAP Client */
 void client_coap_init(coap_lwip_input_wait_handler_t input_wait, void *input_arg,
-                      coap_log_t log_level, const char* do_uri);
+                      int argc, char **argv);
 
 /* Close down CoAP activity */
 

--- a/examples/lwip/client.c
+++ b/examples/lwip/client.c
@@ -47,10 +47,6 @@
 static ip4_addr_t ipaddr, netmask, gw;
 static int quit = 0;
 
-#ifndef COAP_URI
-#define COAP_URI "coap://libcoap.net"
-#endif /* COAP_URI */
-
 static void
 handle_sigint(int signum) {
   (void)signum;
@@ -60,6 +56,10 @@ handle_sigint(int signum) {
   exit(0);
 }
 
+/*
+ * This function is called internally by coap_io_process() to check
+ * for input.
+ */
 static int
 wait_for_input(void *arg, uint32_t milli_secs) {
   struct netif *netif = (struct netif *)arg;
@@ -73,30 +73,12 @@ wait_for_input(void *arg, uint32_t milli_secs) {
 }
 
 int
-main(int argc, char **argv)
-{
+main(int argc, char **argv) {
   struct netif netif;
 #ifndef _WIN32
   struct sigaction sa;
 #endif
   int no_more = 0;
-  int opt;
-  int log_level = 4; /* LOG_WARNING */
-  const char *use_uri = COAP_URI;
-
-  while ((opt = getopt(argc, argv, "v:")) != -1) {
-    switch (opt) {
-    case 'v':
-      log_level = atoi(optarg);
-      break;
-    default:
-      exit(1);
-    }
-  }
-
-  if (optind < argc) {
-    use_uri = argv[optind];
-  }
 
   /* startup defaults (may be overridden by one or more opts). this is
    * hard-coded v4 even in presence of v6, which does auto-discovery and
@@ -134,7 +116,7 @@ main(int argc, char **argv)
   sigaction (SIGPIPE, &sa, NULL);
 #endif
 
-  client_coap_init(wait_for_input, &netif, log_level, use_uri);
+  client_coap_init(wait_for_input, &netif, argc, argv);
 
   printf("Client Application started.\n");
 

--- a/examples/lwip/config/lwipopts.h
+++ b/examples/lwip/config/lwipopts.h
@@ -2,7 +2,7 @@
  * lwipopts.h -- LwIP example
  *
  * Copyright (C) 2013-2016 Christian Amsüss <chrysn@fsfe.org>
- * Copyright (C) 2018 John Shallow <supjps-libcoap@jpshallow.com>
+ * Copyright (C) 2018-2022 Jon Shallow <supjps-libcoap@jpshallow.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  *
@@ -17,6 +17,9 @@
 
 #define LWIP_IPV6                       1
 #define LWIP_IPV6_REASS                 0
+
+#define LWIP_IPV6_MLD                   0
+#define LWIP_ICMP6                      1
 
 #ifndef LWIP_RAND
 #define LWIP_RAND() ((u32_t)rand())

--- a/examples/lwip/server-coap.h
+++ b/examples/lwip/server-coap.h
@@ -14,7 +14,7 @@
 
 /* Start up the CoAP Server */
 void server_coap_init(coap_lwip_input_wait_handler_t input_wait, void *input_arg,
-                      coap_log_t log_level);
+                      int argc, char **argv);
 
 /* Close down CoAP activity */
 

--- a/include/coap3/mem.h
+++ b/include/coap3/mem.h
@@ -54,6 +54,8 @@ typedef enum {
   COAP_LG_CRCV,
   COAP_LG_SRCV,
   COAP_DIGEST_CTX,
+  COAP_SUBSCRIPTION,
+  COAP_DTLS_CONTEXT,
 } coap_memory_tag_t;
 
 #ifndef WITH_LWIP
@@ -124,7 +126,9 @@ COAP_STATIC_INLINE void coap_memory_init(void) {}
  * declaration, but i currently don't see a standard way to check that without
  * sourcing the custom memp pools and becoming dependent of its syntax
  */
-#define coap_malloc_type(type, size) memp_malloc(MEMP_ ## type)
+#define coap_malloc_type(type, asize) \
+ (((asize) <= memp_pools[MEMP_ ## type]->size) ? \
+                                         memp_malloc(MEMP_ ## type) : NULL)
 #define coap_free_type(type, p) memp_free(MEMP_ ## type, p)
 
 /* Those are just here to make uri.c happy where string allocation has not been

--- a/scripts/github_dist.sh
+++ b/scripts/github_dist.sh
@@ -20,7 +20,7 @@ if test $err = 0 -a "x$ARCHIVE" != "x"; then
         make EXTRA_CFLAGS=-Werror && make install EXTRA_CFLAGS=-Werror
     err=$?
     if [ $err = 0 ] ; then
-        make -C $DIR/examples/lwip
+        make -C $DIR/examples/lwip EXTRA_CFLAGS=-Werror
         err=$?
     fi
     if [ $err = 0 ] ; then

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -145,8 +145,6 @@ void coap_socket_close(coap_socket_t *sock) {
 
 #else
 
-#ifndef WITH_LWIP
-
 #if COAP_SERVER_SUPPORT
 coap_endpoint_t *
   coap_malloc_endpoint(void) {
@@ -158,6 +156,8 @@ coap_mfree_endpoint(coap_endpoint_t *ep) {
   coap_free_type(COAP_ENDPOINT, ep);
 }
 #endif /* COAP_SERVER_SUPPORT */
+
+#ifndef WITH_LWIP
 
 int
 coap_socket_bind_udp(coap_socket_t *sock,

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -1186,9 +1186,8 @@ coap_pdu_parse(coap_proto_t proto,
     return 0;
   if (!coap_pdu_resize(pdu, length - hdr_size))
     return 0;
-#ifndef WITH_LWIP
-  memcpy(pdu->token - hdr_size, data, length);
-#endif
+  if (pdu->token - hdr_size != data)
+    memcpy(pdu->token - hdr_size, data, length);
   pdu->hdr_size = (uint8_t)hdr_size;
   pdu->used_size = length - hdr_size;
   return coap_pdu_parse_header(pdu, proto) && coap_pdu_parse_opt(pdu);


### PR DESCRIPTION
The dtls versions of the server and client are built as
server-dtls and client-dtls.

Add in flexible option support for server and client.  These are
a subset of the coap-server and coap-client options.