### PR TITLE
NACK: make sure token is correct as presented to NACK handler

### DIFF
--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -238,6 +238,19 @@ void coap_check_code_lg_xmit(const coap_session_t *session,
                              const coap_resource_t *resource,
                              const coap_string_t *query);
 
+#if COAP_CLIENT_SUPPORT
+/**
+ * The function checks if the token needs to be updated before PDU is
+ * presented to the application (only relevant to clients).
+ *
+ * @param session The session.
+ * @param pdu     The PDU to to check for updating.
+ */
+void coap_check_update_token(coap_session_t *session, coap_pdu_t *pdu);
+#else /* ! COAP_CLIENT_SUPPORT */
+#define coap_check_update_token(a,b)
+#endif /* ! COAP_CLIENT_SUPPORT */
+
 /** @} */
 
 #endif /* COAP_BLOCK_INTERNAL_H_ */

--- a/src/net.c
+++ b/src/net.c
@@ -1520,8 +1520,10 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
  }
 
   /* And finally delete the node */
-  if (node->pdu->type == COAP_MESSAGE_CON && context->nack_handler)
+  if (node->pdu->type == COAP_MESSAGE_CON && context->nack_handler) {
+    coap_check_update_token(node->session, node->pdu);
     context->nack_handler(node->session, node->pdu, COAP_NACK_TOO_MANY_RETRIES, node->id);
+  }
   coap_delete_node(node);
   return COAP_INVALID_MID;
 }
@@ -2107,8 +2109,10 @@ coap_cancel_session_messages(coap_context_t *context, coap_session_t *session,
     context->sendqueue = q->next;
     coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed 3\n",
              coap_session_str(session), q->id);
-    if (q->pdu->type == COAP_MESSAGE_CON && context->nack_handler)
+    if (q->pdu->type == COAP_MESSAGE_CON && context->nack_handler) {
+      coap_check_update_token(session, q->pdu);
       context->nack_handler(session, q->pdu, reason, q->id);
+    }
     coap_delete_node(q);
   }
 
@@ -2123,8 +2127,10 @@ coap_cancel_session_messages(coap_context_t *context, coap_session_t *session,
       p->next = q->next;
       coap_log(LOG_DEBUG, "** %s: mid=0x%x: removed 4\n",
                coap_session_str(session), q->id);
-      if (q->pdu->type == COAP_MESSAGE_CON && context->nack_handler)
+      if (q->pdu->type == COAP_MESSAGE_CON && context->nack_handler) {
+        coap_check_update_token(session, q->pdu);
         context->nack_handler(session, q->pdu, reason, q->id);
+      }
       coap_delete_node(q);
       q = p->next;
     } else {
@@ -3252,9 +3258,11 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
         coap_cancel(context, sent);
 
         if (!is_ping_rst) {
-          if(sent->pdu->type==COAP_MESSAGE_CON && context->nack_handler)
+          if(sent->pdu->type==COAP_MESSAGE_CON && context->nack_handler) {
+            coap_check_update_token(sent->session, sent->pdu);
             context->nack_handler(sent->session, sent->pdu,
                                   COAP_NACK_RST, sent->id);
+          }
         }
         else {
           if (context->pong_handler) {
@@ -3367,6 +3375,7 @@ cleanup:
   if (packet_is_bad) {
     if (sent) {
       if (context->nack_handler) {
+        coap_check_update_token(session, sent->pdu);
         context->nack_handler(session, sent->pdu, COAP_NACK_BAD_RESPONSE, sent->id);
       }
     }


### PR DESCRIPTION
For clients, update the stateless token used for subsequent block transmissions back to the token used for the coap_send() when reporting NACK errors.

See #949.