### PR TITLE
option checking: Do further option syntax checking for incoming PDUs

### DIFF
--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -299,7 +299,7 @@ size_t coap_update_option(coap_pdu_t *pdu,
 
 size_t coap_pdu_encode_header(coap_pdu_t *pdu, coap_proto_t proto);
 
- /**
+/**
  * Updates token in @p pdu with length @p len and @p data.
  * This function returns @c 0 on error or a value greater than zero on success.
  *
@@ -312,6 +312,16 @@ size_t coap_pdu_encode_header(coap_pdu_t *pdu, coap_proto_t proto);
 int coap_update_token(coap_pdu_t *pdu,
                       size_t len,
                       const uint8_t *data);
+
+/**
+ * Check whether the option is allowed to be repeated or not.
+ * This function returns @c 0 if not repeatable or @c 1 if repeatable
+ *
+ * @param number The option number to check for repeatability.
+ *
+ * @return     @c 0 if not repeatable or @c 1 if repeatable.
+ */
+int coap_option_check_repeatable(coap_option_num_t number);
 
 /** @} */
 

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -439,8 +439,8 @@ coap_remove_option(coap_pdu_t *pdu, coap_option_num_t number) {
   return 1;
 }
 
-static int
-check_repeatable(coap_option_num_t number) {
+int
+coap_option_check_repeatable(coap_option_num_t number) {
   /* Validate that the option is repeatable */
   switch (number) {
   /* Ignore list of genuine repeatable */
@@ -515,7 +515,7 @@ coap_insert_option(coap_pdu_t *pdu, coap_option_num_t number, size_t len,
     return 0;
   opt_delta = opt_iter.number - number;
   if (opt_delta == 0) {
-    if (!check_repeatable(number))
+    if (!coap_option_check_repeatable(number))
       return 0;
   }
 
@@ -630,7 +630,7 @@ coap_add_option_internal(coap_pdu_t *pdu, coap_option_num_t number, size_t len,
   assert(pdu);
 
   if (number == pdu->max_opt) {
-    if (!check_repeatable(number))
+    if (!coap_option_check_repeatable(number))
       return 0;
   }
 


### PR DESCRIPTION
Extend coap_option_check_critical() for repeating options that are not repeatable, so 4.02 error code can be returned.
https://www.rfc-editor.org/rfc/rfc7252#section-5.4.5

Check for option Proxy-Scheme and return 4.02 if option Uri-Host is not present.

Clear M bit for option Block2 in a request as it must be ingnored on reception. https://datatracker.ietf.org/doc/html/rfc7959#section-2.2

check_repeatable() now is coap_option_check_repeatable() (still internal).

Found when testing #970 and #971