### PR TITLE
coap-client.c: Cleanup following observe cancellation

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -1826,6 +1826,7 @@ main(int argc, char **argv) {
           for (i = 0; i < tracked_tokens_count; i++) {
             if (tracked_tokens[i].observe) {
               coap_cancel_observe(session, tracked_tokens[i].token, msgtype);
+              coap_io_process(ctx, COAP_IO_NO_WAIT);
             }
           }
           doing_observe = 0;
@@ -1834,6 +1835,10 @@ main(int argc, char **argv) {
           /* make sure that the obs timer does not fire again */
           obs_ms = 0;
           obs_seconds = 0;
+          for (i = 0; i < 5 ; i++) {
+            /* Make sure all is flushed out */
+            coap_io_process(ctx, 100);
+          }
         } else {
           obs_ms -= result;
         }


### PR DESCRIPTION
Delay exit briefly checking if there are any response packets following observe cancellation and process as appropriate.

If multiple observes are outstanding, cancelling them using CON will cause issues as NSTART limit is hit.  The server then does not know about all of the cancellations.

Also, this can allow the server to properly shutdown observe activity when blocks are used.