### PR TITLE
TinyDTLS: Support build with DTLS_PSK not defined.

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2083,7 +2083,7 @@ fill_keystore(coap_context_t *ctx) {
   if (cert_file == NULL && key_defined == 0) {
     if (coap_dtls_is_supported() || coap_tls_is_supported()) {
       coap_log(LOG_DEBUG,
-               "(D)TLS not enabled as neither -k or -c options specified\n");
+           "(D)TLS not enabled as none of -k, -c or -M options specified\n");
     }
     return;
   }
@@ -2100,7 +2100,11 @@ fill_keystore(coap_context_t *ctx) {
   if (key_defined) {
     coap_dtls_spsk_t *dtls_spsk = setup_spsk();
 
-    coap_context_set_psk2(ctx, dtls_spsk);
+    if (!coap_context_set_psk2(ctx, dtls_spsk)) {
+      coap_log(LOG_INFO, "Unable to set up PSK\n");
+      /* So we do not set up DTLS */
+      key_defined = 0;
+    }
   }
 }
 

--- a/include/coap3/coap_dtls.h
+++ b/include/coap3/coap_dtls.h
@@ -50,16 +50,44 @@ typedef enum coap_dtls_role_t {
 /**
  * Check whether DTLS is available.
  *
- * @return @c 1 if support for DTLS is enabled, or @c 0 otherwise.
+ * @return @c 1 if support for DTLS is available, or @c 0 otherwise.
  */
 int coap_dtls_is_supported(void);
 
 /**
  * Check whether TLS is available.
  *
- * @return @c 1 if support for TLS is enabled, or @c 0 otherwise.
+ * @return @c 1 if support for TLS is available, or @c 0 otherwise.
  */
 int coap_tls_is_supported(void);
+
+/**
+ * Check whether (D)TLS PSK is available.
+ *
+ * @return @c 1 if support for (D)TLS PSK is available, or @c 0 otherwise.
+ */
+int coap_dtls_psk_is_supported(void);
+
+/**
+ * Check whether (D)TLS PKI is available.
+ *
+ * @return @c 1 if support for (D)TLS PKI is available, or @c 0 otherwise.
+ */
+int coap_dtls_pki_is_supported(void);
+
+/**
+ * Check whether (D)TLS PKCS11 is available.
+ *
+ * @return @c 1 if support for (D)TLS PKCS11 is available, or @c 0 otherwise.
+ */
+int coap_dtls_pkcs11_is_supported(void);
+
+/**
+ * Check whether (D)TLS RPK is available.
+ *
+ * @return @c 1 if support for (D)TLS RPK is available, or @c 0 otherwise.
+ */
+int coap_dtls_rpk_is_supported(void);
 
 typedef enum coap_tls_library_t {
   COAP_TLS_LIBRARY_NOTLS = 0, /**< No DTLS library */

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -71,6 +71,10 @@ global:
   coap_delete_uri;
   coap_dtls_get_log_level;
   coap_dtls_is_supported;
+  coap_dtls_pkcs11_is_supported;
+  coap_dtls_pki_is_supported;
+  coap_dtls_psk_is_supported;
+  coap_dtls_rpk_is_supported;
   coap_dtls_set_log_level;
   coap_encode_var_safe;
   coap_encode_var_safe8;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -69,6 +69,10 @@ coap_delete_string
 coap_delete_uri
 coap_dtls_get_log_level
 coap_dtls_is_supported
+coap_dtls_pkcs11_is_supported
+coap_dtls_pki_is_supported
+coap_dtls_psk_is_supported
+coap_dtls_rpk_is_supported
 coap_dtls_set_log_level
 coap_encode_var_safe
 coap_encode_var_safe8

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -148,6 +148,9 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_string.3" > coap_make_str_const.3
 	@echo ".so man3/coap_string.3" > coap_string_equal.3
 	@echo ".so man3/coap_string.3" > coap_binary_equal.3
+	@echo ".so man3/coap_tls_library.3" > coap_string_tls_support.3
+	@echo ".so man3/coap_tls_library.3" > coap_string_tls_version.3
+	@echo ".so man3/coap_tls_library.3" > coap_show_tls_version.3
 	$(INSTALL_DATA) $(A2X_EXTRA_PAGES_3) "$(DESTDIR)$(man3dir)"
 	$(INSTALL_DATA) $(A2X_EXTRA_PAGES_5) "$(DESTDIR)$(man5dir)"
 

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -13,6 +13,10 @@ NAME
 coap_tls_library,
 coap_dtls_is_supported,
 coap_tls_is_supported,
+coap_dtls_psk_is_supported,
+coap_dtls_pki_is_supported,
+coap_dtls_pkcs11_is_supported,
+coap_dtls_rpk_is_supported,
 coap_tcp_is_supported,
 coap_get_tls_library_version,
 coap_string_tls_support,
@@ -27,6 +31,14 @@ SYNOPSIS
 *int coap_dtls_is_supported(void);*
 
 *int coap_tls_is_supported(void);*
+
+*int coap_dtls_psk_is_supported(void);*
+
+*int coap_dtls_pki_is_supported(void);*
+
+*int coap_dtls_pkcs11_is_supported(void);*
+
+*int coap_dtls_rpk_is_supported(void);*
 
 *int coap_tcp_is_supported(void);*
 
@@ -74,34 +86,48 @@ However, there is the flexibility of the Callbacks for imposing additional
 security checks etc. when PKI is being used.  These callbacks need to need to
 match the TLS implementation type.
 
+FUNCTIONS
+---------
+
+*Function: coap_dtls_is_supported()*
+
 The *coap_dtls_is_supported*() function returns 1 if support for DTLS is
-enabled, otherwise 0;
+available, otherwise 0;
+
+*Function: coap_tls_is_supported()*
 
 The *coap_tls_is_supported*() function returns 1 if support for TLS is
-enabled, otherwise 0;
+available, otherwise 0;
+
+*Function: coap_dtls_psk_is_supported()*
+
+The *coap_dtls_psk_is_supported*() function returns 1 if support for (D)TLS PSK
+is available, otherwise 0;
+
+*Function: coap_dtls_pki_is_supported()*
+
+The *coap_dtls_pki_is_supported*() function returns 1 if support for (D)TLS PKI
+is available, otherwise 0;
+
+*Function: coap_dtls_pkcs11_is_supported()*
+
+The *coap_dtls_pkcs11_is_supported*() function returns 1 if support for (D)TLS
+PKCS11 is available, otherwise 0;
+
+*Function: coap_dtls_rpk_is_supported()*
+
+The *coap_dtls_rpk_is_supported*() function returns 1 if support for (D)TLS RPK
+is available, otherwise 0;
+
+*Function: coap_tcp_is_supported()*
 
 The *coap_tcp_is_supported*() function returns 1 if support for TCP is
-enabled, otherwise 0.
+available, otherwise 0.
+
+*Function: coap_get_tls_library_version()*
 
 The *coap_get_tls_library_version*() function returns the TLS implementation
 type and library version in a coap_tls_version_t* structure.
-
-The *coap_string_tls_support*() function is used to update the provided buffer
-with ascii readable information about what type of PSK, PKI etc. keys the
-current (D)TLS library supports.
-_buffer_ defines the buffer to provide the information and _bufsize_ is the
-size of _buffer_.
-
-The *coap_string_tls_version*() function is used to update the provided buffer
-with information about the current (D)TLS library that libcoap was built
-against, as well as the current linked version of the (D)TLS library.
-_buffer_ defines the buffer to provide the information and _bufsize_ is the
-size of _buffer_.
-
-The *coap_show_tls_version*() function is used log information about the
-current (D)TLS library that libcoap was built against, as well as the current
-linked version of the (D)TLS library. _level_ defines the minimum logging level
-for this information to be output using coap_log().
 
 [source, c]
 ----
@@ -120,16 +146,41 @@ typedef struct coap_tls_version_t {
 }
 ----
 
+*Function: coap_string_tls_support()*
+
+The *coap_string_tls_support*() function is used to update the provided buffer
+with ascii readable information about what type of PSK, PKI etc. keys the
+current (D)TLS library supports.
+_buffer_ defines the buffer to provide the information and _bufsize_ is the
+size of _buffer_.
+
+*Function: coap_string_tls_version()*
+
+The *coap_string_tls_version*() function is used to update the provided buffer
+with information about the current (D)TLS library that libcoap was built
+against, as well as the current linked version of the (D)TLS library.
+_buffer_ defines the buffer to provide the information and _bufsize_ is the
+size of _buffer_.
+
+*Function: coap_show_tls_version()*
+
+The *coap_show_tls_version*() function is used log information about the
+current (D)TLS library that libcoap was built against, as well as the current
+linked version of the (D)TLS library. _level_ defines the minimum logging level
+for this information to be output using coap_log().
+
 RETURN VALUES
 -------------
-*coap_dtls_is_supported*() and *coap_tls_is_supported*() functions
+*coap_dtls_is_supported*(), *coap_tls_is_supported*(),
+*coap_dtls_psk_is_supported*(), *coap_dtls_pki_is_supported*(),
+*coap_dtls_pkcs11_is_supported*() and *coap_dtls_rpk_is_supported*() functions
 return 0 if there is no support, 1 if support is available.
 
 *coap_get_tls_library_version*() function returns the TLS implementation type
 and library version in a coap_tls_version_t* structure.
 
-The *coap_tcp_is_supported*() function returns 1 if support for TCP is
-enabled, otherwise 0.
+*coap_tcp_is_supported*() function returns 1 if support for TCP is
+available, otherwise 0.
 
 *coap_string_tls_version*() function returns a pointer to the provided buffer.
 
@@ -139,8 +190,13 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+"https://tools.ietf.org/html/rfc8323[RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets]"
+
+for further information.
 
 BUGS
 ----

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -936,52 +936,25 @@ char *coap_string_tls_version(char *buffer, size_t bufsize)
 
 char *coap_string_tls_support(char *buffer, size_t bufsize)
 {
-  coap_tls_version_t *tls_version = coap_get_tls_library_version();
   const int have_tls = coap_tls_is_supported();
   const int have_dtls = coap_dtls_is_supported();
+  const int have_psk = coap_dtls_psk_is_supported();
+  const int have_pki = coap_dtls_pki_is_supported();
+  const int have_pkcs11 = coap_dtls_pkcs11_is_supported();
+  const int have_rpk = coap_dtls_rpk_is_supported();
 
   if (have_dtls == 0 && have_tls == 0) {
     snprintf(buffer, bufsize, "(No DTLS or TLS support)");
     return buffer;
   }
-  switch (tls_version->type) {
-  case COAP_TLS_LIBRARY_NOTLS:
-    snprintf(buffer, bufsize, "(No DTLS or TLS support)");
-    break;
-  case COAP_TLS_LIBRARY_TINYDTLS:
-    snprintf(buffer, bufsize,
-             "(%sDTLS and%s TLS support; PSK, no PKI, no PKCS11, and RPK support)",
-             have_dtls ? "" : " no",
-             have_tls ? "" : " no");
-    break;
-  case COAP_TLS_LIBRARY_OPENSSL:
-    snprintf(buffer, bufsize,
-             "(%sDTLS and%s TLS support; PSK, PKI, PKCS11, and no RPK support)",
-             have_dtls ? "" : " no",
-             have_tls ? "" : " no");
-    break;
-  case COAP_TLS_LIBRARY_GNUTLS:
-    if (tls_version->version >= 0x030606)
-      snprintf(buffer, bufsize,
-               "(%sDTLS and%s TLS support; PSK, PKI, PKCS11, and RPK support)",
-               have_dtls ? "" : " no",
-               have_tls ? "" : " no");
-    else
-      snprintf(buffer, bufsize,
-               "(%sDTLS and%s TLS support; PSK, PKI, PKCS11, and no RPK support)",
-               have_dtls ? "" : " no",
-               have_tls ? "" : " no");
-    break;
-  case COAP_TLS_LIBRARY_MBEDTLS:
-    snprintf(buffer, bufsize,
-             "(%sDTLS and%s TLS support; PSK, PKI, no PKCS11, and no RPK support)",
-             have_dtls ? "" : " no",
-             have_tls ? "" : " no");
-    break;
-  default:
-    buffer[0] = '\000';
-    break;
-  }
+  snprintf(buffer, bufsize,
+           "(%sDTLS and %sTLS support; %sPSK, %sPKI, %sPKCS11, and %sRPK support)",
+           have_dtls ? "" : "No ",
+           have_tls ? "" : "no ",
+           have_psk ? "" : "no ",
+           have_pki ? "" : "no ",
+           have_pkcs11 ? "" : "no ",
+           have_rpk ? "" : "no ");
   return buffer;
 }
 

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -205,6 +205,46 @@ coap_tls_is_supported(void) {
 #endif /* COAP_DISABLE_TCP */
 }
 
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_psk_is_supported(void) {
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_pki_is_supported(void) {
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_pkcs11_is_supported(void) {
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_rpk_is_supported(void) {
+#if (GNUTLS_VERSION_NUMBER >= 0x030606)
+  return 1;
+#else /* GNUTLS_VERSION_NUMBER < 0x030606 */
+  return 0;
+#endif /* GNUTLS_VERSION_NUMBER < 0x030606 */
+}
+
 coap_tls_version_t *
 coap_get_tls_library_version(void) {
   static coap_tls_version_t version;

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -1599,7 +1599,8 @@ fail:
   return NULL;
 }
 
-int coap_dtls_is_supported(void) {
+int
+coap_dtls_is_supported(void) {
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
   return 1;
 #else /* !MBEDTLS_SSL_PROTO_DTLS */
@@ -1614,13 +1615,49 @@ int coap_dtls_is_supported(void) {
 #endif /* !MBEDTLS_SSL_PROTO_DTLS */
 }
 
-int coap_tls_is_supported(void)
-{
+int
+coap_tls_is_supported(void) {
 #if !COAP_DISABLE_TCP
   return 1;
 #else /* COAP_DISABLE_TCP */
   return 0;
 #endif /* COAP_DISABLE_TCP */
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_psk_is_supported(void) {
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_pki_is_supported(void) {
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_pkcs11_is_supported(void) {
+  return 0;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_rpk_is_supported(void) {
+  return 0;
 }
 
 void *coap_dtls_new_context(coap_context_t *c_context)

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -29,6 +29,42 @@ coap_tls_is_supported(void) {
   return 0;
 }
 
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_psk_is_supported(void) {
+  return 0;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_pki_is_supported(void) {
+  return 0;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_pkcs11_is_supported(void) {
+  return 0;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_rpk_is_supported(void) {
+  return 0;
+}
+
 coap_tls_version_t *
 coap_get_tls_library_version(void) {
   static coap_tls_version_t version;

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -165,7 +165,8 @@ static int psk_tls_client_hello_call_back(SSL *ssl, int *al, void *arg);
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10101000L */
 #endif /* COAP_SERVER_SUPPORT */
 
-int coap_dtls_is_supported(void) {
+int
+coap_dtls_is_supported(void) {
   if (SSLeay() < 0x10100000L) {
     coap_log(LOG_WARNING, "OpenSSL version 1.1.0 or later is required\n");
     return 0;
@@ -186,7 +187,8 @@ int coap_dtls_is_supported(void) {
   return 1;
 }
 
-int coap_tls_is_supported(void) {
+int
+coap_tls_is_supported(void) {
 #if !COAP_DISABLE_TCP
   if (SSLeay() < 0x10100000L) {
     coap_log(LOG_WARNING, "OpenSSL version 1.1.0 or later is required\n");
@@ -202,6 +204,42 @@ int coap_tls_is_supported(void) {
 #else /* COAP_DISABLE_TCP */
   return 0;
 #endif /* COAP_DISABLE_TCP */
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_psk_is_supported(void) {
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_pki_is_supported(void) {
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_pkcs11_is_supported(void) {
+  return 1;
+}
+
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_rpk_is_supported(void) {
+  return 0;
 }
 
 coap_tls_version_t *


### PR DESCRIPTION
As well as adding in the DTLS_PSK wrappers in the appropriate place, add in
coap_dtls_psk_is_supported(), coap_dtls_pki_is_supported(), coap_dtls_pkcs11_is_supported()
and coap_dtls_rpk_is_supported() functions to support better granularity of what
capabilities are available in the (D)TLS libraries.

Update coap_string_tls_support() to use these new functions.

Fixes #762