### PR TITLE
coap.txt.in: Fix missing references and hyperlink RFC references

### DIFF
--- a/man/coap.txt.in
+++ b/man/coap.txt.in
@@ -22,8 +22,8 @@ DESCRIPTION
 libcoap is a C implementation of a lightweight application-protocol for
 devices that are constrained by their resources such as computing power, RF
 range, memory, bandwidth, or network packet sizes. This protocol, CoAP, is
-standardized by the IETF as RFC 7252. For further information related to
-CoAP, see http://coap.technology.
+standardized by the IETF as https://tools.ietf.org/html/rfc7252[RFC7252].
+For further information related to CoAP, see http://coap.technology.
 
 Documentation for the specific library calls with examples can be found in the
 man pages referred to in SEE ALSO.
@@ -41,10 +41,10 @@ SEE ALSO
 *coap_async*(3), *coap_attribute*(3), *coap_block*(3), *coap_cache*(3),
 *coap_context*(3), *coap_encryption*(3), *coap_endpoint_client*(3),
 *coap_endpoint_server*(3), *coap_handler*(3), *coap_io*(3),
-*coap_keepalive*(3), *coap_logging*(3), *coap_observe*(3),
+*coap_keepalive*(3), *coap_logging*(3), *coap_lwip*(3), *coap_observe*(3),
 *coap_pdu_access*(3), *coap_pdu_setup*(3), *coap_recovery*(3),
-*coap_resource*(3), *coap_session*(3), *coap_string*(3) and
-*coap_tls_library*(3)
+*coap_resource*(3), *coap_session*(3), *coap_string*(3), *coap_tls_library*(3)
+and *coap_uri*(3)
 
 For example executables, see *coap-client*(5), *coap-rd*(5) and *coap-server*(5)
 
@@ -52,27 +52,27 @@ FURTHER INFORMATION
 -------------------
 See
 
-"RFC7252: The Constrained Application Protocol (CoAP)"
+"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
-"RFC7390: Group Communication for the Constrained Application Protocol (CoAP)"
+"https://tools.ietf.org/html/rfc7390[RFC7390: Group Communication for the Constrained Application Protocol (CoAP)]"
 
-"RFC7641: Observing Resources in the Constrained Application Protocol (CoAP)"
+"https://tools.ietf.org/html/rfc7641[RFC7641: Observing Resources in the Constrained Application Protocol (CoAP)]"
 
-"RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)"
+"https://tools.ietf.org/html/rfc7959[RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)]"
 
-"RFC7967: Constrained Application Protocol (CoAP) Option for No Server Response"
+"https://tools.ietf.org/html/rfc7967[RFC7967: Constrained Application Protocol (CoAP) Option for No Server Response]"
 
-"RFC8132: PATCH and FETCH Methods for the Constrained Application Protocol (CoAP)"
+"https://tools.ietf.org/html/rfc8132[RFC8132: PATCH and FETCH Methods for the Constrained Application Protocol (CoAP)]"
 
-"RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets"
+"https://tools.ietf.org/html/rfc8323[RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets]"
 
-"RFC8516: "Too Many Requests" Response Code for the Constrained Application Protocol"
+"https://tools.ietf.org/html/rfc8516[RFC8516: "Too Many Requests" Response Code for the Constrained Application Protocol]"
 
-"RFC8613: Object Security for Constrained RESTful Environments (OSCORE)"
+"https://tools.ietf.org/html/rfc8613[RFC8613: Object Security for Constrained RESTful Environments (OSCORE)]"
 
-"RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option"
+"https://tools.ietf.org/html/rfc8768[RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option]"
 
-"RFC9175: CoAP: Echo, Request-Tag, and Token Processing"
+"https://tools.ietf.org/html/rfc9175[RFC9175: CoAP: Echo, Request-Tag, and Token Processing]"
 
 for further information.
 


### PR DESCRIPTION
The RFC references appear without the hyperlink in the man pages, but now appear as hyperlinked in the doxygen output.

SEE ALSO updated with missing references.