### PR TITLE
examples: Align exit codes with documentation

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -1531,7 +1531,7 @@ main(int argc, char **argv) {
       block_mode = strtoul(optarg, NULL, 0);
       if (!(block_mode & COAP_BLOCK_USE_LIBCOAP)) {
         fprintf(stderr, "Block mode must include COAP_BLOCK_USE_LIBCOAP (1)\n");
-        exit(-1);
+        exit(1);
       }
       break;
     case 'p':
@@ -1556,7 +1556,7 @@ main(int argc, char **argv) {
 
       if (!output_file.s) {
         fprintf(stderr, "cannot set output file: insufficient memory\n");
-        exit(-1);
+        exit(1);
       } else {
         /* copy filename including trailing zero */
         memcpy(output_file.s, optarg, output_file.length + 1);
@@ -1578,7 +1578,7 @@ main(int argc, char **argv) {
     case 'P':
       if (!cmdline_proxy(optarg)) {
         fprintf(stderr, "error specifying proxy address\n");
-        exit(-1);
+        exit(1);
       }
       break;
     case 'T':
@@ -1633,7 +1633,7 @@ main(int argc, char **argv) {
       break;
     default:
       usage( argv[0], LIBCOAP_PACKAGE_VERSION );
-      exit( 1 );
+      exit(1);
     }
   }
 
@@ -1661,7 +1661,7 @@ main(int argc, char **argv) {
     }
   } else {
     usage( argv[0], LIBCOAP_PACKAGE_VERSION );
-    exit( 1 );
+    exit(1);
   }
 
   if (key_length < 0) {
@@ -1684,7 +1684,7 @@ main(int argc, char **argv) {
 
   if (res < 0) {
     fprintf(stderr, "failed to resolve address\n");
-    exit(-1);
+    exit(1);
   }
 
   ctx = coap_new_context( NULL );

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2675,7 +2675,7 @@ main(int argc, char **argv) {
       block_mode = strtoul(optarg, NULL, 0);
       if (!(block_mode & COAP_BLOCK_USE_LIBCOAP)) {
         fprintf(stderr, "Block mode must include COAP_BLOCK_USE_LIBCOAP (1)\n");
-        exit(-1);
+        exit(1);
       }
       break;
     case 'm':
@@ -2699,12 +2699,12 @@ main(int argc, char **argv) {
 #if SERVER_CAN_PROXY
       if (!cmdline_proxy(optarg)) {
         fprintf(stderr, "error specifying proxy address or host names\n");
-        exit(-1);
+        exit(1);
       }
       block_mode |= COAP_BLOCK_SINGLE_BODY;
 #else /* ! SERVER_CAN_PROXY */
       fprintf(stderr, "Proxy support not available as no Client mode code\n");
-      exit(-1);
+      exit(1);
 #endif /* ! SERVER_CAN_PROXY */
       break;
     case 'r' :
@@ -2730,7 +2730,7 @@ main(int argc, char **argv) {
       user_length = cmdline_read_user(optarg, &user, MAX_USER);
 #else /* ! SERVER_CAN_PROXY */
       fprintf(stderr, "Proxy support not available as no Client mode code\n");
-      exit(-1);
+      exit(1);
 #endif /* ! SERVER_CAN_PROXY */
       break;
     case 'v' :
@@ -2744,7 +2744,7 @@ main(int argc, char **argv) {
       break;
     default:
       usage( argv[0], LIBCOAP_PACKAGE_VERSION );
-      exit( 1 );
+      exit(1);
     }
   }
 


### PR DESCRIPTION
Exit code of -1 is not defined in example man pages - use a value of 1