### PR TITLE
github workflows: Support Ubuntu 22.04 images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,20 +81,20 @@ jobs:
       - name: setup
         run: |
           sudo apt-get update && sudo apt-get install -y libcunit1-dev libmbedtls-dev libgnutls28-dev
-          cmake -E make_directory $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
+          cmake -E make_directory $GITHUB_WORKSPACE/build-${{matrix.TLS}}-cmake
       - name: configure no-TLS
         if: matrix.TLS == 'no'
         run: |
-          cd $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
+          cd $GITHUB_WORKSPACE/build-${{matrix.TLS}}-cmake
           cmake $GITHUB_WORKSPACE -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -DENABLE_DTLS=OFF -DENABLE_DOCS=OFF -DWARNING_TO_ERROR=ON
       - name: configure TLS
         if: matrix.TLS != 'no'
         run: |
-          cd $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
+          cd $GITHUB_WORKSPACE/build-${{matrix.TLS}}-cmake
           cmake $GITHUB_WORKSPACE -DENABLE_EXAMPLES=ON -DENABLE_TESTS=ON -DENABLE_DTLS=ON -DENABLE_DOCS=OFF -DDTLS_BACKEND=${{matrix.TLS}} -DWARNING_TO_ERROR=ON
       - name: build
         run: |
-          cd $GITHUB_WORKSPACE}/build-${{matrix.TLS}}-cmake
+          cd $GITHUB_WORKSPACE/build-${{matrix.TLS}}-cmake
           cmake --build .
   cmake-macos:
     runs-on: macos-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ function(compile_tinydtls)
 
   externalproject_add_step(
     external_tinydtls autoreconf
-    COMMAND autoreconf --force --install
+    COMMAND ./autogen.sh
     ALWAYS 1
     WORKING_DIRECTORY "${TINYDTLS_SOURCES_DIR}"
     DEPENDERS configure

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status: develop](https://github.com/obgm/libcoap/actions/workflows/main.yml/badge.svg?branch=develop)](https://github.com/obgm/libcoap/actions?query=branch:develop)
 [![Static Analysis](https://scan.coverity.com/projects/10970/badge.svg?flat=1)](https://scan.coverity.com/projects/obgm-libcoap)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/libcoap.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:libcoap)
+[![CIFuzz Status](https://github.com/obgm/libcoap/actions/workflows/cifuzz.yml/badge.svg?branch=develop)](https://github.com/obgm/libcoap/actions/workflows/cifuzz.yml)
 
 Copyright (C) 2010—2022 by Olaf Bergmann <bergmann@tzi.org> and others
 

--- a/configure.ac
+++ b/configure.ac
@@ -164,6 +164,11 @@ AX_CHECK_COMPILE_FLAG([-Wlogical-op], [WARNING_CFLAGS="$WARNING_CFLAGS -Wlogical
 AX_CHECK_COMPILE_FLAG([-fdiagnostics-color], [CFLAGS="$CFLAGS -fdiagnostics-color"],,[-Werror])
 AX_CHECK_COMPILE_FLAG([-Wunused-result], [WARNING_CFLAGS="$WARNING_CFLAGS -Wunused-result"])
 
+# clang 14+ generates dwarf-5, which is not currently supported by valgrind
+if test "x$CC" = "xclang"; then
+    WARNING_CFLAGS="$WARNING_CFLAGS -gdwarf-4"
+fi
+
 AC_SUBST([WARNING_CFLAGS])
 
 AX_CHECK_LINK_FLAG([-Wl,--version-script=${srcdir}/libcoap-${LIBCOAP_API_VERSION}.map],


### PR DESCRIPTION
Fix issues thrown up with ubuntu-latest moving to ubuntu-22.04.

clang 14+ generates dwarf-5 code which valgrind does not currently support so downgrade to output dwarf-4.

Use ./autogen.sh for tinydtls builds rather than 'autorecond --force --install'

Remove some spurios } in the workflow