### PR TITLE
uri: include coap_option.h

### DIFF
--- a/include/coap3/uri.h
+++ b/include/coap3/uri.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 
 #include "str.h"
+#include "coap_option.h"
 
 /**
  * The scheme specifiers. Secure schemes have an odd numeric value,


### PR DESCRIPTION
Required for usage of coap_optlist_t.