### PR TITLE
coap_io_pending: Add in new function to check if there is any i/o pending

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -1791,7 +1791,7 @@ main(int argc, char **argv) {
 
   while(!quit &&
         !(ready && !tracked_tokens_count && !is_mcast && !repeat_count &&
-          coap_can_exit(ctx)) ) {
+          !coap_io_pending(ctx)) ) {
     uint32_t timeout_ms;
     /*
      * 3 factors determine how long to wait in coap_io_process()

--- a/include/coap3/net.h
+++ b/include/coap3/net.h
@@ -643,6 +643,20 @@ int coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
                              fd_set *exceptfds);
 #endif /* !RIOT_VERSION */
 
+/**
+ * Check to see if there is any i/o pending for the @p context.
+ *
+ * This includes Observe active (client) and partial large block transfers.
+ *
+ * coap_io_process() is called internally to try to send outstanding
+ * data as well as process any packets just received.
+ *
+ * @param context The CoAP context.
+ *
+ * @return @c 1 I/O still pending, @c 0 no I/O pending.
+ */
+int coap_io_pending(coap_context_t *context);
+
 /**@}*/
 
 /**

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -102,6 +102,7 @@ global:
   coap_insert_optlist;
   coap_io_do_epoll;
   coap_io_do_io;
+  coap_io_pending;
   coap_io_prepare_epoll;
   coap_io_prepare_io;
   coap_io_process;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -100,6 +100,7 @@ coap_handle_event
 coap_insert_optlist
 coap_io_do_epoll
 coap_io_do_io
+coap_io_pending
 coap_io_prepare_epoll
 coap_io_prepare_io
 coap_io_process

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -101,6 +101,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_get_session_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_set_csm_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_get_csm_timeout.3
+	@echo ".so man3/coap_io.3" > coap_can_exit.3
 	@echo ".so man3/coap_logging.3" > coap_log_info.3
 	@echo ".so man3/coap_logging.3" > coap_log_debug.3
 	@echo ".so man3/coap_logging.3" > coap_log_oscore.3

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -18,7 +18,8 @@ coap_io_prepare_io,
 coap_io_do_io,
 coap_io_prepare_epoll,
 coap_io_do_epoll,
-coap_io_can_exit
+coap_io_pending,
+coap_can_exit
 - Work with CoAP I/O to do the packet send and receives
 
 SYNOPSIS
@@ -45,6 +46,8 @@ coap_tick_t _now_)*;
 *void coap_io_do_epoll(coap_context_t *_context_, struct epoll_event *_events_,
 size_t _nevents_)*;
 
+*int coap_io_pending(coap_context_t *_context_)*;
+
 *int coap_can_exit(coap_context_t *_context_)*;
 
 For specific (D)TLS library support, link with
@@ -58,6 +61,29 @@ DESCRIPTION
 After setting up all the contexts, resources, endpoints sessions etc., the
 underlying CoAP and (D)TLS need to send (and possible re-send) created packets
 as well as receive packets for processing.
+
+The *coap_io_process*() function is the primary function applications should
+use. There are internal functions that *coap_io_process*() calls which are
+available to use if absolutely necessary.  These internal functions and how to
+use them is different depending on whether libcoap has been compiled to use
+*epoll* (Linux systems only) or not.
+
+For *epoll* libcoap, *coap_io_process*() in simple terms calls
+*coap_io_prepare_epoll*(), does an *epoll_wait*() and then calls
+*coap_io_do_epoll*() if needed to make sure that all event based i/o has been
+completed.
+
+For *non-epoll* libcoap, *coap_io_process*() in simple terms calls
+*coap_io_prepare_io*() to set up sockets[], sets up all of the *select*()
+parameters based on the COAP_SOCKET_WANT* values in the sockets[], does a
+*select*(), updates the sockets[] with COAP_SOCKET_CAN_* as appropriate and
+then calls *coap_io_do_io*() to make sure that all current i/o has been
+completed.
+
+FUNCTIONS
+---------
+
+*Function: coap_io_process()*
 
 The *coap_io_process*() function will process any outstanding packets to send
 for the specified _context_, process any available input packets and then wait
@@ -97,23 +123,7 @@ the different sessions.
 
 See EXAMPLES below.
 
-The *coap_io_process*() function is the primary function applications should
-use. There are internal functions that *coap_io_process*() calls which are
-available to use if absolutely necessary.  These internal functions and how to
-use them is different depending on whether libcoap has been compiled to use
-*epoll* (Linux systems only) or not.
-
-For *epoll* libcoap, *coap_io_process*() in simple terms calls
-*coap_io_prepare_epoll*(), does an *epoll_wait*() and then calls
-*coap_io_do_epoll*() if needed to make sure that all event based i/o has been
-completed.
-
-For *non-epoll* libcoap, *coap_io_process*() in simple terms calls
-*coap_io_prepare_io*() to set up sockets[], sets up all of the *select*()
-parameters based on the COAP_SOCKET_WANT* values in the sockets[], does a
-*select*(), updates the sockets[] with COAP_SOCKET_CAN_* as appropriate and
-then calls *coap_io_do_io*() to make sure that all current i/o has been
-completed.
+*Function: coap_io_prepare_epoll()*
 
 The *coap_io_prepare_epoll*() function for the specified _context_ will
 iterate through the endpoints and sessions to transmit any triggered observer
@@ -122,11 +132,15 @@ based on _now_, is the number of milli-secs needed to delay until the next
 time that *coap_io_prepare_epoll*() needs to get called.  After this call an
 *epoll_wait*() should done.
 
+*Function: coap_io_do_epoll()*
+
 The *coap_io_do_epoll*() function for the specified _context_ will
 iterate through the _nevents_ of _events_ returned by *epoll_wait*() and
 execute the appropriate low level i/o function to send / receive / process the
 packets. Where appropriate, structure information (endpoints, sessions etc.)
 is updated with the value of _now_ in the lower level functions.
+
+*Function: coap_io_prepare_io()*
 
 The *coap_io_prepare_io*() function for the specified _context_ will iterate
 through the endpoints and sessions to add all of sockets waiting for network
@@ -140,12 +154,16 @@ done on all the file descriptors (COAP_WANT_READ for readfds etc.), and any
 that are returned active should set the appropriate COAP_SOCKET_CAN_* in the
 _sockets_.
 
+*Function: coap_io_do_io()*
+
 The *coap_io_do_io*() function for the specified _context_ will
 iterate through the endpoints and sessions to find all of sockets that have
 COAP_SOCKET_CAN_* set and then execute the appropriate low level i/o function
 to send / receive / process the packets. Where appropriate, structure
 information (endpoints, sessions etc.) is updated with the value of _now_ in
 the lower level functions.
+
+*Function: coap_io_process_with_fds()*
 
 The *coap_io_process_with_fds*() function is the same as *coap_process_io*()
 but supports additional select() style parameters _nfds_, _readfds_,
@@ -157,16 +175,26 @@ structure or NULL if not required. _nfds_ needs to be set to the maximum FD to
 test for in _readfds_, _writefds_ or _exceptfds_ if any of them are set plus 1.
 If none of them are set, then _nfds_ should be set to 0.
 
-NOTE: The additional parameters for *coap_io_process_with_fds*() are only used
+*NOTE:* The additional parameters for *coap_io_process_with_fds*() are only used
 if there is no epoll support in libcoap. If there is epoll support, then
 *coap_context_get_coap_fd*() should be used and this returned FD along with
 other non libcoap FDs can separately be monitored using method 2 above.
+
+*Function: coap_context_get_coap_fd()*
 
 The *coap_context_get_coap_fd*() function obtains from the specified
 _context_ a single file descriptor that can be monitored by a *select*() or
 as an event returned from a *epoll_wait*() call.  This file descriptor will get
 updated with information (read, write etc. available) whenever any of the
 internal to libcoap file descriptors (sockets) change state.
+
+*Function: coap_io_pending()*
+
+The *coap_io_pending*() function checks to see if there are any outstanding
+i/o requests / responses associated with _context_ as well as if Observe has
+been set up (client only) and large transfers are in process.
+
+*Function: coap_can_exit()*
 
 The *coap_can_exit*() function checks to see if there are any outstanding
 PDUs to transmit associated with _context_ and returns 1 if there is nothing
@@ -184,6 +212,8 @@ descriptor to monitor, or -1 if epoll is not configured in libcoap.
 
 *coap_io_prepare_io*() and *coap_io_prepare_epoll*() returns the number of
 milli-seconds that need to be waited before the function should next be called.
+
+*coap_io_pending*() returns 1 if there is outstanding i/o else returns 0.
 
 *coap_can_exit*() returns 1 if there is nothing outstanding to transmit else
 returns 0.
@@ -449,8 +479,11 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/src/net.c
+++ b/src/net.c
@@ -3018,8 +3018,7 @@ handle_response(coap_context_t *context, coap_session_t *session,
     /* Need to see if needing to request next block */
     if (coap_handle_response_get_block(context, session, sent, rcvd,
                                        COAP_RECURSE_OK)) {
-      /* Next block requested, no need to inform app */
-      coap_send_ack(session, rcvd);
+      /* Next block transmitted, ack sent no need to inform app */
       return;
     }
   }


### PR DESCRIPTION
coap_io_pending() checks to see if there are any PDUs pending transmission, whether there are any large (block) transmissions in progress, whether there are still expected response packets(client) or expected request packets(server), and whether the client is expecting further observe responses.  If any of this is true, then it returns 1, else 0.

coap_io_pending() also invokes coap_io_process() to check that all that can be transmitted is, as well as processes any impending input packets.

This takes coap_can_exit() a step further who only checks the transmit state.

coap_handle_response_get_block() has been updated to release the current lg_crcv if all the fragmented body of a large transfer have been received.

See #947 and #494.

Documentation updated.