### PR TITLE
RFC links: Provide consistency for links to RFCs

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -498,7 +498,7 @@ hnd_put_example_data(coap_resource_t *resource,
      * A part of the data has been received (COAP_BLOCK_SINGLE_BODY not set).
      * However, total unfortunately is only an indication, so it is not safe to
      * allocate a block based on total.  As per
-     * https://tools.ietf.org/html/rfc7959#section-4
+     * https://rfc-editor.org/rfc/rfc7959#section-4
      *   o  In a request carrying a Block1 Option, to indicate the current
      *         estimate the client has of the total size of the resource
      *         representation, measured in bytes ("size indication").
@@ -1389,7 +1389,7 @@ hnd_put_post(coap_resource_t *resource,
      * A part of the data has been received (COAP_BLOCK_SINGLE_BODY not set).
      * However, total unfortunately is only an indication, so it is not safe to
      * allocate a block based on total.  As per
-     * https://tools.ietf.org/html/rfc7959#section-4
+     * https://rfc-editor.org/rfc/rfc7959#section-4
      *   o  In a request carrying a Block1 Option, to indicate the current
      *         estimate the client has of the total size of the resource
      *         representation, measured in bytes ("size indication").
@@ -2605,9 +2605,9 @@ main(int argc, char **argv) {
   size_t i;
   uint16_t cache_ignore_options[] = { COAP_OPTION_BLOCK1,
                                       COAP_OPTION_BLOCK2,
-                    /* See https://tools.ietf.org/html/rfc7959#section-2.10 */
+                    /* See https://rfc-editor.org/rfc/rfc7959#section-2.10 */
                                       COAP_OPTION_MAXAGE,
-                    /* See https://tools.ietf.org/html/rfc7959#section-2.10 */
+                    /* See https://rfc-editor.org/rfc/rfc7959#section-2.10 */
                                       COAP_OPTION_IF_NONE_MATCH };
 #ifndef _WIN32
   struct sigaction sa;

--- a/include/coap3/coap_cache.h
+++ b/include/coap3/coap_cache.h
@@ -22,7 +22,7 @@
  * @ingroup application_api
  * @defgroup cache Cache Support
  * API for Cache-Key and Cache-Entry.
- * See https://datatracker.ietf.org/doc/html/rfc7252#section-5.4.2
+ * See https://rfc-editor.org/rfc/rfc7252#section-5.4.2
  * @{
  */
 
@@ -46,7 +46,7 @@ typedef enum coap_cache_record_pdu_t {
 
 /**
  * Calculates a cache-key for the given CoAP PDU. See
- * https://tools.ietf.org/html/rfc7252#section-5.4.2
+ * https://rfc-editor.org/rfc/rfc7252#section-5.4.2
  * for an explanation of CoAP cache keys.
  *
  * Specific CoAP options can be removed from the cache-key.  Examples of
@@ -74,7 +74,7 @@ coap_cache_key_t *coap_cache_derive_key(const coap_session_t *session,
 
 /**
  * Calculates a cache-key for the given CoAP PDU. See
- * https://tools.ietf.org/html/rfc7252#section-5.4.2
+ * https://rfc-editor.org/rfc/rfc7252#section-5.4.2
  * for an explanation of CoAP cache keys.
  *
  * Specific CoAP options can be removed from the cache-key.  Examples of

--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -27,7 +27,7 @@
  * @{
  */
 
-/* https://tools.ietf.org/html/rfc6347#section-4.2.4.1 */
+/* https://rfc-editor.org/rfc/rfc6347#section-4.2.4.1 */
 #ifndef COAP_DTLS_RETRANSMIT_MS
 #define COAP_DTLS_RETRANSMIT_MS 1000
 #endif

--- a/include/coap3/coap_session.h
+++ b/include/coap3/coap_session.h
@@ -401,7 +401,7 @@ coap_session_t *coap_session_get_by_peer(const coap_context_t *ctx,
   * API for updating transmission parameters for CoAP rate control.
   * The transmission parameters for CoAP rate control ("Congestion
   * Control" in stream-oriented protocols) are defined in
-  * https://tools.ietf.org/html/rfc7252#section-4.8
+  * https://rfc-editor.org/rfc/rfc7252#section-4.8
   * @{
   */
 

--- a/include/coap3/pdu.h
+++ b/include/coap3/pdu.h
@@ -86,20 +86,20 @@ typedef enum coap_request_t {
  * The C, U, and N flags indicate the properties
  * Critical, Unsafe, and NoCacheKey, respectively.
  * If U is set, then N has no meaning as per
- * https://tools.ietf.org/html/rfc7252#section-5.10
+ * https://rfc-editor.org/rfc/rfc7252#section-5.10
  * and is set to a -.
  *
  * Separately, R is for the options that can be repeated
  *
  * The least significant byte of the option is set as followed
- * as per https://tools.ietf.org/html/rfc7252#section-5.4.6
+ * as per https://rfc-editor.org/rfc/rfc7252#section-5.4.6
  *
  *   0   1   2   3   4   5   6   7
  * --+---+---+---+---+---+---+---+
  *           | NoCacheKey| U | C |
  * --+---+---+---+---+---+---+---+
  *
- * https://tools.ietf.org/html/rfc8613#section-4 goes on to define E, I and U
+ * https://rfc-editor.org/rfc/rfc8613#section-4 goes on to define E, I and U
  * properties Encrypted and Integrity Protected, Integrity Protected Only, and
  * Unprotected respectively.  Integrity Protected Only is not currently used.
  *

--- a/include/coap3/resource.h
+++ b/include/coap3/resource.h
@@ -55,31 +55,31 @@ typedef void (*coap_method_handler_t)
 /**
  * Observe Notifications will be sent non-confirmable by default. RFC 7641
  * Section 4.5
- * https://tools.ietf.org/html/rfc7641#section-4.5
+ * https://rfc-editor.org/rfc/rfc7641#section-4.5
  * Libcoap will always send every fifth packet as confirmable.
  */
 #define COAP_RESOURCE_FLAGS_NOTIFY_NON  0x0
 
 /**
  * Observe Notifications will be sent confirmable. RFC 7641 Section 4.5
- * https://tools.ietf.org/html/rfc7641#section-4.5
+ * https://rfc-editor.org/rfc/rfc7641#section-4.5
  */
 #define COAP_RESOURCE_FLAGS_NOTIFY_CON  0x2
 
 /**
  * Observe Notifications will always be sent non-confirmable. This is in
  * violation of RFC 7641 Section 4.5
- * https://tools.ietf.org/html/rfc7641#section-4.5
+ * https://rfc-editor.org/rfc/rfc7641#section-4.5
  * but required by the DOTS signal channel protocol which needs to operate in
  * lossy DDoS attack environments.
- * https://tools.ietf.org/html/rfc8782#section-4.4.2.1
+ * https://rfc-editor.org/rfc/rfc8782#section-4.4.2.1
  */
 #define COAP_RESOURCE_FLAGS_NOTIFY_NON_ALWAYS  0x4
 
 /**
  * This resource has support for multicast requests.
- * https://datatracker.ietf.org/doc/html/rfc7252#section-11.3
- * https://datatracker.ietf.org/doc/html/rfc7390#section-2.8
+ * https://rfc-editor.org/rfc/rfc7252#section-11.3
+ * https://rfc-editor.org/rfc/rfc7390#section-2.8
  * https://datatracker.ietf.org/doc/html/draft-ietf-core-groupcomm-bis-06.txt#section-3.6
  * Note: ".well-known/core" always supports multicast.
  * Note: Only tested if coap_mcast_per_resource() has been called.
@@ -90,8 +90,8 @@ typedef void (*coap_method_handler_t)
  * Disable libcoap library from adding in delays to multicast requests before
  * releasing the response back to the client.  It is then the responsibility of
  * the app to delay the responses for multicast requests.
- * https://datatracker.ietf.org/doc/html/rfc7252#section-8.2
- * https://datatracker.ietf.org/doc/html/rfc7390#section-2.8
+ * https://rfc-editor.org/rfc/rfc7252#section-8.2
+ * https://rfc-editor.org/rfc/rfc7390#section-2.8
  * https://datatracker.ietf.org/doc/html/draft-ietf-core-groupcomm-bis-06.txt#section-3.6
  * Note: Only tested if coap_mcast_per_resource() has been called.
  */
@@ -100,7 +100,7 @@ typedef void (*coap_method_handler_t)
 /**
  * Enable libcoap library suppression of 205 multicast responses that are empty
  * (overridden by RFC7969 No-Response option) for multicast requests.
- * https://datatracker.ietf.org/doc/html/rfc7390#section-2.7
+ * https://rfc-editor.org/rfc/rfc7390#section-2.7
  * https://datatracker.ietf.org/doc/html/draft-ietf-core-groupcomm-bis-06.txt#section-3.1.2
  * Note: Only tested if coap_mcast_per_resource() has been called.
  */
@@ -109,7 +109,7 @@ typedef void (*coap_method_handler_t)
 /**
  * Enable libcoap library suppressing 2.xx multicast responses (overridden by
  * RFC7969 No-Response option) for multicast requests.
- * https://datatracker.ietf.org/doc/html/rfc7390#section-2.7
+ * https://rfc-editor.org/rfc/rfc7390#section-2.7
  * https://datatracker.ietf.org/doc/html/draft-ietf-core-groupcomm-bis-06.txt#section-3.1.2
  * Note: Only tested if coap_mcast_per_resource() has been called.
  */
@@ -118,7 +118,7 @@ typedef void (*coap_method_handler_t)
 /**
  * Disable libcoap library suppressing 4.xx multicast responses (overridden by
  * RFC7969 No-Response option) for multicast requests.
- * https://datatracker.ietf.org/doc/html/rfc7390#section-2.7
+ * https://rfc-editor.org/rfc/rfc7390#section-2.7
  * https://datatracker.ietf.org/doc/html/draft-ietf-core-groupcomm-bis-06.txt#section-3.1.2
  * Note: Only tested if coap_mcast_per_resource() has been called.
  */
@@ -127,7 +127,7 @@ typedef void (*coap_method_handler_t)
 /**
  * Disable libcoap library suppressing 5.xx multicast responses (overridden by
  * RFC7969 No-Response option) for multicast requests.
- * https://datatracker.ietf.org/doc/html/rfc7390#section-2.7
+ * https://rfc-editor.org/rfc/rfc7390#section-2.7
  * https://datatracker.ietf.org/doc/html/draft-ietf-core-groupcomm-bis-06.txt#section-3.1.2
  * Note: Only tested if coap_mcast_per_resource() has been called.
  */

--- a/src/block.c
+++ b/src/block.c
@@ -2104,7 +2104,7 @@ coap_block_build_body(coap_binary_t *body_data, size_t length,
   else {
     /*
      * total may be inaccurate as per
-     * https://tools.ietf.org/html/rfc7959#section-4
+     * https://rfc-editor.org/rfc/rfc7959#section-4
      * o In a request carrying a Block1 Option, to indicate the current
      *   estimate the client has of the total size of the resource
      *   representation, measured in bytes ("size indication").

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -24,11 +24,11 @@ is_cache_key(uint16_t option_type, size_t cache_ignore_count,
              const uint16_t *cache_ignore_options) {
   size_t i;
 
-  /* https://tools.ietf.org/html/rfc7252#section-5.4.6 Nocachekey definition */
+  /* https://rfc-editor.org/rfc/rfc7252#section-5.4.6 Nocachekey definition */
   if ((option_type & 0x1e) == 0x1c)
     return 0;
   /*
-   * https://tools.ietf.org/html/rfc7641#section-2 Observe is not a
+   * https://rfc-editor.org/rfc/rfc7641#section-2 Observe is not a
    * part of the cache-key.
    */
   if (option_type == COAP_OPTION_OBSERVE)
@@ -111,7 +111,7 @@ coap_cache_derive_key_w_ignore(const coap_session_t *session,
   }
 
   /* The body of a FETCH payload is part of the cache key,
-   * see https://tools.ietf.org/html/rfc8132#section-2 */
+   * see https://rfc-editor.org/rfc/rfc8132#section-2 */
   if (pdu->code == COAP_REQUEST_CODE_FETCH) {
     size_t len;
     const uint8_t *data;

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -202,8 +202,8 @@ coap_recvc(void *arg, struct udp_pcb *upcb, struct pbuf *p,
 
 error:
   /*
-   * https://tools.ietf.org/html/rfc7252#section-4.2 MUST send RST
-   * https://tools.ietf.org/html/rfc7252#section-4.3 MAY send RST
+   * https://rfc-editor.org/rfc/rfc7252#section-4.2 MUST send RST
+   * https://rfc-editor.org/rfc/rfc7252#section-4.3 MAY send RST
    */
   if (session)
     coap_send_rst(session, pdu);
@@ -290,8 +290,8 @@ coap_recvs(void *arg, struct udp_pcb *upcb, struct pbuf *p,
 
 error:
   /*
-   * https://tools.ietf.org/html/rfc7252#section-4.2 MUST send RST
-   * https://tools.ietf.org/html/rfc7252#section-4.3 MAY send RST
+   * https://rfc-editor.org/rfc/rfc7252#section-4.2 MUST send RST
+   * https://rfc-editor.org/rfc/rfc7252#section-4.3 MAY send RST
    */
   if (session)
     coap_send_rst(session, pdu);

--- a/src/net.c
+++ b/src/net.c
@@ -1127,7 +1127,7 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
 
       if (session->last_token &&
           coap_binary_equal(&token, session->last_token)) {
-        coap_log_debug("Token reused - see https://www.rfc-editor.org/rfc/rfc9175.html#section-4.2\n");
+        coap_log_debug("Token reused - see https://rfc-editor.org/rfc/rfc9175.html#section-4.2\n");
       }
       coap_delete_bin_const(session->last_token);
       session->last_token = coap_new_bin_const(token.s, token.length);
@@ -1237,7 +1237,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
   if (pdu->code == COAP_RESPONSE_CODE(508)) {
     /*
      * Need to prepend our IP identifier to the data as per
-     * https://www.rfc-editor.org/rfc/rfc8768.html#section-4
+     * https://rfc-editor.org/rfc/rfc8768.html#section-4
      */
     char addr_str[INET6_ADDRSTRLEN + 8 + 1];
     coap_opt_t *opt;
@@ -1356,7 +1356,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
       /*
        * Need to check that this instance is not sending any block options as
        * the remote end via CSM has not informed us that there is support
-       * https://tools.ietf.org/html/rfc8323#section-5.3.2
+       * https://rfc-editor.org/rfc/rfc8323#section-5.3.2
        * This includes potential BERT blocks.
        */
       if (coap_check_option(pdu, COAP_OPTION_BLOCK1, &opt_iter) != NULL) {
@@ -2047,8 +2047,8 @@ coap_handle_dgram(coap_context_t *ctx, coap_session_t *session,
 
 error:
   /*
-   * https://tools.ietf.org/html/rfc7252#section-4.2 MUST send RST
-   * https://tools.ietf.org/html/rfc7252#section-4.3 MAY send RST
+   * https://rfc-editor.org/rfc/rfc7252#section-4.2 MUST send RST
+   * https://rfc-editor.org/rfc/rfc7252#section-4.3 MAY send RST
    */
   coap_send_rst(session, pdu);
   coap_delete_pdu(pdu);
@@ -2197,7 +2197,7 @@ coap_new_error_response(const coap_pdu_t *request, coap_pdu_code_t code,
     /*
      * Need space for IP for 5.08 response which is filled in in
      * coap_send_internal()
-     * https://www.rfc-editor.org/rfc/rfc8768.html#section-4
+     * https://rfc-editor.org/rfc/rfc8768.html#section-4
      */
     phrase = NULL;
     size += INET6_ADDRSTRLEN;

--- a/src/resource.c
+++ b/src/resource.c
@@ -730,7 +730,7 @@ coap_add_observer(coap_resource_t *resource,
   coap_cache_key_t *cache_key = NULL;
   size_t len;
   const uint8_t *data;
-/* https://tools.ietf.org/html/rfc7641#section-3.6 */
+/* https://rfc-editor.org/rfc/rfc7641#section-3.6 */
 static const uint16_t cache_ignore_options[] = { COAP_OPTION_ETAG };
 
   assert( session );


### PR DESCRIPTION
Use https://rfc-editor.org/rfc/rfc.... instead of
https://tools.ietf.org/html/rfc.... for the RFC links.

Use https://rfc-editor.org/rfc/rfc.... instead of
https://datatracker.ietf.org/doc/html/rfc.... for the RFC links.