### PR TITLE
logging: Use the new logging macros for libcoap code

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -134,12 +134,12 @@ setup_block_b(coap_session_t *session, coap_pdu_t *pdu, coap_block_b_t *block,
       int new_blk_size;
 
       if (avail < 16) {         /* bad luck, this is the smallest block size */
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
                  "not enough space, even the smallest block does not fit\n");
         return 0;
       }
       new_blk_size = coap_flsll((long long)avail) - 5;
-      coap_log(LOG_DEBUG,
+      coap_log_debug(
                "decrease block size for %zu to %d\n", avail, new_blk_size);
       szx = block->szx;
       block->szx = new_blk_size;
@@ -162,7 +162,7 @@ coap_write_block_opt(coap_block_t *block, coap_option_num_t number,
 
   start = block->num << (block->szx + 4);
   if (block->num != 0 && data_length <= start) {
-    coap_log(LOG_DEBUG, "illegal block requested\n");
+    coap_log_debug("illegal block requested\n");
     return -2;
   }
 
@@ -195,7 +195,7 @@ coap_write_block_b_opt(coap_session_t *session, coap_block_b_t *block,
 
   start = block->num << (block->szx + 4);
   if (block->num != 0 && data_length <= start) {
-    coap_log(LOG_DEBUG, "illegal block requested\n");
+    coap_log_debug("illegal block requested\n");
     return -2;
   }
 
@@ -276,7 +276,7 @@ coap_add_data_blocked_response(const coap_pdu_t *request,
     if (coap_get_block(request, COAP_OPTION_BLOCK2, &block2)) {
       block2_requested = 1;
       if (block2.num != 0 && length <= (block2.num << (block2.szx + 4))) {
-        coap_log(LOG_DEBUG, "Illegal block requested (%d > last = %zu)\n",
+        coap_log_debug("Illegal block requested (%d > last = %zu)\n",
                  block2.num,
                  length >> (block2.szx + 4));
         response->code = COAP_RESPONSE_CODE(400);
@@ -388,7 +388,7 @@ coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
     return 0;
 
   if (!(session->block_mode & COAP_BLOCK_USE_LIBCOAP)) {
-    coap_log(LOG_DEBUG,
+    coap_log_debug(
              "** %s: coap_cancel_observe: COAP_BLOCK_USE_LIBCOAP not enabled\n",
              coap_session_str(session));
     return 0;
@@ -516,14 +516,14 @@ coap_add_data_large_internal(coap_session_t *session,
 
   assert(pdu);
   if (pdu->data) {
-    coap_log(LOG_WARNING, "coap_add_data_large: PDU already contains data\n");
+    coap_log_warn("coap_add_data_large: PDU already contains data\n");
     if (release_func)
       release_func(session, app_ptr);
     return 0;
   }
 
   if (!(session->block_mode & COAP_BLOCK_USE_LIBCOAP)) {
-    coap_log(LOG_DEBUG,
+    coap_log_debug(
              "** %s: coap_add_data_large: COAP_BLOCK_USE_LIBCOAP not enabled\n",
              coap_session_str(session));
     goto add_data;
@@ -541,7 +541,7 @@ coap_add_data_large_internal(coap_session_t *session,
 #define MAX_BLK_LEN (((1 << 20) - 1) * (1 << (6 + 4)))
 
   if (length > MAX_BLK_LEN) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "Size of large buffer restricted to 0x%x bytes\n", MAX_BLK_LEN);
     length = MAX_BLK_LEN;
   }
@@ -604,7 +604,7 @@ coap_add_data_large_internal(coap_session_t *session,
 
   if (avail < 16 && ((ssize_t)length > avail || have_block_defined)) {
     /* bad luck, this is the smallest block size */
-    coap_log(LOG_DEBUG,
+    coap_log_debug(
                 "not enough space, even the smallest block does not fit\n");
     goto fail;
   }
@@ -635,12 +635,12 @@ coap_add_data_large_internal(coap_session_t *session,
     /* Set up for displaying all the data in the pdu */
     pdu->body_data = data;
     pdu->body_length = length;
-    coap_log(LOG_DEBUG, "PDU presented by app.\n");
+    coap_log_debug("PDU presented by app.\n");
     coap_show_pdu(LOG_DEBUG, pdu);
     pdu->body_data = NULL;
     pdu->body_length = 0;
 
-    coap_log(LOG_DEBUG, "** %s: lg_xmit %p initialized\n",
+    coap_log_debug("** %s: lg_xmit %p initialized\n",
              coap_session_str(session), (void*)lg_xmit);
     /* Update lg_xmit with large data information */
     memset(lg_xmit, 0, sizeof(coap_lg_xmit_t));
@@ -766,7 +766,7 @@ coap_add_data_large_internal(coap_session_t *session,
     if (avail < (ssize_t)chunk) {
       /* chunk size change down */
       if (avail < 16) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                 "not enough space, even the smallest block does not fit\n");
         goto fail;
       }
@@ -874,7 +874,7 @@ coap_add_data_large_response(coap_resource_t *resource,
     if (coap_get_block_b(session, request, COAP_OPTION_BLOCK2, &block)) {
       block_requested = 1;
       if (block.num != 0 && length <= (block.num << (block.szx + 4))) {
-        coap_log(LOG_DEBUG, "Illegal block requested (%d > last = %zu)\n",
+        coap_log_debug("Illegal block requested (%d > last = %zu)\n",
                  block.num,
                  length >> (block.szx + 4));
         response->code = COAP_RESPONSE_CODE(400);
@@ -1144,7 +1144,7 @@ coap_block_new_lg_crcv(coap_session_t *session, coap_pdu_t *pdu,
   if (lg_crcv == NULL)
     return NULL;
 
-  coap_log(LOG_DEBUG,
+  coap_log_debug(
            "** %s: lg_crcv %p initialized - stateless token xxxx%012llx\n",
            coap_session_str(session), (void*)lg_crcv,
            STATE_TOKEN_BASE(state_token));
@@ -1203,7 +1203,7 @@ coap_block_delete_lg_crcv(coap_session_t *session,
   if (lg_crcv->pdu.token)
     coap_free_type(COAP_PDU_BUF, lg_crcv->pdu.token - lg_crcv->pdu.max_hdr_size);
   coap_free_type(COAP_STRING, lg_crcv->body_data);
-  coap_log(LOG_DEBUG, "** %s: lg_crcv %p released\n",
+  coap_log_debug("** %s: lg_crcv %p released\n",
            coap_session_str(session), (void*)lg_crcv);
   coap_delete_binary(lg_crcv->app_token);
   for (i = 0; i < lg_crcv->obs_token_cnt; i++) {
@@ -1223,7 +1223,7 @@ coap_block_delete_lg_srcv(coap_session_t *session,
 
   coap_delete_str_const(lg_srcv->uri_path);
   coap_free_type(COAP_STRING, lg_srcv->body_data);
-  coap_log(LOG_DEBUG, "** %s: lg_srcv %p released\n",
+  coap_log_debug("** %s: lg_srcv %p released\n",
          coap_session_str(session), (void*)lg_srcv);
   coap_free_type(COAP_LG_SRCV, lg_srcv);
 }
@@ -1246,7 +1246,7 @@ coap_block_delete_lg_xmit(coap_session_t *session,
   else
     coap_delete_string(lg_xmit->b.b2.query);
 
-  coap_log(LOG_DEBUG, "** %s: lg_xmit %p released\n",
+  coap_log_debug("** %s: lg_xmit %p released\n",
            coap_session_str(session), (void*)lg_xmit);
   coap_free_type(COAP_LG_XMIT, lg_xmit);
 }
@@ -1344,11 +1344,11 @@ coap_handle_request_send_block(coap_session_t *session,
   chunk = (size_t)1 << (p->blk_size + 4);
   if (block_opt) {
     if (block.bert) {
-      coap_log(LOG_DEBUG,
+      coap_log_debug(
                "found Block option, block is BERT, block nr. %u, M %d\n",
                block.num, block.m);
     } else {
-      coap_log(LOG_DEBUG,
+      coap_log_debug(
                "found Block option, block size is %u, block nr. %u, M %d\n",
                1 << (block.szx + 4), block.num, block.m);
     }
@@ -1362,11 +1362,11 @@ coap_handle_request_send_block(coap_session_t *session,
         p->blk_size = block.szx;
         chunk = (size_t)1 << (p->blk_size + 4);
         p->offset = block.num * chunk;
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
                  "new Block size is %u, block number %u completed\n",
                  1 << (block.szx + 4), block.num);
       } else {
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
                  "ignoring request to increase Block size, "
                  "next block is not aligned on requested block size "
                  "boundary. (%zu x %u mod %u = %zu (which is not 0)\n",
@@ -1669,7 +1669,7 @@ coap_handle_request_put_block(coap_context_t *context,
         response->code = COAP_RESPONSE_CODE(500);
         goto skip_app_handler;
       }
-      coap_log(LOG_DEBUG, "** %s: lg_srcv %p initialized\n",
+      coap_log_debug("** %s: lg_srcv %p initialized\n",
                coap_session_str(session), (void*)p);
       memset(p, 0, sizeof(coap_lg_srcv_t));
       coap_ticks(&p->last_used);
@@ -1770,7 +1770,7 @@ coap_handle_request_put_block(coap_context_t *context,
         pdu->body_length = p->total_len;
         pdu->body_offset = 0;
         pdu->body_total = p->total_len;
-        coap_log(LOG_DEBUG, "Server app version of updated PDU\n");
+        coap_log_debug("Server app version of updated PDU\n");
         coap_show_pdu(LOG_DEBUG, pdu);
         *pfree_lg_srcv = p;
         goto call_app_handler;
@@ -1946,11 +1946,11 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *sent,
         coap_get_block_b(session, rcvd, p->option, &block)) {
 
       if (block.bert) {
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
                  "found Block option, block is BERT, block nr. %u (%zu)\n",
                  block.num, p->b.b1.bert_size);
       } else {
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
                  "found Block option, block size is %u, block nr. %u\n",
                  1 << (block.szx + 4), block.num);
       }
@@ -1964,13 +1964,13 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *sent,
           p->blk_size = block.szx;
           chunk = (size_t)1 << (p->blk_size + 4);
           p->offset = block.num * chunk;
-          coap_log(LOG_DEBUG,
+          coap_log_debug(
                    "new Block size is %u, block number %u completed\n",
                    1 << (block.szx + 4), block.num);
           block.bert = 0;
           block.aszx = block.szx;
         } else {
-          coap_log(LOG_DEBUG, "ignoring request to increase Block size, "
+          coap_log_debug("ignoring request to increase Block size, "
              "next block is not aligned on requested block size boundary. "
              "(%zu x %u mod %u = %zu != 0)\n",
              p->offset/chunk + 1, (1 << (p->blk_size + 4)),
@@ -2073,7 +2073,7 @@ lg_xmit_finished:
     if (p->b.b1.app_token)
       coap_update_token(rcvd, p->b.b1.app_token->length,
                         p->b.b1.app_token->s);
-    coap_log(LOG_DEBUG, "Client app version of updated PDU\n");
+    coap_log_debug("Client app version of updated PDU\n");
     coap_show_pdu(LOG_DEBUG, rcvd);
   }
 
@@ -2246,7 +2246,7 @@ coap_handle_response_get_block(coap_context_t *context,
             size_t len = coap_encode_var_safe8(buf, sizeof(token), token);
             coap_opt_filter_t drop_options;
 
-            coap_log(LOG_WARNING,
+            coap_log_warn(
                  "Data body updated during receipt - new request started\n");
             if (!(session->block_mode & COAP_BLOCK_SINGLE_BODY))
               coap_handle_event(context, COAP_EVENT_PARTIAL_BLOCK, session);
@@ -2275,12 +2275,12 @@ coap_handle_response_get_block(coap_context_t *context,
         }
         else if (p->etag_set) {
           /* Cannot handle this change in ETag to not being there */
-          coap_log(LOG_WARNING, "Not all blocks have ETag option\n");
+          coap_log_warn("Not all blocks have ETag option\n");
           goto fail_resp;
         }
 
         if (fmt != p->content_format) {
-          coap_log(LOG_WARNING, "Content-Format option mismatch\n");
+          coap_log_warn("Content-Format option mismatch\n");
           goto fail_resp;
         }
         if (block.num == 0) {
@@ -2382,7 +2382,7 @@ coap_handle_response_get_block(coap_context_t *context,
           }
           if (context->response_handler) {
             if (block.m != 0 || block.num != 0) {
-              coap_log(LOG_DEBUG, "Client app version of updated PDU\n");
+              coap_log_debug("Client app version of updated PDU\n");
               coap_show_pdu(LOG_DEBUG, rcvd);
             }
             if (context->response_handler(session, sent, rcvd,
@@ -2444,7 +2444,7 @@ fail_resp:
     if (!full_match(rcvd->token, rcvd->token_length,
                     p->app_token->s, p->app_token->length)) {
       coap_update_token(rcvd, p->app_token->length, p->app_token->s);
-      coap_log(LOG_DEBUG, "Client app version of updated PDU\n");
+      coap_log_debug("Client app version of updated PDU\n");
       coap_show_pdu(LOG_DEBUG, rcvd);
     }
     break;
@@ -2454,7 +2454,7 @@ fail_resp:
   if (recursive == COAP_RECURSE_OK && !p) {
     if (!sent) {
       if (coap_get_block_b(session, rcvd, COAP_OPTION_BLOCK2, &block)) {
-        coap_log(LOG_DEBUG, "** %s: large body receive internal issue\n",
+        coap_log_debug("** %s: large body receive internal issue\n",
                  coap_session_str(session));
         goto skip_app_handler;
       }
@@ -2502,7 +2502,7 @@ expire_lg_crcv:
   if (!full_match(rcvd->token, rcvd->token_length,
                   p->app_token->s, p->app_token->length)) {
     coap_update_token(rcvd, p->app_token->length, p->app_token->s);
-    coap_log(LOG_DEBUG, "Client app version of updated PDU\n");
+    coap_log_debug("Client app version of updated PDU\n");
     coap_show_pdu(LOG_DEBUG, rcvd);
   }
   /* Expire this entry */

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -61,7 +61,7 @@ coap_register_async(coap_session_t *session,
       snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
                 "%02x", request->token[i]);
     }
-    coap_log(LOG_DEBUG,
+    coap_log_debug(
          "asynchronous state for token '%s' already registered\n", outbuf);
     return NULL;
   }
@@ -69,7 +69,7 @@ coap_register_async(coap_session_t *session,
   /* store information for handling the asynchronous task */
   s = (coap_async_t *)coap_malloc(sizeof(coap_async_t));
   if (!s) {
-    coap_log(LOG_CRIT, "coap_register_async: insufficient memory\n");
+    coap_log_crit("coap_register_async: insufficient memory\n");
     return NULL;
   }
 
@@ -80,7 +80,7 @@ coap_register_async(coap_session_t *session,
                               request->token, NULL);
   if (s->pdu == NULL) {
     coap_free_async(session, s);
-    coap_log(LOG_CRIT, "coap_register_async: insufficient memory\n");
+    coap_log_crit("coap_register_async: insufficient memory\n");
     return NULL;
   }
 
@@ -102,7 +102,7 @@ coap_async_trigger(coap_async_t *async) {
   assert(async != NULL);
   coap_ticks(&async->delay);
 
-  coap_log(LOG_DEBUG, "   %s: Async request triggered\n",
+  coap_log_debug("   %s: Async request triggered\n",
            coap_session_str(async->session));
 #ifdef COAP_EPOLL_SUPPORT
   coap_update_epoll_timer(async->session->context, 0);
@@ -122,7 +122,7 @@ coap_async_set_delay(coap_async_t *async, coap_tick_t delay) {
 #ifdef COAP_EPOLL_SUPPORT
     coap_update_epoll_timer(async->session->context, delay);
 #endif /* COAP_EPOLL_SUPPORT */
-    coap_log(LOG_DEBUG, "   %s: Async request delayed for %u.%03u secs\n",
+    coap_log_debug("   %s: Async request delayed for %u.%03u secs\n",
              coap_session_str(async->session),
              (unsigned int)(delay / COAP_TICKS_PER_SECOND),
              (unsigned int)((delay % COAP_TICKS_PER_SECOND) *
@@ -130,7 +130,7 @@ coap_async_set_delay(coap_async_t *async, coap_tick_t delay) {
   }
   else {
     async->delay = 0;
-    coap_log(LOG_DEBUG, "   %s: Async request indefinately delayed\n",
+    coap_log_debug("   %s: Async request indefinately delayed\n",
              coap_session_str(async->session));
   }
 }

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -59,7 +59,7 @@ coap_cache_ignore_options(coap_context_t *ctx,
       ctx->cache_ignore_count = count;
     }
     else {
-      coap_log(LOG_WARNING, "Unable to create cache_ignore_options\n");
+      coap_log_warn("Unable to create cache_ignore_options\n");
       return 0;
     }
   }

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -1036,7 +1036,7 @@ int coap_debug_set_packet_loss(const char *loss_level) {
     if (n > 100)
       n = 100;
     packet_loss_level = n * 65536 / 100;
-    coap_log(LOG_DEBUG, "packet loss level set to %d%%\n", n);
+    coap_log_debug("packet loss level set to %d%%\n", n);
   } else {
     if (n <= 0)
       return 0;
@@ -1073,7 +1073,7 @@ int coap_debug_send_packet(void) {
     for (i = 0; i < num_packet_loss_intervals; i++) {
       if (send_packet_count >= packet_loss_intervals[i].start
         && send_packet_count <= packet_loss_intervals[i].end) {
-        coap_log(LOG_DEBUG, "Packet %u dropped\n", send_packet_count);
+        coap_log_debug("Packet %u dropped\n", send_packet_count);
         return 0;
       }
     }
@@ -1082,7 +1082,7 @@ int coap_debug_send_packet(void) {
     uint16_t r = 0;
     coap_prng( (uint8_t*)&r, 2 );
     if ( r < packet_loss_level ) {
-      coap_log(LOG_DEBUG, "Packet %u dropped\n", send_packet_count);
+      coap_log_debug("Packet %u dropped\n", send_packet_count);
       return 0;
     }
   }

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -155,7 +155,7 @@ typedef enum coap_free_bye_t {
 
 #define G_CHECK(xx,func) do { \
   if ((ret = (xx)) < 0) { \
-    coap_log(LOG_WARNING, "%s: '%s'\n", func, gnutls_strerror(ret)); \
+    coap_log_warn("%s: '%s'\n", func, gnutls_strerror(ret)); \
     goto fail; \
   } \
 } while (0)
@@ -182,7 +182,7 @@ static int psk_server_callback(gnutls_session_t g_session,
 int
 coap_dtls_is_supported(void) {
   if (gnutls_check_version(MIN_GNUTLS_VERSION) == NULL) {
-    coap_log(LOG_ERR, "GnuTLS " MIN_GNUTLS_VERSION " or later is required\n");
+    coap_log_err("GnuTLS " MIN_GNUTLS_VERSION " or later is required\n");
     return 0;
   }
   return 1;
@@ -196,7 +196,7 @@ int
 coap_tls_is_supported(void) {
 #if !COAP_DISABLE_TCP
   if (gnutls_check_version(MIN_GNUTLS_VERSION) == NULL) {
-    coap_log(LOG_ERR, "GnuTLS " MIN_GNUTLS_VERSION " or later is required\n");
+    coap_log_err("GnuTLS " MIN_GNUTLS_VERSION " or later is required\n");
     return 0;
   }
   return 1;
@@ -268,10 +268,10 @@ coap_gnutls_audit_log_func(gnutls_session_t g_session, const char* text)
   if (g_session) {
     coap_session_t *c_session =
       (coap_session_t *)gnutls_transport_get_ptr(g_session);
-    coap_log(LOG_WARNING, "** %s: %s",
+    coap_log_warn("** %s: %s",
              coap_session_str(c_session), text);
   } else {
-    coap_log(LOG_WARNING, "** (null): %s", text);
+    coap_log_warn("** (null): %s", text);
   }
 }
 
@@ -346,14 +346,14 @@ coap_dtls_context_set_pki_root_cas(coap_context_t *c_context,
   coap_gnutls_context_t *g_context =
                          ((coap_gnutls_context_t *)c_context->dtls_context);
   if (!g_context) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_context_set_pki_root_cas: (D)TLS environment "
              "not set up\n");
     return 0;
   }
 
   if (ca_file == NULL && ca_path == NULL) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_context_set_pki_root_cas: ca_file and/or ca_path "
              "not defined\n");
     return 0;
@@ -373,7 +373,7 @@ coap_dtls_context_set_pki_root_cas(coap_context_t *c_context,
 #if (GNUTLS_VERSION_NUMBER >= 0x030306)
     g_context->root_ca_path = gnutls_strdup(ca_path);
 #else
-    coap_log(LOG_ERR, "ca_path not supported in GnuTLS < 3.3.6\n");
+    coap_log_err("ca_path not supported in GnuTLS < 3.3.6\n");
 #endif
   }
   return 1;
@@ -502,10 +502,10 @@ coap_dtls_new_context(coap_context_t *c_context COAP_UNUSED) {
     ret = gnutls_priority_init(&g_context->priority_cache, priority, &err);
     if (ret != GNUTLS_E_SUCCESS) {
       if (ret == GNUTLS_E_INVALID_REQUEST)
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "gnutls_priority_init: Syntax error at: %s\n", err);
       else
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "gnutls_priority_init: %s\n", gnutls_strerror(ret));
       goto fail;
     }
@@ -587,7 +587,7 @@ psk_client_callback(gnutls_session_t g_session,
   temp.length = strlen((const char*)temp.s);
   coap_session_refresh_psk_hint(c_session, &temp);
 
-  coap_log(LOG_DEBUG, "got psk_identity_hint: '%.*s'\n", (int)temp.length,
+  coap_log_debug("got psk_identity_hint: '%.*s'\n", (int)temp.length,
              (const char *)temp.s);
 
   if (setup_data->validate_ih_call_back) {
@@ -614,7 +614,7 @@ psk_client_callback(gnutls_session_t g_session,
   }
 
   if (psk_identity == NULL || psk_key == NULL) {
-    coap_log(LOG_WARNING, "no PSK available\n");
+    coap_log_warn("no PSK available\n");
     return -1;
   }
 
@@ -813,7 +813,7 @@ static int cert_verify_gnutls(gnutls_session_t g_session)
     if (status & (GNUTLS_CERT_NOT_ACTIVATED|GNUTLS_CERT_EXPIRED)) {
       status &= ~(GNUTLS_CERT_NOT_ACTIVATED|GNUTLS_CERT_EXPIRED);
       if (g_context->setup_data.allow_expired_certs) {
-        coap_log(LOG_INFO,
+        coap_log_info(
                  "   %s: %s: overridden: '%s'\n",
                  coap_session_str(c_session),
                  "The certificate has an invalid usage date",
@@ -821,7 +821,7 @@ static int cert_verify_gnutls(gnutls_session_t g_session)
       }
       else {
         fail = 1;
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "   %s: %s: '%s'\n",
                  coap_session_str(c_session),
                  "The certificate has an invalid usage date",
@@ -833,7 +833,7 @@ static int cert_verify_gnutls(gnutls_session_t g_session)
       status &= ~(GNUTLS_CERT_REVOCATION_DATA_SUPERSEDED|
                   GNUTLS_CERT_REVOCATION_DATA_ISSUED_IN_FUTURE);
       if (g_context->setup_data.allow_expired_crl) {
-        coap_log(LOG_INFO,
+        coap_log_info(
                  "   %s: %s: overridden: '%s'\n",
                  coap_session_str(c_session),
                  "The certificate's CRL entry has an invalid usage date",
@@ -841,7 +841,7 @@ static int cert_verify_gnutls(gnutls_session_t g_session)
       }
       else {
         fail = 1;
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "   %s: %s: '%s'\n",
                  coap_session_str(c_session),
                  "The certificate's CRL entry has an invalid usage date",
@@ -853,7 +853,7 @@ static int cert_verify_gnutls(gnutls_session_t g_session)
       if (cert_info.self_signed) {
         if (g_context->setup_data.allow_self_signed &&
             !g_context->setup_data.check_common_ca) {
-          coap_log(LOG_INFO,
+          coap_log_info(
                    "   %s: %s: overridden: '%s'\n",
                    coap_session_str(c_session),
                    "Self-signed",
@@ -862,7 +862,7 @@ static int cert_verify_gnutls(gnutls_session_t g_session)
         else {
           fail = 1;
           alert = GNUTLS_A_UNKNOWN_CA;
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "   %s: %s: '%s'\n",
                    coap_session_str(c_session),
                    "Self-signed",
@@ -871,7 +871,7 @@ static int cert_verify_gnutls(gnutls_session_t g_session)
       }
       else {
         if (!g_context->setup_data.verify_peer_cert) {
-          coap_log(LOG_INFO,
+          coap_log_info(
                    "   %s: %s: overridden: '%s'\n",
                    coap_session_str(c_session),
                    "The peer certificate's CA is unknown",
@@ -880,7 +880,7 @@ static int cert_verify_gnutls(gnutls_session_t g_session)
         else {
           fail = 1;
           alert = GNUTLS_A_UNKNOWN_CA;
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "   %s: %s: '%s'\n",
                    coap_session_str(c_session),
                    "The peer certificate's CA is unknown",
@@ -891,7 +891,7 @@ static int cert_verify_gnutls(gnutls_session_t g_session)
 
     if (status) {
         fail = 1;
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "   %s: gnutls_certificate_verify_peers() status 0x%x: '%s'\n",
                  coap_session_str(c_session),
                  status, OUTPUT_CERT_NAME);
@@ -1073,7 +1073,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
         setup_data->pki_key.key.pem.private_key &&
         setup_data->pki_key.key.pem.private_key[0]) {
       if (setup_data->is_rpk_not_cert) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "RPK keys cannot be in COAP_PKI_KEY_PEM format\n");
         return GNUTLS_E_INSUFFICIENT_CREDENTIALS;
       }
@@ -1086,7 +1086,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
       }
     }
     else if (role == COAP_DTLS_ROLE_SERVER) {
-      coap_log(LOG_ERR,
+      coap_log_err(
                "***setup_pki: (D)TLS: No %s Certificate + Private "
                "Key defined\n",
                role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
@@ -1098,11 +1098,11 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
                            setup_data->pki_key.key.pem.ca_file,
                            GNUTLS_X509_FMT_PEM);
       if (ret == 0) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
          "gnutls_certificate_set_x509_trust_file: No certificates found\n");
       }
       else if (ret < 0) {
-        coap_log(LOG_WARNING, "%s: '%s'\n",
+        coap_log_warn("%s: '%s'\n",
                  "gnutls_certificate_set_x509_trust_file",
                  gnutls_strerror(ret));
         goto fail;
@@ -1126,7 +1126,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
         alloced_cert_memory = 1;
         cert.data = gnutls_malloc(cert.size + 1);
         if (!cert.data) {
-          coap_log(LOG_ERR, "gnutls_malloc failure\n");
+          coap_log_err("gnutls_malloc failure\n");
           return GNUTLS_E_MEMORY_ERROR;
         }
         memcpy(cert.data, setup_data->pki_key.key.pem_buf.public_cert,
@@ -1145,7 +1145,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
         alloced_key_memory = 1;
         key.data = gnutls_malloc(key.size + 1);
         if (!key.data) {
-          coap_log(LOG_ERR, "gnutls_malloc failure\n");
+          coap_log_err("gnutls_malloc failure\n");
           if (alloced_cert_memory) gnutls_free(cert.data);
           return GNUTLS_E_MEMORY_ERROR;
         }
@@ -1194,7 +1194,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
                    "gnutls_certificate_set_rawpk_key_mem");
         }
 #else /* GNUTLS_VERSION_NUMBER < 0x030606 */
-        coap_log(LOG_ERR,
+        coap_log_err(
               "RPK Support not available (needs gnutls 3.6.6 or later)\n");
         if (alloced_cert_memory) gnutls_free(cert.data);
         if (alloced_key_memory) gnutls_free(key.data);
@@ -1212,7 +1212,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
       if (alloced_key_memory) gnutls_free(key.data);
     }
     else if (role == COAP_DTLS_ROLE_SERVER) {
-      coap_log(LOG_ERR,
+      coap_log_err(
                "***setup_pki: (D)TLS: No Server Certificate + Private "
                "Key defined\n");
       return GNUTLS_E_INSUFFICIENT_CREDENTIALS;
@@ -1228,7 +1228,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
         alloced_ca_memory = 1;
         ca.data = gnutls_malloc(ca.size + 1);
         if (!ca.data) {
-          coap_log(LOG_ERR, "gnutls_malloc failure\n");
+          coap_log_err("gnutls_malloc failure\n");
           return GNUTLS_E_MEMORY_ERROR;
         }
         memcpy(ca.data, setup_data->pki_key.key.pem_buf.ca_cert, ca.size);
@@ -1244,11 +1244,11 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
                            &ca,
                            GNUTLS_X509_FMT_PEM);
       if (ret == 0) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
          "gnutls_certificate_set_x509_trust_mem: No certificates found\n");
       }
       else if (ret < 0) {
-        coap_log(LOG_WARNING, "%s: '%s'\n",
+        coap_log_warn("%s: '%s'\n",
                  "gnutls_certificate_set_x509_trust_mem",
                  gnutls_strerror(ret));
         if (alloced_ca_memory) gnutls_free(ca.data);
@@ -1304,7 +1304,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
                  "gnutls_certificate_set_rawpk_key_mem");
         }
 #else /* GNUTLS_VERSION_NUMBER < 0x030606 */
-        coap_log(LOG_ERR,
+        coap_log_err(
               "RPK Support not available (needs gnutls 3.6.6 or later)\n");
       return GNUTLS_E_INSUFFICIENT_CREDENTIALS;
 #endif /* GNUTLS_VERSION_NUMBER < 0x030606 */
@@ -1318,7 +1318,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
       }
     }
     else if (role == COAP_DTLS_ROLE_SERVER) {
-      coap_log(LOG_ERR,
+      coap_log_err(
                "***setup_pki: (D)TLS: No %s Certificate + Private "
                "Key defined\n",
                role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
@@ -1336,11 +1336,11 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
                            &ca_cert,
                            GNUTLS_X509_FMT_DER);
       if (ret == 0) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
          "gnutls_certificate_set_x509_trust_mem: No certificates found\n");
       }
       else if (ret < 0) {
-        coap_log(LOG_WARNING, "%s: '%s'\n",
+        coap_log_warn("%s: '%s'\n",
                  "gnutls_certificate_set_x509_trust_mem",
                  gnutls_strerror(ret));
         goto fail;
@@ -1365,7 +1365,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
                                    NULL, 0, GNUTLS_PKCS_PLAIN, 0),
                  "gnutls_certificate_set_rawpk_key_file");
 #else /* GNUTLS_VERSION_NUMBER < 0x030606 */
-        coap_log(LOG_ERR,
+        coap_log_err(
               "RPK Support not available (needs gnutls 3.6.6 or later)\n");
       return GNUTLS_E_INSUFFICIENT_CREDENTIALS;
 #endif /* GNUTLS_VERSION_NUMBER < 0x030606 */
@@ -1379,7 +1379,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
       }
     }
     else if (role == COAP_DTLS_ROLE_SERVER) {
-      coap_log(LOG_ERR,
+      coap_log_err(
                "***setup_pki: (D)TLS: No %s Certificate + Private "
                "Key defined\n",
                role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
@@ -1391,11 +1391,11 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
                            setup_data->pki_key.key.pkcs11.ca,
                            GNUTLS_X509_FMT_DER);
       if (ret == 0) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
          "gnutls_certificate_set_x509_trust_file: No certificates found\n");
       }
       else if (ret < 0) {
-        coap_log(LOG_WARNING, "%s: '%s'\n",
+        coap_log_warn("%s: '%s'\n",
                  "gnutls_certificate_set_x509_trust_file",
                  gnutls_strerror(ret));
         goto fail;
@@ -1404,7 +1404,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
     break;
 
   default:
-    coap_log(LOG_ERR,
+    coap_log_err(
              "***setup_pki: (D)TLS: Unknown key type %d\n",
              setup_data->pki_key.key_type);
     return GNUTLS_E_INSUFFICIENT_CREDENTIALS;
@@ -1415,7 +1415,7 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
                          g_context->root_ca_file,
                          GNUTLS_X509_FMT_PEM);
     if (ret == 0) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
        "gnutls_certificate_set_x509_trust_file: Root CA: No certificates found\n");
     }
   }
@@ -1765,10 +1765,10 @@ setup_client_ssl_session(coap_session_t *c_session, coap_gnutls_env_t *g_env)
               priority, &err);
         if (ret < 0) {
           if (ret == GNUTLS_E_INVALID_REQUEST)
-            coap_log(LOG_WARNING,
+            coap_log_warn(
                      "gnutls_priority_set_direct: Syntax error at: %s\n", err);
           else
-            coap_log(LOG_WARNING,
+            coap_log_warn(
                      "gnutls_priority_set_direct: %s\n", gnutls_strerror(ret));
           goto fail;
         }
@@ -1846,7 +1846,7 @@ psk_server_callback(gnutls_session_t g_session,
   lidentity.length = strlen((const char*)lidentity.s);
   coap_session_refresh_psk_identity(c_session, &lidentity);
 
-  coap_log(LOG_DEBUG, "got psk_identity: '%.*s'\n",
+  coap_log_debug("got psk_identity: '%.*s'\n",
                       (int)lidentity.length, (const char *)lidentity.s);
 
   if (setup_data->validate_id_call_back) {
@@ -1990,7 +1990,7 @@ coap_dgram_write(gnutls_transport_ptr_t context, const void *send_buffer,
   if (c_session) {
     result = coap_session_send(c_session, send_buffer, send_buffer_length);
     if (result != (int)send_buffer_length) {
-      coap_log(LOG_WARNING, "coap_network_send failed\n");
+      coap_log_warn("coap_network_send failed\n");
       result = 0;
     }
   } else {
@@ -2156,11 +2156,11 @@ static void log_last_alert(coap_session_t *c_session,
   int last_alert = gnutls_alert_get(g_session);
 
   if (last_alert == GNUTLS_A_CLOSE_NOTIFY)
-    coap_log(LOG_DEBUG, "***%s: Alert '%d': %s\n",
+    coap_log_debug("***%s: Alert '%d': %s\n",
                          coap_session_str(c_session),
                          last_alert, gnutls_alert_get_name(last_alert));
   else
-    coap_log(LOG_WARNING, "***%s: Alert '%d': %s\n",
+    coap_log_warn("***%s: Alert '%d': %s\n",
                           coap_session_str(c_session),
                           last_alert, gnutls_alert_get_name(last_alert));
 }
@@ -2178,7 +2178,7 @@ do_gnutls_handshake(coap_session_t *c_session, coap_gnutls_env_t *g_env) {
   switch (ret) {
   case GNUTLS_E_SUCCESS:
     g_env->established = 1;
-    coap_log(LOG_DEBUG, "*  %s: GnuTLS established\n",
+    coap_log_debug("*  %s: GnuTLS established\n",
                                             coap_session_str(c_session));
     ret = 1;
     break;
@@ -2191,7 +2191,7 @@ do_gnutls_handshake(coap_session_t *c_session, coap_gnutls_env_t *g_env) {
     ret = 0;
     break;
   case GNUTLS_E_INSUFFICIENT_CREDENTIALS:
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "Insufficient credentials provided.\n");
     ret = -1;
     break;
@@ -2214,7 +2214,7 @@ do_gnutls_handshake(coap_session_t *c_session, coap_gnutls_env_t *g_env) {
 #if (GNUTLS_VERSION_NUMBER > 0x030606)
   case GNUTLS_E_CERTIFICATE_REQUIRED:
 #endif /* GNUTLS_VERSION_NUMBER > 0x030606 */
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "Client Certificate requested and required, but not provided\n"
              );
     G_ACTION(gnutls_alert_send(g_env->g_session, GNUTLS_AL_FATAL,
@@ -2224,7 +2224,7 @@ do_gnutls_handshake(coap_session_t *c_session, coap_gnutls_env_t *g_env) {
     ret = -1;
     break;
   case GNUTLS_E_DECRYPTION_FAILED:
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "do_gnutls_handshake: session establish "
              "returned '%s'\n",
              gnutls_strerror(ret));
@@ -2244,7 +2244,7 @@ do_gnutls_handshake(coap_session_t *c_session, coap_gnutls_env_t *g_env) {
   case GNUTLS_E_UNKNOWN_CIPHER_SUITE:
   case GNUTLS_E_NO_CIPHER_SUITES:
   case GNUTLS_E_INVALID_SESSION:
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "do_gnutls_handshake: session establish "
              "returned '%s'\n",
              gnutls_strerror(ret));
@@ -2264,7 +2264,7 @@ do_gnutls_handshake(coap_session_t *c_session, coap_gnutls_env_t *g_env) {
     ret = -1;
     break;
   default:
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "do_gnutls_handshake: session establish "
              "returned %d: '%s'\n",
              ret, gnutls_strerror(ret));
@@ -2345,7 +2345,7 @@ int coap_dtls_send(coap_session_t *c_session,
         ret = -1;
         break;
       default:
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
                  "coap_dtls_send: gnutls_record_send "
                  "returned %d: '%s'\n",
                  ret, gnutls_strerror(ret));
@@ -2353,7 +2353,7 @@ int coap_dtls_send(coap_session_t *c_session,
         break;
       }
       if (ret == -1) {
-        coap_log(LOG_WARNING, "coap_dtls_send: cannot send PDU\n");
+        coap_log_warn("coap_dtls_send: cannot send PDU\n");
       }
     }
   }
@@ -2453,7 +2453,7 @@ coap_dtls_receive(coap_session_t *c_session,
   assert(g_env != NULL);
 
   if (ssl_data->pdu_len)
-    coap_log(LOG_ERR, "** %s: Previous data not read %u bytes\n",
+    coap_log_err("** %s: Previous data not read %u bytes\n",
              coap_session_str(c_session), ssl_data->pdu_len);
   ssl_data->pdu = data;
   ssl_data->pdu_len = data_len;
@@ -2488,7 +2488,7 @@ coap_dtls_receive(coap_session_t *c_session,
         ret = 0;
         break;
       default:
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "coap_dtls_receive: gnutls_record_recv returned %d\n", ret);
         ret = -1;
         break;
@@ -2526,7 +2526,7 @@ coap_dtls_receive(coap_session_t *c_session,
   }
   if (ssl_data && ssl_data->pdu_len) {
     /* pdu data is held on stack which will not stay there */
-    coap_log(LOG_DEBUG, "coap_dtls_receive: ret %d: remaining data %u\n", ret, ssl_data->pdu_len);
+    coap_log_debug("coap_dtls_receive: ret %d: remaining data %u\n", ret, ssl_data->pdu_len);
     ssl_data->pdu_len = 0;
     ssl_data->pdu = NULL;
   }
@@ -2573,7 +2573,7 @@ coap_dtls_hello(coap_session_t *c_session,
                                      data_rw, data_len,
                                      &prestate);
     if (ret < 0) {  /* cookie not valid */
-      coap_log(LOG_DEBUG, "Invalid Cookie - sending Hello Verify\n");
+      coap_log_debug("Invalid Cookie - sending Hello Verify\n");
       gnutls_dtls_cookie_send(&g_env->coap_ssl_data.cookie_key,
                               &c_session->addr_info,
                               sizeof(c_session->addr_info),
@@ -2609,7 +2609,7 @@ coap_dtls_hello(coap_session_t *c_session,
 
   if (ssl_data && ssl_data->pdu_len) {
     /* pdu data is held on stack which will not stay there */
-    coap_log(LOG_DEBUG, "coap_dtls_hello: ret %d: remaining data %u\n", ret, ssl_data->pdu_len);
+    coap_log_debug("coap_dtls_hello: ret %d: remaining data %u\n", ret, ssl_data->pdu_len);
      ssl_data->pdu_len = 0;
      ssl_data->pdu = NULL;
   }
@@ -2639,10 +2639,10 @@ coap_sock_read(gnutls_transport_ptr_t context, void *out, size_t outl) {
     ret = recv(c_session->sock.fd, out, outl, 0);
 #endif
     if (ret > 0) {
-      coap_log(LOG_DEBUG, "*  %s: received %d bytes\n",
+      coap_log_debug("*  %s: received %d bytes\n",
                coap_session_str(c_session), ret);
     } else if (ret < 0 && errno != EAGAIN) {
-      coap_log(LOG_DEBUG,  "*  %s: failed to receive any bytes (%s)\n",
+      coap_log_debug( "*  %s: failed to receive any bytes (%s)\n",
                coap_session_str(c_session), coap_socket_strerror());
     }
     if (ret == 0) {
@@ -2670,7 +2670,7 @@ coap_sock_write(gnutls_transport_ptr_t context, const void *in, size_t inl) {
 
   ret = (int)coap_socket_write(&c_session->sock, in, inl);
   if (ret > 0) {
-    coap_log(LOG_DEBUG, "*  %s: sent %d bytes\n",
+    coap_log_debug("*  %s: sent %d bytes\n",
              coap_session_str(c_session), ret);
   } else if (ret < 0) {
     if ((c_session->state == COAP_SESSION_STATE_CSM ||
@@ -2690,7 +2690,7 @@ coap_sock_write(gnutls_transport_ptr_t context, const void *in, size_t inl) {
       ret = inl;
     }
     else {
-      coap_log(LOG_DEBUG,  "*  %s: failed to send %zd bytes (%s) state %d\n",
+      coap_log_debug( "*  %s: failed to send %zd bytes (%s) state %d\n",
                coap_session_str(c_session), inl, coap_socket_strerror(),
                c_session->state);
     }
@@ -2834,7 +2834,7 @@ ssize_t coap_tls_write(coap_session_t *c_session,
         ret = -1;
         break;
       default:
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "coap_tls_write: gnutls_record_send "
                  "returned %d: '%s'\n",
                  ret, gnutls_strerror(ret));
@@ -2842,7 +2842,7 @@ ssize_t coap_tls_write(coap_session_t *c_session,
         break;
       }
       if (ret == -1) {
-        coap_log(LOG_INFO, "coap_tls_write: cannot send PDU\n");
+        coap_log_info("coap_tls_write: cannot send PDU\n");
       }
     }
   }
@@ -2923,7 +2923,7 @@ ssize_t coap_tls_read(coap_session_t *c_session,
         ret = 0;
         break;
       default:
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "coap_tls_read: gnutls_record_recv "
                  "returned %d: '%s'\n",
                  ret, gnutls_strerror(ret));

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -106,7 +106,7 @@ coap_socket_bind_udp(coap_socket_t *sock,
   sock->conn = udp_new(NULL, 0, NULL);
 
   if (!sock->conn) {
-    coap_log(LOG_WARNING, "coap_socket_bind_udp");
+    coap_log_warn("coap_socket_bind_udp");
     return 0;
   }
 
@@ -173,7 +173,7 @@ coap_socket_bind_udp(coap_socket_t *sock,
   sock->fd = socket(listen_addr->addr.sa.sa_family, SOCK_DGRAM, 0);
 
   if (sock->fd == COAP_INVALID_SOCKET) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_socket_bind_udp: socket: %s\n", coap_socket_strerror());
     goto error;
   }
@@ -183,31 +183,31 @@ coap_socket_bind_udp(coap_socket_t *sock,
 #else
   if (ioctl(sock->fd, FIONBIO, &on) == COAP_SOCKET_ERROR) {
 #endif
-    coap_log(LOG_WARNING,
+    coap_log_warn(
          "coap_socket_bind_udp: ioctl FIONBIO: %s\n", coap_socket_strerror());
   }
 
   if (setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_socket_bind_udp: setsockopt SO_REUSEADDR: %s\n",
               coap_socket_strerror());
 
   switch (listen_addr->addr.sa.sa_family) {
   case AF_INET:
     if (setsockopt(sock->fd, IPPROTO_IP, GEN_IP_PKTINFO, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_ALERT,
+      coap_log_alert(
                "coap_socket_bind_udp: setsockopt IP_PKTINFO: %s\n",
                 coap_socket_strerror());
     break;
   case AF_INET6:
     /* Configure the socket as dual-stacked */
     if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, OPTVAL_T(&off), sizeof(off)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_ALERT,
+      coap_log_alert(
                "coap_socket_bind_udp: setsockopt IPV6_V6ONLY: %s\n",
                 coap_socket_strerror());
 #if !defined(ESPIDF_VERSION)
     if (setsockopt(sock->fd, IPPROTO_IPV6, GEN_IPV6_PKTINFO, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_ALERT,
+      coap_log_alert(
                "coap_socket_bind_udp: setsockopt IPV6_PKTINFO: %s\n",
                 coap_socket_strerror());
 #endif /* !defined(ESPIDF_VERSION) */
@@ -216,7 +216,7 @@ coap_socket_bind_udp(coap_socket_t *sock,
        level */
     break;
   default:
-    coap_log(LOG_ALERT, "coap_socket_bind_udp: unsupported sa_family\n");
+    coap_log_alert("coap_socket_bind_udp: unsupported sa_family\n");
     break;
   }
 #endif /* RIOT_VERSION */
@@ -225,14 +225,14 @@ coap_socket_bind_udp(coap_socket_t *sock,
            listen_addr->addr.sa.sa_family == AF_INET ?
             (socklen_t)sizeof(struct sockaddr_in) :
             (socklen_t)listen_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_bind_udp: bind: %s\n",
+    coap_log_warn("coap_socket_bind_udp: bind: %s\n",
              coap_socket_strerror());
     goto error;
   }
 
   bound_addr->size = (socklen_t)sizeof(*bound_addr);
   if (getsockname(sock->fd, &bound_addr->addr.sa, &bound_addr->size) < 0) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_socket_bind_udp: getsockname: %s\n",
               coap_socket_strerror());
     goto error;
@@ -268,7 +268,7 @@ coap_socket_connect_udp(coap_socket_t *sock,
   sock->fd = socket(connect_addr.addr.sa.sa_family, SOCK_DGRAM, 0);
 
   if (sock->fd == COAP_INVALID_SOCKET) {
-    coap_log(LOG_WARNING, "coap_socket_connect_udp: socket: %s\n",
+    coap_log_warn("coap_socket_connect_udp: socket: %s\n",
              coap_socket_strerror());
     goto error;
   }
@@ -279,7 +279,7 @@ coap_socket_connect_udp(coap_socket_t *sock,
 #else
   if (ioctl(sock->fd, FIONBIO, &on) == COAP_SOCKET_ERROR) {
 #endif
-    coap_log(LOG_WARNING, "coap_socket_connect_udp: ioctl FIONBIO: %s\n",
+    coap_log_warn("coap_socket_connect_udp: ioctl FIONBIO: %s\n",
              coap_socket_strerror());
   }
 #endif /* RIOT_VERSION */
@@ -295,20 +295,20 @@ coap_socket_connect_udp(coap_socket_t *sock,
 #ifndef RIOT_VERSION
     /* Configure the socket as dual-stacked */
     if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, OPTVAL_T(&off), sizeof(off)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_WARNING,
+      coap_log_warn(
                "coap_socket_connect_udp: setsockopt IPV6_V6ONLY: %s\n",
                coap_socket_strerror());
 #endif /* RIOT_VERSION */
     break;
   default:
-    coap_log(LOG_ALERT, "coap_socket_connect_udp: unsupported sa_family\n");
+    coap_log_alert("coap_socket_connect_udp: unsupported sa_family\n");
     break;
   }
 
   if (local_if && local_if->addr.sa.sa_family) {
 #ifndef RIOT_VERSION
     if (setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_WARNING,
+      coap_log_warn(
                "coap_socket_connect_udp: setsockopt SO_REUSEADDR: %s\n",
                coap_socket_strerror());
 #endif /* RIOT_VERSION */
@@ -316,7 +316,7 @@ coap_socket_connect_udp(coap_socket_t *sock,
              local_if->addr.sa.sa_family == AF_INET ?
               (socklen_t)sizeof(struct sockaddr_in) :
               (socklen_t)local_if->size) == COAP_SOCKET_ERROR) {
-      coap_log(LOG_WARNING, "coap_socket_connect_udp: bind: %s\n",
+      coap_log_warn("coap_socket_connect_udp: bind: %s\n",
                coap_socket_strerror());
       goto error;
     }
@@ -334,13 +334,13 @@ coap_socket_connect_udp(coap_socket_t *sock,
                bind_addr.addr.sa.sa_family == AF_INET ?
                 (socklen_t)sizeof(struct sockaddr_in) :
                 (socklen_t)bind_addr.size) == COAP_SOCKET_ERROR) {
-        coap_log(LOG_WARNING, "coap_socket_connect_udp: bind: %s\n",
+        coap_log_warn("coap_socket_connect_udp: bind: %s\n",
                  coap_socket_strerror());
         goto error;
       }
     }
     if (getsockname(sock->fd, &local_addr->addr.sa, &local_addr->size) == COAP_SOCKET_ERROR) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
               "coap_socket_connect_udp: getsockname for multicast socket: %s\n",
               coap_socket_strerror());
     }
@@ -350,18 +350,18 @@ coap_socket_connect_udp(coap_socket_t *sock,
   }
 
   if (connect(sock->fd, &connect_addr.addr.sa, connect_addr.size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_udp: connect: %s\n",
+    coap_log_warn("coap_socket_connect_udp: connect: %s\n",
              coap_socket_strerror());
     goto error;
   }
 
   if (getsockname(sock->fd, &local_addr->addr.sa, &local_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_udp: getsockname: %s\n",
+    coap_log_warn("coap_socket_connect_udp: getsockname: %s\n",
              coap_socket_strerror());
   }
 
   if (getpeername(sock->fd, &remote_addr->addr.sa, &remote_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_udp: getpeername: %s\n",
+    coap_log_warn("coap_socket_connect_udp: getpeername: %s\n",
              coap_socket_strerror());
   }
 
@@ -390,7 +390,7 @@ void coap_socket_close(coap_socket_t *sock) {
       /* Kernels prior to 2.6.9 expect non NULL event parameter */
       ret = epoll_ctl(context->epfd, EPOLL_CTL_DEL, sock->fd, &event);
       if (ret == -1) {
-         coap_log(LOG_ERR,
+         coap_log_err(
                   "%s: epoll_ctl DEL failed: %s (%d)\n",
                   "coap_socket_close",
                   coap_socket_strerror(), errno);
@@ -434,7 +434,7 @@ coap_epoll_ctl_mod(coap_socket_t *sock,
 
   ret = epoll_ctl(context->epfd, EPOLL_CTL_MOD, sock->fd, &event);
   if (ret == -1) {
-     coap_log(LOG_ERR,
+     coap_log_err(
               "%s: epoll_ctl MOD failed: %s (%d)\n",
               func,
               coap_socket_strerror(), errno);
@@ -464,14 +464,14 @@ coap_update_epoll_timer(coap_context_t *context, coap_tick_t delay)
       }
       ret = timerfd_settime(context->eptimerfd, 0, &new_value, NULL);
       if (ret == -1) {
-        coap_log(LOG_ERR,
+        coap_log_err(
                   "%s: timerfd_settime failed: %s (%d)\n",
                   "coap_resource_notify_observers",
                   coap_socket_strerror(), errno);
       }
 #ifdef COAP_DEBUG_WAKEUP_TIMES
       else {
-        coap_log(LOG_DEBUG, "****** Next wakeup time %3ld.%09ld\n",
+        coap_log_debug("****** Next wakeup time %3ld.%09ld\n",
                  new_value.it_value.tv_sec, new_value.it_value.tv_nsec);
       }
 #endif /* COAP_DEBUG_WAKEUP_TIMES */
@@ -513,11 +513,11 @@ coap_socket_write(coap_socket_t *sock, const uint8_t *data, size_t data_len) {
       return 0;
     }
     if (errno == EPIPE || errno == ECONNRESET) {
-      coap_log(LOG_INFO, "coap_socket_write: send: %s\n",
+      coap_log_info("coap_socket_write: send: %s\n",
                coap_socket_strerror());
     }
     else {
-      coap_log(LOG_WARNING, "coap_socket_write: send: %s\n",
+      coap_log_warn("coap_socket_write: send: %s\n",
                coap_socket_strerror());
     }
     return -1;
@@ -568,7 +568,7 @@ coap_socket_read(coap_socket_t *sock, uint8_t *data, size_t data_len) {
 #else
     if (errno != ECONNRESET)
 #endif
-      coap_log(LOG_WARNING, "coap_socket_read: recv: %s\n",
+      coap_log_warn("coap_socket_read: recv: %s\n",
                coap_socket_strerror());
     return -1;
   }
@@ -765,7 +765,7 @@ coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint
     }
     default:
       /* error */
-      coap_log(LOG_WARNING, "protocol not supported\n");
+      coap_log_warn("protocol not supported\n");
       bytes_written = -1;
     }
 #endif /* HAVE_STRUCT_CMSGHDR */
@@ -797,7 +797,7 @@ coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint
   }
 
   if (bytes_written < 0)
-    coap_log(LOG_CRIT, "coap_network_send: %s\n", coap_socket_strerror());
+    coap_log_crit("coap_network_send: %s\n", coap_socket_strerror());
 
   return bytes_written;
 }
@@ -843,13 +843,13 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
       if (errno == ECONNREFUSED || errno == EHOSTUNREACH) {
 #endif
         /* client-side ICMP destination unreachable, ignore it */
-        coap_log(LOG_WARNING, "** %s: coap_network_read: ICMP: %s\n",
+        coap_log_warn("** %s: coap_network_read: ICMP: %s\n",
                  sock->session ?
                    coap_session_str(sock->session) : "",
                  coap_socket_strerror());
         return -2;
       }
-      coap_log(LOG_WARNING, "** %s: coap_network_read: %s\n",
+      coap_log_warn("** %s: coap_network_read: %s\n",
                              sock->session ?
                                 coap_session_str(sock->session) : "",
                              coap_socket_strerror());
@@ -896,7 +896,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
       GUID wsaid = WSAID_WSARECVMSG;
       DWORD cbBytesReturned = 0;
       if (WSAIoctl(sock->fd, SIO_GET_EXTENSION_FUNCTION_POINTER, &wsaid, sizeof(wsaid), &lpWSARecvMsg, sizeof(lpWSARecvMsg), &cbBytesReturned, NULL, NULL) != 0) {
-        coap_log(LOG_WARNING, "coap_network_read: no WSARecvMsg\n");
+        coap_log_warn("coap_network_read: no WSARecvMsg\n");
         return -1;
       }
     }
@@ -922,7 +922,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
         /* server-side ICMP destination unreachable, ignore it. The destination address is in msg_name. */
         return 0;
       }
-      coap_log(LOG_WARNING, "coap_network_read: %s\n", coap_socket_strerror());
+      coap_log_warn("coap_network_read: %s\n", coap_socket_strerror());
       goto error;
     } else {
 #ifdef HAVE_STRUCT_CMSGHDR
@@ -984,7 +984,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
           /* cmsg_level / cmsg_type combination we do not understand
              (ignore preset case for bad recvmsg() not updating cmsg) */
           if (cmsg->cmsg_level != -1 && cmsg->cmsg_type != -1) {
-            coap_log(LOG_DEBUG,
+            coap_log_debug(
                      "cmsg_level = %d and cmsg_type = %d not supported - fix\n",
                      cmsg->cmsg_level, cmsg->cmsg_type);
           }
@@ -996,7 +996,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
         packet->ifindex = (int)sock->fd;
         if (getsockname(sock->fd, &packet->addr_info.local.addr.sa,
             &packet->addr_info.local.size) < 0) {
-          coap_log(LOG_DEBUG, "Cannot determine local port\n");
+          coap_log_debug("Cannot determine local port\n");
         }
       }
 #else /* ! HAVE_STRUCT_CMSGHDR */
@@ -1004,7 +1004,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
       packet->ifindex = 0;
       if (getsockname(sock->fd, &packet->addr_info.local.addr.sa,
                       &packet->addr_info.local.size) < 0) {
-         coap_log(LOG_DEBUG, "Cannot determine local port\n");
+         coap_log_debug("Cannot determine local port\n");
          goto error;
       }
 #endif /* ! HAVE_STRUCT_CMSGHDR */
@@ -1025,7 +1025,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
 
       if (len > COAP_RXBUFFER_SIZE) {
         /* FIXME: we might want to send back a response */
-        coap_log(LOG_WARNING, "discarded oversized packet\n");
+        coap_log_warn("discarded oversized packet\n");
         return -1;
       }
 
@@ -1038,7 +1038,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
 
         if (coap_print_addr(&packet->addr_info.remote, addr_str,
                             INET6_ADDRSTRLEN + 8)) {
-          coap_log(LOG_DEBUG, "received %zd bytes from %s\n", len, addr_str);
+          coap_log_debug("received %zd bytes from %s\n", len, addr_str);
         }
       }
 
@@ -1057,7 +1057,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
       unsigned char addr_str[INET6_ADDRSTRLEN + 8];
 
       if (coap_print_addr(&packet->src, addr_str, INET6_ADDRSTRLEN + 8)) {
-        coap_log(LOG_DEBUG, "received %zd bytes from %s\n", len, addr_str);
+        coap_log_debug("received %zd bytes from %s\n", len, addr_str);
       }
     }
 #endif /* RIOT_VERSION */
@@ -1081,7 +1081,7 @@ coap_io_prepare_epoll(coap_context_t *ctx, coap_tick_t now) {
 #ifndef COAP_EPOLL_SUPPORT
   (void)ctx;
   (void)now;
-   coap_log(LOG_EMERG,
+   coap_log_emerg(
             "coap_io_prepare_epoll() requires libcoap compiled for using epoll\n");
   return 0;
 #else /* COAP_EPOLL_SUPPORT */
@@ -1108,13 +1108,13 @@ coap_io_prepare_epoll(coap_context_t *ctx, coap_tick_t now) {
                                    1000000;
     }
 #ifdef COAP_DEBUG_WAKEUP_TIMES
-    coap_log(LOG_DEBUG, "****** Next wakeup time %3ld.%09ld\n",
+    coap_log_debug("****** Next wakeup time %3ld.%09ld\n",
              new_value.it_value.tv_sec, new_value.it_value.tv_nsec);
 #endif /* COAP_DEBUG_WAKEUP_TIMES */
     /* reset, or specify a future time for eptimerfd to trigger */
     ret = timerfd_settime(ctx->eptimerfd, 0, &new_value, NULL);
     if (ret == -1) {
-      coap_log(LOG_ERR,
+      coap_log_err(
                 "%s: timerfd_settime failed: %s (%d)\n",
                 "coap_io_prepare_epoll",
                 coap_socket_strerror(), errno);
@@ -1176,7 +1176,7 @@ coap_io_prepare_io(coap_context_t *ctx,
       if (tls_timeout > 0) {
         if (tls_timeout < now + COAP_TICKS_PER_SECOND / 10)
           tls_timeout = now + COAP_TICKS_PER_SECOND / 10;
-        coap_log(LOG_DEBUG, "** DTLS global timeout set to %dms\n",
+        coap_log_debug("** DTLS global timeout set to %dms\n",
                  (int)((tls_timeout - now) * 1000 / COAP_TICKS_PER_SECOND));
         if (timeout == 0 || tls_timeout - now < timeout)
           timeout = tls_timeout - now;
@@ -1225,7 +1225,7 @@ coap_io_prepare_io(coap_context_t *ctx,
             s->proto == COAP_PROTO_DTLS && s->tls) {
           coap_tick_t tls_timeout = coap_dtls_get_timeout(s, now);
           while (tls_timeout > 0 && tls_timeout <= now) {
-            coap_log(LOG_DEBUG, "** %s: DTLS retransmit timeout\n",
+            coap_log_debug("** %s: DTLS retransmit timeout\n",
                      coap_session_str(s));
             if (coap_dtls_handle_timeout(s))
               goto release_1;
@@ -1314,7 +1314,7 @@ release_1:
         s->proto == COAP_PROTO_DTLS && s->tls) {
       coap_tick_t tls_timeout = coap_dtls_get_timeout(s, now);
       while (tls_timeout > 0 && tls_timeout <= now) {
-        coap_log(LOG_DEBUG, "** %s: DTLS retransmit timeout\n", coap_session_str(s));
+        coap_log_debug("** %s: DTLS retransmit timeout\n", coap_session_str(s));
         if (coap_dtls_handle_timeout(s))
           goto release_2;
 
@@ -1448,7 +1448,7 @@ coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
     if (errno != EINTR)
 #endif
     {
-      coap_log(LOG_DEBUG, "%s", coap_socket_strerror());
+      coap_log_debug("%s", coap_socket_strerror());
       return -1;
     }
   }

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -68,7 +68,7 @@ coap_io_process_timeout(void *arg) {
     timeout = 1000;
   }
 #ifdef COAP_DEBUG_WAKEUP_TIMES
-  coap_log(LOG_INFO, "****** Next wakeup msecs %u (1)\n",
+  coap_log_info("****** Next wakeup msecs %u (1)\n",
            timeout);
 #endif /* COAP_DEBUG_WAKEUP_TIMES */
   sys_timeout(timeout, coap_io_process_timeout, context);
@@ -97,7 +97,7 @@ coap_io_process(coap_context_t *context, uint32_t timeout_ms) {
     timeout = 1000;
   }
 #ifdef COAP_DEBUG_WAKEUP_TIMES
-  coap_log(LOG_INFO, "****** Next wakeup msecs %u (2)\n",
+  coap_log_info("****** Next wakeup msecs %u (2)\n",
            timeout);
 #endif /* COAP_DEBUG_WAKEUP_TIMES */
   sys_timeout(timeout, coap_io_process_timeout, context);
@@ -176,7 +176,7 @@ coap_recvc(void *arg, struct udp_pcb *upcb, struct pbuf *p,
   packet->addr_info.local.addr = *ip_current_dest_addr();
   packet->ifindex = netif_get_index(ip_current_netif());
 
-  coap_log(LOG_DEBUG, "*  %s: received %d bytes\n",
+  coap_log_debug("*  %s: received %d bytes\n",
            coap_session_str(session), p->len);
   if (session->proto == COAP_PROTO_DTLS) {
     if (session->tls) {
@@ -261,7 +261,7 @@ coap_recvs(void *arg, struct udp_pcb *upcb, struct pbuf *p,
     goto error;
   LWIP_ASSERT("Proto not supported for LWIP", COAP_PROTO_NOT_RELIABLE(session->proto));
 
-  coap_log(LOG_DEBUG, "*  %s: received %d bytes\n",
+  coap_log_debug("*  %s: received %d bytes\n",
            coap_session_str(session), p->len);
 
   if (session->proto == COAP_PROTO_DTLS) {

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -228,7 +228,7 @@ coap_dgram_write(void *ctx, const unsigned char *send_buffer,
     coap_mbedtls_env_t *m_env = (coap_mbedtls_env_t *)c_session->tls;
     result = coap_session_send(c_session, send_buffer, send_buffer_length);
     if (result != (ssize_t)send_buffer_length) {
-      coap_log(LOG_WARNING, "coap_network_send failed (%zd != %zu)\n",
+      coap_log_warn("coap_network_send failed (%zd != %zu)\n",
                result, send_buffer_length);
       result = 0;
     }
@@ -264,7 +264,7 @@ static int psk_server_callback(void *p_info, mbedtls_ssl_context *ssl,
   lidentity.length = identity ? identity_len : 0;
   coap_session_refresh_psk_identity(c_session, &lidentity);
 
-  coap_log(LOG_DEBUG, "got psk_identity: '%.*s'\n",
+  coap_log_debug("got psk_identity: '%.*s'\n",
            (int)lidentity.length, (const char *)lidentity.s);
 
   m_env = (coap_mbedtls_env_t *)c_session->tls;
@@ -367,7 +367,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
   if (*flags & MBEDTLS_X509_BADCERT_EXPIRED) {
     if (setup_data->allow_expired_certs) {
       *flags &= ~MBEDTLS_X509_BADCERT_EXPIRED;
-      coap_log(LOG_INFO,
+      coap_log_info(
                "   %s: %s: overridden: '%s' depth %d\n",
                coap_session_str(c_session),
                "The certificate has expired", cn ? cn : "?", depth);
@@ -376,7 +376,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
   if (*flags & MBEDTLS_X509_BADCERT_FUTURE) {
     if (setup_data->allow_expired_certs) {
       *flags &= ~MBEDTLS_X509_BADCERT_FUTURE;
-      coap_log(LOG_INFO,
+      coap_log_info(
                "   %s: %s: overridden: '%s' depth %d\n",
                coap_session_str(c_session),
                "The certificate has a future date", cn ? cn : "?", depth);
@@ -385,7 +385,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
   if (*flags & MBEDTLS_X509_BADCERT_BAD_MD) {
     if (setup_data->allow_bad_md_hash) {
       *flags &= ~MBEDTLS_X509_BADCERT_BAD_MD;
-      coap_log(LOG_INFO,
+      coap_log_info(
                "   %s: %s: overridden: '%s' depth %d\n",
                coap_session_str(c_session),
                "The certificate has a bad MD hash", cn ? cn : "?", depth);
@@ -394,7 +394,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
   if (*flags & MBEDTLS_X509_BADCERT_BAD_KEY) {
     if (setup_data->allow_short_rsa_length) {
       *flags &= ~MBEDTLS_X509_BADCERT_BAD_KEY;
-      coap_log(LOG_INFO,
+      coap_log_info(
                "   %s: %s: overridden: '%s' depth %d\n",
                coap_session_str(c_session),
                "The certificate has a short RSA length", cn ? cn : "?", depth);
@@ -409,7 +409,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
       if (setup_data->allow_self_signed &&
           !setup_data->check_common_ca) {
         *flags &= ~MBEDTLS_X509_BADCERT_NOT_TRUSTED;
-        coap_log(LOG_INFO,
+        coap_log_info(
                  "   %s: %s: overridden: '%s' depth %d\n",
                  coap_session_str(c_session),
                  "Self-signed",
@@ -419,7 +419,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
     else {
       if (!setup_data->verify_peer_cert) {
         *flags &= ~MBEDTLS_X509_BADCERT_NOT_TRUSTED;
-        coap_log(LOG_INFO,
+        coap_log_info(
                  "   %s: %s: overridden: '%s' depth %d\n",
                  coap_session_str(c_session),
                  "The certificate's CA does not match", cn ? cn : "?", depth);
@@ -429,7 +429,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
   if (*flags & MBEDTLS_X509_BADCRL_EXPIRED) {
     if (setup_data->check_cert_revocation && setup_data->allow_expired_crl) {
       *flags &= ~MBEDTLS_X509_BADCRL_EXPIRED;
-      coap_log(LOG_INFO,
+      coap_log_info(
                "   %s: %s: overridden: '%s' depth %d\n",
                coap_session_str(c_session),
                "The certificate's CRL has expired", cn ? cn : "?", depth);
@@ -441,7 +441,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
   if (*flags & MBEDTLS_X509_BADCRL_FUTURE) {
     if (setup_data->check_cert_revocation && setup_data->allow_expired_crl) {
       *flags &= ~MBEDTLS_X509_BADCRL_FUTURE;
-      coap_log(LOG_INFO,
+      coap_log_info(
                "   %s: %s: overridden: '%s' depth %d\n",
                coap_session_str(c_session),
                "The certificate's CRL has a future date", cn ? cn : "?", depth);
@@ -453,7 +453,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
   if (setup_data->cert_chain_validation &&
       depth > (setup_data->cert_chain_verify_depth + 1)) {
     *flags |= MBEDTLS_X509_BADCERT_OTHER;
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "   %s: %s: '%s' depth %d\n",
              coap_session_str(c_session),
              "The certificate's verify depth is too long",
@@ -483,7 +483,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
       tcp = strchr(buf, '\n');
       while (tcp) {
         *tcp = '\000';
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "   %s: %s: issue 0x%" PRIx32 ": '%s' depth %d\n",
                  coap_session_str(c_session),
                  buf, *flags, cn ? cn : "?", depth);
@@ -491,7 +491,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
       }
     }
     else {
-      coap_log(LOG_ERR, "mbedtls_x509_crt_verify_info returned -0x%x: '%s'\n",
+      coap_log_err("mbedtls_x509_crt_verify_info returned -0x%x: '%s'\n",
                -ret, get_error_string(ret));
     }
   }
@@ -515,7 +515,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
   int ret;
 
   if (setup_data->is_rpk_not_cert) {
-    coap_log(LOG_ERR,
+    coap_log_err(
           "RPK Support not available in Mbed TLS\n");
     return -1;
   }
@@ -532,7 +532,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
       ret = mbedtls_x509_crt_parse_file(public_cert,
                                     setup_data->pki_key.key.pem.public_cert);
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_x509_crt_parse_file returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_x509_crt_parse_file returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
@@ -546,20 +546,20 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
                               NULL, coap_rng, (void *)&m_env->ctr_drbg);
 #endif /* MBEDTLS_2_X_COMPAT */
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_pk_parse_keyfile returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_pk_parse_keyfile returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
 
       ret = mbedtls_ssl_conf_own_cert(&m_env->conf, public_cert, private_key);
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_ssl_conf_own_cert returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_ssl_conf_own_cert returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
     }
     else if (role == COAP_DTLS_ROLE_SERVER) {
-      coap_log(LOG_ERR,
+      coap_log_err(
                "***setup_pki: (D)TLS: No Server Certificate + Private "
                "Key defined\n");
       return -1;
@@ -571,7 +571,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
       ret = mbedtls_x509_crt_parse_file(cacert,
                                         setup_data->pki_key.key.pem.ca_file);
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
@@ -594,7 +594,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
         /* Need to allocate memory to add in NULL terminator */
         buffer = mbedtls_malloc(length + 1);
         if (!buffer) {
-          coap_log(LOG_ERR, "mbedtls_malloc failed\n");
+          coap_log_err("mbedtls_malloc failed\n");
           return MBEDTLS_ERR_SSL_ALLOC_FAILED;
         }
         memcpy(buffer, setup_data->pki_key.key.pem_buf.public_cert, length);
@@ -609,7 +609,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
               setup_data->pki_key.key.pem_buf.public_cert_len);
       }
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
@@ -619,7 +619,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
         /* Need to allocate memory to add in NULL terminator */
         buffer = mbedtls_malloc(length + 1);
         if (!buffer) {
-          coap_log(LOG_ERR, "mbedtls_malloc failed\n");
+          coap_log_err("mbedtls_malloc failed\n");
           return MBEDTLS_ERR_SSL_ALLOC_FAILED;
         }
         memcpy(buffer, setup_data->pki_key.key.pem_buf.private_key, length);
@@ -646,19 +646,19 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
 #endif /* MBEDTLS_2_X_COMPAT */
       }
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_pk_parse_key returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_pk_parse_key returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
 
       ret = mbedtls_ssl_conf_own_cert(&m_env->conf, public_cert, private_key);
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_ssl_conf_own_cert returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_ssl_conf_own_cert returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
     } else if (role == COAP_DTLS_ROLE_SERVER) {
-      coap_log(LOG_ERR,
+      coap_log_err(
               "***setup_pki: (D)TLS: No Server Certificate + Private "
               "Key defined\n");
       return -1;
@@ -675,7 +675,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
         /* Need to allocate memory to add in NULL terminator */
         buffer = mbedtls_malloc(length + 1);
         if (!buffer) {
-          coap_log(LOG_ERR, "mbedtls_malloc failed\n");
+          coap_log_err("mbedtls_malloc failed\n");
           return MBEDTLS_ERR_SSL_ALLOC_FAILED;
         }
         memcpy(buffer, setup_data->pki_key.key.pem_buf.ca_cert, length);
@@ -690,7 +690,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
                 setup_data->pki_key.key.pem_buf.ca_cert_len);
       }
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
@@ -709,7 +709,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
               (const unsigned char *)setup_data->pki_key.key.asn1.public_cert,
               setup_data->pki_key.key.asn1.public_cert_len);
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
@@ -725,19 +725,19 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
               (void *)&m_env->ctr_drbg);
 #endif /* MBEDTLS_2_X_COMPAT */
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_pk_parse_key returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_pk_parse_key returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
 
       ret = mbedtls_ssl_conf_own_cert(&m_env->conf, public_cert, private_key);
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_ssl_conf_own_cert returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_ssl_conf_own_cert returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
     } else if (role == COAP_DTLS_ROLE_SERVER) {
-      coap_log(LOG_ERR,
+      coap_log_err(
                "***setup_pki: (D)TLS: No Server Certificate + Private "
                "Key defined\n");
       return -1;
@@ -750,7 +750,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
                   (const unsigned char *)setup_data->pki_key.key.asn1.ca_cert,
                   setup_data->pki_key.key.asn1.ca_cert_len);
       if (ret < 0) {
-        coap_log(LOG_ERR, "mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         return ret;
       }
@@ -759,12 +759,12 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
     break;
 
   case COAP_PKI_KEY_PKCS11:
-    coap_log(LOG_ERR,
+    coap_log_err(
              "***setup_pki: (D)TLS: PKCS11 not currently supported\n");
     return -1;
 
   default:
-    coap_log(LOG_ERR,
+    coap_log_err(
              "***setup_pki: (D)TLS: Unknown key type %d\n",
              setup_data->pki_key.key_type);
     return -1;
@@ -773,7 +773,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
   if (m_context->root_ca_file) {
     ret = mbedtls_x509_crt_parse_file(cacert, m_context->root_ca_file);
     if (ret < 0) {
-      coap_log(LOG_ERR, "mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
+      coap_log_err("mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
                -ret, get_error_string(ret));
       return ret;
     }
@@ -782,7 +782,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
   if (m_context->root_ca_path) {
     ret = mbedtls_x509_crt_parse_file(cacert, m_context->root_ca_path);
     if (ret < 0) {
-      coap_log(LOG_ERR, "mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
+      coap_log_err("mbedtls_x509_crt_parse returned -0x%x: '%s'\n",
                -ret, get_error_string(ret));
       return ret;
     }
@@ -976,7 +976,7 @@ static int setup_server_ssl_session(coap_session_t *c_session,
                    MBEDTLS_SSL_TRANSPORT_DATAGRAM :
                    MBEDTLS_SSL_TRANSPORT_STREAM,
                   MBEDTLS_SSL_PRESET_DEFAULT)) != 0) {
-    coap_log(LOG_ERR, "mbedtls_ssl_config_defaults returned -0x%x: '%s'\n",
+    coap_log_err("mbedtls_ssl_config_defaults returned -0x%x: '%s'\n",
              -ret, get_error_string(ret));
     goto fail;
   }
@@ -995,7 +995,7 @@ static int setup_server_ssl_session(coap_session_t *c_session,
       mbedtls_ssl_conf_sni(&m_env->conf, psk_sni_callback, c_session);
     }
 #else /* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
-    coap_log(LOG_WARNING, "PSK not enabled in Mbed TLS library\n");
+    coap_log_warn("PSK not enabled in Mbed TLS library\n");
 #endif /* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
   }
 
@@ -1005,7 +1005,7 @@ static int setup_server_ssl_session(coap_session_t *c_session,
                                 c_session, &m_context->setup_data,
                                 COAP_DTLS_ROLE_SERVER);
     if (ret < 0) {
-      coap_log(LOG_ERR, "PKI setup failed\n");
+      coap_log_err("PKI setup failed\n");
       return ret;
     }
     if (m_context->setup_data.validate_sni_call_back) {
@@ -1016,7 +1016,7 @@ static int setup_server_ssl_session(coap_session_t *c_session,
   if ((ret = mbedtls_ssl_cookie_setup(&m_env->cookie_ctx,
                                   mbedtls_ctr_drbg_random,
                                   &m_env->ctr_drbg)) != 0) {
-    coap_log(LOG_ERR, "mbedtls_ssl_cookie_setup: returned -0x%x: '%s'\n",
+    coap_log_err("mbedtls_ssl_cookie_setup: returned -0x%x: '%s'\n",
              -ret, get_error_string(ret));
     goto fail;
   }
@@ -1080,12 +1080,12 @@ set_ciphersuites(mbedtls_ssl_config *conf, coap_enc_method_t method)
 
     psk_ciphers = mbedtls_malloc(psk_count * sizeof(psk_ciphers[0]));
     if (psk_ciphers == NULL) {
-      coap_log(LOG_ERR, "set_ciphers: mbedtls_malloc with count %d failed\n", psk_count);
+      coap_log_err("set_ciphers: mbedtls_malloc with count %d failed\n", psk_count);
       return;
     }
     pki_ciphers = mbedtls_malloc(pki_count * sizeof(pki_ciphers[0]));
     if (pki_ciphers == NULL) {
-      coap_log(LOG_ERR, "set_ciphers: mbedtls_malloc with count %d failed\n", pki_count);
+      coap_log_err("set_ciphers: mbedtls_malloc with count %d failed\n", pki_count);
       mbedtls_free(psk_ciphers);
       psk_ciphers = NULL;
       return;
@@ -1145,7 +1145,7 @@ static int setup_client_ssl_session(coap_session_t *c_session,
                    MBEDTLS_SSL_TRANSPORT_DATAGRAM :
                    MBEDTLS_SSL_TRANSPORT_STREAM,
                   MBEDTLS_SSL_PRESET_DEFAULT)) != 0) {
-      coap_log(LOG_ERR, "mbedtls_ssl_config_defaults returned -0x%x: '%s'\n",
+      coap_log_err("mbedtls_ssl_config_defaults returned -0x%x: '%s'\n",
                -ret, get_error_string(ret));
       goto fail;
   }
@@ -1163,7 +1163,7 @@ static int setup_client_ssl_session(coap_session_t *c_session,
     const coap_bin_const_t *psk_key;
     const coap_bin_const_t *psk_identity;
 
-    coap_log(LOG_INFO, "Setting PSK key\n");
+    coap_log_info("Setting PSK key\n");
 
     psk_key = coap_get_session_client_psk_key(c_session);
     psk_identity = coap_get_session_client_psk_identity(c_session);
@@ -1175,14 +1175,14 @@ static int setup_client_ssl_session(coap_session_t *c_session,
     if ((ret = mbedtls_ssl_conf_psk(&m_env->conf, psk_key->s,
                                     psk_key->length, psk_identity->s,
                                     psk_identity->length)) != 0) {
-      coap_log(LOG_ERR, "mbedtls_ssl_conf_psk returned -0x%x: '%s'\n",
+      coap_log_err("mbedtls_ssl_conf_psk returned -0x%x: '%s'\n",
                -ret, get_error_string(ret));
       goto fail;
     }
     if (c_session->cpsk_setup_data.client_sni) {
        if ((ret = mbedtls_ssl_set_hostname(&m_env->ssl,
                                c_session->cpsk_setup_data.client_sni)) != 0) {
-        coap_log(LOG_ERR, "mbedtls_ssl_set_hostname returned -0x%x: '%s'\n",
+        coap_log_err("mbedtls_ssl_set_hostname returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
         goto fail;
       }
@@ -1191,7 +1191,7 @@ static int setup_client_ssl_session(coap_session_t *c_session,
 
     set_ciphersuites(&m_env->conf, COAP_ENC_PSK);
 #else /* MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
-    coap_log(LOG_WARNING, "PSK not enabled in Mbed TLS library\n");
+    coap_log_warn("PSK not enabled in Mbed TLS library\n");
 #endif /* ! MBEDTLS_KEY_EXCHANGE__SOME__PSK_ENABLED */
   }
   else if ((m_context->psk_pki_enabled & IS_PKI) ||
@@ -1206,7 +1206,7 @@ static int setup_client_ssl_session(coap_session_t *c_session,
                                 c_session, &m_context->setup_data,
                                 COAP_DTLS_ROLE_CLIENT);
     if (ret < 0) {
-      coap_log(LOG_ERR, "PKI setup failed\n");
+      coap_log_err("PKI setup failed\n");
       return ret;
     }
 #if defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_ALPN)
@@ -1215,7 +1215,7 @@ static int setup_client_ssl_session(coap_session_t *c_session,
 
       ret = mbedtls_ssl_conf_alpn_protocols(&m_env->conf, alpn_list);
       if (ret != 0) {
-        coap_log(LOG_ERR, "ALPN setup failed %d)\n", ret);
+        coap_log_err("ALPN setup failed %d)\n", ret);
       }
     }
 #endif /* MBEDTLS_SSL_SRV_C && MBEDTLS_SSL_ALPN */
@@ -1291,7 +1291,7 @@ static int do_mbedtls_handshake(coap_session_t *c_session,
   switch (ret) {
   case 0:
     m_env->established = 1;
-    coap_log(LOG_DEBUG, "*  %s: Mbed TLS established\n",
+    coap_log_debug("*  %s: Mbed TLS established\n",
                                             coap_session_str(c_session));
     ret = 1;
     break;
@@ -1301,7 +1301,7 @@ static int do_mbedtls_handshake(coap_session_t *c_session,
     ret = 0;
     break;
   case MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED:
-    coap_log(LOG_DEBUG, "hello verification requested\n");
+    coap_log_debug("hello verification requested\n");
     goto reset;
   case MBEDTLS_ERR_SSL_INVALID_MAC:
     goto fail;
@@ -1324,7 +1324,7 @@ static int do_mbedtls_handshake(coap_session_t *c_session,
     goto fail;
   case MBEDTLS_ERR_SSL_FATAL_ALERT_MESSAGE:
     if (m_env->ssl.in_msg[1] != MBEDTLS_SSL_ALERT_MSG_CLOSE_NOTIFY)
-      coap_log(LOG_WARNING, "***%s: Alert '%d'%s\n",
+      coap_log_warn("***%s: Alert '%d'%s\n",
                coap_session_str(c_session), m_env->ssl.in_msg[1],
                report_mbedtls_alert(m_env->ssl.in_msg[1]));
     /* Fall through */
@@ -1335,7 +1335,7 @@ static int do_mbedtls_handshake(coap_session_t *c_session,
     ret = -1;
     break;
   default:
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "do_mbedtls_handshake: session establish "
              "returned -0x%x: '%s'\n",
              -ret, get_error_string(ret));
@@ -1351,7 +1351,7 @@ fail_alert:
   m_env->sent_alert = 1;
 fail:
   c_session->dtls_event = COAP_EVENT_DTLS_ERROR;
-  coap_log(LOG_WARNING,
+  coap_log_warn(
            "do_mbedtls_handshake: session establish "
            "returned '%s'\n",
            get_error_string(ret));
@@ -1412,10 +1412,10 @@ coap_sock_read(void *ctx, unsigned char *out, size_t outl) {
     ret = recv(c_session->sock.fd, out, outl, 0);
 #endif
     if (ret > 0) {
-      coap_log(LOG_DEBUG, "*  %s: received %zd bytes\n",
+      coap_log_debug("*  %s: received %zd bytes\n",
                coap_session_str(c_session), ret);
     } else if (ret < 0 && errno != EAGAIN) {
-      coap_log(LOG_DEBUG,  "*  %s: failed to receive any bytes (%s)\n",
+      coap_log_debug( "*  %s: failed to receive any bytes (%s)\n",
                coap_session_str(c_session), coap_socket_strerror());
     }
 
@@ -1466,7 +1466,7 @@ coap_sock_write(void *context, const unsigned char *in, size_t inl) {
 
   ret = (int)coap_socket_write(&c_session->sock, in, inl);
   if (ret > 0) {
-    coap_log(LOG_DEBUG, "*  %s: sent %d bytes\n",
+    coap_log_debug("*  %s: sent %d bytes\n",
              coap_session_str(c_session), ret);
   } else if (ret < 0) {
     if ((c_session->state == COAP_SESSION_STATE_CSM ||
@@ -1506,7 +1506,7 @@ coap_sock_write(void *context, const unsigned char *in, size_t inl) {
       else {
         ret = MBEDTLS_ERR_NET_SEND_FAILED;
       }
-      coap_log(LOG_DEBUG,  "*  %s: failed to send %zd bytes (%s) state %d\n",
+      coap_log_debug( "*  %s: failed to send %zd bytes (%s) state %d\n",
                coap_session_str(c_session), inl, coap_socket_strerror(),
                c_session->state);
     }
@@ -1545,7 +1545,7 @@ static coap_mbedtls_env_t *coap_dtls_new_mbedtls_env(coap_session_t *c_session,
 #endif /* ESPIDF_VERSION && CONFIG_MBEDTLS_DEBUG */
   if ((ret = mbedtls_ctr_drbg_seed(&m_env->ctr_drbg,
                   mbedtls_entropy_func, &m_env->entropy, NULL, 0)) != 0) {
-    coap_log(LOG_ERR, "mbedtls_ctr_drbg_seed returned -0x%x: '%s'\n",
+    coap_log_err("mbedtls_ctr_drbg_seed returned -0x%x: '%s'\n",
              -ret, get_error_string(ret));
     goto fail;
   }
@@ -1613,7 +1613,7 @@ coap_dtls_is_supported(void) {
  static int reported = 0;
   if (!reported) {
     reported = 1;
-    coap_log(LOG_EMERG,
+    coap_log_emerg(
              "libcoap not compiled for DTLS with Mbed TLS"
              " - update Mbed TLS to include DTLS\n");
   }
@@ -1691,7 +1691,7 @@ coap_dtls_context_set_spsk(coap_context_t *c_context,
                          ((coap_mbedtls_context_t *)c_context->dtls_context);
 
 #if !defined(MBEDTLS_SSL_SRV_C)
-  coap_log(LOG_EMERG, "coap_context_set_spsk:"
+  coap_log_emerg("coap_context_set_spsk:"
            " libcoap not compiled for Server Mode for Mbed TLS"
            " - update Mbed TLS to include Server Mode\n");
   return 0;
@@ -1714,7 +1714,7 @@ coap_dtls_context_set_cpsk(coap_context_t *c_context,
                           coap_dtls_cpsk_t *setup_data
 ) {
 #if !defined(MBEDTLS_SSL_CLI_C)
-  coap_log(LOG_EMERG, "coap_context_set_cpsk:"
+  coap_log_emerg("coap_context_set_cpsk:"
            " libcoap not compiled for Client Mode for Mbed TLS"
            " - update Mbed TLS to include Client Mode\n");
   return 0;
@@ -1726,7 +1726,7 @@ coap_dtls_context_set_cpsk(coap_context_t *c_context,
     return 0;
 
   if (setup_data->validate_ih_call_back) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
         "CoAP Client with Mbed TLS does not support Identity Hint selection\n");
   }
   m_context->psk_pki_enabled |= IS_PSK;
@@ -1769,14 +1769,14 @@ int coap_dtls_context_set_pki_root_cas(coap_context_t *c_context,
              ((coap_mbedtls_context_t *)c_context->dtls_context);
 
   if (!m_context) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_context_set_pki_root_cas: (D)TLS environment "
              "not set up\n");
     return 0;
   }
 
   if (ca_file == NULL && ca_path == NULL) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_context_set_pki_root_cas: ca_file and/or ca_path "
              "not defined\n");
     return 0;
@@ -1844,7 +1844,7 @@ void *coap_dtls_new_client_session(coap_session_t *c_session)
 {
 #if !defined(MBEDTLS_SSL_CLI_C)
   (void)c_session;
-  coap_log(LOG_EMERG, "coap_dtls_new_client_session:"
+  coap_log_emerg("coap_dtls_new_client_session:"
            " libcoap not compiled for Client Mode for Mbed TLS"
            " - update Mbed TLS to include Client Mode\n");
   return NULL;
@@ -1874,7 +1874,7 @@ void *coap_dtls_new_server_session(coap_session_t *c_session)
 {
 #if !defined(MBEDTLS_SSL_SRV_C)
   (void)c_session;
-  coap_log(LOG_EMERG, "coap_dtls_new_server_session:"
+  coap_log_emerg("coap_dtls_new_server_session:"
            " libcoap not compiled for Server Mode for Mbed TLS"
            " - update Mbed TLS to include Server Mode\n");
   return NULL;
@@ -1944,7 +1944,7 @@ int coap_dtls_send(coap_session_t *c_session,
         ret = -1;
         break;
       default:
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "coap_dtls_send: "
                  "returned -0x%x: '%s'\n",
                  -ret, get_error_string(ret));
@@ -1952,7 +1952,7 @@ int coap_dtls_send(coap_session_t *c_session,
         break;
       }
       if (ret == -1) {
-        coap_log(LOG_WARNING, "coap_dtls_send: cannot send PDU\n");
+        coap_log_warn("coap_dtls_send: cannot send PDU\n");
       }
     }
   } else {
@@ -2065,7 +2065,7 @@ int coap_dtls_receive(coap_session_t *c_session,
 
   ssl_data = &m_env->coap_ssl_data;
   if (ssl_data->pdu_len) {
-    coap_log(LOG_ERR, "** %s: Previous data not read %u bytes\n",
+    coap_log_err("** %s: Previous data not read %u bytes\n",
              coap_session_str(c_session), ssl_data->pdu_len);
   }
   ssl_data->pdu = data;
@@ -2106,7 +2106,7 @@ int coap_dtls_receive(coap_session_t *c_session,
     case MBEDTLS_ERR_SSL_WANT_READ:
       break;
     default:
-      coap_log(LOG_WARNING,
+      coap_log_warn(
                "coap_dtls_receive: "
                "returned -0x%x: '%s' (length %zd)\n",
                -ret, get_error_string(ret), data_len);
@@ -2150,7 +2150,7 @@ int coap_dtls_receive(coap_session_t *c_session,
 finish:
   if (ssl_data && ssl_data->pdu_len) {
     /* pdu data is held on stack which will not stay there */
-    coap_log(LOG_DEBUG, "coap_dtls_receive: ret %d: remaining data %u\n", ret, ssl_data->pdu_len);
+    coap_log_debug("coap_dtls_receive: ret %d: remaining data %u\n", ret, ssl_data->pdu_len);
     ssl_data->pdu_len = 0;
     ssl_data->pdu = NULL;
   }
@@ -2171,7 +2171,7 @@ int coap_dtls_hello(coap_session_t *c_session,
   (void)c_session;
   (void)data;
   (void)data_len;
-  coap_log(LOG_EMERG, "coap_dtls_hello:"
+  coap_log_emerg("coap_dtls_hello:"
            " libcoap not compiled for DTLS or Server Mode for Mbed TLS"
            " - update Mbed TLS to include DTLS and Server Mode\n");
   return -1;
@@ -2195,7 +2195,7 @@ int coap_dtls_hello(coap_session_t *c_session,
   if((ret = mbedtls_ssl_set_client_transport_id(&m_env->ssl,
                             (unsigned char *)&c_session->addr_info.remote,
                             sizeof(c_session->addr_info.remote))) != 0) {
-    coap_log(LOG_ERR,
+    coap_log_err(
              "mbedtls_ssl_set_client_transport_id() returned -0x%x: '%s'\n",
              -ret, get_error_string(ret));
     return -1;
@@ -2203,7 +2203,7 @@ int coap_dtls_hello(coap_session_t *c_session,
 
   ssl_data = &m_env->coap_ssl_data;
   if (ssl_data->pdu_len) {
-    coap_log(LOG_ERR, "** %s: Previous data not read %u bytes\n",
+    coap_log_err("** %s: Previous data not read %u bytes\n",
              coap_session_str(c_session), ssl_data->pdu_len);
   }
   ssl_data->pdu = data;
@@ -2225,7 +2225,7 @@ int coap_dtls_hello(coap_session_t *c_session,
 
   if (ssl_data->pdu_len) {
     /* pdu data is held on stack which will not stay there */
-    coap_log(LOG_DEBUG, "coap_dtls_hello: ret %d: remaining data %u\n", ret, ssl_data->pdu_len);
+    coap_log_debug("coap_dtls_hello: ret %d: remaining data %u\n", ret, ssl_data->pdu_len);
     ssl_data->pdu_len = 0;
     ssl_data->pdu = NULL;
   }
@@ -2253,7 +2253,7 @@ void *coap_tls_new_client_session(coap_session_t *c_session,
 #if !defined(MBEDTLS_SSL_CLI_C)
   (void)c_session;
   *connected = 0;
-  coap_log(LOG_EMERG, "coap_tls_new_client_session:"
+  coap_log_emerg("coap_tls_new_client_session:"
            " libcoap not compiled for Client Mode for Mbed TLS"
            " - update Mbed TLS to include Client Mode\n");
   return NULL;
@@ -2288,7 +2288,7 @@ void *coap_tls_new_server_session(coap_session_t *c_session COAP_UNUSED,
 {
 #if !defined(MBEDTLS_SSL_SRV_C)
   (void)c_session;
-  coap_log(LOG_EMERG, "coap_tls_new_server_session:"
+  coap_log_emerg("coap_tls_new_server_session:"
            " libcoap not compiled for Server Mode for Mbed TLS"
            " - update Mbed TLS to include Server Mode\n");
   return NULL;
@@ -2351,7 +2351,7 @@ ssize_t coap_tls_write(coap_session_t *c_session,
           ret = -1;
           break;
         default:
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "coap_tls_write: "
                    "returned -0x%x: '%s'\n",
                    -ret, get_error_string(ret));
@@ -2359,7 +2359,7 @@ ssize_t coap_tls_write(coap_session_t *c_session,
           break;
         }
         if (ret == -1) {
-          coap_log(LOG_WARNING, "coap_tls_write: cannot send PDU\n");
+          coap_log_warn("coap_tls_write: cannot send PDU\n");
         }
         break;
       }
@@ -2438,7 +2438,7 @@ ssize_t coap_tls_read(coap_session_t *c_session,
         ret = 0;
         break;
       default:
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "coap_tls_read: "
                  "returned -0x%x: '%s' (length %zd)\n",
                  -ret, get_error_string(ret), data_len);

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -168,7 +168,7 @@ static int psk_tls_client_hello_call_back(SSL *ssl, int *al, void *arg);
 int
 coap_dtls_is_supported(void) {
   if (SSLeay() < 0x10100000L) {
-    coap_log(LOG_WARNING, "OpenSSL version 1.1.0 or later is required\n");
+    coap_log_warn("OpenSSL version 1.1.0 or later is required\n");
     return 0;
   }
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
@@ -180,7 +180,7 @@ coap_dtls_is_supported(void) {
    * as SSL_CTX_set_client_hello_cb() is not there in 1.1.0.
    */
   if (SSLeay() < 0x10101000L) {
-    coap_log(LOG_WARNING, "OpenSSL version 1.1.1 or later is required\n");
+    coap_log_warn("OpenSSL version 1.1.1 or later is required\n");
     return 0;
   }
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10101000L */
@@ -191,12 +191,12 @@ int
 coap_tls_is_supported(void) {
 #if !COAP_DISABLE_TCP
   if (SSLeay() < 0x10100000L) {
-    coap_log(LOG_WARNING, "OpenSSL version 1.1.0 or later is required\n");
+    coap_log_warn("OpenSSL version 1.1.0 or later is required\n");
     return 0;
   }
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
   if (SSLeay() < 0x10101000L) {
-    coap_log(LOG_WARNING, "OpenSSL version 1.1.1 or later is required\n");
+    coap_log_warn("OpenSSL version 1.1.1 or later is required\n");
     return 0;
   }
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10101000L */
@@ -496,7 +496,7 @@ coap_dtls_psk_client_callback(SSL *ssl,
   temp.length = strlen((const char*)temp.s);
   coap_session_refresh_psk_hint(c_session, &temp);
 
-  coap_log(LOG_DEBUG, "got psk_identity_hint: '%.*s'\n", (int)temp.length,
+  coap_log_debug("got psk_identity_hint: '%.*s'\n", (int)temp.length,
              (const char *)temp.s);
 
   if (setup_data->validate_ih_call_back) {
@@ -523,7 +523,7 @@ coap_dtls_psk_client_callback(SSL *ssl,
   }
 
   if (psk_identity == NULL || psk_key == NULL) {
-    coap_log(LOG_WARNING, "no PSK available\n");
+    coap_log_warn("no PSK available\n");
     return 0;
   }
 
@@ -532,7 +532,7 @@ coap_dtls_psk_client_callback(SSL *ssl,
     return 0;
   max_identity_len--;
   if (psk_identity->length > max_identity_len) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "psk_identity too large, truncated to %d bytes\n",
              max_identity_len);
   }
@@ -544,7 +544,7 @@ coap_dtls_psk_client_callback(SSL *ssl,
   identity[max_identity_len] = '\000';
 
   if (psk_key->length > max_psk_len) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "psk_key too large, truncated to %d bytes\n",
              max_psk_len);
   }
@@ -581,7 +581,7 @@ coap_dtls_psk_server_callback(
   lidentity.length = strlen((const char*)lidentity.s);
   coap_session_refresh_psk_identity(c_session, &lidentity);
 
-  coap_log(LOG_DEBUG, "got psk_identity: '%.*s'\n",
+  coap_log_debug("got psk_identity: '%.*s'\n",
            (int)lidentity.length, (const char *)lidentity.s);
 
   if (setup_data->validate_id_call_back) {
@@ -599,7 +599,7 @@ coap_dtls_psk_server_callback(
     return 0;
 
   if (psk_key->length > max_psk_len) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "psk_key too large, truncated to %d bytes\n",
              max_psk_len);
   }
@@ -744,7 +744,7 @@ static int coap_sock_write(BIO *a, const char *in, int inl) {
         ret = inl;
       }
       else {
-        coap_log(LOG_DEBUG,  "*  %s: failed to send %d bytes (%s) state %d\n",
+        coap_log_debug( "*  %s: failed to send %d bytes (%s) state %d\n",
                  coap_session_str(session), inl, coap_socket_strerror(),
                  session->state);
       }
@@ -995,7 +995,7 @@ map_key_type(int asn1_private_key_type
   case COAP_ASN1_PKEY_TLS1_PRF: return EVP_PKEY_TLS1_PRF;
   case COAP_ASN1_PKEY_HKDF: return EVP_PKEY_HKDF;
   default:
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "*** setup_pki: DTLS: Unknown Private Key type %d for ASN1\n",
              asn1_private_key_type);
     break;
@@ -1044,7 +1044,7 @@ add_ca_to_cert_store(X509_STORE *st, X509 *x509)
       int r = ERR_GET_REASON(e);
       if (r != X509_R_CERT_ALREADY_IN_HASH_TABLE) {
         /* Not already added */
-        coap_log(LOG_WARNING, "***setup_pki: (D)TLS: %s%s\n",
+        coap_log_warn("***setup_pki: (D)TLS: %s%s\n",
                  ERR_reason_error_string(e),
                  ssl_function_definition(e));
       }
@@ -1082,7 +1082,7 @@ setup_pki_server(SSL_CTX *ctx,
       if (!(SSL_CTX_use_certificate_file(ctx,
                                         setup_data->pki_key.key.pem.public_cert,
                                         SSL_FILETYPE_PEM))) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "Server Certificate\n",
                  setup_data->pki_key.key.pem.public_cert);
@@ -1090,7 +1090,7 @@ setup_pki_server(SSL_CTX *ctx,
       }
     }
     else {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No Server Certificate defined\n");
       return 0;
     }
@@ -1100,7 +1100,7 @@ setup_pki_server(SSL_CTX *ctx,
       if (!(SSL_CTX_use_PrivateKey_file(ctx,
                                         setup_data->pki_key.key.pem.private_key,
                                         SSL_FILETYPE_PEM))) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "Server Private Key\n",
                   setup_data->pki_key.key.pem.private_key);
@@ -1108,7 +1108,7 @@ setup_pki_server(SSL_CTX *ctx,
       }
     }
     else {
-      coap_log(LOG_ERR,
+      coap_log_err(
            "*** setup_pki: (D)TLS: No Server Private Key defined\n");
       return 0;
     }
@@ -1124,7 +1124,7 @@ setup_pki_server(SSL_CTX *ctx,
       if (cert_names != NULL)
         SSL_CTX_set_client_CA_list(ctx, cert_names);
       else {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "client CA File\n",
                   setup_data->pki_key.key.pem.ca_file);
@@ -1160,7 +1160,7 @@ setup_pki_server(SSL_CTX *ctx,
       X509 *cert = bp ? PEM_read_bio_X509(bp, NULL, 0, NULL) : NULL;
 
       if (!cert || !SSL_CTX_use_certificate(ctx, cert)) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: Unable to configure "
                  "Server PEM Certificate\n");
         if (bp) BIO_free(bp);
@@ -1171,7 +1171,7 @@ setup_pki_server(SSL_CTX *ctx,
       if (cert) X509_free(cert);
     }
     else {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No Server Certificate defined\n");
       return 0;
     }
@@ -1183,7 +1183,7 @@ setup_pki_server(SSL_CTX *ctx,
       EVP_PKEY *pkey = bp ? PEM_read_bio_PrivateKey(bp, NULL, 0, NULL) : NULL;
 
       if (!pkey || !SSL_CTX_use_PrivateKey(ctx, pkey)) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: Unable to configure "
                  "Server PEM Private Key\n");
         if (bp) BIO_free(bp);
@@ -1194,7 +1194,7 @@ setup_pki_server(SSL_CTX *ctx,
       if (pkey) EVP_PKEY_free(pkey);
     }
     else {
-      coap_log(LOG_ERR,
+      coap_log_err(
            "*** setup_pki: (D)TLS: No Server Private Key defined\n");
       return 0;
     }
@@ -1226,7 +1226,7 @@ setup_pki_server(SSL_CTX *ctx,
       if (!(SSL_CTX_use_certificate_ASN1(ctx,
                                  setup_data->pki_key.key.asn1.public_cert_len,
                                  setup_data->pki_key.key.asn1.public_cert))) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "Server Certificate\n",
                  "ASN1");
@@ -1234,7 +1234,7 @@ setup_pki_server(SSL_CTX *ctx,
       }
     }
     else {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No Server Certificate defined\n");
       return 0;
     }
@@ -1245,7 +1245,7 @@ setup_pki_server(SSL_CTX *ctx,
       if (!(SSL_CTX_use_PrivateKey_ASN1(pkey_type, ctx,
                              setup_data->pki_key.key.asn1.private_key,
                              setup_data->pki_key.key.asn1.private_key_len))) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "Server Private Key\n",
                  "ASN1");
@@ -1253,7 +1253,7 @@ setup_pki_server(SSL_CTX *ctx,
       }
     }
     else {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No Server Private Key defined\n");
       return 0;
     }
@@ -1265,7 +1265,7 @@ setup_pki_server(SSL_CTX *ctx,
       X509* x509 = d2i_X509(NULL, &p, setup_data->pki_key.key.asn1.ca_cert_len);
       X509_STORE *st;
       if (!x509 || !SSL_CTX_add_client_CA(ctx, x509)) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "client CA File\n",
                   "ASN1");
@@ -1282,7 +1282,7 @@ setup_pki_server(SSL_CTX *ctx,
     if (!ssl_engine) {
       ssl_engine = ENGINE_by_id("pkcs11");
       if (!ssl_engine) {
-        coap_log(LOG_ERR,
+        coap_log_err(
            "*** setup_pki: (D)TLS: No PKCS11 support\nn");
         return 0;
       }
@@ -1290,7 +1290,7 @@ setup_pki_server(SSL_CTX *ctx,
         /* the engine couldn't initialise, release 'ssl_engine' */
         ENGINE_free(ssl_engine);
         ssl_engine = NULL;
-        coap_log(LOG_ERR,
+        coap_log_err(
            "*** setup_pki: (D)TLS: PKCS11 engine initialize failed\n");
         return 0;
       }
@@ -1300,7 +1300,7 @@ setup_pki_server(SSL_CTX *ctx,
       /* If not set, pin may be held in pkcs11: URI */
       if (ENGINE_ctrl_cmd_string(ssl_engine, "PIN",
                   setup_data->pki_key.key.pkcs11.user_pin, 0) == 0) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: PKCS11: %s: Unable to set pin\n",
                   setup_data->pki_key.key.pkcs11.user_pin);
         return 0;
@@ -1316,14 +1316,14 @@ setup_pki_server(SSL_CTX *ctx,
                                 NULL, NULL);
 
         if (!pkey) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to load "
                    "Server Private Key\n",
                    setup_data->pki_key.key.pkcs11.private_key);
           return 0;
         }
         if (!SSL_CTX_use_PrivateKey(ctx, pkey)) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "Server Private Key\n",
                    setup_data->pki_key.key.pkcs11.private_key);
@@ -1336,7 +1336,7 @@ setup_pki_server(SSL_CTX *ctx,
         if (!(SSL_CTX_use_PrivateKey_file(ctx,
                                     setup_data->pki_key.key.pkcs11.private_key,
                                     SSL_FILETYPE_ASN1))) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "Server Private Key\n",
                    setup_data->pki_key.key.pkcs11.private_key);
@@ -1345,7 +1345,7 @@ setup_pki_server(SSL_CTX *ctx,
       }
     }
     else {
-      coap_log(LOG_ERR,
+      coap_log_err(
            "*** setup_pki: (D)TLS: No Server Private Key defined\n");
       return 0;
     }
@@ -1359,14 +1359,14 @@ setup_pki_server(SSL_CTX *ctx,
         x509 = missing_ENGINE_load_cert(
                              setup_data->pki_key.key.pkcs11.public_cert);
         if (!x509) {
-            coap_log(LOG_WARNING,
+            coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to load "
                    "Server Certificate\n",
                    setup_data->pki_key.key.pkcs11.public_cert);
           return 0;
         }
         if (!SSL_CTX_use_certificate(ctx, x509)) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "Server Certificate\n",
                    setup_data->pki_key.key.pkcs11.public_cert);
@@ -1379,7 +1379,7 @@ setup_pki_server(SSL_CTX *ctx,
         if (!(SSL_CTX_use_certificate_file(ctx,
                                      setup_data->pki_key.key.pkcs11.public_cert,
                                      SSL_FILETYPE_ASN1))) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "Server Certificate\n",
                    setup_data->pki_key.key.pkcs11.public_cert);
@@ -1388,7 +1388,7 @@ setup_pki_server(SSL_CTX *ctx,
       }
     }
     else {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No Server Certificate defined\n");
       return 0;
     }
@@ -1403,14 +1403,14 @@ setup_pki_server(SSL_CTX *ctx,
         x509 = missing_ENGINE_load_cert (
                           setup_data->pki_key.key.pkcs11.ca);
         if (!x509) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to load "
                    "Server CA Certificate\n",
                     setup_data->pki_key.key.pkcs11.ca);
           return 0;
         }
         if (!SSL_CTX_add_client_CA(ctx, x509)) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "Server CA File\n",
                    setup_data->pki_key.key.pkcs11.ca);
@@ -1426,7 +1426,7 @@ setup_pki_server(SSL_CTX *ctx,
         X509 *x509 = fp ? d2i_X509_fp(fp, NULL) : NULL;
 
         if (!x509 || !SSL_CTX_add_client_CA(ctx, x509)) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "client CA File\n",
                     setup_data->pki_key.key.pkcs11.ca);
@@ -1441,7 +1441,7 @@ setup_pki_server(SSL_CTX *ctx,
     break;
 
   default:
-    coap_log(LOG_ERR,
+    coap_log_err(
              "*** setup_pki: (D)TLS: Unknown key type %d\n",
              setup_data->pki_key.key_type);
     return 0;
@@ -1457,7 +1457,7 @@ setup_pki_ssl(SSL *ssl,
                  coap_dtls_pki_t* setup_data, coap_dtls_role_t role
 ) {
   if (setup_data->is_rpk_not_cert) {
-    coap_log(LOG_ERR,
+    coap_log_err(
           "RPK Support not available in OpenSSL\n");
     return 0;
   }
@@ -1468,7 +1468,7 @@ setup_pki_ssl(SSL *ssl,
       if (!(SSL_use_certificate_file(ssl,
                                    setup_data->pki_key.key.pem.public_cert,
                                    SSL_FILETYPE_PEM))) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "%s Certificate\n",
                  setup_data->pki_key.key.pem.public_cert,
@@ -1479,7 +1479,7 @@ setup_pki_ssl(SSL *ssl,
     else if (role == COAP_DTLS_ROLE_SERVER ||
              (setup_data->pki_key.key.pem.private_key &&
               setup_data->pki_key.key.pem.private_key[0])) {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No %s Certificate defined\n",
              role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
       return 0;
@@ -1489,7 +1489,7 @@ setup_pki_ssl(SSL *ssl,
       if (!(SSL_use_PrivateKey_file(ssl,
                                   setup_data->pki_key.key.pem.private_key,
                                   SSL_FILETYPE_PEM))) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "Client Private Key\n",
                   setup_data->pki_key.key.pem.private_key);
@@ -1499,7 +1499,7 @@ setup_pki_ssl(SSL *ssl,
     else if (role == COAP_DTLS_ROLE_SERVER ||
              (setup_data->pki_key.key.pem.public_cert &&
               setup_data->pki_key.key.pem.public_cert[0])) {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No %s Private Key defined\n",
              role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
       return 0;
@@ -1518,7 +1518,7 @@ setup_pki_ssl(SSL *ssl,
         if (cert_names != NULL)
           SSL_set_client_CA_list(ssl, cert_names);
         else {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "%s CA File\n",
                     setup_data->pki_key.key.pem.ca_file,
@@ -1554,7 +1554,7 @@ setup_pki_ssl(SSL *ssl,
       X509 *cert = bp ? PEM_read_bio_X509(bp, NULL, 0, NULL) : NULL;
 
       if (!cert || !SSL_use_certificate(ssl, cert)) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: Unable to configure "
                  "Server PEM Certificate\n");
         if (bp) BIO_free(bp);
@@ -1565,7 +1565,7 @@ setup_pki_ssl(SSL *ssl,
       if (cert) X509_free(cert);
     }
     else {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No Server Certificate defined\n");
       return 0;
     }
@@ -1577,7 +1577,7 @@ setup_pki_ssl(SSL *ssl,
       EVP_PKEY *pkey = bp ? PEM_read_bio_PrivateKey(bp, NULL, 0, NULL) : NULL;
 
       if (!pkey || !SSL_use_PrivateKey(ssl, pkey)) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: Unable to configure "
                  "Server PEM Private Key\n");
         if (bp) BIO_free(bp);
@@ -1588,7 +1588,7 @@ setup_pki_ssl(SSL *ssl,
       if (pkey) EVP_PKEY_free(pkey);
     }
     else {
-      coap_log(LOG_ERR,
+      coap_log_err(
            "*** setup_pki: (D)TLS: No Server Private Key defined\n");
       return 0;
     }
@@ -1620,7 +1620,7 @@ setup_pki_ssl(SSL *ssl,
       if (!(SSL_use_certificate_ASN1(ssl,
                            setup_data->pki_key.key.asn1.public_cert,
                            (int)setup_data->pki_key.key.asn1.public_cert_len))) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "%s Certificate\n",
                  role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client",
@@ -1631,7 +1631,7 @@ setup_pki_ssl(SSL *ssl,
     else if (role == COAP_DTLS_ROLE_SERVER ||
              (setup_data->pki_key.key.asn1.private_key &&
               setup_data->pki_key.key.asn1.private_key[0])) {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No %s Certificate defined\n",
              role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
       return 0;
@@ -1642,7 +1642,7 @@ setup_pki_ssl(SSL *ssl,
       if (!(SSL_use_PrivateKey_ASN1(pkey_type, ssl,
                         setup_data->pki_key.key.asn1.private_key,
                         (long)setup_data->pki_key.key.asn1.private_key_len))) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: %s: Unable to configure "
                  "%s Private Key\n",
                  role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client",
@@ -1653,7 +1653,7 @@ setup_pki_ssl(SSL *ssl,
     else if (role == COAP_DTLS_ROLE_SERVER ||
              (setup_data->pki_key.key.asn1.public_cert &&
               setup_data->pki_key.key.asn1.public_cert_len > 0)) {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No %s Private Key defined",
              role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
       return 0;
@@ -1668,7 +1668,7 @@ setup_pki_ssl(SSL *ssl,
 
       if (role == COAP_DTLS_ROLE_SERVER) {
         if (!x509 || !SSL_add_client_CA(ssl, x509)) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "client CA File\n",
                     "ASN1");
@@ -1688,7 +1688,7 @@ setup_pki_ssl(SSL *ssl,
     if (!ssl_engine) {
       ssl_engine = ENGINE_by_id("pkcs11");
       if (!ssl_engine) {
-        coap_log(LOG_ERR,
+        coap_log_err(
            "*** setup_pki: (D)TLS: No PKCS11 support - need OpenSSL pkcs11 engine\n");
         return 0;
       }
@@ -1696,7 +1696,7 @@ setup_pki_ssl(SSL *ssl,
         /* the engine couldn't initialise, release 'ssl_engine' */
         ENGINE_free(ssl_engine);
         ssl_engine = NULL;
-        coap_log(LOG_ERR,
+        coap_log_err(
            "*** setup_pki: (D)TLS: PKCS11 engine initialize failed\n");
         return 0;
       }
@@ -1707,7 +1707,7 @@ setup_pki_ssl(SSL *ssl,
       if (ENGINE_ctrl_cmd_string(ssl_engine,
                           "PIN",
                           setup_data->pki_key.key.pkcs11.user_pin, 0) == 0) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "*** setup_pki: (D)TLS: PKCS11: %s: Unable to set pin\n",
                   setup_data->pki_key.key.pkcs11.user_pin);
         return 0;
@@ -1723,7 +1723,7 @@ setup_pki_ssl(SSL *ssl,
                                 NULL, NULL);
 
         if (!pkey) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to load "
                    "%s Private Key\n",
                    setup_data->pki_key.key.pkcs11.private_key,
@@ -1731,7 +1731,7 @@ setup_pki_ssl(SSL *ssl,
           return 0;
         }
         if (!SSL_use_PrivateKey(ssl, pkey)) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "%s Private Key\n",
                    setup_data->pki_key.key.pkcs11.private_key,
@@ -1745,7 +1745,7 @@ setup_pki_ssl(SSL *ssl,
         if (!(SSL_use_PrivateKey_file(ssl,
                                     setup_data->pki_key.key.pkcs11.private_key,
                                     SSL_FILETYPE_ASN1))) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "%s Private Key\n",
                    setup_data->pki_key.key.pkcs11.private_key,
@@ -1755,7 +1755,7 @@ setup_pki_ssl(SSL *ssl,
       }
     }
     else if (role == COAP_DTLS_ROLE_SERVER) {
-      coap_log(LOG_ERR,
+      coap_log_err(
            "*** setup_pki: (D)TLS: No Server Private Key defined\n");
       return 0;
     }
@@ -1769,7 +1769,7 @@ setup_pki_ssl(SSL *ssl,
         x509 = missing_ENGINE_load_cert(
                              setup_data->pki_key.key.pkcs11.public_cert);
         if (!x509) {
-            coap_log(LOG_WARNING,
+            coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to load "
                    "%s Certificate\n",
                    setup_data->pki_key.key.pkcs11.public_cert,
@@ -1777,7 +1777,7 @@ setup_pki_ssl(SSL *ssl,
           return 0;
         }
         if (!SSL_use_certificate(ssl, x509)) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "%s Certificate\n",
                    setup_data->pki_key.key.pkcs11.public_cert,
@@ -1791,7 +1791,7 @@ setup_pki_ssl(SSL *ssl,
         if (!(SSL_use_certificate_file(ssl,
                                      setup_data->pki_key.key.pkcs11.public_cert,
                                      SSL_FILETYPE_ASN1))) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "%s Certificate\n",
                    setup_data->pki_key.key.pkcs11.public_cert,
@@ -1801,7 +1801,7 @@ setup_pki_ssl(SSL *ssl,
       }
     }
     else if (role == COAP_DTLS_ROLE_SERVER) {
-      coap_log(LOG_ERR,
+      coap_log_err(
              "*** setup_pki: (D)TLS: No Server Certificate defined\n");
       return 0;
     }
@@ -1817,7 +1817,7 @@ setup_pki_ssl(SSL *ssl,
         x509 = missing_ENGINE_load_cert(
                            setup_data->pki_key.key.pkcs11.ca);
         if (!x509) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to load "
                    "%s CA Certificate\n",
                    setup_data->pki_key.key.pkcs11.ca,
@@ -1825,7 +1825,7 @@ setup_pki_ssl(SSL *ssl,
           return 0;
         }
         if (!SSL_add_client_CA(ssl, x509)) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "%s CA Certificate\n",
                    setup_data->pki_key.key.pkcs11.ca,
@@ -1843,7 +1843,7 @@ setup_pki_ssl(SSL *ssl,
         SSL_CTX *ctx = SSL_get_SSL_CTX(ssl);
 
         if (!x509 || !SSL_add_client_CA(ssl, x509)) {
-          coap_log(LOG_WARNING,
+          coap_log_warn(
                    "*** setup_pki: (D)TLS: %s: Unable to configure "
                    "%s CA File\n",
                     setup_data->pki_key.key.pkcs11.ca,
@@ -1859,7 +1859,7 @@ setup_pki_ssl(SSL *ssl,
     break;
 
   default:
-    coap_log(LOG_ERR,
+    coap_log_err(
              "*** setup_pki: (D)TLS: Unknown key type %d\n",
              setup_data->pki_key.key_type);
     return 0;
@@ -1980,20 +1980,20 @@ tls_verify_call_back(int preverify_ok, X509_STORE_CTX *ctx) {
     }
     if (!preverify_ok) {
       if (err == X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                "   %s: %s: '%s' depth=%d\n",
                coap_session_str(session),
                "Unknown CA", cn ? cn : "?", depth);
       }
       else {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                "   %s: %s: '%s' depth=%d\n",
                coap_session_str(session),
                X509_verify_cert_error_string(err), cn ? cn : "?", depth);
       }
     }
     else {
-      coap_log(LOG_INFO,
+      coap_log_info(
                "   %s: %s: overridden: '%s' depth=%d\n",
                coap_session_str(session),
                X509_verify_cert_error_string(err), cn ? cn : "?", depth);
@@ -2069,7 +2069,7 @@ tls_secret_call_back(SSL *ssl,
     }
   }
   if (!psk_requested) {
-    coap_log(LOG_DEBUG, "   %s: Using PKI ciphers\n",
+    coap_log_debug("   %s: Using PKI ciphers\n",
              coap_session_str(session));
 
     if (setup_data->verify_peer_cert) {
@@ -2113,7 +2113,7 @@ tls_secret_call_back(SSL *ssl,
              session->context->spsk_setup_data.psk_info.key.length);
       *secretlen = session->context->spsk_setup_data.psk_info.key.length;
     }
-    coap_log(LOG_DEBUG, "   %s: Setting PSK ciphers\n",
+    coap_log_debug("   %s: Setting PSK ciphers\n",
              coap_session_str(session));
     /*
      * Force a PSK algorithm to be used, so we do PSK
@@ -2400,7 +2400,7 @@ tls_client_hello_call_back(SSL *ssl,
     /*
      * Client has requested PSK and it is supported
      */
-    coap_log(LOG_DEBUG, "   %s: PSK request\n",
+    coap_log_debug("   %s: PSK request\n",
              coap_session_str(session));
     SSL_set_psk_server_callback(ssl, coap_dtls_psk_server_callback);
     if (setup_data->additional_tls_setup_call_back) {
@@ -2501,7 +2501,7 @@ is_x509:
     setup_pki_ssl(ssl, setup_data, COAP_DTLS_ROLE_SERVER);
   }
 
-  coap_log(LOG_DEBUG, "   %s: Using PKI ciphers\n",
+  coap_log_debug("   %s: Using PKI ciphers\n",
            coap_session_str(session));
 
   if (setup_data->verify_peer_cert) {
@@ -2695,7 +2695,7 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
        */
 #if OPENSSL_VERSION_NUMBER < 0x10101000L
       if (SSLeay() >= 0x10101000L) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "OpenSSL compiled with %lux, linked with %lux, so "
                  "no certificate checking\n",
                  OPENSSL_VERSION_NUMBER, SSLeay());
@@ -2724,7 +2724,7 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
        */
 #if OPENSSL_VERSION_NUMBER < 0x10101000L
       if (SSLeay() >= 0x10101000L) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "OpenSSL compiled with %lux, linked with %lux, so "
                  "no certificate checking\n",
                  OPENSSL_VERSION_NUMBER, SSLeay());
@@ -2775,7 +2775,7 @@ coap_dtls_context_set_pki_root_cas(coap_context_t *ctx,
                                 ((coap_openssl_context_t *)ctx->dtls_context);
   if (context->dtls.ctx) {
     if (!SSL_CTX_load_verify_locations(context->dtls.ctx, ca_file, ca_dir)) {
-      coap_log(LOG_WARNING, "Unable to install root CAs (%s/%s)\n",
+      coap_log_warn("Unable to install root CAs (%s/%s)\n",
                ca_file ? ca_file : "NULL", ca_dir ? ca_dir : "NULL");
       return 0;
     }
@@ -2783,7 +2783,7 @@ coap_dtls_context_set_pki_root_cas(coap_context_t *ctx,
 #if !COAP_DISABLE_TCP
   if (context->tls.ctx) {
     if (!SSL_CTX_load_verify_locations(context->tls.ctx, ca_file, ca_dir)) {
-      coap_log(LOG_WARNING, "Unable to install root CAs (%s/%s)\n",
+      coap_log_warn("Unable to install root CAs (%s/%s)\n",
                ca_file ? ca_file : "NULL", ca_dir ? ca_dir : "NULL");
       return 0;
     }
@@ -2878,7 +2878,7 @@ void * coap_dtls_new_server_session(coap_session_t *session) {
       SSL_use_psk_identity_hint(ssl, hint);
       OPENSSL_free(hint);
     } else {
-      coap_log(LOG_WARNING, "hint malloc failure\n");
+      coap_log_warn("hint malloc failure\n");
     }
   }
 
@@ -2916,7 +2916,7 @@ setup_client_ssl_session(coap_session_t *session, SSL *ssl
     /* Issue SNI if requested */
     if (setup_data->client_sni &&
         SSL_set_tlsext_host_name (ssl, setup_data->client_sni) != 1) {
-          coap_log(LOG_WARNING, "SSL_set_tlsext_host_name: set '%s' failed",
+          coap_log_warn("SSL_set_tlsext_host_name: set '%s' failed",
                    setup_data->client_sni);
     }
     SSL_set_psk_client_callback(ssl, coap_dtls_psk_client_callback);
@@ -2933,7 +2933,7 @@ setup_client_ssl_session(coap_session_t *session, SSL *ssl
         SSL_set_max_proto_version(ssl, TLS1_2_VERSION);
       }
 #endif /* !COAP_DISABLE_TCP */
-      coap_log(LOG_DEBUG,
+      coap_log_debug(
         "CoAP Client restricted to (D)TLS1.2 with Identity Hint callback\n");
     }
   }
@@ -2950,7 +2950,7 @@ setup_client_ssl_session(coap_session_t *session, SSL *ssl
     /* Issue SNI if requested */
     if (setup_data->client_sni &&
         SSL_set_tlsext_host_name (ssl, setup_data->client_sni) != 1) {
-          coap_log(LOG_WARNING, "SSL_set_tlsext_host_name: set '%s' failed",
+          coap_log_warn("SSL_set_tlsext_host_name: set '%s' failed",
                    setup_data->client_sni);
     }
     /* Certificate Revocation */
@@ -3061,7 +3061,7 @@ int coap_dtls_send(coap_session_t *session,
     if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
       r = 0;
     } else {
-      coap_log(LOG_WARNING, "coap_dtls_send: cannot send PDU\n");
+      coap_log_warn("coap_dtls_send: cannot send PDU\n");
       if (err == SSL_ERROR_ZERO_RETURN)
         session->dtls_event = COAP_EVENT_DTLS_CLOSED;
       else if (err == SSL_ERROR_SSL)
@@ -3131,7 +3131,7 @@ int coap_dtls_hello(coap_session_t *session,
   ssl_data = (coap_ssl_data*)BIO_get_data(SSL_get_rbio(dtls->ssl));
   assert(ssl_data != NULL);
   if (ssl_data->pdu_len) {
-    coap_log(LOG_ERR, "** %s: Previous data not read %u bytes\n",
+    coap_log_err("** %s: Previous data not read %u bytes\n",
              coap_session_str(session), ssl_data->pdu_len);
   }
   ssl_data->session = session;
@@ -3172,7 +3172,7 @@ int coap_dtls_receive(coap_session_t *session,
   assert(ssl_data != NULL);
 
   if (ssl_data->pdu_len) {
-    coap_log(LOG_ERR, "** %s: Previous data not read %u bytes\n",
+    coap_log_err("** %s: Previous data not read %u bytes\n",
              coap_session_str(session), ssl_data->pdu_len);
   }
   ssl_data->pdu = data;
@@ -3216,7 +3216,7 @@ int coap_dtls_receive(coap_session_t *session,
 finished:
   if (ssl_data && ssl_data->pdu_len) {
     /* pdu data is held on stack which will not stay there */
-    coap_log(LOG_DEBUG, "coap_dtls_receive: ret %d: remaining data %u\n", r, ssl_data->pdu_len);
+    coap_log_debug("coap_dtls_receive: ret %d: remaining data %u\n", r, ssl_data->pdu_len);
     ssl_data->pdu_len = 0;
     ssl_data->pdu = NULL;
   }
@@ -3268,7 +3268,7 @@ unsigned int coap_dtls_get_overhead(coap_session_t *session) {
 
     default:
       SSL_CIPHER_description(s_ciph, cipher, sizeof(cipher));
-      coap_log(LOG_WARNING, "Unknown overhead for DTLS with cipher %s\n",
+      coap_log_warn("Unknown overhead for DTLS with cipher %s\n",
                cipher);
       ivlen = 8;
       maclen = 16;
@@ -3364,7 +3364,7 @@ void *coap_tls_new_server_session(coap_session_t *session, int *connected) {
       SSL_use_psk_identity_hint(ssl, hint);
       OPENSSL_free(hint);
     } else {
-      coap_log(LOG_WARNING, "hint malloc failure\n");
+      coap_log_warn("hint malloc failure\n");
     }
   }
 
@@ -3452,7 +3452,7 @@ ssize_t coap_tls_write(coap_session_t *session,
       }
       r = 0;
     } else {
-      coap_log(LOG_INFO, "***%s: coap_tls_write: cannot send PDU\n",
+      coap_log_info("***%s: coap_tls_write: cannot send PDU\n",
                coap_session_str(session));
       if (err == SSL_ERROR_ZERO_RETURN)
         session->dtls_event = COAP_EVENT_DTLS_CLOSED;

--- a/src/coap_option.c
+++ b/src/coap_option.c
@@ -20,7 +20,7 @@
 #include <string.h>
 
 #define ADVANCE_OPT(o,e,step) if ((e) < step) {           \
-    coap_log(LOG_DEBUG, "cannot advance opt past end\n"); \
+    coap_log_debug("cannot advance opt past end\n"); \
     return 0;                                             \
   } else {                                                \
     (e) -= step;                                          \
@@ -53,7 +53,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
   switch(result->delta) {
   case 15:
     if (*opt != COAP_PAYLOAD_START) {
-      coap_log(LOG_DEBUG, "ignored reserved option delta 15\n");
+      coap_log_debug("ignored reserved option delta 15\n");
     }
     return 0;
   case 14:
@@ -63,7 +63,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
     ADVANCE_OPT_CHECK(opt,length,1);
     result->delta = ((*opt & 0xff) << 8) + 269;
     if (result->delta < 269) {
-      coap_log(LOG_DEBUG, "delta too large\n");
+      coap_log_debug("delta too large\n");
       return 0;
     }
     /* fall through */
@@ -78,7 +78,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
 
   switch(result->length) {
   case 15:
-    coap_log(LOG_DEBUG, "found reserved option length 15\n");
+    coap_log_debug("found reserved option length 15\n");
     return 0;
   case 14:
     /* Handle two-byte value: First, the MSB + 269 is stored as delta value.
@@ -102,7 +102,7 @@ coap_opt_parse(const coap_opt_t *opt, size_t length, coap_option_t *result) {
 
   result->value = opt;
   if (length < result->length) {
-    coap_log(LOG_DEBUG, "invalid option length\n");
+    coap_log_debug("invalid option length\n");
     return 0;
   }
 
@@ -214,7 +214,7 @@ coap_opt_length(const coap_opt_t *opt) {
   length = *opt & 0x0f;
   switch (*opt & 0xf0) {
   case 0xf0:
-    coap_log(LOG_DEBUG, "illegal option delta\n");
+    coap_log_debug("illegal option delta\n");
     return 0;
   case 0xe0:
     ++opt;
@@ -230,7 +230,7 @@ coap_opt_length(const coap_opt_t *opt) {
 
   switch (length) {
   case 0x0f:
-    coap_log(LOG_DEBUG, "illegal option length\n");
+    coap_log_debug("illegal option length\n");
     return 0;
   case 0x0e:
     length = (*opt++ << 8) + 269;
@@ -250,7 +250,7 @@ coap_opt_value(const coap_opt_t *opt) {
 
   switch (*opt & 0xf0) {
   case 0xf0:
-    coap_log(LOG_DEBUG, "illegal option delta\n");
+    coap_log_debug("illegal option delta\n");
     return 0;
   case 0xe0:
     ++ofs;
@@ -264,7 +264,7 @@ coap_opt_value(const coap_opt_t *opt) {
 
   switch (*opt & 0x0f) {
   case 0x0f:
-    coap_log(LOG_DEBUG, "illegal option length\n");
+    coap_log_debug("illegal option length\n");
     return 0;
   case 0x0e:
     ++ofs;
@@ -301,7 +301,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[0] = (coap_opt_t)(delta << 4);
   } else if (delta < 269) {
     if (maxlen < 2) {
-      coap_log(LOG_DEBUG, "insufficient space to encode option delta %d\n",
+      coap_log_debug("insufficient space to encode option delta %d\n",
                delta);
       return 0;
     }
@@ -310,7 +310,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[++skip] = (coap_opt_t)(delta - 13);
   } else {
     if (maxlen < 3) {
-      coap_log(LOG_DEBUG, "insufficient space to encode option delta %d\n",
+      coap_log_debug("insufficient space to encode option delta %d\n",
                delta);
       return 0;
     }
@@ -324,7 +324,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[0] |= length & 0x0f;
   } else if (length < 269) {
     if (maxlen < skip + 2) {
-      coap_log(LOG_DEBUG, "insufficient space to encode option length %zu\n",
+      coap_log_debug("insufficient space to encode option length %zu\n",
                length);
       return 0;
     }
@@ -333,7 +333,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[++skip] = (coap_opt_t)(length - 13);
   } else {
     if (maxlen < skip + 3) {
-      coap_log(LOG_DEBUG, "insufficient space to encode option delta %d\n",
+      coap_log_debug("insufficient space to encode option delta %d\n",
                delta);
       return 0;
     }
@@ -376,7 +376,7 @@ coap_opt_encode(coap_opt_t *opt, size_t maxlen, uint16_t delta,
   assert(l <= maxlen);
 
   if (!l) {
-    coap_log(LOG_DEBUG, "coap_opt_encode: cannot set option header\n");
+    coap_log_debug("coap_opt_encode: cannot set option header\n");
     return 0;
   }
 
@@ -384,7 +384,7 @@ coap_opt_encode(coap_opt_t *opt, size_t maxlen, uint16_t delta,
   opt += l;
 
   if (maxlen < length) {
-    coap_log(LOG_DEBUG, "coap_opt_encode: option too large for buffer\n");
+    coap_log_debug("coap_opt_encode: option too large for buffer\n");
     return 0;
   }
 
@@ -513,7 +513,7 @@ coap_new_optlist(uint16_t number,
 
 #ifdef WITH_LWIP
   if (length > MEMP_LEN_COAPOPTLIST) {
-    coap_log(LOG_CRIT,
+    coap_log_crit(
              "coap_new_optlist: size too large (%zu > MEMP_LEN_COAPOPTLIST)\n",
              length);
     return NULL;
@@ -528,7 +528,7 @@ coap_new_optlist(uint16_t number,
     node->data = (uint8_t *)&node[1];
     memcpy(node->data, data, length);
   } else {
-    coap_log(LOG_WARNING, "coap_new_optlist: malloc failure\n");
+    coap_log_warn("coap_new_optlist: malloc failure\n");
   }
 
   return node;
@@ -551,7 +551,7 @@ coap_add_optlist_pdu(coap_pdu_t *pdu, coap_optlist_t** options) {
 
   if (options && *options) {
     if (pdu->data) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
                "coap_add_optlist_pdu: PDU already contains data\n");
       return 0;
     }
@@ -569,7 +569,7 @@ coap_add_optlist_pdu(coap_pdu_t *pdu, coap_optlist_t** options) {
 int
 coap_insert_optlist(coap_optlist_t **head, coap_optlist_t *node) {
   if (!node) {
-    coap_log(LOG_DEBUG, "optlist not provided\n");
+    coap_log_debug("optlist not provided\n");
   } else {
     /* must append at the list end to avoid re-ordering of
      * options during sort */

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -37,7 +37,7 @@ void
 coap_session_set_ack_timeout(coap_session_t *session, coap_fixed_point_t value) {
   if (value.integer_part > 0 && value.fractional_part < 1000) {
     session->ack_timeout = value;
-    coap_log(LOG_DEBUG, "***%s: session ack_timeout set to %u.%03u\n",
+    coap_log_debug("***%s: session ack_timeout set to %u.%03u\n",
            coap_session_str(session), session->ack_timeout.integer_part,
            session->ack_timeout.fractional_part);
   }
@@ -48,7 +48,7 @@ coap_session_set_ack_random_factor(coap_session_t *session,
                                    coap_fixed_point_t value) {
   if (value.integer_part > 0 && value.fractional_part < 1000) {
     session->ack_random_factor = value;
-    coap_log(LOG_DEBUG, "***%s: session ack_random_factor set to %u.%03u\n",
+    coap_log_debug("***%s: session ack_random_factor set to %u.%03u\n",
            coap_session_str(session), session->ack_random_factor.integer_part,
            session->ack_random_factor.fractional_part);
   }
@@ -58,7 +58,7 @@ void
 coap_session_set_max_retransmit(coap_session_t *session, uint16_t value) {
   if (value > 0) {
     session->max_retransmit = value;
-    coap_log(LOG_DEBUG, "***%s: session max_retransmit set to %u\n",
+    coap_log_debug("***%s: session max_retransmit set to %u\n",
            coap_session_str(session), session->max_retransmit);
   }
 }
@@ -67,7 +67,7 @@ void
 coap_session_set_nstart(coap_session_t *session, uint16_t value) {
   if (value > 0) {
     session->nstart = value;
-    coap_log(LOG_DEBUG, "***%s: session nstart set to %u\n",
+    coap_log_debug("***%s: session nstart set to %u\n",
            coap_session_str(session), session->nstart);
   }
 }
@@ -77,7 +77,7 @@ coap_session_set_default_leisure(coap_session_t *session,
                                  coap_fixed_point_t value) {
   if (value.integer_part > 0 && value.fractional_part < 1000) {
     session->default_leisure = value;
-    coap_log(LOG_DEBUG, "***%s: session default_leisure set to %u.%03u\n",
+    coap_log_debug("***%s: session default_leisure set to %u.%03u\n",
            coap_session_str(session), session->default_leisure.integer_part,
            session->default_leisure.fractional_part);
   }
@@ -87,7 +87,7 @@ void
 coap_session_set_probing_rate(coap_session_t *session, uint32_t value) {
   if (value > 0) {
     session->probing_rate = value;
-    coap_log(LOG_DEBUG, "***%s: session probing_rate set to %" PRIu32 "\n",
+    coap_log_debug("***%s: session probing_rate set to %" PRIu32 "\n",
            coap_session_str(session), session->probing_rate);
   }
 }
@@ -204,7 +204,7 @@ coap_make_session(coap_proto_t proto, coap_session_type_t type,
     session->tls_overhead = 29;
     if (session->tls_overhead >= session->mtu) {
       session->tls_overhead = session->mtu;
-      coap_log(LOG_ERR, "DTLS overhead exceeds MTU\n");
+      coap_log_err("DTLS overhead exceeds MTU\n");
     }
   }
   session->ack_timeout = COAP_DEFAULT_ACK_TIMEOUT;
@@ -323,7 +323,7 @@ void coap_session_free(coap_session_t *session) {
   }
 #endif /* COAP_CLIENT_SUPPORT */
   coap_delete_bin_const(session->last_token);
-  coap_log(LOG_DEBUG, "***%s: session %p: closed\n", coap_session_str(session),
+  coap_log_debug("***%s: session %p: closed\n", coap_session_str(session),
            (void *)session);
 
   coap_free_type(COAP_SESSION, session);
@@ -379,7 +379,7 @@ coap_session_max_pdu_size(const coap_session_t *session) {
    */
   memcpy(&session_rw, &session, sizeof(session_rw));
   if (coap_client_delay_first(session_rw) == 0) {
-    coap_log(LOG_DEBUG, "coap_client_delay_first: timeout\n");
+    coap_log_debug("coap_client_delay_first: timeout\n");
     /* Have to go with the defaults */
   }
 #endif /* COAP_CLIENT_SUPPORT */
@@ -399,7 +399,7 @@ void coap_session_set_mtu(coap_session_t *session, unsigned mtu) {
   session->mtu = mtu;
   if (session->tls_overhead >= session->mtu) {
     session->tls_overhead = session->mtu;
-    coap_log(LOG_ERR, "DTLS overhead exceeds MTU\n");
+    coap_log_err("DTLS overhead exceeds MTU\n");
   }
 }
 
@@ -417,10 +417,10 @@ ssize_t coap_session_send(coap_session_t *session, const uint8_t *data, size_t d
   bytes_written = coap_socket_send(sock, session, data, datalen);
   if (bytes_written == (ssize_t)datalen) {
     coap_ticks(&session->last_rx_tx);
-    coap_log(LOG_DEBUG, "*  %s: sent %zd bytes\n",
+    coap_log_debug("*  %s: sent %zd bytes\n",
              coap_session_str(session), datalen);
   } else {
-    coap_log(LOG_DEBUG, "*  %s: failed to send %zd bytes\n",
+    coap_log_debug("*  %s: failed to send %zd bytes\n",
              coap_session_str(session), datalen);
   }
   return bytes_written;
@@ -430,10 +430,10 @@ ssize_t coap_session_write(coap_session_t *session, const uint8_t *data, size_t 
   ssize_t bytes_written = coap_socket_write(&session->sock, data, datalen);
   if (bytes_written > 0) {
     coap_ticks(&session->last_rx_tx);
-    coap_log(LOG_DEBUG, "*  %s: sent %zd bytes\n",
+    coap_log_debug("*  %s: sent %zd bytes\n",
              coap_session_str(session), bytes_written);
   } else if (bytes_written < 0) {
-    coap_log(LOG_DEBUG, "*  %s: failed to send %zd bytes\n",
+    coap_log_debug("*  %s: failed to send %zd bytes\n",
              coap_session_str(session), datalen );
   }
   return bytes_written;
@@ -456,7 +456,7 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
       /* Check same mid is not getting re-used in violation of RFC7252 */
       LL_FOREACH(session->delayqueue, q) {
         if (q->id == pdu->mid) {
-          coap_log(LOG_ERR, "**  %s: mid=0x%x: already in-use - dropped\n",
+          coap_log_err("**  %s: mid=0x%x: already in-use - dropped\n",
                    coap_session_str(session), pdu->mid);
           return COAP_INVALID_MID;
         }
@@ -475,7 +475,7 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
     }
   }
   LL_APPEND(session->delayqueue, node);
-  coap_log(LOG_DEBUG, "** %s: mid=0x%x: delayed\n",
+  coap_log_debug("** %s: mid=0x%x: delayed\n",
            coap_session_str(session), node->id);
   return COAP_PDU_DELAYED;
 }
@@ -485,7 +485,7 @@ void coap_session_send_csm(coap_session_t *session) {
   coap_pdu_t *pdu;
   uint8_t buf[4];
   assert(COAP_PROTO_RELIABLE(session->proto));
-  coap_log(LOG_DEBUG, "***%s: sending CSM\n", coap_session_str(session));
+  coap_log_debug("***%s: sending CSM\n", coap_session_str(session));
   session->state = COAP_SESSION_STATE_CSM;
   session->partial_write = 0;
   if (session->mtu == 0)
@@ -538,7 +538,7 @@ coap_mid_t coap_session_send_ping(coap_session_t *session) {
 
 void coap_session_connected(coap_session_t *session) {
   if (session->state != COAP_SESSION_STATE_ESTABLISHED) {
-    coap_log(LOG_DEBUG, "***%s: session connected\n",
+    coap_log_debug("***%s: session connected\n",
              coap_session_str(session));
     if (session->state == COAP_SESSION_STATE_CSM)
       coap_handle_event(session->context, COAP_EVENT_SESSION_CONNECTED, session);
@@ -553,7 +553,7 @@ void coap_session_connected(coap_session_t *session) {
     session->tls_overhead = coap_dtls_get_overhead(session);
     if (session->tls_overhead >= session->mtu) {
       session->tls_overhead = session->mtu;
-      coap_log(LOG_ERR, "DTLS overhead exceeds MTU\n");
+      coap_log_err("DTLS overhead exceeds MTU\n");
     }
   }
 
@@ -569,7 +569,7 @@ void coap_session_connected(coap_session_t *session) {
     session->delayqueue = q->next;
     q->next = NULL;
 
-    coap_log(LOG_DEBUG, "** %s: mid=0x%x: transmitted after delay\n",
+    coap_log_debug("** %s: mid=0x%x: transmitted after delay\n",
              coap_session_str(session), (int)q->pdu->mid);
     bytes_written = coap_session_send_pdu(session, q->pdu);
     if (q->pdu->type == COAP_MESSAGE_CON && COAP_PROTO_NOT_RELIABLE(session->proto)) {
@@ -600,7 +600,7 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
   coap_session_state_t state = session->state;
 #endif /* !COAP_DISABLE_TCP */
 
-  coap_log(LOG_DEBUG, "***%s: session disconnected (reason %d)\n",
+  coap_log_debug("***%s: session disconnected (reason %d)\n",
            coap_session_str(session), reason);
 #if COAP_SERVER_SUPPORT
   coap_delete_observers( session->context, session );
@@ -633,7 +633,7 @@ void coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reaso
     coap_queue_t *q = session->delayqueue;
     session->delayqueue = q->next;
     q->next = NULL;
-    coap_log(LOG_DEBUG, "** %s: mid=0x%x: not transmitted after disconnect\n",
+    coap_log_debug("** %s: mid=0x%x: not transmitted after disconnect\n",
              coap_session_str(session), q->id);
     if (q->pdu->type==COAP_MESSAGE_CON
       && COAP_PROTO_NOT_RELIABLE(session->proto)
@@ -779,7 +779,7 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
     coap_session_free(oldest);
   }
   else if (oldest_hs) {
-    coap_log(LOG_WARNING, "***%s: Incomplete session timed out\n",
+    coap_log_warn("***%s: Incomplete session timed out\n",
              coap_session_str(oldest_hs));
     coap_handle_event(oldest_hs->context, COAP_EVENT_SERVER_SESSION_DEL, oldest_hs);
     coap_session_free(oldest_hs);
@@ -789,7 +789,7 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
               endpoint->context->max_handshake_sessions :
               COAP_DEFAULT_MAX_HANDSHAKE_SESSIONS)) {
     /* Maxed out on number of sessions in (D)TLS negotiation state */
-    coap_log(LOG_DEBUG,
+    coap_log_debug(
              "Oustanding sessions in COAP_SESSION_STATE_HANDSHAKE too "
              "large.  New request ignored\n");
     return NULL;
@@ -826,7 +826,7 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
     size_t length = packet->length;
 #endif /* ! WITH_LWIP */
     if (length < (OFF_HANDSHAKE_TYPE + 1)) {
-      coap_log(LOG_DEBUG,
+      coap_log_debug(
          "coap_dtls_hello: ContentType %d Short Packet (%zu < %d) dropped\n",
          payload[OFF_CONTENT_TYPE], length,
          OFF_HANDSHAKE_TYPE + 1);
@@ -836,7 +836,7 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
         payload[OFF_HANDSHAKE_TYPE] != DTLS_HT_CLIENT_HELLO) {
       /* only log if not a late alert */
       if (payload[OFF_CONTENT_TYPE] != DTLS_CT_ALERT)
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
          "coap_dtls_hello: ContentType %d Handshake %d dropped\n",
          payload[OFF_CONTENT_TYPE], payload[OFF_HANDSHAKE_TYPE]);
       return NULL;
@@ -855,7 +855,7 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
       session->type = COAP_SESSION_TYPE_HELLO;
     }
     SESSIONS_ADD(endpoint->sessions, session);
-    coap_log(LOG_DEBUG, "***%s: session %p: new incoming session\n",
+    coap_log_debug("***%s: session %p: new incoming session\n",
              coap_session_str(session), (void *)session);
     coap_handle_event(session->context, COAP_EVENT_SERVER_SESSION_NEW, session);
   }
@@ -909,7 +909,7 @@ coap_epoll_ctl_add(coap_socket_t *sock,
 
   ret = epoll_ctl(context->epfd, EPOLL_CTL_ADD, sock->fd, &event);
   if (ret == -1) {
-     coap_log(LOG_ERR,
+     coap_log_err(
               "%s: epoll_ctl ADD failed: %s (%d)\n",
               func,
               coap_socket_strerror(), errno);
@@ -934,19 +934,19 @@ coap_session_create_client(
     break;
   case COAP_PROTO_DTLS:
     if (!coap_dtls_is_supported()) {
-      coap_log(LOG_CRIT, "coap_new_client_session*: DTLS not supported\n");
+      coap_log_crit("coap_new_client_session*: DTLS not supported\n");
       return NULL;
     }
     break;
   case COAP_PROTO_TCP:
     if (!coap_tcp_is_supported()) {
-      coap_log(LOG_CRIT, "coap_new_client_session*: TCP not supported\n");
+      coap_log_crit("coap_new_client_session*: TCP not supported\n");
       return NULL;
     }
     break;
   case COAP_PROTO_TLS:
     if (!coap_tls_is_supported()) {
-      coap_log(LOG_CRIT, "coap_new_client_session*: TLS not supported\n");
+      coap_log_crit("coap_new_client_session*: TLS not supported\n");
       return NULL;
     }
     break;
@@ -977,7 +977,7 @@ coap_session_create_client(
                               &s->addr_info.local) &&
           coap_address_equals(&session->addr_info.remote,
                               &s->addr_info.remote)) {
-        coap_log(LOG_WARNING, "***%s: session %p: duplicate - already exists\n",
+        coap_log_warn("***%s: session %p: duplicate - already exists\n",
                  coap_session_str(session), (void *)session);
         goto error;
       }
@@ -1119,7 +1119,7 @@ coap_session_t *coap_new_client_session(
   coap_session_t *session = coap_session_create_client(ctx, local_if, server,
                                                        proto);
   if (session) {
-    coap_log(LOG_DEBUG, "***%s: session %p: created outgoing session\n",
+    coap_log_debug("***%s: session %p: created outgoing session\n",
              coap_session_str(session), (void *)session);
     session = coap_session_connect(session);
     session->context = ctx;
@@ -1174,13 +1174,13 @@ coap_session_t *coap_new_client_session_psk2(
                       coap_new_bin_const(setup_data->psk_info.identity.s,
                                          setup_data->psk_info.identity.length);
     if (!session->psk_identity) {
-      coap_log(LOG_WARNING, "Cannot store session Identity (PSK)\n");
+      coap_log_warn("Cannot store session Identity (PSK)\n");
       coap_session_release(session);
       return NULL;
     }
   }
   else if (coap_dtls_is_supported() || coap_tls_is_supported()) {
-    coap_log(LOG_WARNING, "Identity (PSK) not defined\n");
+    coap_log_warn("Identity (PSK) not defined\n");
     coap_session_release(session);
     return NULL;
   }
@@ -1189,13 +1189,13 @@ coap_session_t *coap_new_client_session_psk2(
     session->psk_key = coap_new_bin_const(setup_data->psk_info.key.s,
                                           setup_data->psk_info.key.length);
     if (!session->psk_key) {
-      coap_log(LOG_WARNING, "Cannot store session pre-shared key (PSK)\n");
+      coap_log_warn("Cannot store session pre-shared key (PSK)\n");
       coap_session_release(session);
       return NULL;
     }
   }
   else if (coap_dtls_is_supported() || coap_tls_is_supported()) {
-    coap_log(LOG_WARNING, "Pre-shared key (PSK) not defined\n");
+    coap_log_warn("Pre-shared key (PSK) not defined\n");
     coap_session_release(session);
     return NULL;
   }
@@ -1206,7 +1206,7 @@ coap_session_t *coap_new_client_session_psk2(
       return NULL;
     }
   }
-  coap_log(LOG_DEBUG, "***%s: new outgoing session\n",
+  coap_log_debug("***%s: new outgoing session\n",
            coap_session_str(session));
   return coap_session_connect(session);
 }
@@ -1227,7 +1227,7 @@ coap_session_refresh_psk_hint(coap_session_t *session,
     session->psk_hint = coap_new_bin_const(psk_hint->s,
                                            psk_hint->length);
     if (!session->psk_hint) {
-      coap_log(LOG_ERR, "No memory to store identity hint (PSK)\n");
+      coap_log_err("No memory to store identity hint (PSK)\n");
       if (old_psk_hint)
         coap_delete_bin_const(old_psk_hint);
       return 0;
@@ -1256,7 +1256,7 @@ coap_session_refresh_psk_key(coap_session_t *session,
     }
     session->psk_key = coap_new_bin_const(psk_key->s, psk_key->length);
     if (!session->psk_key) {
-      coap_log(LOG_ERR, "No memory to store pre-shared key (PSK)\n");
+      coap_log_err("No memory to store pre-shared key (PSK)\n");
       if (old_psk_key)
         coap_delete_bin_const(old_psk_key);
       return 0;
@@ -1286,7 +1286,7 @@ coap_session_refresh_psk_identity(coap_session_t *session,
     session->psk_identity = coap_new_bin_const(psk_identity->s,
                                                psk_identity->length);
     if (!session->psk_identity) {
-      coap_log(LOG_ERR, "No memory to store pre-shared key identity (PSK)\n");
+      coap_log_err("No memory to store pre-shared key identity (PSK)\n");
       if (old_psk_identity)
         coap_delete_bin_const(old_psk_identity);
       return 0;
@@ -1344,7 +1344,7 @@ coap_session_t *coap_new_client_session_pki(
       return NULL;
     } else {
       if (setup_data->version != COAP_DTLS_PKI_SETUP_VERSION) {
-        coap_log(LOG_ERR,
+        coap_log_err(
                  "coap_new_client_session_pki: Wrong version of setup_data\n");
         return NULL;
       }
@@ -1364,7 +1364,7 @@ coap_session_t *coap_new_client_session_pki(
       return NULL;
     }
   }
-  coap_log(LOG_DEBUG, "***%s: new outgoing session\n",
+  coap_log_debug("***%s: new outgoing session\n",
            coap_session_str(session));
   return coap_session_connect(session);
 }
@@ -1399,7 +1399,7 @@ coap_session_t *coap_new_server_session(
 #endif /* COAP_EPOLL_SUPPORT */
   SESSIONS_ADD(ep->sessions, session);
   if (session) {
-    coap_log(LOG_DEBUG, "***%s: session %p: new incoming session\n",
+    coap_log_debug("***%s: session %p: new incoming session\n",
              coap_session_str(session), (void *)session);
     /* Returned session may already have been released and is now NULL */
     session = coap_session_accept(session);
@@ -1523,23 +1523,23 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
   assert(proto != COAP_PROTO_NONE);
 
   if (proto == COAP_PROTO_DTLS && !coap_dtls_is_supported()) {
-    coap_log(LOG_CRIT, "coap_new_endpoint: DTLS not supported\n");
+    coap_log_crit("coap_new_endpoint: DTLS not supported\n");
     goto error;
   }
 
   if (proto == COAP_PROTO_TLS && !coap_tls_is_supported()) {
-    coap_log(LOG_CRIT, "coap_new_endpoint: TLS not supported\n");
+    coap_log_crit("coap_new_endpoint: TLS not supported\n");
     goto error;
   }
 
   if (proto == COAP_PROTO_TCP && !coap_tcp_is_supported()) {
-    coap_log(LOG_CRIT, "coap_new_endpoint: TCP not supported\n");
+    coap_log_crit("coap_new_endpoint: TCP not supported\n");
     goto error;
   }
 
   if (proto == COAP_PROTO_DTLS || proto == COAP_PROTO_TLS) {
     if (!coap_dtls_context_check_keys_enabled(context)) {
-      coap_log(LOG_INFO,
+      coap_log_info(
                "coap_new_endpoint: one of coap_context_set_psk() or "
                "coap_context_set_pki() not called\n");
       goto error;
@@ -1548,7 +1548,7 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
 
   ep = coap_malloc_endpoint();
   if (!ep) {
-    coap_log(LOG_WARNING, "coap_new_endpoint: malloc");
+    coap_log_warn("coap_new_endpoint: malloc");
     goto error;
   }
 
@@ -1568,7 +1568,7 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
     ep->sock.flags |= COAP_SOCKET_WANT_ACCEPT;
 #endif /* !COAP_DISABLE_TCP */
   } else {
-    coap_log(LOG_CRIT, "coap_new_endpoint: protocol not supported\n");
+    coap_log_crit("coap_new_endpoint: protocol not supported\n");
     goto error;
   }
 
@@ -1579,7 +1579,7 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
     unsigned char addr_str[INET6_ADDRSTRLEN + 8];
 
     if (coap_print_addr(&ep->bind_addr, addr_str, INET6_ADDRSTRLEN + 8)) {
-      coap_log(LOG_DEBUG, "created %s endpoint %s\n",
+      coap_log_debug("created %s endpoint %s\n",
           ep->proto == COAP_PROTO_TLS ? "TLS "
         : ep->proto == COAP_PROTO_TCP ? "TCP "
         : ep->proto == COAP_PROTO_DTLS ? "DTLS" : "UDP ",

--- a/src/coap_tcp.c
+++ b/src/coap_tcp.c
@@ -61,7 +61,7 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
   sock->fd = socket(server->addr.sa.sa_family, SOCK_STREAM, 0);
 
   if (sock->fd == COAP_INVALID_SOCKET) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_socket_connect_tcp1: socket: %s\n",
              coap_socket_strerror());
     goto error;
@@ -73,7 +73,7 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
 #else
   if (ioctl(sock->fd, FIONBIO, &on) == COAP_SOCKET_ERROR) {
 #endif
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_socket_connect_tcp1: ioctl FIONBIO: %s\n",
              coap_socket_strerror());
   }
@@ -90,27 +90,27 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
 #ifndef RIOT_VERSION
     /* Configure the socket as dual-stacked */
     if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, OPTVAL_T(&off), sizeof(off)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_WARNING,
+      coap_log_warn(
                "coap_socket_connect_tcp1: setsockopt IPV6_V6ONLY: %s\n",
                coap_socket_strerror());
 #endif /* RIOT_VERSION */
     break;
   default:
-    coap_log(LOG_ALERT, "coap_socket_connect_tcp1: unsupported sa_family\n");
+    coap_log_alert("coap_socket_connect_tcp1: unsupported sa_family\n");
     break;
   }
 
   if (local_if && local_if->addr.sa.sa_family) {
     coap_address_copy(local_addr, local_if);
     if (setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, OPTVAL_T(&on), sizeof(on)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_WARNING,
+      coap_log_warn(
                "coap_socket_connect_tcp1: setsockopt SO_REUSEADDR: %s\n",
                coap_socket_strerror());
     if (bind(sock->fd, &local_if->addr.sa,
              local_if->addr.sa.sa_family == AF_INET ?
               (socklen_t)sizeof(struct sockaddr_in) :
               (socklen_t)local_if->size) == COAP_SOCKET_ERROR) {
-      coap_log(LOG_WARNING, "coap_socket_connect_tcp1: bind: %s\n",
+      coap_log_warn("coap_socket_connect_tcp1: bind: %s\n",
                coap_socket_strerror());
       goto error;
     }
@@ -132,18 +132,18 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
       sock->flags |= COAP_SOCKET_WANT_CONNECT | COAP_SOCKET_CONNECTED;
       return 1;
     }
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: connect: %s\n",
+    coap_log_warn("coap_socket_connect_tcp1: connect: %s\n",
              coap_socket_strerror());
     goto error;
   }
 
   if (getsockname(sock->fd, &local_addr->addr.sa, &local_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: getsockname: %s\n",
+    coap_log_warn("coap_socket_connect_tcp1: getsockname: %s\n",
              coap_socket_strerror());
   }
 
   if (getpeername(sock->fd, &remote_addr->addr.sa, &remote_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp1: getpeername: %s\n",
+    coap_log_warn("coap_socket_connect_tcp1: getpeername: %s\n",
              coap_socket_strerror());
   }
 
@@ -170,12 +170,12 @@ coap_socket_connect_tcp2(coap_socket_t *sock,
 
   if (getsockopt(sock->fd, SOL_SOCKET, SO_ERROR, OPTVAL_GT(&error),
     &optlen) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_finish_connect_tcp: getsockopt: %s\n",
+    coap_log_warn("coap_socket_finish_connect_tcp: getsockopt: %s\n",
       coap_socket_strerror());
   }
 
   if (error) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_socket_finish_connect_tcp: connect failed: %s\n",
              coap_socket_format_errno(error));
     coap_socket_close(sock);
@@ -183,12 +183,12 @@ coap_socket_connect_tcp2(coap_socket_t *sock,
   }
 
   if (getsockname(sock->fd, &local_addr->addr.sa, &local_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp: getsockname: %s\n",
+    coap_log_warn("coap_socket_connect_tcp: getsockname: %s\n",
              coap_socket_strerror());
   }
 
   if (getpeername(sock->fd, &remote_addr->addr.sa, &remote_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_WARNING, "coap_socket_connect_tcp: getpeername: %s\n",
+    coap_log_warn("coap_socket_connect_tcp: getpeername: %s\n",
              coap_socket_strerror());
   }
 
@@ -210,7 +210,7 @@ coap_socket_bind_tcp(coap_socket_t *sock,
   sock->fd = socket(listen_addr->addr.sa.sa_family, SOCK_STREAM, 0);
 
   if (sock->fd == COAP_INVALID_SOCKET) {
-    coap_log(LOG_WARNING, "coap_socket_bind_tcp: socket: %s\n",
+    coap_log_warn("coap_socket_bind_tcp: socket: %s\n",
              coap_socket_strerror());
     goto error;
   }
@@ -221,19 +221,19 @@ coap_socket_bind_tcp(coap_socket_t *sock,
 #else
   if (ioctl(sock->fd, FIONBIO, &on) == COAP_SOCKET_ERROR) {
 #endif
-    coap_log(LOG_WARNING, "coap_socket_bind_tcp: ioctl FIONBIO: %s\n",
+    coap_log_warn("coap_socket_bind_tcp: ioctl FIONBIO: %s\n",
                            coap_socket_strerror());
   }
 #endif /* RIOT_VERSION */
   if (setsockopt (sock->fd, SOL_SOCKET, SO_KEEPALIVE, OPTVAL_T(&on),
                   sizeof (on)) == COAP_SOCKET_ERROR)
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_socket_bind_tcp: setsockopt SO_KEEPALIVE: %s\n",
              coap_socket_strerror());
 
   if (setsockopt(sock->fd, SOL_SOCKET, SO_REUSEADDR, OPTVAL_T(&on),
                  sizeof(on)) == COAP_SOCKET_ERROR)
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_socket_bind_tcp: setsockopt SO_REUSEADDR: %s\n",
              coap_socket_strerror());
 
@@ -244,33 +244,33 @@ coap_socket_bind_tcp(coap_socket_t *sock,
 #ifndef RIOT_VERSION
     /* Configure the socket as dual-stacked */
     if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, OPTVAL_T(&off), sizeof(off)) == COAP_SOCKET_ERROR)
-      coap_log(LOG_ALERT,
+      coap_log_alert(
                "coap_socket_bind_tcp: setsockopt IPV6_V6ONLY: %s\n",
                coap_socket_strerror());
 #endif /* RIOT_VERSION */
     break;
   default:
-    coap_log(LOG_ALERT, "coap_socket_bind_tcp: unsupported sa_family\n");
+    coap_log_alert("coap_socket_bind_tcp: unsupported sa_family\n");
   }
 
   if (bind(sock->fd, &listen_addr->addr.sa,
            listen_addr->addr.sa.sa_family == AF_INET ?
             (socklen_t)sizeof(struct sockaddr_in) :
             (socklen_t)listen_addr->size) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_ALERT, "coap_socket_bind_tcp: bind: %s\n",
+    coap_log_alert("coap_socket_bind_tcp: bind: %s\n",
              coap_socket_strerror());
     goto error;
   }
 
   bound_addr->size = (socklen_t)sizeof(*bound_addr);
   if (getsockname(sock->fd, &bound_addr->addr.sa, &bound_addr->size) < 0) {
-    coap_log(LOG_WARNING, "coap_socket_bind_tcp: getsockname: %s\n",
+    coap_log_warn("coap_socket_bind_tcp: getsockname: %s\n",
              coap_socket_strerror());
     goto error;
   }
 
   if (listen(sock->fd, 5) == COAP_SOCKET_ERROR) {
-    coap_log(LOG_ALERT, "coap_socket_bind_tcp: listen: %s\n",
+    coap_log_alert("coap_socket_bind_tcp: listen: %s\n",
              coap_socket_strerror());
     goto  error;
   }
@@ -300,13 +300,13 @@ coap_socket_accept_tcp(coap_socket_t *server,
   new_client->fd = accept(server->fd, &remote_addr->addr.sa,
                           &remote_addr->size);
   if (new_client->fd == COAP_INVALID_SOCKET) {
-    coap_log(LOG_WARNING, "coap_socket_accept_tcp: accept: %s\n",
+    coap_log_warn("coap_socket_accept_tcp: accept: %s\n",
              coap_socket_strerror());
     return 0;
   }
 
   if (getsockname( new_client->fd, &local_addr->addr.sa, &local_addr->size) < 0)
-    coap_log(LOG_WARNING, "coap_socket_accept_tcp: getsockname: %s\n",
+    coap_log_warn("coap_socket_accept_tcp: getsockname: %s\n",
              coap_socket_strerror());
 
 #ifndef RIOT_VERSION
@@ -315,7 +315,7 @@ coap_socket_accept_tcp(coap_socket_t *server,
 #else
   if (ioctl(new_client->fd, FIONBIO, &on) == COAP_SOCKET_ERROR) {
 #endif
-    coap_log(LOG_WARNING, "coap_socket_accept_tcp: ioctl FIONBIO: %s\n",
+    coap_log_warn("coap_socket_accept_tcp: ioctl FIONBIO: %s\n",
              coap_socket_strerror());
   }
 #endif /* RIOT_VERSION */

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -257,7 +257,7 @@ dtls_send_to_peer(struct dtls_context_t *dtls_context,
   get_session_addr(dtls_session, &remote_addr);
   coap_session = coap_session_get_by_peer(coap_context, &remote_addr, dtls_session->ifindex);
   if (!coap_session) {
-    coap_log(LOG_WARNING, "dtls_send_to_peer: cannot find local interface\n");
+    coap_log_warn("dtls_send_to_peer: cannot find local interface\n");
     return -3;
   }
   return (int)coap_session_send(coap_session, data, len);
@@ -276,7 +276,7 @@ dtls_application_data(struct dtls_context_t *dtls_context,
   get_session_addr(dtls_session, &remote_addr);
   coap_session = coap_session_get_by_peer(coap_context, &remote_addr, dtls_session->ifindex);
   if (!coap_session) {
-    coap_log(LOG_DEBUG,
+    coap_log_debug(
              "dropped message that was received on invalid interface\n");
     return -1;
   }
@@ -353,7 +353,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
   get_session_addr(dtls_session, &remote_addr);
   coap_session = coap_session_get_by_peer(coap_context, &remote_addr, dtls_session->ifindex);
   if (!coap_session) {
-    coap_log(LOG_DEBUG, "cannot get PSK, session not found\n");
+    coap_log_debug("cannot get PSK, session not found\n");
     goto error;
   }
 
@@ -371,7 +371,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
     temp.length = id_len;
     coap_session_refresh_psk_hint(coap_session, &temp);
 
-    coap_log(LOG_DEBUG, "got psk_identity_hint: '%.*s'\n", (int)id_len,
+    coap_log_debug("got psk_identity_hint: '%.*s'\n", (int)id_len,
              id ? (const char*)id : "");
 
     if (setup_cdata->validate_ih_call_back) {
@@ -396,12 +396,12 @@ get_psk_info(struct dtls_context_t *dtls_context,
       psk_identity = coap_get_session_client_psk_identity(coap_session);
     }
     if (psk_identity == NULL) {
-      coap_log(LOG_WARNING, "no PSK identity given\n");
+      coap_log_warn("no PSK identity given\n");
       fatal_error = DTLS_ALERT_CLOSE_NOTIFY;
       goto error;
     }
     if (psk_identity->length > result_length) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
                "psk_identity too large, truncated to %zd bytes\n",
                result_length);
     }
@@ -420,12 +420,12 @@ get_psk_info(struct dtls_context_t *dtls_context,
     if (coap_session->type == COAP_SESSION_TYPE_CLIENT) {
       psk_key = coap_get_session_client_psk_key(coap_session);
       if (psk_key == NULL) {
-        coap_log(LOG_WARNING, "no PSK key given\n");
+        coap_log_warn("no PSK key given\n");
         fatal_error = DTLS_ALERT_CLOSE_NOTIFY;
         goto error;
       }
       if (psk_key->length > result_length) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "psk_key too large, truncated to %zd bytes\n",
                  result_length);
       }
@@ -448,7 +448,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
       /* Track the Identity being used */
       coap_session_refresh_psk_identity(coap_session, &lidentity);
 
-      coap_log(LOG_DEBUG, "got psk_identity: '%.*s'\n",
+      coap_log_debug("got psk_identity: '%.*s'\n",
                (int)lidentity.length, lidentity.s);
 
       if (setup_sdata->validate_id_call_back) {
@@ -462,13 +462,13 @@ get_psk_info(struct dtls_context_t *dtls_context,
       }
 
       if (psk_key == NULL) {
-        coap_log(LOG_WARNING, "no PSK key given\n");
+        coap_log_warn("no PSK key given\n");
         return 0;
       }
       if (setup_sdata->validate_id_call_back)
         coap_session_refresh_psk_key(coap_session, psk_key);
       if (psk_key->length > result_length) {
-        coap_log(LOG_WARNING,
+        coap_log_warn(
                  "psk_key too large, truncated to %zd bytes\n",
                  result_length);
       }
@@ -488,7 +488,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
     if (psk_hint == NULL)
       return 0;
     if (psk_hint->length > result_length) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
                "psk_hint too large, truncated to %zd bytes\n",
                result_length);
     }
@@ -503,7 +503,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
 #endif /* COAP_SERVER_SUPPORT */
 
   default:
-    coap_log(LOG_WARNING, "unsupported request type: %d\n", type);
+    coap_log_warn("unsupported request type: %d\n", type);
   }
 
 error:
@@ -659,7 +659,7 @@ coap_dtls_new_session(coap_session_t *session) {
     dtls_session_init(dtls_session);
     put_session_addr(&session->addr_info.remote, dtls_session);
     dtls_session->ifindex = session->ifindex;
-    coap_log(LOG_DEBUG, "***new session %p\n", (void *)dtls_session);
+    coap_log_debug("***new session %p\n", (void *)dtls_session);
   }
 
   return dtls_session;
@@ -722,7 +722,7 @@ coap_dtls_free_session(coap_session_t *coap_session) {
       dtls_reset_peer(dtls_context, peer);
     else
       dtls_close(dtls_context, (session_t *)coap_session->tls);
-    coap_log(LOG_DEBUG, "***removed session %p\n", coap_session->tls);
+    coap_log_debug("***removed session %p\n", coap_session->tls);
     coap_free_type(COAP_DTLS_SESSION, coap_session->tls);
     coap_session->tls = NULL;
     coap_handle_event(coap_session->context, COAP_EVENT_DTLS_CLOSED, coap_session);
@@ -748,7 +748,7 @@ coap_dtls_send(coap_session_t *session,
     (session_t *)session->tls, data_rw, data_len);
 
   if (res < 0)
-    coap_log(LOG_WARNING, "coap_dtls_send: cannot send PDU\n");
+    coap_log_warn("coap_dtls_send: cannot send PDU\n");
 
   if (coap_event_dtls >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
@@ -1071,7 +1071,7 @@ asn1_derive_keys(coap_tiny_context_t *t_context,
   t_context->priv_key = get_asn1_tag(COAP_ASN1_OCTETSTRING, priv_data,
                                      priv_len, asn1_verify_privkey);
   if (!t_context->priv_key) {
-    coap_log(LOG_INFO, "EC Private Key (RPK) invalid\n");
+    coap_log_info("EC Private Key (RPK) invalid\n");
     return 0;
   }
   /* skip leading 0x00 */
@@ -1086,7 +1086,7 @@ asn1_derive_keys(coap_tiny_context_t *t_context,
     test = get_asn1_tag(COAP_ASN1_IDENTIFIER, priv_data, priv_len,
                                     asn1_verify_curve);
     if (!test) {
-      coap_log(LOG_INFO, "EC Private Key (RPK) invalid elliptic curve\n");
+      coap_log_info("EC Private Key (RPK) invalid elliptic curve\n");
       coap_delete_binary(t_context->priv_key);
       t_context->priv_key = NULL;
       return 0;
@@ -1097,7 +1097,7 @@ asn1_derive_keys(coap_tiny_context_t *t_context,
   t_context->pub_key = get_asn1_tag(COAP_ASN1_BITSTRING, pub_data, pub_len,
                                               asn1_verify_pubkey);
   if (!t_context->pub_key) {
-    coap_log(LOG_INFO, "EC Public Key (RPK) invalid\n");
+    coap_log_info("EC Public Key (RPK) invalid\n");
     coap_delete_binary(t_context->priv_key);
     t_context->priv_key = NULL;
     return 0;
@@ -1130,7 +1130,7 @@ ec_abstract_pkcs8_asn1(const uint8_t *asn1_ptr, size_t asn1_length)
   test = get_asn1_tag(COAP_ASN1_IDENTIFIER, asn1_ptr, asn1_length,
                                asn1_verify_curve);
   if (!test) {
-    coap_log(LOG_INFO, "EC Private Key (RPK) invalid elliptic curve\n");
+    coap_log_info("EC Private Key (RPK) invalid elliptic curve\n");
     return 0;
   }
   coap_delete_binary(test);
@@ -1171,7 +1171,7 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
   if (setup_data->version != COAP_DTLS_PKI_SETUP_VERSION)
     return 0;
   if (!setup_data->is_rpk_not_cert) {
-    coap_log(LOG_WARNING, "Only RPK, not full PKI is supported\n");
+    coap_log_warn("Only RPK, not full PKI is supported\n");
     return 0;
   }
   if (!ctx)
@@ -1192,7 +1192,7 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
   /* All should be RPK only now */
   switch (setup_data->pki_key.key_type) {
   case COAP_PKI_KEY_PEM:
-    coap_log(LOG_WARNING, "RPK keys cannot be in COAP_PKI_KEY_PEM format\n");
+    coap_log_warn("RPK keys cannot be in COAP_PKI_KEY_PEM format\n");
     break;
   case COAP_PKI_KEY_PEM_BUF:
     if (setup_data->pki_key.key.pem_buf.public_cert &&
@@ -1206,12 +1206,12 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
         asn1_priv = pem_decode_mem_asn1("-----BEGIN PRIVATE KEY-----",
                                  setup_data->pki_key.key.pem_buf.private_key);
         if (!asn1_priv) {
-          coap_log(LOG_INFO, "Private Key (RPK) invalid\n");
+          coap_log_info("Private Key (RPK) invalid\n");
           return 0;
         }
         asn1_temp = ec_abstract_pkcs8_asn1(asn1_priv->s, asn1_priv->length);
         if (!asn1_temp) {
-          coap_log(LOG_INFO, "PKCS#8 Private Key (RPK) invalid\n");
+          coap_log_info("PKCS#8 Private Key (RPK) invalid\n");
           coap_delete_binary(asn1_priv);
           return 0;
         }
@@ -1229,13 +1229,13 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
           asn1_pub = pem_decode_mem_asn1("-----BEGIN PRIVATE KEY-----",
                                  setup_data->pki_key.key.pem_buf.private_key);
           if (!asn1_pub) {
-            coap_log(LOG_INFO, "Public Key (RPK) invalid\n");
+            coap_log_info("Public Key (RPK) invalid\n");
             coap_delete_binary(asn1_priv);
             return 0;
           }
           asn1_temp = ec_abstract_pkcs8_asn1(asn1_pub->s, asn1_pub->length);
           if (!asn1_temp) {
-            coap_log(LOG_INFO, "PKCS#8 Private Key (RPK) invalid\n");
+            coap_log_info("PKCS#8 Private Key (RPK) invalid\n");
             coap_delete_binary(asn1_priv);
             coap_delete_binary(asn1_pub);
             return 0;
@@ -1247,7 +1247,7 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
       }
       if (!asn1_derive_keys(t_context, asn1_priv->s, asn1_priv->length,
                             asn1_pub->s, asn1_pub->length, is_pkcs8)) {
-        coap_log(LOG_INFO, "Unable to derive Public/Private Keys\n");
+        coap_log_info("Unable to derive Public/Private Keys\n");
         coap_delete_binary(asn1_priv);
         coap_delete_binary(asn1_pub);
         return 0;
@@ -1282,7 +1282,7 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
                               setup_data->pki_key.key.asn1.public_cert,
                               setup_data->pki_key.key.asn1.public_cert_len,
                               is_pkcs8)) {
-          coap_log(LOG_INFO, "Unable to derive Public/Private Keys\n");
+          coap_log_info("Unable to derive Public/Private Keys\n");
           if (asn1_temp) coap_delete_binary(asn1_temp);
           return 0;
         }
@@ -1294,7 +1294,7 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
                               private_key,
                               private_key_len,
                               is_pkcs8)) {
-          coap_log(LOG_INFO, "Unable to derive Public/Private Keys\n");
+          coap_log_info("Unable to derive Public/Private Keys\n");
           if (asn1_temp) coap_delete_binary(asn1_temp);
           return 0;
         }
@@ -1303,7 +1303,7 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
     }
     break;
   case COAP_PKI_KEY_PKCS11:
-    coap_log(LOG_WARNING, "RPK keys cannot be in COAP_PKI_KEY_PCKS11 format\n");
+    coap_log_warn("RPK keys cannot be in COAP_PKI_KEY_PCKS11 format\n");
     break;
   default:
     break;
@@ -1312,7 +1312,7 @@ coap_dtls_context_set_pki(coap_context_t *ctx,
   (void)ctx;
   (void)setup_data;
 #endif /* ! DTLS_ECC */
-  coap_log(LOG_WARNING, "TinyDTLS not compiled with ECC support\n");
+  coap_log_warn("TinyDTLS not compiled with ECC support\n");
   return 0;
 }
 
@@ -1321,7 +1321,7 @@ coap_dtls_context_set_pki_root_cas(coap_context_t *ctx COAP_UNUSED,
   const char *ca_file COAP_UNUSED,
   const char *ca_path COAP_UNUSED
 ) {
-  coap_log(LOG_WARNING, "Root CAs PKI not supported\n");
+  coap_log_warn("Root CAs PKI not supported\n");
   return 0;
 }
 
@@ -1336,7 +1336,7 @@ coap_dtls_context_set_cpsk(coap_context_t *coap_context COAP_UNUSED,
 #ifdef DTLS_PSK
   return 1;
 #else /* ! DTLS_PSK */
-  coap_log(LOG_WARNING, "TinyDTLS not compiled with PSK support\n");
+  coap_log_warn("TinyDTLS not compiled with PSK support\n");
   return 0;
 #endif /* ! DTLS_PSK */
 }
@@ -1352,13 +1352,13 @@ coap_dtls_context_set_spsk(coap_context_t *coap_context COAP_UNUSED,
 
 #ifdef DTLS_PSK
   if (setup_data->validate_sni_call_back) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
         "CoAP Server with TinyDTLS does not support SNI selection\n");
   }
 
   return 1;
 #else /* ! DTLS_PSK */
-  coap_log(LOG_WARNING, "TinyDTLS not compiled with PSK support\n");
+  coap_log_warn("TinyDTLS not compiled with PSK support\n");
   return 0;
 #endif /* ! DTLS_PSK */
 }

--- a/src/mem.c
+++ b/src/mem.c
@@ -310,7 +310,7 @@ coap_malloc_type(coap_memory_tag_t type, size_t size) {
   assert(container);
 
   if (size > container->size) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_malloc_type: Requested memory exceeds maximum object "
              "size (type %d, size %zu, max %d)\n",
              type, size, container->size);
@@ -319,7 +319,7 @@ coap_malloc_type(coap_memory_tag_t type, size_t size) {
 
   ptr = memarray_alloc(container);
   if (!ptr)
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_malloc_type: Failure (no free blocks) for type %d\n",
              type);
   return ptr;
@@ -339,7 +339,7 @@ coap_realloc_type(coap_memory_tag_t type, void *p, size_t size) {
   /* The fixed container is all we have to work with */
   if (p) {
     if (size > container->size) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
                "coap_realloc_type: Requested memory exceeds maximum object "
                "size (type %d, size %zu, max %d)\n",
                type, size, container->size);
@@ -474,7 +474,7 @@ coap_malloc_type(coap_memory_tag_t type, size_t size) {
   assert(container);
 
   if (size > container->size) {
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_malloc_type: Requested memory exceeds maximum object "
              "size (type %d, size %d, max %d)\n",
              type, (int)size, container->size);
@@ -483,7 +483,7 @@ coap_malloc_type(coap_memory_tag_t type, size_t size) {
 
   ptr = memb_alloc(container);
   if (!ptr)
-    coap_log(LOG_WARNING,
+    coap_log_warn(
              "coap_malloc_type: Failure (no free blocks) for type %d\n",
              type);
   return ptr;
@@ -502,7 +502,7 @@ coap_realloc_type(coap_memory_tag_t type, void *p, size_t size) {
   /* The fixed container is all we have to work with */
   if (p) {
     if (size > container->size) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
                "coap_realloc_type: Requested memory exceeds maximum object "
                "size (type %d, size %zu, max %d)\n",
                type, size, container->size);

--- a/src/resource.c
+++ b/src/resource.c
@@ -311,7 +311,7 @@ coap_resource_init(coap_str_const_t *uri_path, int flags) {
     r->flags = flags;
     r->observe = 2;
   } else {
-    coap_log(LOG_DEBUG, "coap_resource_init: no memory left\n");
+    coap_log_debug("coap_resource_init: no memory left\n");
   }
 
   return r;
@@ -333,7 +333,7 @@ coap_resource_unknown_init2(coap_method_handler_t put_handler, int flags) {
     r->flags = flags & COAP_RESOURCE_FLAGS_MCAST_LIST;
     coap_register_handler(r, COAP_REQUEST_PUT, put_handler);
   } else {
-    coap_log(LOG_DEBUG, "coap_resource_unknown_init: no memory left\n");
+    coap_log_debug("coap_resource_unknown_init: no memory left\n");
   }
 
   return r;
@@ -354,7 +354,7 @@ coap_resource_proxy_uri_init2(coap_method_handler_t handler,
   coap_resource_t *r;
 
   if (host_name_count == 0) {
-    coap_log(LOG_ERR,
+    coap_log_err(
           "coap_resource_proxy_uri_init: Must have one or more host names defined\n");
     return NULL;
   }
@@ -378,7 +378,7 @@ coap_resource_proxy_uri_init2(coap_method_handler_t handler,
               coap_new_str_const((const uint8_t*)host_name_list[i],
                                  strlen(host_name_list[i]));
           if (!r->proxy_name_list[i]) {
-            coap_log(LOG_ERR,
+            coap_log_err(
                      "coap_resource_proxy_uri_init: unable to add host name\n");
             if (i == 0) {
               coap_free(r->proxy_name_list);
@@ -392,7 +392,7 @@ coap_resource_proxy_uri_init2(coap_method_handler_t handler,
     }
     r->flags = flags & COAP_RESOURCE_FLAGS_MCAST_LIST;
   } else {
-    coap_log(LOG_DEBUG, "coap_resource_proxy_uri_init2: no memory left\n");
+    coap_log_debug("coap_resource_proxy_uri_init2: no memory left\n");
   }
 
   return r;
@@ -436,7 +436,7 @@ coap_add_attr(coap_resource_t *resource,
     /* add attribute to resource list */
     LL_PREPEND(resource->link_attr, attr);
   } else {
-    coap_log(LOG_DEBUG, "coap_add_attr: no memory left\n");
+    coap_log_debug("coap_add_attr: no memory left\n");
   }
 
   return attr;
@@ -541,7 +541,7 @@ coap_add_resource(coap_context_t *context, coap_resource_t *resource) {
                                                          resource->uri_path);
 
     if (r) {
-      coap_log(LOG_WARNING,
+      coap_log_warn(
         "coap_add_resource: Duplicate uri_path '%*.*s', old resource deleted\n",
               (int)resource->uri_path->length, (int)resource->uri_path->length,
               resource->uri_path->s);
@@ -802,7 +802,7 @@ static const uint16_t cache_ignore_options[] = { COAP_OPTION_ETAG };
   /* add subscriber to resource */
   LL_PREPEND(resource->subscribers, s);
 
-  coap_log(LOG_DEBUG, "create new subscription %p key 0x%02x%02x%02x%02x\n",
+  coap_log_debug("create new subscription %p key 0x%02x%02x%02x%02x\n",
            (void*)s, s->cache_key->key[0], s->cache_key->key[1],
            s->cache_key->key[2], s->cache_key->key[3]);
 
@@ -834,7 +834,7 @@ coap_delete_observer(coap_resource_t *resource, coap_session_t *session,
     unsigned int i;
     for ( i = 0; i < s->pdu->token_length; i++ )
       snprintf( &outbuf[2 * i], 3, "%02x", s->pdu->token[i] );
-    coap_log(LOG_DEBUG,
+    coap_log_debug(
              "removed subscription %p with token '%s' key 0x%02x%02x%02x%02x\n",
              (void*)s, outbuf, s->cache_key->key[0], s->cache_key->key[1],
              s->cache_key->key[2], s-> cache_key->key[3]);
@@ -921,7 +921,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         obs->dirty = 1;
         r->partiallydirty = 1;
         context->observe_pending = 1;
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
                  "coap_check_notify: pdu init failed, resource stays "
                  "partially dirty\n");
         continue;
@@ -931,7 +931,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         obs->dirty = 1;
         r->partiallydirty = 1;
         context->observe_pending = 1;
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
                  "coap_check_notify: cannot add token, resource stays "
                  "partially dirty\n");
         coap_delete_pdu(response);
@@ -973,9 +973,9 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         assert(h);      /* we do not allow subscriptions if no
                          * GET/FETCH handler is defined */
         query = coap_get_query(obs->pdu);
-        coap_log(LOG_DEBUG, "Observe PDU presented to app.\n");
+        coap_log_debug("Observe PDU presented to app.\n");
         coap_show_pdu(LOG_DEBUG, obs->pdu);
-        coap_log(LOG_DEBUG, "call custom handler for resource '%*.*s'\n",
+        coap_log_debug("call custom handler for resource '%*.*s'\n",
                  (int)r->uri_path->length, (int)r->uri_path->length,
                  r->uri_path->s);
         h(r, obs->session, obs->pdu, query, response);
@@ -1011,7 +1011,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
 
       if (COAP_INVALID_MID == mid && obs) {
         coap_subscription_t *s;
-        coap_log(LOG_DEBUG,
+        coap_log_debug(
                  "coap_check_notify: sending failed, resource stays "
                  "partially dirty\n");
         LL_FOREACH(r->subscribers, s) {

--- a/src/str.c
+++ b/src/str.c
@@ -21,7 +21,7 @@ coap_string_t *coap_new_string(size_t size) {
   coap_string_t *s;
 #ifdef WITH_LWIP
   if (size >= MEMP_LEN_COAPSTRING) {
-    coap_log(LOG_CRIT,
+    coap_log_crit(
              "coap_new_string: size too large (%zu +1 > MEMP_LEN_COAPSTRING)\n",
              size);
     return NULL;
@@ -31,7 +31,7 @@ coap_string_t *coap_new_string(size_t size) {
   s = (coap_string_t *)coap_malloc_type(COAP_STRING,
                                         sizeof(coap_string_t) + size + 1);
   if ( !s ) {
-    coap_log(LOG_CRIT, "coap_new_string: malloc: failed\n");
+    coap_log_crit("coap_new_string: malloc: failed\n");
     return NULL;
   }
 

--- a/src/uri.c
+++ b/src/uri.c
@@ -266,7 +266,7 @@ coap_uri_into_options(coap_uri_t *uri,
 
   if (uri->path.length) {
     if (uri->path.length > buflen)
-      coap_log(LOG_WARNING, "URI path will be truncated (max buffer %zu)\n",
+      coap_log_warn("URI path will be truncated (max buffer %zu)\n",
                buflen);
     res = coap_split_path(uri->path.s, uri->path.length, buf, &buflen);
     if (res < 0)
@@ -286,7 +286,7 @@ coap_uri_into_options(coap_uri_t *uri,
     buflen = _buflen;
     buf = _buf;
     if (uri->query.length > buflen)
-      coap_log(LOG_WARNING, "URI query will be truncated (max buffer %zu)\n",
+      coap_log_warn("URI query will be truncated (max buffer %zu)\n",
                buflen);
     res = coap_split_query(uri->query.s, uri->query.length, buf, &buflen);
     if (res < 0)
@@ -396,7 +396,7 @@ make_decoded_option(const uint8_t *s, size_t length,
   size_t written;
 
   if (!buflen) {
-    coap_log(LOG_DEBUG, "make_decoded_option(): buflen is 0!\n");
+    coap_log_debug("make_decoded_option(): buflen is 0!\n");
     return -1;
   }
 
@@ -416,7 +416,7 @@ make_decoded_option(const uint8_t *s, size_t length,
   buflen -= written;
 
   if (buflen < segmentlen) {
-    coap_log(LOG_DEBUG, "buffer too small for option\n");
+    coap_log_debug("buffer too small for option\n");
     return -1;
   }
 


### PR DESCRIPTION
Drop the use of syslog LOG_DEBUG etc. for coap_log() and use the coap_log_debug() etc. macros which make use of COAP_LOG_DEBUG etc.