### PR TITLE
mem: Use coap_malloc_type() and coap_free_type() in libcoap

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -1209,7 +1209,7 @@ coap_block_delete_lg_crcv(coap_session_t *session,
   for (i = 0; i < lg_crcv->obs_token_cnt; i++) {
     coap_delete_binary(lg_crcv->obs_token[i]);
   }
-  coap_free(lg_crcv->obs_token);
+  coap_free_type(COAP_STRING, lg_crcv->obs_token);
   coap_free_type(COAP_LG_CRCV, lg_crcv);
 }
 #endif /* COAP_CLIENT_SUPPORT */

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -67,7 +67,7 @@ coap_register_async(coap_session_t *session,
   }
 
   /* store information for handling the asynchronous task */
-  s = (coap_async_t *)coap_malloc(sizeof(coap_async_t));
+  s = (coap_async_t *)coap_malloc_type(COAP_STRING, sizeof(coap_async_t));
   if (!s) {
     coap_log(LOG_CRIT, "coap_register_async: insufficient memory\n");
     return NULL;
@@ -156,7 +156,7 @@ coap_free_async_sub(coap_context_t *context, coap_async_t *s) {
       coap_delete_pdu(s->pdu);
       s->pdu = NULL;
     }
-    coap_free(s);
+    coap_free_type(COAP_STRING, s);
   }
 }
 

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -49,11 +49,11 @@ coap_cache_ignore_options(coap_context_t *ctx,
                           const uint16_t *options,
                           size_t count) {
   if (ctx->cache_ignore_options) {
-    coap_free(ctx->cache_ignore_options);
+    coap_free_type(COAP_STRING, ctx->cache_ignore_options);
   }
   if (count) {
     assert(options);
-    ctx->cache_ignore_options = coap_malloc(count * sizeof(options[0]));
+    ctx->cache_ignore_options = coap_malloc_type(COAP_STRING, count * sizeof(options[0]));
     if (ctx->cache_ignore_options) {
       memcpy(ctx->cache_ignore_options, options, count * sizeof(options[0]));
       ctx->cache_ignore_count = count;

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -799,7 +799,7 @@ void *coap_dtls_new_context(coap_context_t *coap_context) {
   coap_openssl_context_t *context;
   (void)coap_context;
 
-  context = (coap_openssl_context_t *)coap_malloc(sizeof(coap_openssl_context_t));
+  context = (coap_openssl_context_t *)coap_malloc_type(COAP_STRING, sizeof(coap_openssl_context_t));
   if (context) {
     uint8_t cookie_secret[32];
 
@@ -2837,7 +2837,7 @@ void coap_dtls_free_context(void *handle) {
   }
   if (context->psk_sni_count)
     OPENSSL_free(context->psk_sni_entry_list);
-  coap_free(context);
+  coap_free_type(COAP_STRING, context);
 }
 
 #if COAP_SERVER_SUPPORT

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -921,7 +921,7 @@ static const uint8_t b64_6[256] =
 static coap_binary_t *
 pem_base64_decode (const uint8_t *data, size_t size)
 {
-  uint8_t *tbuf = coap_malloc(size);
+  uint8_t *tbuf = coap_malloc_type(COAP_STRING, size);
   size_t nbytesdecoded;
   size_t i;
   coap_binary_t *decoded;
@@ -973,7 +973,7 @@ end:
   }
 
   decoded->length = nbytesdecoded - ((4 - nb64bytes) & 3);
-  coap_free(tbuf);
+  coap_free_type(COAP_STRING, tbuf);
   return decoded;
 }
 
@@ -1404,7 +1404,7 @@ ssize_t coap_tls_read(coap_session_t *session COAP_UNUSED,
 #if COAP_SERVER_SUPPORT
 coap_digest_ctx_t *
 coap_digest_setup(void) {
-  dtls_sha256_ctx *digest_ctx = coap_malloc(sizeof(dtls_sha256_ctx));
+  dtls_sha256_ctx *digest_ctx = coap_malloc_type(COAP_STRING, sizeof(dtls_sha256_ctx));
 
   if (digest_ctx) {
     dtls_sha256_init(digest_ctx);
@@ -1415,7 +1415,7 @@ coap_digest_setup(void) {
 
 void
 coap_digest_free(coap_digest_ctx_t *digest_ctx) {
-  coap_free(digest_ctx);
+  coap_free_type(COAP_STRING, digest_ctx);
 }
 
 int

--- a/src/net.c
+++ b/src/net.c
@@ -619,7 +619,7 @@ coap_free_context(coap_context_t *context) {
     coap_delete_cache_entry(context, cp);
   }
   if (context->cache_ignore_count) {
-    coap_free(context->cache_ignore_options);
+    coap_free_type(COAP_STRING, context->cache_ignore_options);
   }
 
   coap_endpoint_t *ep, *tmp;

--- a/src/resource.c
+++ b/src/resource.c
@@ -370,7 +370,7 @@ coap_resource_proxy_uri_init2(coap_method_handler_t handler,
       r->handler[i] = handler;
     }
     if (host_name_count) {
-      r->proxy_name_list = coap_malloc(host_name_count *
+      r->proxy_name_list = coap_malloc_type(COAP_STRING, host_name_count *
                                        sizeof(coap_str_const_t*));
       if (r->proxy_name_list) {
         for (i = 0; i < host_name_count; i++) {
@@ -381,7 +381,7 @@ coap_resource_proxy_uri_init2(coap_method_handler_t handler,
             coap_log(LOG_ERR,
                      "coap_resource_proxy_uri_init: unable to add host name\n");
             if (i == 0) {
-              coap_free(r->proxy_name_list);
+              coap_free_type(COAP_STRING, r->proxy_name_list);
               r->proxy_name_list = NULL;
             }
             break;
@@ -518,7 +518,7 @@ coap_free_resource(coap_resource_t *resource) {
     for (i = 0; i < resource->proxy_name_count; i++) {
       coap_delete_str_const(resource->proxy_name_list[i]);
     }
-    coap_free(resource->proxy_name_list);
+    coap_free_type(COAP_STRING, resource->proxy_name_list);
   }
 
   coap_free_type(COAP_RESOURCE, resource);

--- a/src/uri.c
+++ b/src/uri.c
@@ -544,7 +544,7 @@ coap_uri_t *
 coap_new_uri(const uint8_t *uri, unsigned int length) {
   unsigned char *result;
 
-  result = (unsigned char*)coap_malloc(length + 1 + sizeof(coap_uri_t));
+  result = (unsigned char*)coap_malloc_type(COAP_STRING, length + 1 + sizeof(coap_uri_t));
 
   if (!result)
     return NULL;
@@ -553,7 +553,7 @@ coap_new_uri(const uint8_t *uri, unsigned int length) {
   URI_DATA(result)[length] = '\0'; /* make it zero-terminated */
 
   if (coap_split_uri(URI_DATA(result), length, (coap_uri_t *)result) < 0) {
-    coap_free(result);
+    coap_free_type(COAP_STRING, result);
     return NULL;
   }
   return (coap_uri_t *)result;
@@ -567,7 +567,7 @@ coap_clone_uri(const coap_uri_t *uri) {
   if ( !uri )
     return  NULL;
 
-  result = (coap_uri_t *)coap_malloc( uri->query.length + uri->host.length +
+  result = (coap_uri_t *)coap_malloc_type(COAP_STRING,  uri->query.length + uri->host.length +
                                       uri->path.length + sizeof(coap_uri_t) + 1);
 
   if ( !result )
@@ -603,7 +603,7 @@ coap_clone_uri(const coap_uri_t *uri) {
 
 void
 coap_delete_uri(coap_uri_t *uri) {
-  coap_free(uri);
+  coap_free_type(COAP_STRING, uri);
 }
 
 COAP_STATIC_INLINE int


### PR DESCRIPTION
The use of coap_malloc() and coap_free() does not work with environments that have their own memory managers (e.g. LwIP).

Convert coap_malloc() to coap_malloc_type(COAP_STRING,) and coap_free() to coap_free_type(COAP_STRING,) in the library.