### PR TITLE
log_levels: Replace usage of syslog LOG_ with COAP_LOG_

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -412,8 +412,8 @@ message_handler(coap_session_t *session COAP_UNUSED,
 
   coap_log_debug("** process incoming %d.%02d response:\n",
            COAP_RESPONSE_CLASS(rcv_code), rcv_code & 0x1F);
-  if (coap_get_log_level() < LOG_DEBUG)
-    coap_show_pdu(LOG_INFO, received);
+  if (coap_get_log_level() < COAP_LOG_DEBUG)
+    coap_show_pdu(COAP_LOG_INFO, received);
 
   /* check if this is a response to our original request */
   if (!track_check_token(&token)) {
@@ -1785,8 +1785,8 @@ main(int argc, char **argv) {
   coap_log_debug("timeout is set to %u seconds\n", wait_seconds);
 
   coap_log_debug("sending CoAP request:\n");
-  if (coap_get_log_level() < LOG_DEBUG)
-    coap_show_pdu(LOG_INFO, pdu);
+  if (coap_get_log_level() < COAP_LOG_DEBUG)
+    coap_show_pdu(COAP_LOG_INFO, pdu);
 
   if (coap_send(session, pdu) == COAP_INVALID_MID) {
     coap_log_err("cannot send CoAP pdu\n");
@@ -1865,8 +1865,8 @@ main(int argc, char **argv) {
             goto finish;
           }
           coap_log_debug("sending CoAP request:\n");
-          if (coap_get_log_level() < LOG_DEBUG)
-            coap_show_pdu(LOG_INFO, pdu);
+          if (coap_get_log_level() < COAP_LOG_DEBUG)
+            coap_show_pdu(COAP_LOG_INFO, pdu);
 
           ready = 0;
           if (coap_send(session, pdu) == COAP_INVALID_MID) {

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1175,8 +1175,8 @@ add_in:
       }
     }
 
-    if (coap_get_log_level() < LOG_DEBUG)
-      coap_show_pdu(LOG_INFO, pdu);
+    if (coap_get_log_level() < COAP_LOG_DEBUG)
+      coap_show_pdu(COAP_LOG_INFO, pdu);
 
     coap_send(ongoing, pdu);
     /*
@@ -1636,8 +1636,8 @@ proxy_response_handler(coap_session_t *session,
 
   coap_log_debug("** process upstream incoming %d.%02d response:\n",
            COAP_RESPONSE_CLASS(rcv_code), rcv_code & 0x1F);
-  if (coap_get_log_level() < LOG_DEBUG)
-    coap_show_pdu(LOG_INFO, received);
+  if (coap_get_log_level() < COAP_LOG_DEBUG)
+    coap_show_pdu(COAP_LOG_INFO, received);
 
   if (coap_get_data_large(received, &size, &data, &offset, &total)) {
     /* COAP_BLOCK_SINGLE_BODY is set, so single body should be given */
@@ -1713,8 +1713,8 @@ proxy_response_handler(coap_session_t *session,
     coap_delete_pdu(dummy_pdu);
   }
 
-  if (coap_get_log_level() < LOG_DEBUG)
-    coap_show_pdu(LOG_INFO, pdu);
+  if (coap_get_log_level() < COAP_LOG_DEBUG)
+    coap_show_pdu(COAP_LOG_INFO, pdu);
 
   coap_send(incoming, pdu);
   return COAP_RESPONSE_OK;

--- a/examples/contiki/coap-observer.c
+++ b/examples/contiki/coap-observer.c
@@ -85,7 +85,7 @@ init_coap() {
 
   coap_context = coap_new_context(&listen_addr);
 
-  coap_set_log_level(LOG_DEBUG);
+  coap_set_log_level(COAP_LOG_DEBUG);
 
   if (!coap_context)
     coap_log_crit("cannot create CoAP context\r\n");
@@ -102,7 +102,7 @@ message_handler(coap_context_t  *ctx,
 
   coap_log_debug("** process incoming %d.%02d response:\n",
         (received->hdr->code >> 5), received->hdr->code & 0x1F);
-  coap_show_pdu(LOG_WARNING, received);
+  coap_show_pdu(COAP_LOG_WARN, received);
 
   coap_ticks(&last_seen);
 }

--- a/examples/contiki/server.c
+++ b/examples/contiki/server.c
@@ -57,7 +57,7 @@ init_coap_server(coap_context_t **ctx) {
 
   assert(ctx);
 
-  coap_set_log_level(LOG_DEBUG);
+  coap_set_log_level(COAP_LOG_DEBUG);
 
   coap_address_init(&listen_addr);
   listen_addr.port = UIP_HTONS(COAP_DEFAULT_PORT);

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -579,7 +579,7 @@ main(int argc, char **argv) {
   char addr_str[NI_MAXHOST] = "::";
   char port_str[NI_MAXSERV] = "5683";
   int opt;
-  coap_log_t log_level = LOG_WARNING;
+  coap_log_t log_level = COAP_LOG_WARN;
   struct sigaction sa;
 
   while ((opt = getopt(argc, argv, "A:p:v:")) != -1) {

--- a/examples/lwip/client-coap.c
+++ b/examples/lwip/client-coap.c
@@ -136,8 +136,8 @@ client_coap_init(coap_lwip_input_wait_handler_t input_wait, void *input_arg,
   int res;
   const char *use_uri = COAP_URI;
   int opt;
-  coap_log_t log_level = LOG_WARNING;
-  coap_log_t dtls_log_level = LOG_ERR;
+  coap_log_t log_level = COAP_LOG_WARN;
+  coap_log_t dtls_log_level = COAP_LOG_ERR;
   const char *use_psk = "secretPSK";
   const char *use_id = "abc";
 

--- a/examples/lwip/server-coap.c
+++ b/examples/lwip/server-coap.c
@@ -119,8 +119,8 @@ void server_coap_init(coap_lwip_input_wait_handler_t input_wait,
                       void *input_arg, int argc, char **argv) {
   coap_address_t listenaddress;
   int opt;
-  coap_log_t log_level = LOG_WARNING;
-  coap_log_t dtls_log_level = LOG_ERR;
+  coap_log_t log_level = COAP_LOG_WARN;
+  coap_log_t dtls_log_level = COAP_LOG_ERR;
   const char *use_psk = "secretPSK";
 
   while ((opt = getopt(argc, argv, ":k:v:V:")) != -1) {

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -101,8 +101,8 @@ Logging by default is to stderr or stdout depending on the logging level of
 the log entry.  It ia possible to send the logging information to an
 application logging callback handler for processing by the application.
 
-Logging levels (*coap_log_t*) are defined by (initially the same as for
-*syslog*()), which are numerically incrementing in value:
+Logging levels (*coap_log_t*) are defined as follows (based on the *syslog*()
+names and values):
 
 *COAP_LOG_EMERG*::
 Emergency level (0).

--- a/src/block.c
+++ b/src/block.c
@@ -636,7 +636,7 @@ coap_add_data_large_internal(coap_session_t *session,
     pdu->body_data = data;
     pdu->body_length = length;
     coap_log_debug("PDU presented by app.\n");
-    coap_show_pdu(LOG_DEBUG, pdu);
+    coap_show_pdu(COAP_LOG_DEBUG, pdu);
     pdu->body_data = NULL;
     pdu->body_length = 0;
 
@@ -1771,7 +1771,7 @@ coap_handle_request_put_block(coap_context_t *context,
         pdu->body_offset = 0;
         pdu->body_total = p->total_len;
         coap_log_debug("Server app version of updated PDU\n");
-        coap_show_pdu(LOG_DEBUG, pdu);
+        coap_show_pdu(COAP_LOG_DEBUG, pdu);
         *pfree_lg_srcv = p;
         goto call_app_handler;
       }
@@ -2074,7 +2074,7 @@ lg_xmit_finished:
       coap_update_token(rcvd, p->b.b1.app_token->length,
                         p->b.b1.app_token->s);
     coap_log_debug("Client app version of updated PDU\n");
-    coap_show_pdu(LOG_DEBUG, rcvd);
+    coap_show_pdu(COAP_LOG_DEBUG, rcvd);
   }
 
   LL_DELETE(session->lg_xmit, p);
@@ -2383,7 +2383,7 @@ coap_handle_response_get_block(coap_context_t *context,
           if (context->response_handler) {
             if (block.m != 0 || block.num != 0) {
               coap_log_debug("Client app version of updated PDU\n");
-              coap_show_pdu(LOG_DEBUG, rcvd);
+              coap_show_pdu(COAP_LOG_DEBUG, rcvd);
             }
             if (context->response_handler(session, sent, rcvd,
                                           rcvd->mid) == COAP_RESPONSE_FAIL)
@@ -2445,7 +2445,7 @@ fail_resp:
                     p->app_token->s, p->app_token->length)) {
       coap_update_token(rcvd, p->app_token->length, p->app_token->s);
       coap_log_debug("Client app version of updated PDU\n");
-      coap_show_pdu(LOG_DEBUG, rcvd);
+      coap_show_pdu(COAP_LOG_DEBUG, rcvd);
     }
     break;
   } /* LL_FOREACH() */
@@ -2503,7 +2503,7 @@ expire_lg_crcv:
                   p->app_token->s, p->app_token->length)) {
     coap_update_token(rcvd, p->app_token->length, p->app_token->s);
     coap_log_debug("Client app version of updated PDU\n");
-    coap_show_pdu(LOG_DEBUG, rcvd);
+    coap_show_pdu(COAP_LOG_DEBUG, rcvd);
   }
   /* Expire this entry */
   LL_DELETE(session->lg_crcv, p);
@@ -2555,7 +2555,7 @@ coap_check_update_token(coap_session_t *session, coap_pdu_t *pdu) {
         coap_update_token(pdu, lg_crcv->app_token->length,
                           lg_crcv->app_token->s);
         coap_log_debug("Client app version of updated PDU\n");
-        coap_show_pdu(LOG_DEBUG, pdu);
+        coap_show_pdu(COAP_LOG_DEBUG, pdu);
         return;
       }
     }
@@ -2569,7 +2569,7 @@ coap_check_update_token(coap_session_t *session, coap_pdu_t *pdu) {
         coap_update_token(pdu, lg_xmit->b.b1.app_token->length,
                           lg_xmit->b.b1.app_token->s);
         coap_log_debug("Client app version of updated PDU\n");
-        coap_show_pdu(LOG_DEBUG, pdu);
+        coap_show_pdu(COAP_LOG_DEBUG, pdu);
         return;
       }
     }

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -998,7 +998,7 @@ coap_log_impl(coap_log_t level, const char *format, ...) {
     FILE *log_fd;
     size_t len;
 
-    log_fd = level <= LOG_CRIT ? COAP_ERR_FD : COAP_DEBUG_FD;
+    log_fd = level <= COAP_LOG_CRIT ? COAP_ERR_FD : COAP_DEBUG_FD;
 
     coap_ticks(&now);
     len = print_timestamp(timebuf,sizeof(timebuf), now);

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1030,7 +1030,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
       }
 
       ((char *)uip_appdata)[len] = 0;
-      if (LOG_DEBUG <= coap_get_log_level()) {
+      if (COAP_LOG_DEBUG <= coap_get_log_level()) {
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN 40
 #endif
@@ -1053,7 +1053,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
     packet->src.size = sizeof(packet->src.addr);
     len = recvfrom (sock->fd, packet->payload, COAP_RXBUFFER_SIZE,
                     0, &packet->src.addr.sa, &packet->src.size);
-    if (LOG_DEBUG <= coap_get_log_level()) {
+    if (COAP_LOG_DEBUG <= coap_get_log_level()) {
       unsigned char addr_str[INET6_ADDRSTRLEN + 8];
 
       if (coap_print_addr(&packet->src, addr_str, INET6_ADDRSTRLEN + 8)) {
@@ -1516,7 +1516,7 @@ coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
     nfds = epoll_wait(ctx->epfd, events, COAP_MAX_EPOLL_EVENTS, etimeout);
     if (nfds < 0) {
       if (errno != EINTR) {
-        coap_log (LOG_ERR, "epoll_wait: unexpected error: %s (%d)\n",
+        coap_log (COAP_LOG_ERR, "epoll_wait: unexpected error: %s (%d)\n",
                             coap_socket_strerror(), nfds);
       }
       break;

--- a/src/coap_io_riot.c
+++ b/src/coap_io_riot.c
@@ -134,7 +134,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
   packet->ifindex = sock->fd;
   packet->length = (len > 0) ? len : 0;
   memcpy(packet->payload, (uint8_t*)udp_hdr + sizeof(udp_hdr_t), len);
-  if (LOG_DEBUG <= coap_get_log_level()) {
+  if (COAP_LOG_DEBUG <= coap_get_log_level()) {
     unsigned char addr_str[INET6_ADDRSTRLEN + 8];
 
     if (coap_print_addr(&packet->addr_info.remote, addr_str, INET6_ADDRSTRLEN + 8)) {

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1584,7 +1584,7 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
     goto error;
   }
 
-  if (LOG_DEBUG <= coap_get_log_level()) {
+  if (COAP_LOG_DEBUG <= coap_get_log_level()) {
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN 40
 #endif

--- a/src/net.c
+++ b/src/net.c
@@ -668,7 +668,7 @@ coap_free_context(coap_context_t *context) {
   initialized = 0;
 #endif /* WITH_CONTIKI */
 #ifdef WITH_LWIP
-  coap_lwip_dump_memory_pools(LOG_DEBUG);
+  coap_lwip_dump_memory_pools(COAP_LOG_DEBUG);
 #endif /* WITH_LWIP */
 }
 
@@ -813,7 +813,7 @@ coap_session_send_pdu(coap_session_t *session, coap_pdu_t *pdu) {
     default:
       break;
   }
-  coap_show_pdu(LOG_DEBUG, pdu);
+  coap_show_pdu(COAP_LOG_DEBUG, pdu);
   return bytes_written;
 }
 
@@ -1156,7 +1156,7 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
 
     if (!session->lg_xmit) {
       coap_log_debug("PDU presented by app\n");
-      coap_show_pdu(LOG_DEBUG, pdu);
+      coap_show_pdu(COAP_LOG_DEBUG, pdu);
     }
     /* See if this token is already in use for large body responses */
     LL_FOREACH(session->lg_crcv, lg_crcv) {
@@ -3049,7 +3049,7 @@ skip_handler:
         coap_log_debug("   %s: mid=0x%x: response dropped\n",
                  coap_session_str(session),
                  response->mid);
-        coap_show_pdu(LOG_DEBUG, response);
+        coap_show_pdu(COAP_LOG_DEBUG, response);
 drop_it_no_debug:
         coap_delete_pdu(response);
       }
@@ -3194,7 +3194,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
   int is_ping_rst;
   int packet_is_bad = 0;
 
-  coap_show_pdu(LOG_DEBUG, pdu);
+  coap_show_pdu(COAP_LOG_DEBUG, pdu);
 
   memset(&opt_filter, 0, sizeof(coap_opt_filter_t));
 

--- a/src/resource.c
+++ b/src/resource.c
@@ -829,7 +829,7 @@ coap_delete_observer(coap_resource_t *resource, coap_session_t *session,
 
   s = coap_find_observer(resource, session, token);
 
-  if ( s && coap_get_log_level() >= LOG_DEBUG ) {
+  if ( s && coap_get_log_level() >= COAP_LOG_DEBUG ) {
     char outbuf[2 * 8 + 1] = "";
     unsigned int i;
     for ( i = 0; i < s->pdu->token_length; i++ )
@@ -974,7 +974,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
                          * GET/FETCH handler is defined */
         query = coap_get_query(obs->pdu);
         coap_log_debug("Observe PDU presented to app.\n");
-        coap_show_pdu(LOG_DEBUG, obs->pdu);
+        coap_show_pdu(COAP_LOG_DEBUG, obs->pdu);
         coap_log_debug("call custom handler for resource '%*.*s'\n",
                  (int)r->uri_path->length, (int)r->uri_path->length,
                  r->uri_path->s);

--- a/tests/oss-fuzz/pdu_parse_target.c
+++ b/tests/oss-fuzz/pdu_parse_target.c
@@ -7,11 +7,11 @@ int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     coap_pdu_t *pdu = coap_pdu_init(0, 0, 0, size);
     if (pdu) {
-        coap_set_log_level(LOG_DEBUG);
+        coap_set_log_level(COAP_LOG_DEBUG);
         if (coap_pdu_parse(COAP_PROTO_UDP, data, size, pdu)) {
             coap_string_t *query = coap_get_query(pdu);
             coap_string_t *uri_path = coap_get_uri_path(pdu);
-            coap_show_pdu(LOG_DEBUG, pdu);
+            coap_show_pdu(COAP_LOG_DEBUG, pdu);
             coap_pdu_encode_header(pdu, COAP_PROTO_UDP);
 
             coap_delete_string(query);

--- a/tests/test_options.c
+++ b/tests/test_options.c
@@ -428,7 +428,7 @@ t_access_option6(void) {
   const uint8_t teststr[] = { 0xf2, 'a', 'b' };
   coap_option_t opt;
 
-  coap_set_log_level(LOG_CRIT);
+  coap_set_log_level(COAP_LOG_CRIT);
 
   CU_ASSERT(0 == coap_opt_parse((const coap_opt_t *)teststr,
                                 sizeof(teststr), &opt));

--- a/tests/test_pdu.c
+++ b/tests/test_pdu.c
@@ -302,7 +302,7 @@ t_parse_pdu16(void) {
 
   coap_set_show_pdu_output(0);
   coap_set_log_handler(log_handler);
-  coap_show_pdu(LOG_ERR, testpdu);        /* display PDU */
+  coap_show_pdu(COAP_LOG_ERR, testpdu);        /* display PDU */
   coap_set_log_handler(NULL);
 
   coap_delete_pdu(testpdu);
@@ -690,7 +690,7 @@ t_encode_pdu11(void) {
   coap_pdu_clear(pdu, 8);        /* clear PDU, with small maximum */
 
   CU_ASSERT(pdu->data == NULL);
-  coap_set_log_level(LOG_CRIT);
+  coap_set_log_level(COAP_LOG_CRIT);
   result = coap_add_data(pdu, 10, (const uint8_t *)"0123456789");
   coap_set_log_level(level);
 


### PR DESCRIPTION
This removes the reliance of syslog definitions in libcoap by using libcoap's version.