### PR TITLE
coap_event: Add COAP_EVENT_MSG_RETRANSMITTED

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -358,6 +358,7 @@ event_handler(coap_session_t *session COAP_UNUSED,
   case COAP_EVENT_SERVER_SESSION_NEW:
   case COAP_EVENT_SERVER_SESSION_DEL:
   case COAP_EVENT_BAD_PACKET:
+  case COAP_EVENT_MSG_RETRANSMITTED:
   default:
     break;
   }

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1582,6 +1582,7 @@ proxy_event_handler(coap_session_t *session,
   case COAP_EVENT_SERVER_SESSION_NEW:
   case COAP_EVENT_SERVER_SESSION_DEL:
   case COAP_EVENT_BAD_PACKET:
+  case COAP_EVENT_MSG_RETRANSMITTED:
   default:
     break;
   }

--- a/include/coap3/coap_event.h
+++ b/include/coap3/coap_event.h
@@ -94,10 +94,12 @@ typedef enum {
   COAP_EVENT_SERVER_SESSION_DEL = 0x4002,
 
 /*
- * Received packet formatting errors
+ * Message receive and transmit events
  */
   /** Triggered when badly formatted packet received */
-  COAP_EVENT_BAD_PACKET         = 0x5001
+  COAP_EVENT_BAD_PACKET         = 0x5001,
+  /** Triggered when a message is retransmitted */
+  COAP_EVENT_MSG_RETRANSMITTED  = 0x5002
 
 } coap_event_t;
 

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -219,9 +219,10 @@ COAP_EVENT_XMIT_BLOCK_FAIL    0x3002
 COAP_EVENT_SERVER_SESSION_NEW 0x4001
 COAP_EVENT_SERVER_SESSION_DEL 0x4002
 /**
- * Unrecognizable received packet events
+ * Message receive and transmit events
  */
 COAP_EVENT_BAD_PACKET         0x5001
+COAP_EVENT_MSG_RETRANSMITTED  0x5002
 ----
 
 EXAMPLES

--- a/src/net.c
+++ b/src/net.c
@@ -1439,6 +1439,8 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
     coap_tick_t now;
 
     node->retransmit_cnt++;
+    coap_handle_event(context, COAP_EVENT_MSG_RETRANSMITTED, node->session);
+
     coap_ticks(&now);
     if (context->sendqueue == NULL) {
       node->t = node->timeout << node->retransmit_cnt;


### PR DESCRIPTION
Apart from debug log messages, there is no way for a user to be notified when a message retransmission happens.

This event can be useful for diagnosing issues related to lossy networks or unresponsive CoAP servers (e.g. user can track total retransmissions as an indicator for general link quality).

Assigned event ID to 0x5002 to avoid creating a new 0x6000 event group, and because it's similar to COAP_EVENT_BAD_PACKET (0x5001).