### PR TITLE
coap_io_process_with_fds: Move mutex protected variables into coap_context_t

### DIFF
--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -146,7 +146,13 @@ struct coap_context_t {
   int epfd;                        /**< External FD for epoll */
   int eptimerfd;                   /**< Internal FD for timeout */
   coap_tick_t next_timeout;        /**< When the next timeout is to occur */
-#endif /* COAP_EPOLL_SUPPORT */
+#else /* ! COAP_EPOLL_SUPPORT */
+  fd_set readfds, writefds, exceptfds; /**< Used for select call
+                                            in coap_io_process_with_fds() */
+  coap_socket_t *sockets[64];      /**< Track different socket information
+                                        in coap_io_process_with_fds */
+  unsigned int num_sockets;        /**< Number of sockets being tracked */
+#endif /* ! COAP_EPOLL_SUPPORT */
 #if COAP_SERVER_SUPPORT
   uint8_t observe_pending;         /**< Observe response pending */
   uint8_t mcast_per_resource;      /**< Mcast controlled on a per resource


### PR DESCRIPTION
coap_io_process_with_fds() can lock up a mutex for a long time for stack constrained systems.

If 2 threads (in embedded system) provide client and server functionality using separate coap_context_t, then there will be random delays on the other thread while the first is waiting having called coap_io_process() or coap_io_process_with_fds().

No thread should lock up a mutex for a long time.  Moved the (mutex protected) variables into coap_context_t so there is no need to use a mutex.

See issue #845.