### PR TITLE
coap_openssl.c: Support OpenSSL 3.0+ client talking to legacy server

### DIFF
--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -786,6 +786,9 @@ void *coap_dtls_new_context(coap_context_t *coap_context) {
     SSL_CTX_set_cookie_verify_cb(context->dtls.ctx, coap_dtls_verify_cookie);
     SSL_CTX_set_info_callback(context->dtls.ctx, coap_dtls_info_callback);
     SSL_CTX_set_options(context->dtls.ctx, SSL_OP_NO_QUERY_MTU);
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    SSL_CTX_set_options(context->dtls.ctx, SSL_OP_LEGACY_SERVER_CONNECT );
+#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
     context->dtls.meth = BIO_meth_new(BIO_TYPE_DGRAM, "coapdgram");
     if (!context->dtls.meth)
       goto error;


### PR DESCRIPTION
OpenSSL 3.0+ has removed the SSL_OP_LEGACY_SERVER_CONNECT option from the default set list meaning that a OpenSSL 3.0+ client is unable to set up a session with a TinyDTLS server.

This fix adds back in SSL_OP_LEGACY_SERVER_CONNECT to the set list of options.

This removes the message that reports the failure
"unsafe legacy renegotiation disabled"
that causes the session set up to fail.

There is debate as to whether RFC 5746 is appropriate for DTLS sessions, which is what OpenSSL 3.0+ now enforces unless 
SSL_OP_LEGACY_SERVER_CONNECT is set.

See https://github.com/eclipse/tinydtls/issues/175