### PR TITLE
Modeline: Correct vim modline syntax for missing files

### DIFF
--- a/man/coap_lwip.txt.in
+++ b/man/coap_lwip.txt.in
@@ -1,5 +1,5 @@
 // -*- mode:doc; -*-
-// vim: set syntax=asciidoc,tw=0:
+// vim: set syntax=asciidoc tw=0
 
 coap_lwip(3)
 ============

--- a/man/coap_uri.txt.in
+++ b/man/coap_uri.txt.in
@@ -1,5 +1,5 @@
 // -*- mode:doc; -*-
-// vim: set syntax=asciidoc,tw=0:
+// vim: set syntax=asciidoc tw=0
 
 coap_uri(3)
 ============


### PR DESCRIPTION
The modline entries for Vim were not correct, various options get declared by a space in between, and also no special character at the end of the line are allowed.