### PR TITLE
options: Update documentation and fix incorrect function usage

### DIFF
--- a/include/coap3/coap_option.h
+++ b/include/coap3/coap_option.h
@@ -118,7 +118,7 @@ coap_option_filter_clear(coap_opt_filter_t *filter);
 /**
  * Sets the corresponding entry for @p number in @p filter. This
  * function returns @c 1 if bit was set or @c 0 on error (i.e. when
- * the given number does not fit in the filter).
+ * there is not enough space to fit the given number in the filter).
  *
  * @param filter The filter object to change.
  * @param number The option number for which the bit should be set.
@@ -129,26 +129,24 @@ int coap_option_filter_set(coap_opt_filter_t *filter, coap_option_num_t number);
 
 /**
  * Clears the corresponding entry for @p number in @p filter. This
- * function returns @c 1 if bit was set or @c 0 on error (i.e. when
- * the given number does not fit in the filter).
+ * function returns @c 1 if bit was set or @c 0 if not previously set.
  *
  * @param filter The filter object to change.
  * @param number The option number that should be cleared from the filter.
  *
- * @return       @c 1 if bit was set, @c 0 otherwise.
+ * @return       @c 1 if bit was cleared, @c 0 otherwise.
  */
 int coap_option_filter_unset(coap_opt_filter_t *filter,
                              coap_option_num_t number);
 
 /**
  * Checks if @p number is contained in @p filter. This function returns
- * @c 1 if found, @c 0 if not, or @c -1 on error (i.e. when the given
- * number does not fit in the filter).
+ * @c 1 if found, @c 0 if not.
  *
  * @param filter The filter object to search.
  * @param number The option number to search for.
  *
- * @return       @c 1 if @p number was found, @c 0 otherwise, or @c -1 on error.
+ * @return       @c 1 if @p number was found, @c 0 otherwise
  */
 int coap_option_filter_get(coap_opt_filter_t *filter, coap_option_num_t number);
 
@@ -405,8 +403,7 @@ coap_option_setb(coap_opt_filter_t *filter, uint16_t type) {
 
 /**
  * Clears the corresponding bit for @p type in @p filter. This function returns
- * @c 1 if bit was cleared or @c -1 on error (i.e. when the given type does not
- * fit in the filter).
+ * @c 1 if bit was cleared or @c -1 on error (i.e. bit not set).
  *
  * @deprecated Use coap_option_filter_unset() instead.
  *
@@ -422,15 +419,14 @@ coap_option_clrb(coap_opt_filter_t *filter, uint16_t type) {
 
 /**
  * Gets the corresponding bit for @p type in @p filter. This function returns @c
- * 1 if the bit is set @c 0 if not, or @c -1 on error (i.e. when the given type
- * does not fit in the filter).
+ * 1 if the bit is set @c 0 if not.
  *
  * @deprecated Use coap_option_filter_get() instead.
  *
  * @param filter The filter object to read bit from.
  * @param type   The type for which the bit should be read.
  *
- * @return       @c 1 if bit was set, @c 0 if not, @c -1 on error.
+ * @return       @c 1 if bit was set, @c 0 if not.
  */
 COAP_STATIC_INLINE COAP_DEPRECATED int
 coap_option_getb(coap_opt_filter_t *filter, uint16_t type) {

--- a/src/coap_option.c
+++ b/src/coap_option.c
@@ -153,7 +153,6 @@ coap_option_next(coap_opt_iterator_t *oi) {
   coap_option_t option;
   coap_opt_t *current_opt = NULL;
   size_t optsize;
-  int b;                   /* to store result of coap_option_getb() */
 
   assert(oi);
 
@@ -161,13 +160,15 @@ coap_option_next(coap_opt_iterator_t *oi) {
     return NULL;
 
   while (1) {
-    /* oi->option always points to the next option to deliver; as
+    /* oi->next_option always points to the next option to deliver; as
      * opt_finished() filters out any bad conditions, we can assume that
-     * oi->option is valid. */
+     * oi->next_option is valid. */
     current_opt = oi->next_option;
 
-    /* Advance internal pointer to next option, skipping any option that
-     * is not included in oi->filter. */
+    /*
+     * Advance internal pointer to next option.
+     * optsize will be 0 when no more options
+     */
     optsize = coap_opt_parse(oi->next_option, oi->length, &option);
     if (optsize) {
       assert(optsize <= oi->length);
@@ -184,15 +185,10 @@ coap_option_next(coap_opt_iterator_t *oi) {
     /* Exit the while loop when:
      *   - no filtering is done at all
      *   - the filter matches for the current option
-     *   - the filter is too small for the current option number
      */
     if (!oi->filtered ||
-        (b = coap_option_filter_get(&oi->filter, oi->number)) > 0)
+        coap_option_filter_get(&oi->filter, oi->number) > 0)
       break;
-    else if (b < 0) {                /* filter too small, cannot proceed */
-      oi->bad = 1;
-      return NULL;
-    }
   }
 
   return current_opt;

--- a/src/net.c
+++ b/src/net.c
@@ -684,13 +684,6 @@ coap_option_check_critical(coap_session_t *session,
   coap_option_iterator_init(pdu, &opt_iter, COAP_OPT_ALL);
 
   while (coap_option_next(&opt_iter)) {
-
-    /* The following condition makes use of the fact that
-     * coap_option_getb() returns -1 if type exceeds the bit-vector
-     * filter. As the vector is supposed to be large enough to hold
-     * the largest known option, we know that everything beyond is
-     * bad.
-     */
     if (opt_iter.number & 0x01) {
       /* first check the known built-in critical options */
       switch (opt_iter.number) {
@@ -726,10 +719,10 @@ coap_option_check_critical(coap_session_t *session,
           coap_log(LOG_DEBUG, "unknown critical option %d\n", opt_iter.number);
           ok = 0;
 
-          /* When opt_iter.number is beyond our known option range,
-           * coap_option_filter_set() will return -1 and we are safe to leave
-           * this loop. */
-          if (coap_option_filter_set(unknown, opt_iter.number) == -1) {
+          /* When opt_iter.number cannot be set in unknown, all of the appropriate
+           * slots have been used up and no more options can be tracked.
+           * Safe to break out of this loop as ok is already set. */
+          if (coap_option_filter_set(unknown, opt_iter.number) == 0) {
             break;
           }
         }


### PR DESCRIPTION
Correct documented return values from changes back in 2015 for option filter checking (option numbers could only be 1 byte then).

Correct code in coap_option_next() that assumed one of the defunct return values.