### PR TITLE
Reliable: Fix usage of PDU type and mid

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -529,6 +529,10 @@ coap_add_data_large_internal(coap_session_t *session,
     goto add_data;
   }
 
+  /* A lot of the reliable code assumes type is CON */
+  if (COAP_PROTO_RELIABLE(session->proto) && pdu->type == COAP_MESSAGE_NON)
+    pdu->type = COAP_MESSAGE_CON;
+
   /* Block NUM max 20 bits and block size is "2**(SZX + 4)"
      and using SZX max of 6 gives maximum size = 1,073,740,800
      CSM Max-Message-Size theoretical maximum = 4,294,967,295

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -219,7 +219,9 @@ coap_make_session(coap_proto_t proto, coap_session_type_t type,
   session->last_con_mid = COAP_INVALID_MID;
 
   /* Randomly initialize */
-  coap_prng((unsigned char *)&session->tx_mid, sizeof(session->tx_mid));
+  /* TCP/TLS have no notion of mid */
+  if (COAP_PROTO_NOT_RELIABLE(session->proto))
+    coap_prng((unsigned char *)&session->tx_mid, sizeof(session->tx_mid));
   coap_prng((unsigned char *)&session->tx_rtag, sizeof(session->tx_rtag));
 
   return session;
@@ -1434,7 +1436,10 @@ void coap_session_new_token(coap_session_t *session, size_t *len,
 
 uint16_t
 coap_new_message_id(coap_session_t *session) {
-  return ++session->tx_mid;
+  if (COAP_PROTO_NOT_RELIABLE(session->proto))
+    return ++session->tx_mid;
+  /* TCP/TLS have no notion of mid */
+  return 0;
 }
 
 const coap_address_t *

--- a/src/net.c
+++ b/src/net.c
@@ -927,7 +927,7 @@ coap_send_message_type(coap_session_t *session, const coap_pdu_t *request,
   coap_pdu_t *response;
   coap_mid_t result = COAP_INVALID_MID;
 
-  if (request) {
+  if (request && COAP_PROTO_NOT_RELIABLE(session->proto)) {
     response = coap_pdu_init(type, 0, request->mid, 0);
     if (response)
       result = coap_send_internal(session, response);
@@ -1099,6 +1099,10 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
   int observe_action = -1;
   int have_block1 = 0;
   coap_opt_t *opt;
+
+  /* A lot of the reliable code assumes type is CON */
+  if (COAP_PROTO_RELIABLE(session->proto) && pdu->type == COAP_MESSAGE_NON)
+    pdu->type = COAP_MESSAGE_CON;
 
   if (!(session->block_mode & COAP_BLOCK_USE_LIBCOAP)) {
     return coap_send_internal(session, pdu);

--- a/src/resource.c
+++ b/src/resource.c
@@ -942,7 +942,9 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
       token.s = obs->pdu->token;
 
       obs->pdu->mid = response->mid = coap_new_message_id(obs->session);
-      if ((r->flags & COAP_RESOURCE_FLAGS_NOTIFY_CON) == 0 &&
+      /* A lot of the reliable code assumes type is CON */
+      if (COAP_PROTO_NOT_RELIABLE(obs->session->proto) &&
+          (r->flags & COAP_RESOURCE_FLAGS_NOTIFY_CON) == 0 &&
           ((r->flags & COAP_RESOURCE_FLAGS_NOTIFY_NON_ALWAYS) ||
            obs->non_cnt < COAP_OBS_MAX_NON)) {
         response->type = COAP_MESSAGE_NON;


### PR DESCRIPTION
Reliable code expects type to be CON and can get confused by NON.

Having random values for mid for reliable sessions makes no sense as the mid is not in the packet..

Only send out RST if non-reliable session.