### PR TITLE
resource.c: Add COAP_RESOURCE_MAX_SUBSCRIBER to limit subscribers

### DIFF
--- a/include/coap3/coap_resource_internal.h
+++ b/include/coap3/coap_resource_internal.h
@@ -29,6 +29,14 @@
  */
 
 /**
+ * Limits the number of subscribers for each resource that this server support.
+ * Zero means there is no maximum.
+ */
+#ifndef COAP_RESOURCE_MAX_SUBSCRIBER
+#define COAP_RESOURCE_MAX_SUBSCRIBER 0
+#endif /* COAP_RESOURCE_MAX_SUBSCRIBER */
+
+/**
 * Abstraction of attribute associated with a resource.
 */
 struct coap_attr_t {

--- a/src/resource.c
+++ b/src/resource.c
@@ -763,6 +763,15 @@ static const uint16_t cache_ignore_options[] = { COAP_OPTION_ETAG };
     return s;
   }
 
+  /* Check if there is already maximum number of subscribers present */
+#if (COAP_RESOURCE_MAX_SUBSCRIBER > 0)
+  uint32_t subscriber_count = 0;
+  LL_COUNT(resource->subscribers, s, subscriber_count);
+  if (subscriber_count >= COAP_RESOURCE_MAX_SUBSCRIBER) {
+    return NULL; /* Signal error */
+  }
+#endif /* COAP_RESOURCE_MAX_SUBSCRIBER */
+
   /* Create a new subscription */
   s = coap_malloc_type(COAP_SUBSCRIPTION, sizeof(coap_subscription_t));
 


### PR DESCRIPTION
    resource.c: Add COAP_RESOURCE_MAX_SUBSCRIBER to limit subscribers
    
    If COAP_RESOURCE_MAX_SUBSCRIBER is > 0
    coap_add_observer() now checks and returns NULL
    if COAP_RESOURCE_MAX_SUBSCRIBER is exceeded.
    
    net.c then detects this and respond.
    
    Per RFC7641 4.1. Request:
    
      A server that is unable or unwilling to add a new entry to the list
      of observers of a resource MAY silently ignore the registration
      request and process the GET request as usual.  The resulting response
      MUST NOT include an Observe Option, the absence of which signals to
      the client that it will not be notified of changes to the resource
      and, e.g., needs to poll the resource for its state instead.
    
    Useful for constrained systems that wants to support
    observers but need to be mindful of memory usage.
