### PR TITLE
documentation: Tidy up documentation

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -215,12 +215,14 @@ man-page-build: upg-page-build man-page-start
 		ENTRY=`basename $${FILE} | cut -d . -f1` ;\
 		## Functions defined in the body
 		$(SED) -i "s^\(<span class=\"strong\"><strong>\)\(coap[_-][0-9a-z_]*\)\(</strong></span>(\|(\)^\1<a class=\"st-desc\" href=\"man_\2.html#\2\" target=\"_self\">\2</a>\3^g" $(top_builddir)/doc/man_html/$${ENTRY}.html ;\
+		## Function definitions
+		$(SED) -i "s^\(<span class=\"strong\"><strong>Function: \)\(coap_[0-9a-z_]*\)\(</strong></span>(\|(\)^\1<a class=\"st-desc\" href=\"man_\2.html#\2\" target=\"_self\">\2</a>\3^g" $(top_builddir)/doc/man_html/$${ENTRY}.html ;\
 		## The SYNOPSIS entries
 		$(SED) -i "s^\(<p><span class=\"strong\"><strong>[a-z0-9_ \*]*\)\(coap_[0-9a-z_]*\)\([(;]\)^\1<a class=\"st-synopsis\" href=\"man_\2.html#\2\" target=\"_self\">\2</a>\3^g" $(top_builddir)/doc/man_html/$${ENTRY}.html ;\
 		## Function in NAME and Examples
-		$(SED) -i "s^\([ =,] \|[(!>]\|\^\)\(coap_[0-9a-z_]*\)\([(,]\| \-\| \xe2\x80\x94\)^\1<a href=\"man_\2.html#\2\" target=\"_self\">\2</a>\3^g" $(top_builddir)/doc/man_html/$${ENTRY}.html ;\
+		$(SED) -i "s^\([ =,]\|[(!>]\|\^\)\(coap_[0-9a-z_]*\)\([(,]\| \-\| \xe2\x80\x94\)^\1<a href=\"man_\2.html#\2\" target=\"_self\">\2</a>\3^g" $(top_builddir)/doc/man_html/$${ENTRY}.html ;\
 		## Do for a second time in case of overlaps
-		$(SED) -i "s^\([ =,] \|[(!>]\|\^\)\(coap_[0-9a-z_]*\)\([(,]\| \-\| \xe2\x80\x94\)^\1<a href=\"man_\2.html#\2\" target=\"_self\">\2</a>\3^g" $(top_builddir)/doc/man_html/$${ENTRY}.html ;\
+		$(SED) -i "s^\([ =,]\|[(!>]\|\^\)\(coap_[0-9a-z_]*\)\([(,]\| \-\| \xe2\x80\x94\)^\1<a href=\"man_\2.html#\2\" target=\"_self\">\2</a>\3^g" $(top_builddir)/doc/man_html/$${ENTRY}.html ;\
 	done ;\
 	##
 	## Do the highlighting

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -128,6 +128,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_pdu_access.3" > coap_pdu_get_token.3
 	@echo ".so man3/coap_pdu_access.3" > coap_pdu_get_type.3
 	@echo ".so man3/coap_pdu_access.3" > coap_get_uri_path.3
+	@echo ".so man3/coap_pdu_setup.3" > coap_insert_optlist.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_delete_optlist.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_encode_var_safe.3
 	@echo ".so man3/coap_pdu_setup.3" > coap_encode_var_safe8.3

--- a/man/coap.txt.in
+++ b/man/coap.txt.in
@@ -22,7 +22,7 @@ DESCRIPTION
 libcoap is a C implementation of a lightweight application-protocol for
 devices that are constrained by their resources such as computing power, RF
 range, memory, bandwidth, or network packet sizes. This protocol, CoAP, is
-standardized by the IETF as https://tools.ietf.org/html/rfc7252[RFC7252].
+standardized by the IETF as https://rfc-editor.org/rfc/rfc7252[RFC7252].
 For further information related to CoAP, see http://coap.technology.
 
 Documentation for the specific library calls with examples can be found in the
@@ -52,27 +52,27 @@ FURTHER INFORMATION
 -------------------
 See
 
-"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
-"https://tools.ietf.org/html/rfc7390[RFC7390: Group Communication for the Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7390[RFC7390: Group Communication for the Constrained Application Protocol (CoAP)]"
 
-"https://tools.ietf.org/html/rfc7641[RFC7641: Observing Resources in the Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7641[RFC7641: Observing Resources in the Constrained Application Protocol (CoAP)]"
 
-"https://tools.ietf.org/html/rfc7959[RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7959[RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)]"
 
-"https://tools.ietf.org/html/rfc7967[RFC7967: Constrained Application Protocol (CoAP) Option for No Server Response]"
+"https://rfc-editor.org/rfc/rfc7967[RFC7967: Constrained Application Protocol (CoAP) Option for No Server Response]"
 
-"https://tools.ietf.org/html/rfc8132[RFC8132: PATCH and FETCH Methods for the Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc8132[RFC8132: PATCH and FETCH Methods for the Constrained Application Protocol (CoAP)]"
 
-"https://tools.ietf.org/html/rfc8323[RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets]"
+"https://rfc-editor.org/rfc/rfc8323[RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets]"
 
-"https://tools.ietf.org/html/rfc8516[RFC8516: "Too Many Requests" Response Code for the Constrained Application Protocol]"
+"https://rfc-editor.org/rfc/rfc8516[RFC8516: "Too Many Requests" Response Code for the Constrained Application Protocol]"
 
-"https://tools.ietf.org/html/rfc8613[RFC8613: Object Security for Constrained RESTful Environments (OSCORE)]"
+"https://rfc-editor.org/rfc/rfc8613[RFC8613: Object Security for Constrained RESTful Environments (OSCORE)]"
 
-"https://tools.ietf.org/html/rfc8768[RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option]"
+"https://rfc-editor.org/rfc/rfc8768[RFC8768: Constrained Application Protocol (CoAP) Hop-Limit Option]"
 
-"https://tools.ietf.org/html/rfc9175[RFC9175: CoAP: Echo, Request-Tag, and Token Processing]"
+"https://rfc-editor.org/rfc/rfc9175[RFC9175: CoAP: Echo, Request-Tag, and Token Processing]"
 
 for further information.
 

--- a/man/coap_async.txt.in
+++ b/man/coap_async.txt.in
@@ -51,8 +51,10 @@ or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
 
 DESCRIPTION
 -----------
-CoAP server responses can be piggybacked (RFC7252 5.2.1) or separate
-(RFC7252 5.2.2).
+CoAP server responses can be piggybacked
+("https://rfc-editor.org/rfc/rfc7252#section-5.2.1[RFC7252 5.2.1. Piggybacked]")
+or separate
+("https://rfc-editor.org/rfc/rfc7252#section-5.2.2[RFC7252 5.2.2. Separate]").
 
 For piggybacked responses, the response packet contains both the status and
 any data.
@@ -64,8 +66,15 @@ by the packet containing the status and any data.
 Usually responses are piggybacked, but this man page focuses on separate
 (async) support.
 
-The function *coap_async_is_supported*() is used to determine if there is
+FUNCTIONS
+---------
+
+*Function: coap_async_is_supported()*
+
+The *coap_async_is_supported*() function is used to determine if there is
 async support or not.
+
+*Function: coap_register_async()*
 
 The *coap_register_async*() function is used to set up an asynchronous delayed
 request for the _request_ PDU associated with the _session_. The
@@ -74,9 +83,13 @@ _delay_ ticks which will then cause a response to be sent.  If _delay_ is 0,
 then the application request handler will not get called until
 *coap_async_trigger*() or *coap_async_set_delay*() is called.
 
+*Function: coap_async_trigger()*
+
 The *coap_async_trigger*() function is used to expire the delay for the
 _async_ definition, so the application request handler is almost
 immediately called.
+
+*Function: coap_async_set_delay()*
 
 The *coap_async_set_delay*() function is used to update the remaining _delay_
 before the application request handler is called for the _async_ definition. If
@@ -87,15 +100,23 @@ then when the response is ready at an indeterminate point in the future,
 *coap_async_set_delay*() is called setting _delay_ to 1. Alternatively,
 *coap_async_trigger*() can be called.
 
+*Function: coap_free_async()*
+
 The *coap_free_async*() function is used to delete an _async_ definition.
+
+*Function: coap_find_async()*
 
 The *coap_find_async*() function is used to determine if there is an async
 definition based on the _session_ and token _token_.
+
+*Function: coap_async_ser_app_data()*
 
 The *coap_async_set_app_data*() function is used to add in user defined
 _app_data_ to the _async_ definition.  It is the responsibility of the
 application to release this data if appropriate.  This would usually be done
 when the application request handler is called under 'async' control.
+
+*Function: coap_async_get_app_data()*
 
 The *coap_async_get_app_data*() function is used to retrieve any defined
 application data from the  _async_ definition.
@@ -188,7 +209,7 @@ FURTHER INFORMATION
 -------------------
 See
 
-"RFC7252: The Constrained Application Protocol (CoAP)"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
 for further information.
 

--- a/man/coap_attribute.txt.in
+++ b/man/coap_attribute.txt.in
@@ -48,11 +48,17 @@ request methods.
 Adding Attributes allows textual information to be added to the resource
 which can then be reported back to any client doing a Resource Discovery using
 a "GET /.well-known/core" request with an optional query.
-See https://tools.ietf.org/html/rfc6690#section-5 for some examples of
+See "https://rfc-editor.org/rfc/rfc6690#section-5[RFC6690 5. Examples] for
+some examples of
 resource discovery usage.  Common attribute names are rt, if, sz, ct, obs, rel,
 anchor, rev, hreflang, media, title and type. href cannot be an attribute name.
 
 Attributes are automatically deleted when a Resource is deleted.
+
+FUNCTIONS
+---------
+
+*Function: coap_add_attr()*
 
 The *coap_add_attr*() function
 registers a new attribute called _name_ for the _resource_.
@@ -69,8 +75,12 @@ Free off _name_ when attribute is deleted with *coap_delete_resource*().
 *COAP_ATTR_FLAGS_RELEASE_VALUE*::
 Free off _value_ when attribute is deleted with *coap_delete_resource*().
 
+*Function: coap_find_attr()*
+
 The *coap_find_attr*() function returns the attribute with the _name_,
 if found, associated with _resource_.
+
+*Function: coap_attr_get_value()*
 
 The *coap_attr_get_value*() function returns the _value_ associated with the
 specified _attribute_.
@@ -141,9 +151,9 @@ FURTHER INFORMATION
 -------------------
 See
 
-"RFC7252: The Constrained Application Protocol (CoAP)"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
-"RFC6690: Constrained RESTful Environments (CoRE) Link Format"
+"https://rfc-editor.org/rfc/rfc6690[RFC6690: Constrained RESTful Environments (CoRE) Link Format]"
 
 for further information.
 

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -52,7 +52,8 @@ DESCRIPTION
 Regular setting up of a PDU and transmission is covered in *coap_pdu_setup*(3)
 where all the payload data can fit in a single packet.  This man page covers
 how to work with PDUs where the overall body of information may need to be
-split across several packets by using CoAP Block-Wise Transfers (RFC 7959).
+split across several packets by using CoAP Block-Wise Transfers
+(https://rfc-editor.org/rfc/rfc7959[RFC7959]).
 
 The block-wise transfers can be controlled by the application, or libcoap is
 instructed to do all the requests for the next blocks and only present the
@@ -62,7 +63,8 @@ payloads (blocks).
 
 1. Application does all the work +
 It is the responsibility of the application to analyze each block transmission
-at receipt and then generate the next request as per RFC 7959.  In this case,
+at receipt and then generate the next request as per
+https://rfc-editor.org/rfc/rfc7959[RFC7959].  In this case,
 *coap_context_set_block_mode*() function must not be called to maintain
 backward compatibility with applications that did the block handling within the
 application.
@@ -131,7 +133,8 @@ FUNCTIONS
 *Function: coap_context_set_block_mode()*
 
 The *coap_context_set_block_mode*() function is used to set up the _context_
-level _block_mode_ block handling bits for supporting RFC7959. _block_mode_
+level _block_mode_ block handling bits for supporting
+https://rfc-editor.org/rfc/rfc7959[RFC7959] _block_mode_
 flows down to a session when a session is created and if the peer does not
 support the respective block mode, an appropriate bit may get disabled in the
 session _block_mode_.
@@ -234,7 +237,9 @@ be generated, else is the ETag value to use.
 The _media_type_ is for the format of the _data_ and _maxage_ defines the
 lifetime of the response.  If _maxage_ is set to -1,  then the Max-Age option
 does not get included (which indicates the default value of 60 seconds
-according to RFC 7252).
+according to
+"https://rfc-editor.org/rfc/rfc7252#section-5.6.1[RFC7252 5.6.1. Freshness
+Model]").
 
 The application request handler for the resource is only called once instead of
 potentially multiple times.
@@ -526,9 +531,9 @@ FURTHER INFORMATION
 -------------------
 See
 
-"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
-"https://tools.ietf.org/html/rfc7959[RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7959[RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)]"
 
 for further information.
 

--- a/man/coap_cache.txt.in
+++ b/man/coap_cache.txt.in
@@ -75,13 +75,15 @@ tracking requests and responses.
 
 The first is the ability to derive a Cache Key from the cacheable parts of a
 CoAP PDU as defined in
-https://tools.ietf.org/html/rfc7252#section-5.6 updated by
-https://tools.ietf.org/html/rfc7641#section-2 and
-https://tools.ietf.org/html/rfc8132#section-2 .
+"https://rfc-editor.org/rfc/rfc7252#section-5.6[RFC7252 5.6. Caching]"
+updated by
+"https://rfc-editor.org/rfc/rfc7641#section-2[RFC7641 2. The Observe Option]"
+and
+"https://rfc-editor.org/rfc/rfc8132#section-2[RFC8132 2. Fetch Method]".
 
 The Cache Key is a SHA256 digest if libcoap was built with TLS support,
-otherwise it uses the coap_hash() function, using the information abstracted
-from the PDU and (optionally) the CoAP session.
+otherwise it uses the internal coap_hash() function, using the information
+abstracted from the PDU and (optionally) the CoAP session.
 
 This Cache Key can then be used to match against incoming PDUs and then
 appropriate action logic can take place.
@@ -113,12 +115,19 @@ typedef enum coap_cache_record_pdu_t {
 } coap_cache_record_pdu_t;
 ----
 
+FUNCTIONS
+---------
+
+*Function: coap_cache_derive_key()*
+
 The *coap_cache_derive_key*() function abstracts all the non NoCacheKey CoAP
 options, ignores the CoAP Observer option and includes a FETCH body from _pdu_.
 If _session_based_ is COAP_CACHE_IS_SESSION_BASED, then _session_ pointer is
 also included. CoAP options can be specifically ignored by the use of
 *coap_cache_ignore_options*().  A digest is then built from all of the
 information and returned. NULL is returned on error.
+
+*Function: coap_cache_derive_key_w_ignore()*
 
 The *coap_cache_derive_key_w_ignore*() function abstracts all the non
 NoCacheKey CoAP options, ignores the CoAP Observer option and includes a FETCH
@@ -127,12 +136,18 @@ of _ignore_options_.  If _session_based_ is COAP_CACHE_IS_SESSION_BASED, then
 _session_ pointer is also included. A digest is then built from all of the
 information and returned. NULL is returned on error.
 
+*Function: coap_delete_cache_key()*
+
 The *coap_delete_cache_key*() function deletes the _cache_key_ that was
 returned from a *coap_cache_derive_key*() call.
+
+*Function: coap_cache_ignore_options()*
 
 The *coap_cache_ignore_options*() function is used to store in _context_ a
 list of _count_ options held in _options_.  The specified _options_ will not
 be included in the data used for the *coap_cache_derive_key*() function.
+
+*Function: coap_new_cache_entry()*
 
 The *coap_new_cache_entry*() function will create a new Cache Entry based on
 the Cache Key derived from the _pdu_, _session_based_ and _session_. If
@@ -144,6 +159,8 @@ time not being used before it gets deleted.  If _idle_timeout_ is set to
 0, then the Cache Entry will not get idle expired. The created Cache
 Entry is returned, or NULL on error.
 
+*Function: coap_delete_cache_entry()*
+
 The *coap_delete_cache_entry*() function can be used to delete the Cache Entry
 _cache_entry_ held within _context_.  This will remove the Cache Entry from
 the hash lookup list and
@@ -151,9 +168,13 @@ free off any internally held data.  If the Cache Entry is session based, then
 it will automatically get deleted when the session is freed off or when the
 idle timeout expires.
 
+*Function: coap_cache_get_by_key()*
+
 The *coap_cache_get_by_key*() function will locate the Cache Entry held in the
 _context_ environment that has Cache Key _cache_key_.  Returns NULL if the
 Cache Key was not found.
+
+*Function: coap_cache_get_by_pdu()*
 
 The *coap_cache_get_by_pdu*() function will locate the Cache Entry held in the
 _session_ environment that has a Cache Key derived from the _pdu_ and
@@ -162,12 +183,16 @@ internally, and so normally *coap_cache_ignore_options*() would have
 previously been called with COAP_OPTION_BLOCK1 or COAP_OPTION_BLOCK2 to
 ignore the values held within these options.
 
+*Function: coap_cache_get_pdu()*
+
 The *coap_cache_get_pdu*() function returns the PDU that was stored with the
 Cache Entry when it was created with *coap_new_cache_entry*() and _record_pdu_
 was set to COAP_CACHE_RECORD_PDU.  If a PDU was not initially stored, NULL is
 returned. +
 *NOTE:* A copy of the returned PDU must be taken for using in sending a CoAP
 packet using *coap_pdu_duplicate*().
+
+*Function: coap_cache_set_app_data()*
 
 The *coap_cache_set_app_data*() function is used to associate _data_ with the
 _cache_entry_.  If _callback_ is not NULL, it points to a function to free off
@@ -182,6 +207,8 @@ typedef void (*coap_cache_app_data_free_callback_t)(void *data);
 ----
 where _data_ is passed into the callback function whenever the Cache Entry is
 deleted.
+
+*Function: coap_cache_get_app_data()*
 
 The *coap_cache_get_app_data*() function is used to get the previously stored
 _data_ in the _cache_entry_.
@@ -249,7 +276,7 @@ hnd_put_example_data(coap_context_t *ctx,
      * A part of the data has been received (COAP_BLOCK_SINGLE_BODY not set).
      * However, total unfortunately is only an indication, so it is not safe to
      * allocate a block based on total.  As per
-     * https://tools.ietf.org/html/rfc7959#section-4
+     * https://rfc-editor.org/rfc/rfc7959#section-4
      *   o  In a request carrying a Block1 Option, to indicate the current
      *         estimate the client has of the total size of the resource
      *         representation, measured in bytes ("size indication").
@@ -373,9 +400,9 @@ FURTHER INFORMATION
 -------------------
 See
 
-"RFC7252: The Constrained Application Protocol (CoAP)"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
-"RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)"
+"https://rfc-editor.org/rfc/rfc7959[RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)]"
 
 for further information.
 

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -70,24 +70,37 @@ Resources, Endpoints and Sessions are associated with this context object.
 There can be more than one coap_context_t object per application, it is up to
 the application to manage each one accordingly.
 
+FUNCTIONS
+---------
+
+*Function: coap_new_context()*
+
 The *coap_new_context*() function creates a new Context that is then used
 to keep all the CoAP Resources, Endpoints and Sessions information.
 The optional _listen_addr_ parameter, if set for a CoAP server, creates an
 Endpoint that is added to the _context_ that is listening for un-encrypted
 traffic on the IP address and port number defined by _listen_addr_.
 
+*Function: coap_free_context()*
+
 The *coap_free_context*() function must be used to release the CoAP stack
 _context_.  It clears all entries from the receive queue and send queue and
 deletes the Resources that have been registered with _context_, and frees the
 attached Sessions and Endpoints.
+
+*Function: coap_context_set_max_idle_sessions()*
 
 The *coap_context_set_max_idle_sessions*() function sets the maximum number of
 idle server sessions to _max_idle_sessions_ for _context_.  If this number is
 exceeded, the least recently used server session is completely removed. 0 (the
 initial default) means that the number of idle sessions is not monitored.
 
+*Function: coap_context_get_max_idle_sessions()*
+
 The *coap_context_get_max_idle_sessions*() function returns the maximum number
 of idle server sessions for _context_.
+
+*Function: coap_context_set_max_handshake_sessions()*
 
 The *coap_context_set_max_handshake_sessions*() function sets the maximum
 number of outstanding server sessions in (D)TLS handshake to
@@ -95,19 +108,29 @@ _max_handshake_sessions_ for _context_.  If this number is exceeded, the least
 recently used server session in handshake is completely removed. 0 (the default)
 means that the number of handshakes is not monitored.
 
+*Function: coap_context_get_max_handshake_sessions()*
+
 The *coap_context_get_max_handshake_sessions*() function returns the maximum
 number of outstanding server sessions in (D)TLS handshake for _context_.
+
+*Function: coap_context_set_session_timeout()*
 
 The *coap_context_set_session_timeout*() function sets the number of seconds of
 inactivity to _session_timeout_ for _context_ before an idle server session is
 removed. 0 (the default) means wait for the default of 300 seconds.
 
+*Function: coap_context_get_session_timeout()*
+
 The *coap_context_get_session_timeout*() function returns the seconds to wait
 before timing out an idle server session for _context_.
+
+*Function: coap_context_set_csm_timeout()*
 
 The *coap_context_set_csm_timeout*() function sets the number of seconds to
 wait for a (TCP) CSM negotiation response from the peer to _csm_timeout_ for
 _context_.  0 (the default) means wait forever.
+
+*Function: coap_context_get_csm_timeout()*
 
 The *coap_context_get_csm_timeout*() function returns the seconds to wait for
 a (TCP) CSM negotiation response from the peer for _context_,
@@ -135,8 +158,11 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -1223,8 +1223,11 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_endpoint_client.txt.in
+++ b/man/coap_endpoint_client.txt.in
@@ -102,6 +102,11 @@ COAP_PROTO_TLS
 TCP or (D)TLS protocol support is available.  See *coap_tls_library(3)* for
 further information.
 
+FUNCTIONS
+---------
+
+*Function: coap_new_client_session()*
+
 The *coap_new_client_session*() function creates a client endpoint for a
 specific _context_ and initiates a new client session to the specified _server_
 using the CoAP protocol
@@ -109,6 +114,8 @@ _proto_.  If the port is set to 0 in _server_, then the default CoAP
 port is used.  Normally _local_if_ would be set to NULL, but by specifying
 _local_if_ the source of the network session can be bound to a specific IP
 address or port.  The session will initially have a reference count of 1.
+
+*Function: coap_new_client_session_pki()*
 
 The *coap_new_client_session_pki*() function, for a specific _context_, is
 used to configure the TLS context using the _setup_data_ variables as defined
@@ -119,6 +126,8 @@ default CoAP port is used.  Normally _local_if_ would be set to NULL, but by
 specifying _local_if_ the source of the network session can be bound to a
 specific IP address or port. The session will initially have a reference count
 of 1.
+
+*Function: coap_new_client_session_psk2()*
 
 The *coap_new_client_session_psk2*() function, for a specific _context_, is
 used to configure the TLS context using the _setup_data_ variables as defined
@@ -134,10 +143,14 @@ To stop using a client session, the reference count must be decremented to 0
 by calling *coap_session_release*(). See *coap_session*(3). This will remove
 the client endpoint.
 
+*Function: coap_sesson_set_default_mtu()*
+
 The *coap_sesson_set_default_mtu*() function is used to set the MTU size
 (the maximum message size) of the data in a packet, excluding any IP or
 TCP/UDP overhead to _mtu_ for the client endpoint's _session_.  The default
 MTU is 1152.
+
+*Function: coap_session_max_pdu_size()*
 
 The *coap_session_max_pdu_size*() function is used to get the maximum MTU
 size of the data for the client endpoint's _session_.
@@ -407,8 +420,11 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_endpoint_server.txt.in
+++ b/man/coap_endpoint_server.txt.in
@@ -95,9 +95,16 @@ flow with different TCP/UDP protocols, TLS protocols, port numbers etc. When a
 new traffic flow is started, then the CoAP library will create and start a new
 server session.
 
+FUNCTIONS
+---------
+
+*Function: coap_context_set_pki()*
+
 The *coap_context_set_pki*() function, for a specific _context_, is used to
 configure the TLS context using the _setup_data_ variables as defined in the
 coap_dtls_pki_t structure  - see *coap_encryption*(3).
+
+*Function: coap_context_set_pki_root_cas()*
 
 The *coap_context_set_pki_root_cas*() function is used to define a set of
 root CAs to be used instead of the default set of root CAs provided as a part
@@ -111,11 +118,15 @@ single CA using the _ca_file_ definition in _pki_key_ in _setup_data_ variable
 when calling *coap_context_set_pki*(), or set _check_common_ca to 0 in
 _setup_data_ variable. See *coap_encryption*(3).
 
+*Function: coap_context_set_psk2()*
+
 The *coap_context_set_psk2*() function is used to configure the TLS context
 using the _setup_data_ variables as defined in the
 coap_dtls_spsk_t structure  - see *coap_encryption*(3).
 This function can only be used for servers as _setup_data_ provides
 a _hint_, not an _identity_.
+
+*Function: coap_new_endpoint()*
 
 The *coap_new_endpoint*() function creates a new endpoint for _context_ that
 is listening for new traffic on the IP address and port number defined by
@@ -142,12 +153,18 @@ count of 0. This means that if the server session is not used for 5 minutes,
 then it will get completely freed off.  See coap_session_reference(3) and
 coap_session_release(3) for further information.
 
+*Function: coap_free_endpoint()*
+
 The *coap_free_endpoint*() function must be used to free off the _endpoint_.
 It clears out all the sessions associated with this endpoint.
+
+*Function: coap_endpoint_set_default_mtu()*
 
 The *coap_endpoint_set_default_mtu*() function is used to set the MTU size
 (the maximum message size) of the data in a packet, excluding any IP or
 TCP/UDP overhead to _mtu_ for the _endpoint_.  A sensible default is 1280.
+
+*Function: coap_join_mcast_group_intf()*
 
 The *coap_join_mcast_group_intf*() function is used to join the currently
 defined endpoints that are UDP, associated with _context_, to the defined
@@ -157,6 +174,8 @@ first appropriate interface. When the endpoint is freed off, the associated
 multicast group will be removed. The registered multicast addresses for CoAP
 are 224.0.1.187, ff0x::fd (Variable-Scope) - i.e. ff02::fd (Link-Local) and
 ff05::fd (Site-Local).
+
+*Function: coap_mcast_per_resource()*
 
 The *coap_mcast_per_resource*() function enables mcast to be controlled on a
 per resource basis giving the server application flexibility in how to respond
@@ -570,8 +589,11 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -50,6 +50,14 @@ or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
 DESCRIPTION
 -----------
 
+This documents the different callback handlers that can optionally be invoked
+on receipt of a packet or when a timeout occurs.
+
+FUNCTIONS
+---------
+
+*Function: coap_register_request_handler()*
+
 The *coap_register_request_handler*() is a server side function that registers
 a callback handler _handler_ that is called when there is an incoming request
 PDU and there is a URI match against the _resource_ and there is a _method_
@@ -93,6 +101,8 @@ taken.
 set up using *coap_resource_unknown_init2*(3)), so
 *coap_resource_get_uri_path*(3) can be used to determine the URI in this case.
 
+*Function: coap_register_response_handler()*
+
 The *coap_register_response_handler*() is a client side function that registers
 a request's response callback _handler_ for traffic associated with the
 _context_.  The application can use this for handling any response packets,
@@ -125,6 +135,8 @@ Request and then matching up based on the Token in _received_ Response.
 will get sent to the server by libcoap.  The returned value of COAP_RESPONSE_OK
 indicates that all is OK.
 
+*Function: coap_register_nack_handler()*
+
 The *coap_register_nack_handler*() is a client side function that registers a
 request's negative response callback _handler_ for traffic associated with the
 _context_.  If _handler_ is NULL, then the handler is de-registered.
@@ -149,6 +161,8 @@ COAP_NACK_BAD_RESPONSE
 
 _sent_ can be NULL.  _mid_ can be used for determining which is the transmitting
 request.
+
+*Function: coap_register_ping_handler()*
 
 The *coap_register_ping_handler*() function registers a callback _handler_ for
 tracking receipt of CoAP ping traffic associated with the _context_. If
@@ -175,6 +189,8 @@ typedef void (*coap_pong_handler_t)(coap_session_t *session,
                                     const coap_pdu_t *received,
                                     const coap_mid_t mid);
 ----
+
+*Function: coap_register_event_handler()*
 
 The *coap_register_event_handler*() function registers a callback _handler_
 for tracking network events associated with the _context_. If _handler_ is
@@ -340,8 +356,11 @@ and *coap_resource*(3)
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -481,7 +481,7 @@ FURTHER INFORMATION
 -------------------
 See
 
-"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
 for further information.
 

--- a/man/coap_keepalive.txt.in
+++ b/man/coap_keepalive.txt.in
@@ -39,6 +39,11 @@ For UDP/DTLS, this is done with the confirmable CoAP (0.00) Ping packet, which
 solicits a CoAP RST response.  For TCP/TLS, this is done with CoAP (7.02) Ping
 packet, which solicits a CoAP (7.03) Pong response, all handled by libcoap.
 
+FUNCTIONS
+---------
+
+*Function: coap_context_set_keepalive()*
+
 The *coap_context_set_keepalive*() function needs to be called to update the
 _context_ with the keepalive for idle traffic timeout of _seconds_.  If
 _seconds_ is set to 0 (the default), then the sending of keepalives is
@@ -63,9 +68,13 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-"RFC7252: The Constrained Application Protocol (CoAP)"
+See
 
-"RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+"https://rfc-editor.org/rfc/rfc8323[RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -2,7 +2,7 @@
 // vim: set syntax=asciidoc tw=0
 
 coap_logging(3)
-=================
+===============
 :doctype: manpage
 :man source:   coap_logging
 :man version:  @PACKAGE_VERSION@
@@ -298,7 +298,7 @@ FURTHER INFORMATION
 -------------------
 See
 
-"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
 for further information.
 

--- a/man/coap_lwip.txt.in
+++ b/man/coap_lwip.txt.in
@@ -63,7 +63,6 @@ FUNCTIONS
 
 *Function: coap_lwip_set_input_wait_handler()*
 
-
 The *coap_lwip_set_input_wait_handler*() function is used to define a callback
 _handler_ that is invoked by *coap_io_process*(3) which passes in the
 _input_arg_ parameter along with a suggested milli-sec wait time parameter
@@ -77,7 +76,7 @@ The *coap_lwip_dump_memory_pools*() function is used to dump out the current
 state of the LwIP memory pools at logging level _log_level_.
 
 This function is always invoked by *coap_free_context*(3) with a _log_level_ of
-LOG_DEBUG.
+COAP_LOG_DEBUG.
 
 *NOTE:* For information to be printed out, you need the following two lines in
 lwipopts.h
@@ -94,8 +93,11 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -2,7 +2,7 @@
 // vim: set syntax=asciidoc tw=0
 
 coap_observe(3)
-=================
+===============
 :doctype: manpage
 :man source:   coap_observe
 :man version:  @PACKAGE_VERSION@
@@ -40,8 +40,8 @@ or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
 
 DESCRIPTION
 -----------
-RFC 7641 extends the CoAP protocol to be able to monitor the state of a
-resource over time.
+https://rfc-editor.org/rfc/rfc7641[RFC7641] extends the CoAP protocol to be
+able to monitor the state of a resource over time.
 
 This enables clients to "observe" resources with a defined query, i.e., to
 retrieve a representation of a resource and keep this representation updated
@@ -51,7 +51,8 @@ The server has to flag a resource as "observable", and then the client has
 to request in a GET request that it wants to observe this resource by the use
 of the COAP_OPTION_OBSERVE Option with a value of COAP_OBSERVE_ESTABLISH.
 Optionally, the client can specify query options for the resource, or by using
-a FETCH request instead of a GET to define a query (RFC8132).
+a FETCH request instead of a GET to define a query
+(https://rfc-editor.org/rfc/rfc8132[RFC8132]).
 
 To remove the "observe" subscription, the client has to issue a GET (or FETCH)
 request with the COAP_OPTION_OBSERVE Option with a value of
@@ -81,6 +82,11 @@ in the handler defined by *coap_register_response_handler*(3).  It is the
 responsibility of the client application to match the supplied token and
 update the appropriate internal information.
 
+FUNCTIONS
+---------
+
+*Function: coap_resource_set_get_observable()*
+
 The *coap_resource_set_get_observable*() function enables or disables the
 observable status of the _resource_ by the setting of _mode_.  If _mode_ is
 1, then the _resource_ is observable.  If _mode_ is 0, then the
@@ -96,29 +102,37 @@ manage the deletion of the resource at the appropriate time.
 *NOTE:* The type (confirmable or non-confirmable) of the triggered observe
 GET response is determined not by the initial GET/FETCH request, but
 independently by the server as per
-https://tools.ietf.org/html/rfc7641#section-3.5.  This is controlled by the
-flags (one of COAP_RESOURCE_FLAGS_NOTIFY_NON,
+"https://rfc-editor.org/rfc/rfc7641#section-3.5[RFC7641 3.5. Transmission]".
+This is controlled by the flags (one of COAP_RESOURCE_FLAGS_NOTIFY_NON,
 COAP_RESOURCE_FLAGS_NOTIFY_NON_ALWAYS or COAP_RESOURCE_FLAGS_NOTIFY_CON)
 used when creating the resource using *coap_resource_init*(3).
 
 *NOTE:* Furthermore, the server must send at least one "observe" response as
 confirmable, when generally sending non-confirmable, at least every 24 hours
-as per https://tools.ietf.org/html/rfc7641#section-4.5.
+as per "https://rfc-editor.org/rfc/rfc7641#section-4.5[RFC7641
+4.5. Transmission]".
 Libcoap automatically handles this by sending every fifth (COAP_OBS_MAX_NON)
 response as a confirmable response for detection that the client is still
 responding unless if COAP_RESOURCE_FLAGS_NOTIFY_NON_ALWAYS is set, which is a
-RFC7641 violation, where non-confirmable "observe" responses are always sent
+"https://rfc-editor.org/rfc/rfc7641#section-4.5[RFC7641 4.5. Transmission]"
+violation, where non-confirmable "observe" responses are always sent
 as required by some higher layer protocols.
+
+*Function: coap_resource_notify_observers()*
 
 The *coap_resource_notify_observers*() function needs to be called whenever the
 server application determines that there has been a change to the state of
 _resource_.  The _query_ parameter is obsolete and ignored.
+
+*Function: coap_cancel_observe()*
 
 The *coap_cancel_observe*() function can be used by the client to cancel an
 observe request that is being tracked. This will cause the
 appropriate PDU to be sent to the server to cancel the observation, based on
 the _session_ and _token_ used to set up the observe and the PDU is of type
 _message_type_ (use COAP_MESSAGE_NON or COAP_MESSAGE_CON).
+
+*Function: coap_session_set_no_observe_cancel()*
 
 The *coap_session_set_no_observe_cancel*() function can be called by the
 client to disable calling *coap_cancel_observe*() when the _session_ is being
@@ -388,11 +402,16 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-"RFC7252: The Constrained Application Protocol (CoAP)"
+See
 
-"RFC7641: Observing Resources in the Constrained Application Protocol (CoAP)"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
-"RFC8132: PATCH and FETCH Methods for the Constrained Application Protocol (CoAP)"
+"https://rfc-editor.org/rfc/rfc7641[RFC7641: Observing Resources in the Constrained Application Protocol (CoAP)]"
+
+"https://rfc-editor.org/rfc/rfc8132[RFC8132: PATCH and FETCH Methods for the Constrained Application Protocol (CoAP)]"
+
+for further information.
+
 
 BUGS
 ----

--- a/man/coap_pdu_access.txt.in
+++ b/man/coap_pdu_access.txt.in
@@ -87,14 +87,18 @@ The CoAP PDU is of the form
 --header--|--optional token--|--optional options--|--optional payload--
 
 The terminology used is taken mainly from
-https://tools.ietf.org/html/rfc7252#section-1.2
+"https://rfc-editor.org/rfc/rfc7252#section-1.2[RFC7252 1.2. Terminology]".
 
-The following functions provide access to the information held within a PDU.
+The following functions provide access to the information held within
+different parts of a PDU.
 
-*Header:*
+PDU HEADER FUNCTIONS
+--------------------
+
+*Function: coap_pdu_get_type()*
 
 The *coap_pdu_get_type*() function returns one of the messages types below from
-the PDU _pdu_.
+the PDU _pdu_ header.
 
 [source, c]
 ----
@@ -104,8 +108,13 @@ COAP_MESSAGE_ACK  Type acknowledge
 COAP_MESSAGE_RST  Type reset.
 ----
 
+*NOTE:* For reliable messages https://rfc-editor.org/rfc/rfc8323[RFC8323],
+this will always return COAP_MESSAGE_CON.
+
+*Function: coap_pdu_get_code()*
+
 The *coap_pdu_get_code*() function returns one of the codes below from the
-PDU _pdu_. It is possible that new codes are added in over time.
+PDU _pdu_ header. It is possible that new codes are added in over time.
 
 [source, c]
 ----
@@ -152,14 +161,26 @@ COAP_SIGNALING_CODE_RELEASE                   7.04
 COAP_SIGNALING_CODE_ABORT                     7.05
 ----
 
-The *coap_pdu_get_mid*() returns the message id from the PDU _pdu_.
+*NOTE:* For reliable messages "ttps://rfc-editor.org/rfc/rfc8323[RFC8323],
+this will always return COAP_EMPTY_CODE.
 
-*Token:*
+*Function: coap_pdu_get_mid()*
+
+The *coap_pdu_get_mid*() returns the message id from the PDU _pdu_ header.
+
+*NOTE:* For reliable messages https://rfc-editor.org/rfc/rfc8323[RFC8323],
+this will always return 0.
+
+PDU TOKEN FUNCTIONS
+-------------------
+
+*Function: coap_pdu_get_token()*
 
 The *coap_pdu_get_token*() returns the token information held in the PDU _pdu_
-which may be zero length.
+token which may be zero length.
 
-*Options:*
+PDU OPTIONS FUNCTIONS
+---------------------
 
 The following is the current list of options with their numeric value
 ----
@@ -167,19 +188,19 @@ The following is the current list of options with their numeric value
  * The C, U, and N flags indicate the properties
  * Critical, Unsafe, and NoCacheKey, respectively.
  * If U is set, then N has no meaning as per
- * https://tools.ietf.org/html/rfc7252#section-5.10
+ * https://rfc-editor.org/rfc/rfc7252#section-5.10
  * and is set to a -.
  * Separately, R is for the options that can be repeated
  *
  * The least significant byte of the option is set as followed
- * as per https://tools.ietf.org/html/rfc7252#section-5.4.6
+ * as per https://rfc-editor.org/rfc/rfc7252#section-5.4.6
  *
  *   0   1   2   3   4   5   6   7
  * --+---+---+---+---+---+---+---+
  *           | NoCacheKey| U | C |
  * --+---+---+---+---+---+---+---+
  *
- * https://tools.ietf.org/html/rfc8613#section-4 goes on to define E, I and U
+ * https://rfc-editor.org/rfc/rfc8613#section-4 goes on to define E, I and U
  * properties Encrypted and Integrity Protected, Integrity Protected Only and
  * Unprotected respectively.  Integrity Protected Only is not currently used.
  *
@@ -214,52 +235,81 @@ COAP_OPTION_NORESPONSE    258 /* _U-_E_U, uint,      0-1 B, RFC7967 */
 ----
 See FURTHER INFORMATION as to how to get the latest list.
 
+*Function: coap_check_option()*
+
 The *coap_check_option*() function is used to check whether the specified option
-_number_ is in the PDU _pdu_.  The option iterator _oi_ is used as an internal
+_number_ is in the PDU _pdu_ options.  The option iterator _oi_ is used as a
+scratch (does not need to be initialized) internal
 storage location while iterating through the options looking for the specific
 _number_.  If the _number_ is repeated in the _pdu_, only the first occurrence
 will be returned.  If the option is not found, NULL is returned.
 
-Alternatively, the *coap_option_iterator_init*() function can be used to
+*Function: coap_option_iterator_init()*
+
+The *coap_option_iterator_init*() function can be used to
 initialize option iterator _oi_, applying a filter _filter_ to indicate which
 options are to be ignored when iterating through the options.  The _filter_ can
-be NULL (or COAP_OPT_ALL) if all of the options are required. Then this is
-followed by using the *coap_option_next*() function in a loop to return all
-the appropriate options until NULL is returned -  indicating the end of
-available the options. See EXAMPLES below for further information.
+be NULL (or COAP_OPT_ALL) if all of the options are required.
+To set up the filter otherwise, the following 4 functions are available.
 
-To set up the filter, the following 4 functions are available.
+*Function: coap_option_filter_clear()*
 
 The *coap_option_filter_clear*() function initializes _filter_ to have no
 options set.
 
+*Function: coap_option_filter_get()*
+
 The *coap_option_filter_get*() function is used to check whether option _number_
 is set in _filter_.
+
+*Function: coap_option_filter_set()*
 
 The *coap_option_filter_set*() function is used to set option _number_ in
 _filter_.
 
+*Function: coap_option_filter_unset()*
+
 The *coap_option_filter_unset*() function is used to remove option _number_ in
 _filter_.
 
-The *coap_opt_length*() function returns the length of the option _opt_.
+*Function: coap_option_next()*
+
+The *coap_option_next*() function is then used following
+*coap_option_iterator_init*() in a loop to return all
+the appropriate options until NULL is returned - indicating the end of
+the available options. See EXAMPLES below for further information.
+
+*Function: coap_opt_length()*
+
+The *coap_opt_length*() function returns the length of the option _opt_
+(as returned by *coap_check_option*() or *coap_option_next*()).
+
+*Function: coap_opt_value()*
 
 The *coap_opt_value*() function returns a pointer to the start of the data for
-the option.
+the option _opt_ (as returned by *coap_check_option*() or *coap_option_next*()).
 
-The *coap_decode_var_bytes*() function will decode an option up to 4 bytes
+*Function: coap_decode_var_bytes()*
+
+The *coap_decode_var_bytes*() function will decode an option value up to 4 bytes
 long from _buf_ and _length_ into an unsigned 32bit number.
 
-The *coap_decode_var_bytes8*() function will decode an option up to 8 bytes
-long from _buf_ and _length_ into an unsigned 64bit number.
+*Function: coap_decode_var_bytes8()*
+
+The *coap_decode_var_bytes8*() function will decode an option value up to 8
+bytes long from _buf_ and _length_ into an unsigned 64bit number.
+
+*Function: coap_get_uri_path()*
 
 The *coap_get_uri_path*() function will abstract the uri path from the
-specified _pdu_. The returned uri path will need to be freed off when no
-longer required.
+specified _pdu_ options. The returned uri path will need to be freed off when no longer required.
 
-*Payload:*
+PDU PAYLOAD FUNCTIONS
+---------------------
 
-The *coap_get_data*() function is used abstract from the _pdu_
+*Function: coap_get_data()*
+
+The *coap_get_data*() function is used abstract from the _pdu_ payload
 information about the received data by updating _length_ with the length of
 data available, and _data_ with a pointer to where the data is located.
 
@@ -373,13 +423,14 @@ FURTHER INFORMATION
 -------------------
 See
 
-"RFC7252: The Constrained Application Protocol (CoAP)"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
-"RFC8613: Object Security for Constrained RESTful Environments (OSCORE)"
+"https://rfc-editor.org/rfc/rfc8613[RFC8613: Object Security for Constrained RESTful Environments (OSCORE)]"
 
 for further information.
 
-See https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#option-numbers
+See
+https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#option-numbers
 for the current set of defined CoAP Options.
 
 BUGS

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -13,6 +13,7 @@ NAME
 coap_pdu_setup,
 coap_new_pdu,
 coap_pdu_init,
+coap_new_message_id,
 coap_session_init_token,
 coap_session_new_token,
 coap_add_token,
@@ -42,6 +43,8 @@ coap_session_t *_session_);*
 
 *coap_pdu_t *coap_pdu_init(coap_pdu_type_t _type_, coap_pdu_code_t _code_,
 coap_mid_t _message_id_, size_t _max_size_);*
+
+*uint16_t coap_new_message_id(coap_session_t *_session_);*
 
 *void coap_session_init_token(coap_session_t *_session_, size_t _length_,
 const uint8_t *_token_);*
@@ -104,7 +107,7 @@ The CoAP PDU is of the form
 --header--|--optional token--|--optional options--|--optional payload--
 
 The terminology used is taken mainly from
-https://tools.ietf.org/html/rfc7252#section-1.2
+"https://rfc-editor.org/rfc/rfc7252#section-1.2[RFC7252 1.2. Terminology]".
 
 The PDU must be built in the correct order, from left to right.  In particular,
 the options need to be added in the correct numerical option order as they are
@@ -129,8 +132,8 @@ packet. The response pdu is always freed off by the underlying library.
 For handling situations where the data to be transmitted does not fit into a
 single packet, see *coap_block*(3).
 
-PDU CREATE AND HEADER
----------------------
+PDU CREATE AND HEADER FUNCTIONS
+-------------------------------
 
 *Function: coap_new_pdu()*
 
@@ -219,6 +222,14 @@ back a "separate" response).
 The _max_size_ parameter defines the maximum size of a _PDU_ and is usually
 determined by calling coap_session_max_pdu_size(session);
 
+*Function: coap_new_message_id()*
+
+The *coap_new_message_id*() function returns the next message id to use for
+sending a new request message.
+
+*NOTE:* For reliable messages https://rfc-editor.org/rfc/rfc8323[RFC8323],
+this will always return 0.
+
 *Function: coap_pdu_set_mid()*
 
 The *coap_pdu_set_mid*() function is used to set the message id _mid_ in the
@@ -239,8 +250,8 @@ COAP_EMPTY_CODE, appropriate message_id, matching token and potentially some
 other options before calling the appropriate request handler (See
 *coap_register_request_handler*(3)).
 
-PDU TOKEN
----------
+PDU TOKEN FUNCTIONS
+-------------------
 
 *Function: coap_session_init_token()*
 
@@ -272,8 +283,8 @@ the body of data is spread over multiple payloads (see *coap_block*(3)).
 However, when the data transfers complete, the application will receive the
 corrected token in the response PDU.
 
-PDU OPTIONS
------------
+PDU OPTIONS FUNCTIONS
+---------------------
 
 The following is the current list of options with their numeric value
 ----
@@ -281,19 +292,19 @@ The following is the current list of options with their numeric value
  * The C, U, and N flags indicate the properties
  * Critical, Unsafe, and NoCacheKey, respectively.
  * If U is set, then N has no meaning as per
- * https://tools.ietf.org/html/rfc7252#section-5.10
+ * https://rfc-editor.org/rfc/rfc7252#section-5.10
  * and is set to a -.
  * Separately, R is for the options that can be repeated
  *
  * The least significant byte of the option is set as followed
- * as per https://tools.ietf.org/html/rfc7252#section-5.4.6
+ * as per https://rfc-editor.org/rfc/rfc7252#section-5.4.6
  *
  *   0   1   2   3   4   5   6   7
  * --+---+---+---+---+---+---+---+
  *           | NoCacheKey| U | C |
  * --+---+---+---+---+---+---+---+
  *
- * https://tools.ietf.org/html/rfc8613#section-4 goes on to define E, I and U
+ * https://rfc-editor.org/rfc/rfc8613#section-4 goes on to define E, I and U
  * properties Encrypted and Integrity Protected, Integrity Protected Only and
  * Unprotected respectively.  Integrity Protected Only is not currently used.
  *
@@ -461,8 +472,8 @@ libcoap client logic, Size2 by libcoap server logic) indication to the
 recipient of the size of the large body that is to be transferred. See
 *coap_block*(3).
 
-PDU PAYLOAD DATA
-----------------
+PDU PAYLOAD FUNCTIONS
+---------------------
 
 *Function: coap_add_data()*
 
@@ -490,8 +501,8 @@ by this function.
 *NOTE:* This function has been superseded by *coap_add_data_large_response*().
 See *coap_block*(3).
 
-PDU TRANSMIT
-------------
+PDU TRANSMIT FUNCTIONS
+----------------------
 
 *Function: coap_send()*
 
@@ -699,11 +710,11 @@ FURTHER INFORMATION
 -------------------
 See
 
-"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
-"https://tools.ietf.org/html/rfc7959[RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7959[RFC7959: Block-Wise Transfers in the Constrained Application Protocol (CoAP)]"
 
-"https://tools.ietf.org/html/rfc9175[RFC9175: CoAP: Echo, Request-Tag, and Token Processing]"
+"https://rfc-editor.org/rfc/rfc9175[RFC9175: CoAP: Echo, Request-Tag, and Token Processing]"
 
 for further information.
 

--- a/man/coap_recovery.txt.in
+++ b/man/coap_recovery.txt.in
@@ -2,7 +2,7 @@
 // vim: set syntax=asciidoc tw=0
 
 coap_recovery(3)
-=================
+================
 :doctype: manpage
 :man source:   coap_recovery
 :man version:  @PACKAGE_VERSION@
@@ -74,8 +74,11 @@ DESCRIPTION
 -----------
 For CoAP Confirmable messages, it is possible to define the retry counts,
 repeat rate etc. for error recovery.  Further information can be found in
-"RFC7272: 4.2. Messages Transmitted Reliably", with the default values
-defined in "RFC7272: 4.8 Transmission Parameters".
+"https://rfc-editor.org/rfc/rfc7252#section-4.2[RFC7272 4.2. Messages
+Transmitted Reliably]",
+with the default values defined in
+"https://rfc-editor.org/rfc/rfc7252#section-4.8[RFC7272 4.8. Transmission
+Parameters]".
 
 It is not recommended that the suggested default setting are changed, but
 there may be some special requirements that need different values and the
@@ -101,7 +104,8 @@ The CoAP message retry rules are (with the default values to compute the time)
 
 As max_retransmit (by default) is 4, then the 5th retransmit does not get sent,
 but at that point COAP_NACK_TOO_MANY_RETRIES gets raised in the nack_handler
-(if defined). Note that the sum of the seconds is 93 matching RFC7252.
+(if defined). Note that the sum of the seconds is 93 matching RFC7252 4.8.2.
+MAX_TRANSMIT_WAIT.
 ----
 
 It should be noted that these retries are separate from the DTLS or TLS
@@ -116,42 +120,71 @@ transmission recovery as well as application handling of lossy networks.
 The following functions reflect the RFC7252 uppercase names in lowercase
 following the coap_session[sg]_ function prefix.
 
+FUNCTIONS
+---------
+
+*Function: coap_session_set_ack_random_factor()*
+
 The *coap_session_set_ack_random_factor*() function updates the _session_ ack
 random wait factor, used to randomize re-transmissions, with the new _value_.
 The default value is 1.5.
 
+*Function: coap_session_get_ack_random_factor()*
+
 The *coap_session_get_ack_random_factor*() function returns the current
 _session_ ack random wait factor.
+
+*Function: coap_session_set_ack_timeout()*
 
 The *coap_session_set_ack_timeout*() function updates the _session_ initial
 ack or response timeout with the new _value_.  The default value is 2.0.
 
+*Function: coap_session_get_ack_timeout()*
+
 The *coap_session_get_ack_timeout*() function returns the current _session_
 initial ack or response timeout.
+
+*Function: coap_session_set_default_leisure()*
 
 The *coap_session_set_default_leisure*() function updates the _session_
 default leisure time with the new _value_.  The initial default value is 5.0.
 
+*Function: coap_session_get_default_leisure()*
+
 The *coap_session_get_default_leisure*() function returns the current _session_
 default leisure time.
+
+*Function: coap_session_set_max_retransmit()*
 
 The *coap_session_set_max_retransmit*() function updates the _session_ maximum
 retransmit count with the new _value_.  The default value is 4.
 
+*Function: coap_session_get_max_retransmit()*
+
 The *coap_session_get_max_retransmit*() function returns the current _session_
 maximum retransmit count.
+
+*Function: coap_session_set_nstart()*
 
 The *coap_session_set_nstart*() function updates the _session_ nstart
 with the new _value_.  The default value is 1.
 
+*Function: coap_session_set_probing_rate()*
+
 The *coap_session_get_nstart*() function returns the current _session_
+
+*Function: coap_session_set_probing_rate()*
 nstart value.
 
 The *coap_session_set_probing_rate*() function updates the _session_ probing
 rate with the new _value_.  The default value is 1 byte per second.
 
+*Function: coap_session_get_probing_rate()*
+
 The *coap_session_get_probing_rate*() function returns the current _session_
 probing rate value.
+
+*Function: coap_debug_set_packet_loss()*
 
 The *coap_debug_set_packet_loss*() function is uses to set the packet loss
 levels as defined in _loss_level_.  _loss_level_ can be set as a percentage
@@ -179,8 +212,8 @@ TESTING
 The libcoap recovery/re-transmit logic will only work for confirmable requests.
 
 To see what is happening (other than by sniffing the network traffic), the
-logging level needs to be set to LOG_DEBUG in the client by using
-coap_set_log_level(LOG_DEBUG) and coap_dtls_set_log_level(LOG_DEBUG).
+logging level needs to be set to COAP_LOG_DEBUG in the client by using
+coap_set_log_level(COAP_LOG_DEBUG) and coap_dtls_set_log_level(COAP_LOG_DEBUG).
 
 The client needs to be sending confirmable requests during the test.
 
@@ -202,8 +235,11 @@ confirmable request cannot be successfully transmitted.
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -95,7 +95,8 @@ This could, for example, happen when a PUT request is trying to create a new
 resource. It is the responsibility of the unknown resource callback handler
 to either create a new resource for the URI or just manage things separately.
 
-CoAP Observe (RFC 7641) is not supported for unknown resources, so a new
+CoAP Observe (https://rfc-editor.org/rfc/rfc7641[RFC7641]) is not supported
+for unknown resources, so a new
 resource with GET handler must be created by the unknown resource callback
 handle matching the URI which then can be Observable.
 
@@ -119,7 +120,7 @@ _flags_ can be one of the following definitions ored together.
 *COAP_RESOURCE_FLAGS_NOTIFY_NON*::
 Set the notification message type to non-confirmable for any trigggered
 "observe" responses with type set to confirmable every 5 packets as required by
-RFC7641 section-4.5.
+"https://rfc-editor.org/rfc/rfc7641#section-4.5[RFC7641 4.5. Transmission]".
 
 *COAP_RESOURCE_FLAGS_NOTIFY_NON_ALWAYS*::
 Set the notification message type to always non-confirmable for any trigggered
@@ -146,27 +147,34 @@ This resource has support for multicast requests.
 Disable libcoap library from adding in delays to multicast requests before
 releasing the response back to the client.  It is then the responsibility of
 the app to delay the responses for multicast requests. See
-https://datatracker.ietf.org/doc/html/rfc7252#section-8.2.  However, the
-pseudo resource for ".well-known/core" always has multicast support enabled.
+"https://rfc-editor.org/rfc/rfc7252#section-8.2[RFC7252 8.2. Request/Response
+Layer]".
+ However, the pseudo resource for ".well-known/core" always has multicast
+support enabled.
 
 *COAP_RESOURCE_FLAGS_LIB_ENA_MCAST_SUPPRESS_2_05*::
 Enable libcoap library suppression of 205 multicast responses that are empty
-(overridden by RFC7969 No-Response option) for multicast requests.
+(overridden by https://rfc-editor.org/rfc/rfc7967[RFC7967] No-Response option)
+for multicast requests.
 
 *COAP_RESOURCE_FLAGS_LIB_ENA_MCAST_SUPPRESS_2_XX*::
 Enable libcoap library suppressing 2.xx multicast responses (overridden by
-RFC7969 No-Response option) for multicast requests.
+https://rfc-editor.org/rfc/rfc7967[RFC7967] No-Response option) for multicast
+requests.
 
 *COAP_RESOURCE_FLAGS_LIB_DIS_MCAST_SUPPRESS_4_XX*::
 Disable libcoap library suppressing 4.xx multicast responses (overridden by
-RFC7969 No-Response option) for multicast requests.
+https://rfc-editor.org/rfc/rfc7967[RFC7967] No-Response option) for multicast
+requests.
 
 *COAP_RESOURCE_FLAGS_LIB_DIS_MCAST_SUPPRESS_5_XX*::
 Disable libcoap library suppressing 5.xx multicast responses (overridden by
-RFC7969 No-Response option) for multicast requests.
+https://rfc-editor.org/rfc/rfc7967[RFC7967] No-Response option) for multicast
+requests.
 
 *NOTE:* _uri_path_, if not 7 bit readable ASCII, binary bytes must be hex
-encoded according to the rules defined in RFC3968 Section 2.1.
+encoded according to the rules defined in
+"https://rfc-editor.org/rfc/rfc3986#section-2.1[RFC3986 2.1. Percent-Encoding]".
 
 *Function: coap_resource_unknown_init()*
 
@@ -570,8 +578,13 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+"https://rfc-editor.org/rfc/rfc3986[RFC3986: Uniform Resource Identifier (URI): Generic Syntax]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -88,10 +88,17 @@ is tracked by local port, CoAP protocol, remote IP address and remote port.
 The Session network traffic can be encrypted or un-encrypted if there is an
 underlying TLS library.
 
+FUNCTIONS
+---------
+
+*Function: coap_session_reference()*
+
 The *coap_session_reference*() function is used to increment the reference
 count of the _session_.  Incrementing the reference count by an application
 means that the library will not inadvertently remove the session when it has
 finished processing the session.
+
+*Function: coap_session_release()*
 
 The *coap_session_release*() function is be used to decrement the _session_
 reference count, which when it gets to 0, will:-
@@ -106,29 +113,45 @@ completely freed off.  *NOTE:* Unless the application increments the
 reference count, this is the case for all type server sessions as they start
 with a reference count of 0.
 
+*Function: coap_session_disconnected()*
+
 The *coap_session_disconnected*() function is used to force the closure of a
 _session_ for the reason _reason_. It will cause any outstanding traffic to
 get dropped.
+
+*Function: coap_session_set_type_client()*
 
 The *coap_session_set_type_client*() function is used to convert the _session_
 frrm a session endpoint type of Server to Client.  This typically is used in a
 Call-Home type environment where the roles have to change following the
 establishment of a session.  The reference count is incremented by 1.
 
+*Function: coap_session_set_app_data()*
+
 The *coap_session_set_app_data*() function is used to define a _data_ pointer
 for the _session_ which can then be retrieved at a later date.
+
+*Function: coap_session_get_app_data()*
 
 The *coap_session_get_app_data*() function is used to retrieve the data
 pointer previously defined by *coap_session_set_app_data*().
 
+*Function: coap_session_get_addr_local()*
+
 The *coap_session_get_addr_local*() function is used to get the local IP
 address and port information from the _session_.
+
+*Function: coap_session_get_addr_remote()*
 
 The *coap_session_get_addr_remote*() function is used to get the remote (peer)
 IP address and port information from the _session_.
 
+*Function: coap_session_get_context()*
+
 The *coap_session_get_context*() function is used to get the CoAP context
 associated with the _session_.
+
+*Function: coap_session_get_ifindex()*
 
 The  *coap_session_get_ifindex*() function is used to get the network interface
 index that the traffic came in over from the _session_.
@@ -224,8 +247,11 @@ SEE ALSO
 
 FURTHER INFORMATION
 -------------------
-See "RFC7252: The Constrained Application Protocol (CoAP)" for further
-information.
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_string.txt.in
+++ b/man/coap_string.txt.in
@@ -102,45 +102,72 @@ typedef struct coap_bin_const_t {
 } coap_bin_const_t;
 ----
 
+FUNCTIONS
+---------
+
+*Function: coap_new_string()*
+
 The *coap_new_string*() function allocates a new coap_string_t of _size_
 where _s_ points to uninitialized data of length _size_ with an extra trailing
 NULL at _size_ + 1. _length_ is set to _size_.
 
+*Function: coap_delete_string()*
+
 The *coap_delete_string*() function is used to delete the coap_string_t
 created by *coap_new_string*().
+
+*Function: coap_new_str_const()*
 
 The *coap_new_str_const*() function allocates a coap_str_const_t of _size_
 where _s_ is filled in with _data_ and has a trailing NULL added.
 _length_ is set to _size_. _s_ is read-only.
 
+*Function: coap_delete_str_const()*
+
 The *coap_delete_str_const*() function is used to delete the coap_str_const_t
 created by *coap_new_str_const*().
+
+*Function: coap_make_str_const()*
 
 The *coap_make_str_const*() function is used to take some read-only text and
 uses a static coap_str_const_t for use in different function calls. There are
 two static entries that are cycled through so that a single function call can
 call *coap_make_str_const*() twice.
 
+*Function: coap_string_equal()*
+
 The *coap_string_equal*() function is used to compare two different string
 objects _string1_ and _string2_.
+
+*Function: coap_new_binary()*
 
 The *coap_new_binary*() function allocates a new coap_binary_t of _size_
 where _s_ points to uninitialized data of length _size_. _length_ is set
 to _size_.
 
+*Function: coap_resize_binary()*
+
 The *coap_resize_binary*() function is used resize the size of _s_ to the new
 size of _new_size_.  The data between the old _length_ and the _new_size_ is
 unitialized.  _length_ is set to _new_size_.
 
+*Function: coap_delete_binary()*
+
 The *coap_delete_binary*() function is used to delete the coap_binary_t
 created by *coap_new_binary*().
+
+*Function: coap_new_bin_const()*
 
 The *coap_new_bin_const*() function allocates a coap_bin_const_t of _size_
 where _s_ is filled in with in with _data_ and has a trailing NULL added.
 _length_ is set to _size_. _s_ is read-only.
 
+*Function: coap_delete_bin_const()*
+
 The *coap_delete_bin_const*() function is used to delete the coap_bin_const_t
 created by *coap_new_bin_const*().
+
+*Function: coap_binary_equal()*
 
 The *coap_binary_equal*() function is used to compare two different binary
 objects _binary1_ and _binary2_.
@@ -169,7 +196,11 @@ and *coap_resource*(3)
 
 FURTHER INFORMATION
 -------------------
-"RFC7252: The Constrained Application Protocol (CoAP)"
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
 
 BUGS
 ----

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -192,9 +192,9 @@ FURTHER INFORMATION
 -------------------
 See
 
-"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
-"https://tools.ietf.org/html/rfc8323[RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets]"
+"https://rfc-editor.org/rfc/rfc8323[RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets]"
 
 for further information.
 

--- a/man/coap_uri.txt.in
+++ b/man/coap_uri.txt.in
@@ -229,7 +229,7 @@ FURTHER INFORMATION
 -------------------
 See
 
-"https://tools.ietf.org/html/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
 
 for further information.
 


### PR DESCRIPTION
Provide consistency across all of the man pages as per :-

Provide missing function headers for functions.

Hyper link the function definitions.

Hyper link RFC references (except in code blocks).

Use https://rfc-editor.org/rfc/rfc.... instead of
https://tools.ietf.org/html/rfc.... for the RFC links.

Use https://rfc-editor.org/rfc/rfc.... instead of
https://datatracker.ietf.org/doc/html/rfc.... for the RFC links.