### PR TITLE
logging: Use new logging macros for examples and man pages

### DIFF
--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -169,7 +169,7 @@ hnd_put_resource(coap_resource_t *resource COAP_UNUSED,
 
         tmp.s = (unsigned char *)coap_malloc(tmp.length);
         if (!tmp.s) {
-          coap_log(LOG_DEBUG,
+          coap_log_debug(
                    "hnd_put_rd: cannot allocate storage for new rd\n");
           code = COAP_RESPONSE_CODE_SERVICE_UNAVAILABLE;
           goto finish;
@@ -200,7 +200,7 @@ hnd_put_resource(coap_resource_t *resource COAP_UNUSED,
   response = coap_pdu_init(type, code, request->hdr->id, size);
 
   if (!response) {
-    coap_log(LOG_DEBUG, "cannot create response for mid=0x%x\n",
+    coap_log_debug("cannot create response for mid=0x%x\n",
              request->hdr->id);
     return;
   }
@@ -209,7 +209,7 @@ hnd_put_resource(coap_resource_t *resource COAP_UNUSED,
     coap_add_token(response, request->hdr->token_length, request->hdr->token);
 
   if (coap_send(ctx, peer, response) == COAP_INVALID_MID) {
-    coap_log(LOG_DEBUG, "hnd_get_rd: cannot send response for mid=0x%x\n",
+    coap_log_debug("hnd_get_rd: cannot send response for mid=0x%x\n",
     request->hdr->id);
   }
 #endif
@@ -374,14 +374,14 @@ make_rd(const coap_pdu_t *pdu) {
   rd = rd_new();
 
   if (!rd) {
-    coap_log(LOG_DEBUG, "hnd_get_rd: cannot allocate storage for rd\n");
+    coap_log_debug("hnd_get_rd: cannot allocate storage for rd\n");
     return NULL;
   }
 
   if (coap_get_data(pdu, &rd->data.length, &data)) {
     rd->data.s = (unsigned char *)coap_malloc(rd->data.length);
     if (!rd->data.s) {
-      coap_log(LOG_DEBUG, "hnd_get_rd: cannot allocate storage for rd->data\n");
+      coap_log_debug("hnd_get_rd: cannot allocate storage for rd->data\n");
       rd_delete(rd);
       return NULL;
     }
@@ -639,7 +639,7 @@ static void
 fill_keystore(coap_context_t *ctx) {
   if (cert_file == NULL && key_defined == 0) {
     if (coap_dtls_is_supported() || coap_tls_is_supported()) {
-      coap_log(LOG_DEBUG,
+      coap_log_debug(
                "(D)TLS not enabled as neither -k or -c options specified\n");
     }
   }
@@ -747,10 +747,10 @@ get_context(const char *node, const char *port) {
         if (coap_dtls_is_supported() && (key_defined || cert_file)) {
           ep_dtls = coap_new_endpoint(ctx, &addrs, COAP_PROTO_DTLS);
           if (!ep_dtls)
-            coap_log(LOG_CRIT, "cannot create DTLS endpoint\n");
+            coap_log_crit("cannot create DTLS endpoint\n");
         }
       } else {
-        coap_log(LOG_CRIT, "cannot create UDP endpoint\n");
+        coap_log_crit("cannot create UDP endpoint\n");
         continue;
       }
       ep_tcp = coap_new_endpoint(ctx, &addr, COAP_PROTO_TCP);
@@ -758,10 +758,10 @@ get_context(const char *node, const char *port) {
         if (coap_tls_is_supported() && (key_defined || cert_file)) {
           ep_tls = coap_new_endpoint(ctx, &addrs, COAP_PROTO_TLS);
           if (!ep_tls)
-            coap_log(LOG_CRIT, "cannot create TLS endpoint\n");
+            coap_log_crit("cannot create TLS endpoint\n");
         }
       } else {
-        coap_log(LOG_CRIT, "cannot create TCP endpoint\n");
+        coap_log_crit("cannot create TCP endpoint\n");
       }
       if (ep_udp)
         goto finish;
@@ -818,7 +818,7 @@ main(int argc, char **argv) {
     case 'k' :
       key_length = cmdline_read_key(optarg, key, MAX_KEY);
       if (key_length < 0) {
-        coap_log( LOG_CRIT, "Invalid Pre-Shared Key specified\n" );
+        coap_log_crit("Invalid Pre-Shared Key specified\n" );
         break;
       }
       key_defined = 1;

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -401,7 +401,7 @@ hnd_get_async(coap_resource_t *resource,
                 "async: query is just a number of seconds to alter delay\n");
       }
       if (delay == 0) {
-        coap_log(LOG_INFO, "async: delay of 0 not supported\n");
+        coap_log_info("async: delay of 0 not supported\n");
         coap_pdu_set_code(response, COAP_RESPONSE_CODE_BAD_REQUEST);
         return;
       }
@@ -531,9 +531,9 @@ hnd_put_example_data(coap_resource_t *resource,
     }
     if (!cache_entry) {
       if (offset == 0) {
-        coap_log(LOG_WARNING, "Unable to create a new cache entry\n");
+        coap_log_warn("Unable to create a new cache entry\n");
       } else {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "No cache entry available for the non-first BLOCK\n");
       }
       coap_pdu_set_code(response, COAP_RESPONSE_CODE_INTERNAL_ERROR);
@@ -698,7 +698,7 @@ get_uri_proxy_scheme_info(const coap_pdu_t *request,
     uri->scheme = COAP_URI_SCHEME_COAP;
     uri->port = COAP_DEFAULT_PORT;
   } else {
-    coap_log(LOG_WARNING, "Unsupported Proxy Scheme '%*.*s'\n",
+    coap_log_warn("Unsupported Proxy Scheme '%*.*s'\n",
              opt_len, opt_len, opt_val);
     return 0;
   }
@@ -708,7 +708,7 @@ get_uri_proxy_scheme_info(const coap_pdu_t *request,
     uri->host.length = coap_opt_length(opt);
     uri->host.s = coap_opt_value(opt);
   } else {
-    coap_log(LOG_WARNING, "Proxy Scheme requires Uri-Host\n");
+    coap_log_warn("Proxy Scheme requires Uri-Host\n");
     return 0;
   }
   opt = coap_check_option(request, COAP_OPTION_URI_PORT, &opt_iter);
@@ -737,33 +737,33 @@ verify_proxy_scheme_supported(coap_uri_scheme_t scheme) {
   switch (scheme) {
   case COAP_URI_SCHEME_HTTP:
   case COAP_URI_SCHEME_HTTPS:
-  coap_log(LOG_WARNING, "Proxy URI http or https not supported\n");
+  coap_log_warn("Proxy URI http or https not supported\n");
     return 0;
   case COAP_URI_SCHEME_COAP:
     break;
   case COAP_URI_SCHEME_COAPS:
     if (!coap_dtls_is_supported()) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
         "coaps URI scheme not supported for proxy\n");
       return 0;
     }
     break;
   case COAP_URI_SCHEME_COAP_TCP:
     if (!coap_tcp_is_supported()) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
         "coap+tcp URI scheme not supported for proxy\n");
       return 0;
     }
     break;
   case COAP_URI_SCHEME_COAPS_TCP:
     if (!coap_tls_is_supported()) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
         "coaps+tcp URI scheme not supported for proxy\n");
       return 0;
     }
     break;
   default:
-      coap_log(LOG_WARNING,
+      coap_log_warn(
         "%d URI scheme not supported\n", scheme);
     break;
   }
@@ -858,20 +858,20 @@ remove_proxy_association(coap_session_t *session, int send_failure) {
                                coap_new_message_id(proxy_list[i].incoming),
                           coap_session_max_pdu_size(proxy_list[i].incoming));
       if (!response) {
-        coap_log(LOG_INFO, "PDU creation issue\n");
+        coap_log_info("PDU creation issue\n");
         return;
       }
 
       if (proxy_list[i].token &&
           !coap_add_token(response, proxy_list[i].token->length,
                           proxy_list[i].token->s)) {
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
                        "Cannot add token to incoming proxy response PDU\n");
       }
 
       if (coap_send(proxy_list[i].incoming, response) ==
                                                           COAP_INVALID_MID) {
-        coap_log(LOG_INFO, "Failed to send PDU with 5.02 gateway issue\n");
+        coap_log_info("Failed to send PDU with 5.02 gateway issue\n");
       }
       break;
     }
@@ -1040,14 +1040,14 @@ hnd_proxy_uri(coap_resource_t *resource COAP_UNUSED,
    */
   proxy_uri = coap_check_option(request, COAP_OPTION_PROXY_URI, &opt_iter);
   if (proxy_uri) {
-    coap_log(LOG_INFO, "Proxy URI '%.*s'\n",
+    coap_log_info("Proxy URI '%.*s'\n",
              coap_opt_length(proxy_uri),
              (const char*)coap_opt_value(proxy_uri));
     if (coap_split_proxy_uri(coap_opt_value(proxy_uri),
                              coap_opt_length(proxy_uri),
                              &uri) < 0) {
       /* Need to return a 5.05 RFC7252 Section 5.7.2 */
-      coap_log(LOG_WARNING, "Proxy URI not decodable\n");
+      coap_log_warn("Proxy URI not decodable\n");
       coap_pdu_set_code(response,
                              COAP_RESPONSE_CODE_PROXYING_NOT_SUPPORTED);
       goto cleanup;
@@ -1086,7 +1086,7 @@ hnd_proxy_uri(coap_resource_t *resource COAP_UNUSED,
       assert(size == total);
       body_data = coap_new_binary(total);
       if (!body_data) {
-        coap_log(LOG_DEBUG, "body build memory error\n");
+        coap_log_debug("body build memory error\n");
         goto cleanup;
       }
       memcpy(body_data->s, data, size);
@@ -1111,7 +1111,7 @@ hnd_proxy_uri(coap_resource_t *resource COAP_UNUSED,
     }
 
     if (!coap_add_token(pdu, token.length, token.s)) {
-      coap_log(LOG_DEBUG, "cannot add token to proxy request\n");
+      coap_log_debug("cannot add token to proxy request\n");
       coap_pdu_set_code(response, COAP_RESPONSE_CODE_INTERNAL_ERROR);
       coap_delete_pdu(pdu);
       goto cleanup;
@@ -1124,7 +1124,7 @@ hnd_proxy_uri(coap_resource_t *resource COAP_UNUSED,
 
       if (coap_uri_into_options(&uri, &optlist, 1,
                                 buf, sizeof(buf)) < 0) {
-        coap_log(LOG_ERR, "Failed to create options for URI\n");
+        coap_log_err("Failed to create options for URI\n");
         goto cleanup;
       }
     }
@@ -1169,7 +1169,7 @@ add_in:
     if (size) {
       if (!coap_add_data_large_request(ongoing, pdu, size, data,
                                        release_proxy_body_data, body_data)) {
-        coap_log(LOG_DEBUG, "cannot add data to proxy request\n");
+        coap_log_debug("cannot add data to proxy request\n");
       } else {
         body_data = NULL;
       }
@@ -1186,7 +1186,7 @@ add_in:
     goto cleanup;
   } else {
     /* TODO http & https */
-    coap_log(LOG_ERR, "Proxy-Uri scheme %d unknown\n", uri.scheme);
+    coap_log_err("Proxy-Uri scheme %d unknown\n", uri.scheme);
   }
 cleanup:
   coap_delete_string(uri_path);
@@ -1417,9 +1417,9 @@ hnd_put_post(coap_resource_t *resource,
     }
     if (!cache_entry) {
       if (offset == 0) {
-        coap_log(LOG_WARNING, "Unable to create a new cache entry\n");
+        coap_log_warn("Unable to create a new cache entry\n");
       } else {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "No cache entry available for the non-first BLOCK\n");
       }
       coap_pdu_set_code(response, COAP_RESPONSE_CODE_INTERNAL_ERROR);
@@ -1630,11 +1630,11 @@ proxy_response_handler(coap_session_t *session,
     }
   }
   if (i == proxy_list_count) {
-    coap_log(LOG_DEBUG, "Unknown proxy ongoing session response received\n");
+    coap_log_debug("Unknown proxy ongoing session response received\n");
     return COAP_RESPONSE_OK;
   }
 
-  coap_log(LOG_DEBUG, "** process upstream incoming %d.%02d response:\n",
+  coap_log_debug("** process upstream incoming %d.%02d response:\n",
            COAP_RESPONSE_CLASS(rcv_code), rcv_code & 0x1F);
   if (coap_get_log_level() < LOG_DEBUG)
     coap_show_pdu(LOG_INFO, received);
@@ -1644,7 +1644,7 @@ proxy_response_handler(coap_session_t *session,
     assert(size == total);
     body_data = coap_new_binary(total);
     if (!body_data) {
-      coap_log(LOG_DEBUG, "body build memory error\n");
+      coap_log_debug("body build memory error\n");
       return COAP_RESPONSE_OK;
     }
     memcpy(body_data->s, data, size);
@@ -1659,12 +1659,12 @@ proxy_response_handler(coap_session_t *session,
                       coap_new_message_id(incoming),
                       coap_session_max_pdu_size(incoming));
   if (!pdu) {
-    coap_log(LOG_DEBUG, "Failed to create ongoing proxy response PDU\n");
+    coap_log_debug("Failed to create ongoing proxy response PDU\n");
     return COAP_RESPONSE_OK;
   }
 
   if (!coap_add_token(pdu, rcv_token.length, rcv_token.s)) {
-    coap_log(LOG_DEBUG, "cannot add token to ongoing proxy response PDU\n");
+    coap_log_debug("cannot add token to ongoing proxy response PDU\n");
   }
 
   /*
@@ -1828,7 +1828,7 @@ verify_cn_callback(const char *cn,
     void *v;
   } role = { .v = arg };
 
-  coap_log(LOG_INFO, "CN '%s' presented by %s (%s)\n",
+  coap_log_info("CN '%s' presented by %s (%s)\n",
            cn, role.r == COAP_DTLS_ROLE_SERVER ? "client" : "server",
            depth ? "CA" : "Certificate");
   return 1;
@@ -1912,11 +1912,11 @@ verify_pki_sni_callback(const char *sni,
 
   if (sni[0]) {
     size_t i;
-    coap_log(LOG_INFO, "SNI '%s' requested\n", sni);
+    coap_log_info("SNI '%s' requested\n", sni);
     for (i = 0; i < valid_pki_snis.count; i++) {
       /* Test for SNI to change cert + ca */
       if (strcasecmp(sni, valid_pki_snis.pki_sni_list[i].sni_match) == 0) {
-        coap_log(LOG_INFO, "Switching to using cert '%s' + ca '%s'\n",
+        coap_log_info("Switching to using cert '%s' + ca '%s'\n",
                  valid_pki_snis.pki_sni_list[i].new_cert,
                  valid_pki_snis.pki_sni_list[i].new_ca);
         update_pki_key(&dtls_key, valid_pki_snis.pki_sni_list[i].new_cert,
@@ -1926,7 +1926,7 @@ verify_pki_sni_callback(const char *sni,
       }
     }
   } else {
-    coap_log(LOG_DEBUG, "SNI not requested\n");
+    coap_log_debug("SNI not requested\n");
   }
   return &dtls_key;
 }
@@ -1945,12 +1945,12 @@ verify_psk_sni_callback(const char *sni,
   psk_info.key.length = key_length;
   if (sni) {
     size_t i;
-    coap_log(LOG_INFO, "SNI '%s' requested\n", sni);
+    coap_log_info("SNI '%s' requested\n", sni);
     for (i = 0; i < valid_psk_snis.count; i++) {
       /* Test for identity match to change key */
       if (strcasecmp(sni,
                  valid_psk_snis.psk_sni_list[i].sni_match) == 0) {
-        coap_log(LOG_INFO, "Switching to using '%.*s' hint + '%.*s' key\n",
+        coap_log_info("Switching to using '%.*s' hint + '%.*s' key\n",
                  (int)valid_psk_snis.psk_sni_list[i].new_hint->length,
                  valid_psk_snis.psk_sni_list[i].new_hint->s,
                  (int)valid_psk_snis.psk_sni_list[i].new_key->length,
@@ -1961,7 +1961,7 @@ verify_psk_sni_callback(const char *sni,
       }
     }
   } else {
-    coap_log(LOG_DEBUG, "SNI not requested\n");
+    coap_log_debug("SNI not requested\n");
   }
   return &psk_info;
 }
@@ -1975,7 +1975,7 @@ verify_id_callback(coap_bin_const_t *identity,
   const coap_bin_const_t *s_psk_key;
   size_t i;
 
-  coap_log(LOG_INFO, "Identity '%.*s' requested, current hint '%.*s'\n", (int)identity->length,
+  coap_log_info("Identity '%.*s' requested, current hint '%.*s'\n", (int)identity->length,
            identity->s,
            s_psk_hint ? (int)s_psk_hint->length : 0,
            s_psk_hint ? (const char *)s_psk_hint->s : "");
@@ -1989,7 +1989,7 @@ verify_id_callback(coap_bin_const_t *identity,
     }
     /* Test for identity match to change key */
     if (coap_binary_equal(identity, valid_ids.id_list[i].identity_match)) {
-      coap_log(LOG_INFO, "Switching to using '%.*s' key\n",
+      coap_log_info("Switching to using '%.*s' key\n",
                (int)valid_ids.id_list[i].new_key->length,
                valid_ids.id_list[i].new_key->s);
       return valid_ids.id_list[i].new_key;
@@ -2092,7 +2092,7 @@ fill_keystore(coap_context_t *ctx) {
 
   if (cert_file == NULL && key_defined == 0) {
     if (coap_dtls_is_supported() || coap_tls_is_supported()) {
-      coap_log(LOG_DEBUG,
+      coap_log_debug(
            "(D)TLS not enabled as none of -k, -c or -M options specified\n");
     }
     return;
@@ -2101,7 +2101,7 @@ fill_keystore(coap_context_t *ctx) {
     coap_dtls_pki_t *dtls_pki = setup_pki(ctx,
                                           COAP_DTLS_ROLE_SERVER, NULL);
     if (!coap_context_set_pki(ctx, dtls_pki)) {
-      coap_log(LOG_INFO, "Unable to set up %s keys\n",
+      coap_log_info("Unable to set up %s keys\n",
                is_rpk_not_cert ? "RPK" : "PKI");
       /* So we do not set up DTLS */
       cert_file = NULL;
@@ -2111,7 +2111,7 @@ fill_keystore(coap_context_t *ctx) {
     coap_dtls_spsk_t *dtls_spsk = setup_spsk();
 
     if (!coap_context_set_psk2(ctx, dtls_spsk)) {
-      coap_log(LOG_INFO, "Unable to set up PSK\n");
+      coap_log_info("Unable to set up PSK\n");
       /* So we do not set up DTLS */
       key_defined = 0;
     }
@@ -2332,10 +2332,10 @@ get_context(const char *node, const char *port) {
         if (coap_dtls_is_supported() && (key_defined || cert_file)) {
           ep_dtls = coap_new_endpoint(ctx, &addrs, COAP_PROTO_DTLS);
           if (!ep_dtls)
-            coap_log(LOG_CRIT, "cannot create DTLS endpoint\n");
+            coap_log_crit("cannot create DTLS endpoint\n");
         }
       } else {
-        coap_log(LOG_CRIT, "cannot create UDP endpoint\n");
+        coap_log_crit("cannot create UDP endpoint\n");
         continue;
       }
       if (coap_tcp_is_supported()) {
@@ -2346,10 +2346,10 @@ get_context(const char *node, const char *port) {
             coap_endpoint_t *ep_tls;
             ep_tls = coap_new_endpoint(ctx, &addrs, COAP_PROTO_TLS);
             if (!ep_tls)
-              coap_log(LOG_CRIT, "cannot create TLS endpoint\n");
+              coap_log_crit("cannot create TLS endpoint\n");
           }
         } else {
-          coap_log(LOG_CRIT, "cannot create TCP endpoint\n");
+          coap_log_crit("cannot create TCP endpoint\n");
         }
       }
       if (ep_udp)
@@ -2374,7 +2374,7 @@ cmdline_proxy(char *arg) {
   size_t ofs;
 
   if (!host_start) {
-    coap_log(LOG_WARNING, "Zero or more proxy host names not defined\n");
+    coap_log_warn("Zero or more proxy host names not defined\n");
     return 0;
   }
   *host_start = '\000';
@@ -2383,7 +2383,7 @@ cmdline_proxy(char *arg) {
     /* Next upstream proxy is defined */
     if (coap_split_uri((unsigned char *)arg, strlen(arg), &proxy) < 0 ||
         proxy.path.length != 0 || proxy.query.length != 0) {
-      coap_log(LOG_ERR, "invalid CoAP Proxy definition\n");
+      coap_log_err("invalid CoAP Proxy definition\n");
       return 0;
     }
   }
@@ -2425,7 +2425,7 @@ cmdline_read_key(char *arg, unsigned char **buf, size_t maxlen) {
     return len;
   }
   /* Need at least one byte for the pre-shared key */
-  coap_log( LOG_CRIT, "Invalid Pre-Shared Key specified\n" );
+  coap_log_crit("Invalid Pre-Shared Key specified\n" );
   return -1;
 }
 
@@ -2433,7 +2433,7 @@ static int cmdline_read_psk_sni_check(char *arg) {
   FILE *fp = fopen(arg, "r");
   static char tmpbuf[256];
   if (fp == NULL) {
-    coap_log(LOG_ERR, "SNI file: %s: Unable to open\n", arg);
+    coap_log_err("SNI file: %s: Unable to open\n", arg);
     return 0;
   }
   while (fgets(tmpbuf, sizeof(tmpbuf), fp) != NULL) {
@@ -2478,7 +2478,7 @@ cmdline_read_identity_check(char *arg) {
   FILE *fp = fopen(arg, "r");
   static char tmpbuf[256];
   if (fp == NULL) {
-    coap_log(LOG_ERR, "Identity file: %s: Unable to open\n", arg);
+    coap_log_err("Identity file: %s: Unable to open\n", arg);
     return 0;
   }
   while (fgets(tmpbuf, sizeof(tmpbuf), fp) != NULL) {
@@ -2523,7 +2523,7 @@ cmdline_read_pki_sni_check(char *arg) {
   FILE *fp = fopen(arg, "r");
   static char tmpbuf[256];
   if (fp == NULL) {
-    coap_log(LOG_ERR, "SNI file: %s: Unable to open\n", arg);
+    coap_log_err("SNI file: %s: Unable to open\n", arg);
     return 0;
   }
   while (fgets(tmpbuf, sizeof(tmpbuf), fp) != NULL) {
@@ -2557,13 +2557,13 @@ cmdline_read_pki_sni_check(char *arg) {
                              strndup(cp, strlen(cp));
         if (access(valid_pki_snis.pki_sni_list[valid_pki_snis.count].new_cert,
             R_OK)) {
-          coap_log(LOG_ERR, "SNI file: Cert File: %s: Unable to access\n",
+          coap_log_err("SNI file: Cert File: %s: Unable to access\n",
                    valid_pki_snis.pki_sni_list[valid_pki_snis.count].new_cert);
           fail = 1;
         }
         if (access(valid_pki_snis.pki_sni_list[valid_pki_snis.count].new_ca,
             R_OK)) {
-          coap_log(LOG_ERR, "SNI file: CA File: %s: Unable to access\n",
+          coap_log_err("SNI file: CA File: %s: Unable to access\n",
                    valid_pki_snis.pki_sni_list[valid_pki_snis.count].new_ca);
           fail = 1;
         }
@@ -2575,7 +2575,7 @@ cmdline_read_pki_sni_check(char *arg) {
           valid_pki_snis.count++;
         }
       } else {
-        coap_log(LOG_ERR,
+        coap_log_err(
                 "SNI file: SNI_match,Use_Cert_file,Use_CA_file not defined\n");
         free(valid_pki_snis.pki_sni_list[valid_pki_snis.count].sni_match);
       }
@@ -2816,7 +2816,7 @@ main(int argc, char **argv) {
       result = select (nfds, &readfds, NULL, NULL, &tv);
       if (result == -1) {
         if (errno != EAGAIN) {
-          coap_log(LOG_DEBUG, "select: %s (%d)\n", coap_socket_strerror(), errno);
+          coap_log_debug("select: %s (%d)\n", coap_socket_strerror(), errno);
           break;
         }
       }

--- a/examples/coap_list.c
+++ b/examples/coap_list.c
@@ -35,7 +35,7 @@
 int
 coap_insert(coap_list_t **head, coap_list_t *node) {
   if (!node) {
-    coap_log(LOG_WARNING, "cannot create option Proxy-Uri\n");
+    coap_log_warn("cannot create option Proxy-Uri\n");
   } else {
     /* must append at the list end to avoid re-ordering of
      * options during sort */

--- a/examples/contiki/coap-observer.c
+++ b/examples/contiki/coap-observer.c
@@ -88,7 +88,7 @@ init_coap() {
   coap_set_log_level(LOG_DEBUG);
 
   if (!coap_context)
-    coap_log(LOG_CRIT, "cannot create CoAP context\r\n");
+    coap_log_crit("cannot create CoAP context\r\n");
 }
 
 void
@@ -100,7 +100,7 @@ message_handler(coap_context_t  *ctx,
   /* send ACK if received message is confirmable (i.e. a separate response) */
   coap_send_ack(ctx, remote, received);
 
-  coap_log(LOG_DEBUG, "** process incoming %d.%02d response:\n",
+  coap_log_debug("** process incoming %d.%02d response:\n",
         (received->hdr->code >> 5), received->hdr->code & 0x1F);
   coap_show_pdu(LOG_WARNING, received);
 
@@ -117,7 +117,7 @@ PROCESS_THREAD(coap_server_process, ev, data)
   init_coap();
 
   if (!coap_context) {
-    coap_log(LOG_EMERG, "cannot create context\n");
+    coap_log_emerg("cannot create context\n");
     PROCESS_EXIT();
   }
 

--- a/examples/contiki/server.c
+++ b/examples/contiki/server.c
@@ -81,7 +81,7 @@ init_coap_server(coap_context_t **ctx) {
   *ctx = coap_new_context(&listen_addr);
 
   if (!*ctx) {
-    coap_log(LOG_CRIT, "cannot create CoAP context\r\n");
+    coap_log_crit("cannot create CoAP context\r\n");
   }
 }
 
@@ -177,7 +177,7 @@ init_coap_resources(coap_context_t *ctx) {
 
   return;
  error:
-  coap_log(LOG_CRIT, "cannot create resource\n");
+  coap_log_crit("cannot create resource\n");
 }
 
 /* struct etimer notify_timer; */
@@ -192,14 +192,14 @@ PROCESS_THREAD(coap_server_process, ev, data)
   init_coap_server(&coap_context);
 
   if (!coap_context) {
-    coap_log(LOG_EMERG, "cannot create context\n");
+    coap_log_emerg("cannot create context\n");
     PROCESS_EXIT();
   }
 
   init_coap_resources(coap_context);
 
   if (!coap_context) {
-    coap_log(LOG_EMERG, "cannot create context\n");
+    coap_log_emerg("cannot create context\n");
     PROCESS_EXIT();
   }
 

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -182,7 +182,7 @@ hnd_post_test(coap_resource_t *resource COAP_UNUSED,
   snprintf((char *)buf, buflen, "test/%p", (void *)test_payload);
   uri = coap_new_str_const(buf, strlen((char *)buf));
   if (!(test_payload && uri)) {
-    coap_log(LOG_CRIT, "cannot allocate new resource under /test");
+    coap_log_crit("cannot allocate new resource under /test");
     coap_pdu_set_code(response, COAP_RESPONSE_CODE_INTERNAL_ERROR);
     coap_free(test_payload);
     coap_free(uri);
@@ -271,7 +271,7 @@ hnd_put_test(coap_resource_t *resource,
 
   return;
  error:
-  coap_log(LOG_WARNING, "cannot modify resource\n");
+  coap_log_warn("cannot modify resource\n");
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_INTERNAL_ERROR);
 }
 
@@ -373,7 +373,7 @@ hnd_get_separate(coap_resource_t *resource COAP_UNUSED,
           delay = d < COAP_RESOURCE_CHECK_TIME_SEC
             ? COAP_RESOURCE_CHECK_TIME_SEC
             : d;
-          coap_log(LOG_DEBUG, "set delay to %lu\n", delay);
+          coap_log_debug("set delay to %lu\n", delay);
           break;
         }
       }
@@ -408,7 +408,7 @@ make_large(const char *filename) {
 
   /* read from specified input file */
   if (stat(filename, &statbuf) < 0) {
-    coap_log(LOG_WARNING, "cannot stat file %s\n", filename);
+    coap_log_warn("cannot stat file %s\n", filename);
     return NULL;
   }
 
@@ -418,7 +418,7 @@ make_large(const char *filename) {
 
   inputfile = fopen(filename, "r");
   if ( !inputfile ) {
-    coap_log(LOG_WARNING, "cannot read file %s\n", filename);
+    coap_log_warn("cannot read file %s\n", filename);
     coap_free(payload);
     return NULL;
   }
@@ -438,7 +438,7 @@ init_resources(coap_context_t *ctx) {
 
   test_payload = coap_new_payload(200);
   if (!test_payload) {
-    coap_log(LOG_CRIT, "cannot allocate resource /test");
+    coap_log_crit("cannot allocate resource /test");
   } else {
     test_payload->length = 13;
     memcpy(test_payload->data, "put data here", test_payload->length);
@@ -465,7 +465,7 @@ init_resources(coap_context_t *ctx) {
    * TD_COAP_BLOCK_02 */
   test_payload = make_large("etsi_iot_01_largedata.txt");
   if (!test_payload) {
-    coap_log(LOG_CRIT, "cannot allocate resource /large\n");
+    coap_log_crit("cannot allocate resource /large\n");
   } else {
     r = coap_resource_init(coap_make_str_const("large"), 0);
     coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_resource);
@@ -482,7 +482,7 @@ init_resources(coap_context_t *ctx) {
   /* For TD_COAP_CORE_12 */
   test_payload = coap_new_payload(20);
   if (!test_payload) {
-    coap_log(LOG_CRIT, "cannot allocate resource /seg1/seg2/seg3\n");
+    coap_log_crit("cannot allocate resource /seg1/seg2/seg3\n");
   } else {
     test_payload->length = 10;
     memcpy(test_payload->data, "segsegseg!", test_payload->length);

--- a/examples/lwip/client-coap.c
+++ b/examples/lwip/client-coap.c
@@ -64,7 +64,7 @@ nack_handler(coap_session_t *session COAP_UNUSED,
   case COAP_NACK_NOT_DELIVERABLE:
   case COAP_NACK_RST:
   case COAP_NACK_TLS_FAILED:
-    coap_log(LOG_ERR, "cannot send CoAP pdu\n");
+    coap_log_err("cannot send CoAP pdu\n");
     quit = 1;
     break;
   case COAP_NACK_ICMP_ISSUE:

--- a/examples/lwip/server-coap.c
+++ b/examples/lwip/server-coap.c
@@ -112,7 +112,7 @@ init_coap_resources(coap_context_t *ctx) {
 
   return;
  error:
-  coap_log(LOG_CRIT, "cannot create resource\n");
+  coap_log_crit("cannot create resource\n");
 }
 
 void server_coap_init(coap_lwip_input_wait_handler_t input_wait,

--- a/man/coap_async.txt.in
+++ b/man/coap_async.txt.in
@@ -147,7 +147,7 @@ hnd_get_with_delay(coap_session_t *session,
       for (size = query->length; size; --size, ++p)
         delay = delay * 10 + (*p - '0');
       if (delay == 0) {
-        coap_log(LOG_INFO, "async: delay of 0 not supported\n");
+        coap_log_info("async: delay of 0 not supported\n");
         coap_pdu_set_code(response, COAP_RESPONSE_CODE_BAD_REQUEST);
         return;
       }

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -315,7 +315,7 @@ unsigned char *data, size_t length, int observe) {
    */
   coap_session_new_token(session, &buflen, buf);
   if (!coap_add_token(pdu, buflen, buf)) {
-    coap_log(LOG_DEBUG, "cannot add token to request\n");
+    coap_log_debug("cannot add token to request\n");
     goto error;
   }
 

--- a/man/coap_cache.txt.in
+++ b/man/coap_cache.txt.in
@@ -283,10 +283,10 @@ hnd_put_example_data(coap_context_t *ctx,
     }
     if (!cache_entry) {
       if (offset == 0) {
-        coap_log(LOG_WARNING, "Unable to create a new cache entry\n");
+        coap_log_warn("Unable to create a new cache entry\n");
       }
       else {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "No cache entry available for the non-first BLOCK\n");
       }
       coap_pdu_set_code(response, COAP_RESPONSE_CODE_INTERNAL_ERROR);

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -1157,7 +1157,7 @@ verify_ih_callback(coap_str_const_t *hint,
   /* Remove (void) definition if variable is used */
   (void)c_session;
 
-  coap_log(LOG_INFO, "Identity Hint '%.*s' provided\n", (int)hint->length, hint->s);
+  coap_log_info("Identity Hint '%.*s' provided\n", (int)hint->length, hint->s);
 
   /* Just use the defined information for now as passed in by arg */
   return psk_info;

--- a/man/coap_endpoint_client.txt.in
+++ b/man/coap_endpoint_client.txt.in
@@ -303,7 +303,7 @@ verify_ih_callback(coap_str_const_t *hint,
   /* Remove (void) definition if variable is used */
   (void)c_session;
 
-  coap_log(LOG_INFO, "Identity Hint '%.*s' provided\n", (int)hint->length, hint->s);
+  coap_log_info("Identity Hint '%.*s' provided\n", (int)hint->length, hint->s);
 
   /* Just use the defined information for now as passed in by arg */
   return psk_info;

--- a/man/coap_endpoint_server.txt.in
+++ b/man/coap_endpoint_server.txt.in
@@ -503,7 +503,7 @@ verify_ih_callback(coap_str_const_t *hint,
   (void)c_session;
 
   snprintf(lhint, sizeof(lhint), "%.*s", (int)hint->length, hint->s);
-  coap_log(LOG_INFO, "Identity Hint '%s' provided\n", lhint);
+  coap_log_info("Identity Hint '%s' provided\n", lhint);
 
   /* Just use the defined information for now as passed in by arg */
   return psk_info;

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -319,7 +319,7 @@ coap_pdu_t *sent, coap_pdu_t *received, const coap_mid_t mid) {
   }
 
   if (rcv_type == COAP_MESSAGE_RST) {
-    coap_log(LOG_INFO, "got RST\n");
+    coap_log_info("got RST\n");
     return COAP_RESPONSE_OK;
   }
 

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -362,7 +362,7 @@ int main(int argc, char *argv[]){
     result = select (nfds, &readfds, NULL, NULL, NULL);
     if (result == -1) {
       if (errno != EAGAIN) {
-        coap_log(LOG_DEBUG, "select: %s (%d)\n", coap_socket_strerror(), errno);
+        coap_log_debug("select: %s (%d)\n", coap_socket_strerror(), errno);
         break;
       }
     }
@@ -442,7 +442,7 @@ int main(int argc, char *argv[]){
     nevents = epoll_wait(epoll_fd, events, MAX_EVENTS, -1);
     if (nevents == -1) {
       if (errno != EAGAIN) {
-        coap_log(LOG_DEBUG, "epoll_wait: %s (%d)\n", coap_socket_strerror(), errno);
+        coap_log_debug("epoll_wait: %s (%d)\n", coap_socket_strerror(), errno);
         break;
       }
     }
@@ -462,7 +462,7 @@ int main(int argc, char *argv[]){
   }
 
   if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, coap_fd, &ev) == -1) {
-    coap_log(LOG_DEBUG, "epoll_ctl: %s (%d)\n", coap_socket_strerror(), errno);
+    coap_log_debug("epoll_ctl: %s (%d)\n", coap_socket_strerror(), errno);
   }
   coap_free_context(ctx);
 

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -347,7 +347,7 @@ coap_optlist_t **options, unsigned char *data, size_t length, int observe) {
    */
   token++;
   if (!coap_add_token(pdu, sizeof(token), (unsigned char*)&token)) {
-    coap_log(LOG_DEBUG, "cannot add token to request\n");
+    coap_log_debug("cannot add token to request\n");
     goto error;
   }
 

--- a/man/coap_pdu_access.txt.in
+++ b/man/coap_pdu_access.txt.in
@@ -339,12 +339,12 @@ get_pdu_information(coap_pdu_t *pdu) {
   if (option) {
     uint32_t value = coap_decode_var_bytes(coap_opt_value(option),
                                            coap_opt_length(option));
-    coap_log(LOG_INFO, "Option OBSERVE, value %u\n", value);
+    coap_log_info("Option OBSERVE, value %u\n", value);
   }
   /* Iterate through all options */
   coap_option_iterator_init(pdu, &opt_iter, COAP_OPT_ALL);
   while ((option = coap_option_next(&opt_iter))) {
-    coap_log(LOG_INFO, "A: Option %d, Length %u\n",
+    coap_log_info("A: Option %d, Length %u\n",
              opt_iter.number, coap_opt_length(option));
   }
   /* Iterate through options, some ignored */
@@ -352,7 +352,7 @@ get_pdu_information(coap_pdu_t *pdu) {
   coap_option_filter_set(&ignore_options, COAP_OPTION_OBSERVE);
   coap_option_iterator_init(pdu, &opt_iter, &ignore_options);
   while ((option = coap_option_next(&opt_iter))) {
-    coap_log(LOG_INFO, "I: Option %d, Length %u\n",
+    coap_log_info("I: Option %d, Length %u\n",
              opt_iter.number, coap_opt_length(option));
   }
 

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -564,7 +564,7 @@ unsigned char *data, size_t length, int observe) {
    */
   coap_session_new_token(session, &buflen, buf);
   if (!coap_add_token(pdu, buflen, buf)) {
-    coap_log(LOG_DEBUG, "cannot add token to request\n");
+    coap_log_debug("cannot add token to request\n");
     goto error;
   }
 


### PR DESCRIPTION
Drop the use of syslog LOG_DEBUG etc. for coap_log() and use the coap_log_debug() etc. macros which make use of COAP_LOG_DEBUG etc.

Application examples updated, as well as the man page examples.

Continuation of work done in #891.