### PR TITLE
Unix Domain: Add in support for Unix Domains

### DIFF
--- a/include/coap3/uri.h
+++ b/include/coap3/uri.h
@@ -75,6 +75,17 @@ coap_uri_scheme_is_secure(const coap_uri_t *uri) {
 }
 
 /**
+ * Determines from the @p host whether this is a Unix Domain socket
+ * request.
+ *
+ * @param host    The host object.
+ *
+ * @return        @c 0 on failure, or @c 1 on success.
+ *
+ */
+int coap_host_is_unix_domain(const coap_str_const_t *host);
+
+/**
  * Creates a new coap_uri_t object from the specified URI. Returns the new
  * object or NULL on error. The memory allocated by the new coap_uri_t
  * should be released using coap_delete_uri().

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -15,6 +15,7 @@ global:
   coap_address_get_port;
   coap_address_init;
   coap_address_set_port;
+  coap_address_set_unix_domain;
   coap_add_token;
   coap_async_get_app_data;
   coap_async_is_supported;
@@ -104,6 +105,7 @@ global:
   coap_get_tls_library_version;
   coap_get_uri_path;
   coap_handle_event;
+  coap_host_is_unix_domain;
   coap_insert_optlist;
   coap_io_do_epoll;
   coap_io_do_io;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -13,6 +13,7 @@ coap_address_equals
 coap_address_get_port
 coap_address_init
 coap_address_set_port
+coap_address_set_unix_domain
 coap_add_token
 coap_async_get_app_data
 coap_async_is_supported
@@ -102,6 +103,7 @@ coap_get_resource_from_uri_path
 coap_get_tls_library_version
 coap_get_uri_path
 coap_handle_event
+coap_host_is_unix_domain
 coap_insert_optlist
 coap_io_do_epoll
 coap_io_do_io

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -40,15 +40,19 @@ DESCRIPTION
 *coap-client* is a CoAP client to communicate with 6LoWPAN devices via
 the protocol CoAP (RFC 7252) using the URI given as argument on the
 command line. The URI must have the scheme 'coap', 'coap+tcp', 'coaps' or
-'coaps+tcp'. 'coaps' and 'coaps+tcp' are only supported when coap-client is
-built with support for secure (D)TLS communication.
+'coaps+tcp'.
+
+'coaps' and 'coaps+tcp' are only supported when
+coap-client is built with support for secure (D)TLS communication.
 
 If 'coaps' or 'coaps+tcp' is being used, provided the CoAP server supports PKI
 and is configured with a certificate and private key, the coap-client does not
 need to have a Pre-Shared Key (-k) or certificate (-c) configured.
 
-The URI's host part may be a DNS name or a literal IP address. Note that, for
-IPv6 address references, angle brackets are required (c.f. EXAMPLES).
+The URI's host part may be a DNS name, a literal IP address or a Unix domain
+name. For Unix domain names, %2F is used as the / seperator to differentiate
+between the host and patch definitions. For IPv6 address references, angle
+brackets are required (c.f. EXAMPLES) to delimit the host portion of the URI.
 
 OPTIONS - General
 -----------------
@@ -262,7 +266,17 @@ Query the resource '/' from server 'libcoap.net' (using the GET method).
 coap-client -m get coap://[::1]/
 ----
 Query the resource '/' on localhost using the 'GET' method to get back the
-summary defined attributes.
+summary information.
+
+* Example
+----
+coap-client -m get coap://%2Fsome%2Funix%2Fdomain%2Fpath/time
+----
+Query the resource '/time' on server listening on datagram Unix domain
+'/some/unix/domain/path' using the 'GET' method to get back the
+current time. The %2F is the hex encoding for / and indicates
+which is the 'host' definition seperator and the simple / is for the path
+definition seperator.
 
 * Example
 ----

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -23,7 +23,7 @@ SYNOPSIS
               [*-v* num] [*-A* address] [*-E* oscore_conf_file[,seq_file]]
               [*-G* group_if] [*-L* value] [*-N*]
               [*-P* scheme://addr[:port],[name1[,name2..]]]
-              [*-T* max_token_size] [*-V* num] [*-X* size]
+              [*-T* max_token_size] [*-U* type] [*-V* num] [*-X* size]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
               [*-s* match_psk_sni_file] [*-u* user]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
@@ -116,6 +116,11 @@ OPTIONS - General
 
 *-T* max_token_size::
    Set the maximum token length (8-65804).
+
+*-U* type::
+   Treat address defined by *-A* as a Unix socket address.
+   Type is 'coap' (using datagram), 'coap+tcp' (using stream), 'coaps'
+   (DTLS using datagram) or 'coaps+tcp' (TLS using stream).
 
 *-V* num::
    The verbosity level to use (default 3, maximum is 7) for (D)TLS

--- a/man/coap_address.txt.in
+++ b/man/coap_address.txt.in
@@ -11,7 +11,8 @@ coap_address(3)
 NAME
 ----
 coap_address,
-coap_address_t
+coap_address_t,
+coap_address_init
 - Work with CoAP Socket Address Types
 
 SYNOPSIS
@@ -30,6 +31,9 @@ int _scheme_hint_bits_);*
 
 *void coap_free_address_info(coap_addr_info_t *_info_list_);*
 
+*int coap_address_set_unix_domain(coap_address_t *_addr_,
+const uint8_t *_host_, size_t _host_len_);*
+
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
 *-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*
@@ -42,12 +46,13 @@ This man page focuses on setting up CoAP endpoint address definitions.
 
 *Supported Socket Types*
 
-Libcoap supports 2 different socket types that can be used:
+Libcoap supports 3 different socket types that can be used:
 
 [source, c]
 ----
 AF_INET  IPv4 IP addresses and ports
 AF_INET6 IPv6 IP addresses and ports and can be dual IPv4/IPv6 stacked
+AF_UNIX  Unix Domain using file path names
 ----
 
 which are all handled by the *coap_address_t* structure.
@@ -63,9 +68,9 @@ typedef struct coap_address_t {
     struct sockaddr         sa;
     struct sockaddr_in      sin;
     struct sockaddr_in6     sin6;
+    struct coap_sockaddr_un cun; /* CoAP shortened special */
   } addr;
 } coap_address_t;
-----
 
 which is used in the *coap_addr_info_t* structure as returned by
 *coap_resolve_address_info()*.
@@ -81,6 +86,23 @@ typedef struct coap_addr_info_t {
   coap_address_t addr;           /* The address to connect / bind to */
 } coap_addr_info_t;
 ----
+
+*Structure coap_sockaddr_un*
+
+[source, c]
+----
+#define COAP_UNIX_PATH_MAX   (sizeof(struct sockaddr_in6) - sizeof(sa_family_t))
+
+struct coap_sockaddr_un {
+        sa_family_t sun_family; /* AF_UNIX */
+        char sun_path[COAP_UNIX_PATH_MAX];   /* pathname max 26 with NUL byte */
+};
+----
+
+The *coap_sockaddr_un* structure is modeled on the *sockaddr_un* structure
+(see *unix*(7)) but has a smaller sun_path so that the overall size of
+*coap_address_t* is not changed by its inclusion. COAP_UNIX_MAX_PATH includes
+the trailing zero terminator of a domain unix file name.
 
 FUNCTIONS
 ---------
@@ -112,10 +134,19 @@ caller using *coap_free_address_info*().
 The *coap_free_address_info*() function frees off all the _info_list_
 linked entries.
 
+*Function: coap_address_set_unix_domain()*
+
+The *coap_address_set_unix_domain*() function initializes _addr_ and then
+populates _addr_ with all the appropriate information for a Unix Domain Socket.
+The _host_ information with length _host_len_ abstracted from a CoAP URI
+is copied into _addr_'s _sun_path_ translating any %2F encoding to /.
+
 RETURN VALUES
 -------------
 *coap_resolve_address_info*() returns a linked list of addresses that can be
 used for session setup or NULL if there is a failure.
+
+*coap_address_set_unix_domain*() function returns 1 on success or 0 on failure.
 
 EXAMPLES
 --------

--- a/man/coap_endpoint_client.txt.in
+++ b/man/coap_endpoint_client.txt.in
@@ -60,7 +60,8 @@ the application to manage each one accordingly.
 A CoAP _session_ maintains the state of an ongoing connection between a Client
 and Server which is stored in a coap_session_t _session_ object. A CoAP
 _session_ is tracked by local port, CoAP protocol, remote IP address and
-remote port.
+remote port, or in the case of Unix Domain sockets, the local path and the
+remote path.
 
 The _session_ network traffic can be encrypted or un-encrypted if there is an
 underlying TLS library.
@@ -104,20 +105,25 @@ COAP_PROTO_TLS
 TCP or (D)TLS protocol support is available.  See *coap_tls_library(3)* for
 further information.
 
-Libcoap supports 2 different socket types:
+Libcoap supports 3 different socket types:
 
 [source, c]
 ----
 AF_INET  IPv4 IP addresses and ports
 AF_INET6 IPv6 IP addresses and ports and can be dual IPv4/IPv6 stacked
+AF_UNIX  Unix Domain using file path names
 ----
 
 For AF_INET and AF_INET6, the client does not need to specify a local IP
-address and/or port as default values will get filled in.
+address and/or port as default values will get filled in. However for AF_UNIX,
+the local pathname must be provided and must be unique per client session. This
+unique local pathname will get deleted on the session being properly closed at
+application exit.
 
 The client must specify IP and port when defining the *coap_address_t* (see
-*coap_address_t*(3)) for the remote end of the session for AF_INET or AF_INET6.
-If port is 0, then the default CoAP port is used instead.
+*coap_address_t*(3)) for the remote end of the session if AF_INET or AF_INET6.
+If port is 0, then the default CoAP port is used instead.  If AF_UNIX, the
+unix domain path to connect to must be specified.
 
 FUNCTIONS
 ---------
@@ -131,9 +137,10 @@ to 0 in _server_ (for AF_INET or AF_INET6), then the default CoAP port is used.
 
 Normally _local_if_ would be set to NULL, but by specifying
 _local_if_ the source of the network session can be bound to a specific IP
-address or port. If _local_if_ is defined, the address families for _local_if_
-and _server_ must be identical. The session will initially have a reference
-count of 1.
+address or port. For AF_UNIX, _local_if_ must be specified pointing to an
+appropriate *coap_address_t*.  If _local_if_ is defined, the address families
+for _local_if_ and _server_ must be identical. The session will initially have
+a reference count of 1.
 
 To stop using a client session, the reference count must be decremented to 0
 by calling *coap_session_release*(3). See *coap_session*(3). This will remove
@@ -150,9 +157,10 @@ _server_ (for AF_INET or AF_INET6), then the default CoAP port is used.
 
 Normally _local_if_ would be set to NULL, but by specifying
 _local_if_ the source of the network session can be bound to a specific IP
-address or port. If _local_if_ is defined, the address families for _local_if_
-and _server_ must be identical. The session will initially have a reference
-count of 1.
+address or port. For AF_UNIX, _local_if_ must be specified pointing to an
+appropriate *coap_address_t*.  If _local_if_ is defined, the address families
+for _local_if_ and _server_ must be identical. The session will initially have
+a reference count of 1.
 
 To stop using a client session, the reference count must be decremented to 0
 by calling *coap_session_release*(3). See *coap_session*(3). This will remove
@@ -169,9 +177,10 @@ _server_ (for AF_INET or AF_INET6), then the default CoAP port is used.
 
 Normally _local_if_ would be set to NULL, but by specifying
 _local_if_ the source of the network session can be bound to a specific IP
-address or port. If _local_if_ is defined, the address families for _local_if_
-and _server_ must be identical. The session will initially have a reference
-count of 1.
+address or port. For AF_UNIX, _local_if_ must be specified pointing to an
+appropriate *coap_address_t*.  If _local_if_ is defined, the address families
+for _local_if_ and _server_ must be identical. The session will initially have
+a reference count of 1.
 
 To stop using a client session, the reference count must be decremented to 0
 by calling *coap_session_release*(3). See *coap_session*(3). This will remove
@@ -227,6 +236,54 @@ setup_client_session (struct in_addr ip_address) {
   server.addr.sin.sin_port = htons (5683);
 
   session = coap_new_client_session(context, NULL, &server, COAP_PROTO_UDP);
+  if (!session) {
+    coap_free_context(context);
+    return NULL;
+  }
+  /* The context is in session->context */
+  return session;
+}
+----
+
+*CoAP Client Non-Encrypted Unix Domain Setup*
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static coap_session_t *
+setup_client_session (const char *server_ud) {
+  coap_session_t *session;
+  coap_address_t server;
+  coap_address_t local;
+  /* See coap_context(3) */
+  coap_context_t *context = coap_new_context(NULL);
+
+  if (!context)
+    return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
+
+  /* See coap_address(3) */
+  coap_address_init(&server);
+  server.addr.sa.sa_family = AF_UNIX;
+  snprintf(server.addr.cun.sun_path, sizeof(server.addr.cun.sun_path),
+           "%s", server_ud);
+
+  /* Need to have a uniquely named local address */
+  coap_address_init(&local);
+  local.addr.sa.sa_family = AF_UNIX;
+  snprintf(local.addr.cun.sun_path, sizeof(server.addr.cun.sun_path),
+           "/tmp/client.%d", getpid());
+  /* Only do this if you know it is safe to do so */
+  unlink(local.addr.cun.sun_path);
+
+  session = coap_new_client_session(context, &local, &server, COAP_PROTO_UDP);
   if (!session) {
     coap_free_context(context);
     return NULL;

--- a/man/coap_endpoint_server.txt.in
+++ b/man/coap_endpoint_server.txt.in
@@ -66,7 +66,8 @@ the application to manage each one accordingly.
 A CoAP _session_ maintains the state of an ongoing connection between a Client
 and Server which is stored in a coap_session_t _session_ object. A CoAP
 _session_ is tracked by local port, CoAP protocol, remote IP address and
-remote port.
+remote port, or in the case of Unix Domain sockets, the local path and the
+remote path.
 
 The _session_ network traffic can be encrypted or un-encrypted if there is an
 underlying TLS library.
@@ -92,7 +93,8 @@ coap_new_endpoint()
 ----
 
 Multiple endpoints can be set up per _context_, each listening for a new traffic
-flow with different TCP/UDP protocols, (D)TLS protocols, port numbers etc. When
+flow with different TCP/UDP protocols, (D)TLS protocols, port numbers, Unix
+pathnames etc. When
 a new traffic flow is started, then the CoAP library will create and start a new
 server _session_.
 
@@ -133,7 +135,10 @@ The *coap_new_endpoint*() function creates a new endpoint for _context_ that
 is listening for new traffic as defined in _listen_addr_
 (see *coap_address_t*(3)). If the address family is AF_INET or AF_INET6, then it
 listens on the IP address and port number defined by _listen_addr_. If the
-port number is 0, then the default CoAP port is used.
+port number is 0, then the default CoAP port is used. If the address family is
+AF_UNIX, then it listens on the defined unix domain path which has to be
+unique per endpoint. This unique unix domain path will get deleted on
+clean application exit.
 
 Different CoAP protocols can be defined for _proto_ - the current supported
 list is:
@@ -161,7 +166,8 @@ then it will get completely freed off.  See *coap_session_reference*(3) and
 
 The *coap_free_endpoint*() function must be used to free off the _endpoint_.
 It clears out all the sessions associated with this endpoint along with
-any data associated with the sessions.
+any data associated with the sessions as well as
+deleting the unix domain path if the address family is AF_UNIX.
 
 *Function: coap_endpoint_set_default_mtu()*
 
@@ -179,6 +185,8 @@ first appropriate interface. When the endpoint is freed off, the associated
 multicast group will be removed. The registered multicast addresses for CoAP
 are 224.0.1.187, ff0x::fd (Variable-Scope) - i.e. ff02::fd (Link-Local) and
 ff05::fd (Site-Local).
+
+*NOTE:* multicast is not supported for address family type AF_UNIX.
 
 *Function: coap_mcast_per_resource()*
 
@@ -222,6 +230,50 @@ setup_server_context (void) {
   coap_address_init(&listen_addr);
   listen_addr.addr.sa.sa_family = AF_INET;
   listen_addr.addr.sin.sin_port = htons (5683);
+
+  endpoint = coap_new_endpoint(context, &listen_addr, COAP_PROTO_UDP);
+  if (!endpoint) {
+    coap_free_context(context);
+    return NULL;
+  }
+
+  /* Initialize resources - See coap_resource(3) init_resources() example */
+
+  return context;
+}
+----
+
+*CoAP Server Non-Encrypted Unix Domain Setup*
+
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <stdio.h>
+#include <unistd.h>
+
+/* This need to be unique per endpoint */
+#define UNIX_DOMAIN_LISTEN_DGRAM "/tmp/server.dgram"
+
+static coap_context_t *
+setup_server_context (void) {
+  coap_endpoint_t *endpoint;
+  coap_address_t listen_addr;
+  coap_context_t *context = coap_new_context(NULL);
+
+  if (!context)
+    return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
+
+  /* See coap_address(3) */
+  coap_address_set_unix_domain(&listen_addr,
+                        (const uint8_t *)UNIX_DOMAIN_LISTEN_DGRAM,
+                         strlen(UNIX_DOMAIN_LISTEN_DGRAM));
+  /* Only do this if you know it is safe to do so */
+  unlink(listen_addr.addr.cun.sun_path);
 
   endpoint = coap_new_endpoint(context, &listen_addr, COAP_PROTO_UDP);
   if (!endpoint) {

--- a/man/coap_uri.txt.in
+++ b/man/coap_uri.txt.in
@@ -56,6 +56,13 @@ A CoAP URI is of the form
 
 where _scheme_ can be one of coap://, coaps://, coap+tcp:// and coaps+tcp://.
 
+_host_ can be an IPv4 or IPv6 (enclosed in []) address, a DNS resolvable name or
+a Unix domain socket name which is encoded as a unix file name with %2F
+replacing each / of the file name so that the start of the _path_ can easily be
+determined.
+
+'(optional):port' is ignored for Unix domain socket's _host_ definitions.
+
 The parsed uri structure is of the form
 
 [source, c]

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -237,6 +237,9 @@ coap_print_addr(const coap_address_t *addr, unsigned char *buf, size_t len) {
     need_buf = INET6_ADDRSTRLEN;
 
     break;
+  case AF_UNIX:
+    snprintf((char *)p, len, "'%s'", addr->addr.cun.sun_path);
+    return strlen((char *)buf);
   default:
     /* Include trailing NULL if possible */
     memcpy(buf, "(unknown address type)", min(22+1, len));

--- a/src/coap_tcp.c
+++ b/src/coap_tcp.c
@@ -95,6 +95,8 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
                coap_socket_strerror());
 #endif /* RIOT_VERSION */
     break;
+  case AF_UNIX:
+    break;
   default:
     coap_log_alert("coap_socket_connect_tcp1: unsupported sa_family\n");
     break;
@@ -248,6 +250,8 @@ coap_socket_bind_tcp(coap_socket_t *sock,
                "coap_socket_bind_tcp: setsockopt IPV6_V6ONLY: %s\n",
                coap_socket_strerror());
 #endif /* RIOT_VERSION */
+    break;
+  case AF_UNIX:
     break;
   default:
     coap_log_alert("coap_socket_bind_tcp: unsupported sa_family\n");


### PR DESCRIPTION
Support the AF_UNIX address family for transporting CoAP internally within
an appliance.

[The format of the URI for the client to parse may get updated]

The URI prefix for a client is coap:// for datagram sockets,
coap+tcp:// for stream sockets, coaps:// for DTLS over datagram sockets
and coaps+tcp:// for TLS over stream sockets.  In otherwords, no change.

The host portion of the URI is the unix domain name with / substituted with
%2F so that the host and uri-path can be delimited.  The initial %2F 
determines that Unix Domain sockets will be used instead of IP based
sockets.

i.e. coap://%2Fsome%2Funix%2Fdomain%2Fpath/some/path

gives an unix uri-host of `%2Fsome%2Funix%2Fdomain%2Fpath` and
overall uri-path of `/some/path` when parsed.

For the server, a new -U option defines the COAP protocol to use, and the
existing -A option defines the Unix Domain file path to use.

The main changes are to the documentation.

See #958.