### PR TITLE
coap-client.c: Fix case when no host is specified in the URI

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -1746,7 +1746,7 @@ main(int argc, char **argv) {
 
   /* construct CoAP message */
 
-  if (!uri_host_option && (!proxy.host.length && addrptr
+  if (!uri_host_option && (!proxy.host.length && uri.host.length && addrptr
       && (inet_ntop(dst.addr.sa.sa_family, addrptr, addr, sizeof(addr)) != 0)
       && (strlen(addr) != uri.host.length
       || memcmp(addr, uri.host.s, uri.host.length) != 0)


### PR DESCRIPTION
If the host has not been specified in the URI, do not add in an empty Uri-Host option as that is illegal.