### PR TITLE
net.c: Report the node's retransmit timeout as actual timeout

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -987,7 +987,8 @@ coap_wait_ack(coap_context_t *context, coap_session_t *session,
 
   coap_log(LOG_DEBUG, "** %s: mid=0x%x: added to retransmit queue (%ums)\n",
     coap_session_str(node->session), node->id,
-    (unsigned)(node->t * 1000 / COAP_TICKS_PER_SECOND));
+    (unsigned)((node->timeout << node->retransmit_cnt) * 1000 /
+                                                         COAP_TICKS_PER_SECOND));
 
 #ifdef COAP_EPOLL_SUPPORT
   coap_update_epoll_timer(context, node->t);


### PR DESCRIPTION
If NSTART > 1, any retransmit timeouts are reported on the difference in time with an earlier entry in the transmit queue, rather than the actual delay before the node entry gets retransmitted.

This change reports on the actual delay for a node before it gets retransmitted, which more accurately records when the node will get retransmitted.

See #949.