### PR TITLE
block.c: Make sure ETAG option gets properly added

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -289,7 +289,7 @@ coap_add_data_blocked_response(const coap_pdu_t *request,
   /* add etag for the resource */
   memset(etag, 0, sizeof(etag));
   coap_hash(data, length, etag);
-  coap_add_option_internal(response, COAP_OPTION_ETAG, sizeof(etag), etag);
+  coap_insert_option(response, COAP_OPTION_ETAG, sizeof(etag), etag);
 
   coap_insert_option(response, COAP_OPTION_CONTENT_FORMAT,
                   coap_encode_var_safe(buf, sizeof(buf),


### PR DESCRIPTION
It is possible that there is, say, a Block2 option already in the PDU so need to make sure ETAG option is always added in.