### PR TITLE
documentation: Tidy up man pages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -984,6 +984,7 @@ examples/lwip/config/coap_config.h
 include/coap$LIBCOAP_API_VERSION/coap.h
 include/coap$LIBCOAP_API_VERSION/coap.h.windows
 man/coap.txt
+man/coap_address.txt
 man/coap_async.txt
 man/coap_attribute.txt
 man/coap_block.txt

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -18,8 +18,9 @@ if BUILD_MANPAGES
 
 # building the manpages
 
-TXT3 = coap_async.txt \
-        coap_attribute.txt \
+TXT3 = coap_address.txt \
+	coap_async.txt \
+	coap_attribute.txt \
 	coap_block.txt \
 	coap_cache.txt \
 	coap_context.txt \

--- a/man/coap-rd.txt.in
+++ b/man/coap-rd.txt.in
@@ -15,7 +15,7 @@ coap-rd-gnutls ,
 coap-rd-mbedtls,
 coap-rd-openssl,
 coap-rd-notls
-- A CoAP Resource Directory based on libcoap
+- CoAP Resource Directory based on libcoap
 
 SYNOPSIS
 --------

--- a/man/coap.txt.in
+++ b/man/coap.txt.in
@@ -38,6 +38,7 @@ examples directory.
 
 SEE ALSO
 --------
+*coap_address*(3),
 *coap_async*(3), *coap_attribute*(3), *coap_block*(3), *coap_cache*(3),
 *coap_context*(3), *coap_encryption*(3), *coap_endpoint_client*(3),
 *coap_endpoint_server*(3), *coap_handler*(3), *coap_io*(3),

--- a/man/coap_address.txt.in
+++ b/man/coap_address.txt.in
@@ -1,0 +1,96 @@
+// -*- mode:doc; -*-
+// vim: set syntax=asciidoc tw=0
+
+coap_address(3)
+===============
+:doctype: manpage
+:man source:   coap_address
+:man version:  @PACKAGE_VERSION@
+:man manual:   libcoap Manual
+
+NAME
+----
+coap_address,
+coap_address_t,
+- Work with CoAP Socket Address Types
+
+SYNOPSIS
+--------
+*#include <coap@LIBCOAP_API_VERSION@/coap.h>*
+
+*struct coap_address_t;*
+
+*struct coap_sockaddr_un;*
+
+*void coap_address_init(coap_address_t *_addr_);*
+
+For specific (D)TLS library support, link with
+*-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
+*-lcoap-@LIBCOAP_API_VERSION@* to get the default (D)TLS library support.
+
+DESCRIPTION
+-----------
+This man page focuses on setting up CoAP endpoint address definitions.
+
+*Supported Socket Types*
+
+Libcoap supports 2 different socket types that can be used:
+
+[source, c]
+----
+AF_INET  IPv4 IP addresses and ports
+AF_INET6 IPv6 IP addresses and ports and can be dual IPv4/IPv6 stacked
+----
+
+which are all handled by the *coap_address_t* structure.
+
+*Structure coap_address_t*
+
+[source, c]
+----
+ /** multi-purpose address abstraction */
+typedef struct coap_address_t {
+  socklen_t size;           /* size of addr */
+  union {
+    struct sockaddr         sa;
+    struct sockaddr_in      sin;
+    struct sockaddr_in6     sin6;
+  } addr;
+} coap_address_t;
+----
+
+FUNCTIONS
+---------
+
+*Function: coap_address_init()*
+
+The *coap_address_init*() function initializes _addr_ for later use.  In
+particular it sets the _size_ variable and sets all other values to be 0.
+
+It is then the responsibility of the application to set the address family
+in addr.sa.sa_family and then fill in the the appropriate union structure
+based on the address family before the coap_address_t _addr_ is used.
+
+SEE ALSO
+--------
+*coap_endpoint_client*(3) and *coap_endpoint_server*(3)
+
+FURTHER INFORMATION
+-------------------
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
+
+BUGS
+----
+Please report bugs on the mailing list for libcoap:
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
+
+AUTHORS
+-------
+The libcoap project <libcoap-developers@lists.sourceforge.net>

--- a/man/coap_endpoint_client.txt.in
+++ b/man/coap_endpoint_client.txt.in
@@ -47,44 +47,46 @@ or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
 DESCRIPTION
 -----------
 This man page focuses on the setting up of a CoAP client endpoint and hence
-creation of a CoAP Session used to connect to a server.  For a CoAP server
+creation of a CoAP _session_ used to connect to a server.  For a CoAP server
 endpoint, see *coap_endpoint_server*(3). There is no need to call
 *coap_new_endpoint*(3) for a client as well as one of the
 *coap_new_client_server**() functions.
 
-The CoAP stack's global state is stored in a coap_context_t Context object.
-Resources, Endpoints and Sessions are associated with this context object.
+The CoAP stack's global state is stored in a coap_context_t _context_ object.
+Resources, Endpoints and Sessions are associated with this _context_ object.
 There can be more than one coap_context_t object per application, it is up to
 the application to manage each one accordingly.
 
-A CoAP Ssssion maintains the state of an ongoing connection between a Client
-and Server which is stored in a coap_session_t Session object. A CoAP session
-is tracked by local port, CoAP protocol, remote IP address and remote port.
+A CoAP _session_ maintains the state of an ongoing connection between a Client
+and Server which is stored in a coap_session_t _session_ object. A CoAP
+_session_ is tracked by local port, CoAP protocol, remote IP address and
+remote port.
 
-The Session network traffic can be encrypted or un-encrypted if there is an
+The _session_ network traffic can be encrypted or un-encrypted if there is an
 underlying TLS library.
 
-If TLS is going to be used for encrypting the network traffic, then the TLS
+If (D)TLS is going to be used for encrypting the network traffic, then the
+(D)TLS
 information for Pre-Shared Keys (PSK) or Public Key Infrastructure (PKI) needs
-to be configured before any network traffic starts to flow. For Servers, this
-has to be done before the Endpoint is created, for Clients, this is done
-during the Client Endpoint/Session set up.
+to be configured before any network traffic starts to flow. For Clients, this
+is done during the Client _session_ set up.
 
-For Clients, all the encryption information can be held at the TLS Context and
-CoAP Context levels, or at the TLS Session and CoAP Session levels.  If
-defined at the Context level, then when Sessions are created, they will
-inherit the Context definitions, unless they have separately been defined for
-the Session level, in which case the Session version will get used.
-Typically the information will be configured at the Session level for Clients.
+For Clients, all the encryption information can be held at the (D)TLS
+context and CoAP _context_ levels, or at the (D)TLS session and CoAP
+_session_ levels.  If defined at the _context_ level, then when a _session_ is
+created, it will inherit the _context_ definitions, unless they have separately
+been defined for the _session_ level, in which case the _session_ version will
+get used.  Typically the information will be configured at the _session_ level
+for Clients.
 
 In principle the set-up sequence for CoAP client endpoints looks like
 ----
 coap_new_context()
-coap_context_set_pki_root_cas() if the root CAs need to be updated and PKI
+coap_context_set_pki_root_cas() - if the root CAs need to be updated and using PKI
 coap_new_client_session(), coap_new_client_session_pki() or coap_new_client_session_psk2()
 ----
 
-Multiple client endpoints and hence sessions are supported per Context.
+Multiple client endpoints and hence sessions are supported per _context_.
 
 Different CoAP protocols can be defined for _proto_ - the current supported
 list is:
@@ -97,10 +99,25 @@ COAP_PROTO_TCP
 COAP_PROTO_TLS
 ----
 
-*coap_tcp_is_supported*(), *coap_dtls_is_supported*() and
-*coap_tls_is_supported*() can be used for checking whether the underlying
+*coap_tcp_is_supported*(3), *coap_dtls_is_supported*(3) and
+*coap_tls_is_supported*(3) can be used for checking whether the underlying
 TCP or (D)TLS protocol support is available.  See *coap_tls_library(3)* for
 further information.
+
+Libcoap supports 2 different socket types:
+
+[source, c]
+----
+AF_INET  IPv4 IP addresses and ports
+AF_INET6 IPv6 IP addresses and ports and can be dual IPv4/IPv6 stacked
+----
+
+For AF_INET and AF_INET6, the client does not need to specify a local IP
+address and/or port as default values will get filled in.
+
+The client must specify IP and port when defining the *coap_address_t* (see
+*coap_address_t*(3)) for the remote end of the session for AF_INET or AF_INET6.
+If port is 0, then the default CoAP port is used instead.
 
 FUNCTIONS
 ---------
@@ -108,40 +125,57 @@ FUNCTIONS
 *Function: coap_new_client_session()*
 
 The *coap_new_client_session*() function creates a client endpoint for a
-specific _context_ and initiates a new client session to the specified _server_
-using the CoAP protocol
-_proto_.  If the port is set to 0 in _server_, then the default CoAP
-port is used.  Normally _local_if_ would be set to NULL, but by specifying
+specific _context_ and initiates a new client session to the specified
+_server_ using the CoAP protocol _proto_ as defined above. If the port is set
+to 0 in _server_ (for AF_INET or AF_INET6), then the default CoAP port is used.
+
+Normally _local_if_ would be set to NULL, but by specifying
 _local_if_ the source of the network session can be bound to a specific IP
-address or port.  The session will initially have a reference count of 1.
+address or port. If _local_if_ is defined, the address families for _local_if_
+and _server_ must be identical. The session will initially have a reference
+count of 1.
+
+To stop using a client session, the reference count must be decremented to 0
+by calling *coap_session_release*(3). See *coap_session*(3). This will remove
+the client endpoint's _session_ and all its associated information.
 
 *Function: coap_new_client_session_pki()*
 
 The *coap_new_client_session_pki*() function, for a specific _context_, is
-used to configure the TLS context using the _setup_data_ variables as defined
+used to configure the (D)TLS context using the _setup_data_ variables as defined
 in the coap_dtls_pki_t structure in the newly created endpoint session -
 see *coap_encryption*(3). The connection is to the specified _server_ using
-the CoAP protocol _proto_.  If the port is set to 0 in _server_, then the
-default CoAP port is used.  Normally _local_if_ would be set to NULL, but by
-specifying _local_if_ the source of the network session can be bound to a
-specific IP address or port. The session will initially have a reference count
-of 1.
+the CoAP protocol _proto_ as defined above.  If the port is set to 0 in
+_server_ (for AF_INET or AF_INET6), then the default CoAP port is used.
+
+Normally _local_if_ would be set to NULL, but by specifying
+_local_if_ the source of the network session can be bound to a specific IP
+address or port. If _local_if_ is defined, the address families for _local_if_
+and _server_ must be identical. The session will initially have a reference
+count of 1.
+
+To stop using a client session, the reference count must be decremented to 0
+by calling *coap_session_release*(3). See *coap_session*(3). This will remove
+the client endpoint's _session_ and all its associated information.
 
 *Function: coap_new_client_session_psk2()*
 
 The *coap_new_client_session_psk2*() function, for a specific _context_, is
-used to configure the TLS context using the _setup_data_ variables as defined
+used to configure the (D)TLS context using the _setup_data_ variables as defined
 in the coap_dtls_cpsk_t structure in the newly created endpoint session -
 see *coap_encryption*(3). The connection is to the specified _server_ using
-the CoAP protocol _proto_.  If the port is set to 0 in _server_, then the
-default CoAP port is used.  Normally _local_if_ would be set to NULL, but by
-specifying _local_if_ the source of the network session can be bound to a
-specific IP address or port. The session will initially have a reference count
-of 1.
+the CoAP protocol _proto_ as defined above.  If the port is set to 0 in
+_server_ (for AF_INET or AF_INET6), then the default CoAP port is used.
+
+Normally _local_if_ would be set to NULL, but by specifying
+_local_if_ the source of the network session can be bound to a specific IP
+address or port. If _local_if_ is defined, the address families for _local_if_
+and _server_ must be identical. The session will initially have a reference
+count of 1.
 
 To stop using a client session, the reference count must be decremented to 0
-by calling *coap_session_release*(). See *coap_session*(3). This will remove
-the client endpoint.
+by calling *coap_session_release*(3). See *coap_session*(3). This will remove
+the client endpoint's _session_ and all its associated information.
 
 *Function: coap_session_set_mtu()*
 
@@ -186,6 +220,7 @@ setup_client_session (struct in_addr ip_address) {
                               COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
 
 
+  /* See coap_address(3) */
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
   server.addr.sin.sin_addr = ip_address;
@@ -252,6 +287,7 @@ setup_client_session_pki (struct in_addr ip_address,
                               COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
 
 
+  /* See coap_address(3) */
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
   server.addr.sin.sin_addr = ip_address;
@@ -345,6 +381,7 @@ setup_client_session_psk (const char *uri,
                               COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
 
 
+  /* See coap_address(3) */
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
   server.addr.sin.sin_addr = ip_address;
@@ -396,6 +433,7 @@ setup_client_session_dtls (struct in_addr ip_address) {
                               COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
 
 
+  /* See coap_address(3) */
   coap_address_init(&server);
   server.addr.sa.sa_family = AF_INET;
   server.addr.sin.sin_addr = ip_address;
@@ -414,7 +452,7 @@ setup_client_session_dtls (struct in_addr ip_address) {
 
 SEE ALSO
 --------
-*coap_block*(3), *coap_context*(3), *coap_encryption*(3),
+*coap_address*(3), *coap_block*(3), *coap_context*(3), *coap_encryption*(3),
 *coap_endpoint_server*(3), *coap_resource*(3), *coap_session*(3) and
 *coap_tls_library*(3)
 
@@ -423,6 +461,8 @@ FURTHER INFORMATION
 See
 
 "https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+"https://rfc-editor.org/rfc/rfc8323[RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets]"
 
 for further information.
 

--- a/man/coap_endpoint_server.txt.in
+++ b/man/coap_endpoint_server.txt.in
@@ -58,42 +58,43 @@ DESCRIPTION
 This man page focuses on the setting up of a CoAP server endpoint. For a CoAP
 client endpoint, see *coap_endpoint_client*(3).
 
-The CoAP stack's global state is stored in a coap_context_t Context object.
-Resources, Endpoints and Sessions are associated with this context object.
+The CoAP stack's global state is stored in a coap_context_t _context_ object.
+Resources, Endpoints and Sessions are associated with this _context_ object.
 There can be more than one coap_context_t object per application, it is up to
 the application to manage each one accordingly.
 
-A CoAP Session maintains the state of an ongoing connection between a Client
-and Server which is stored in a coap_session_t Session object. A CoAP session
-is tracked by local port, CoAP protocol, remote IP address and remote port.
+A CoAP _session_ maintains the state of an ongoing connection between a Client
+and Server which is stored in a coap_session_t _session_ object. A CoAP
+_session_ is tracked by local port, CoAP protocol, remote IP address and
+remote port.
 
-The Session network traffic can be encrypted or un-encrypted if there is an
+The _session_ network traffic can be encrypted or un-encrypted if there is an
 underlying TLS library.
 
-If TLS is going to be used for encrypting the network traffic, then the TLS
+If (D)TLS is going to be used for encrypting the network traffic, then the
+(D)TLS
 information for Pre-Shared Keys (PSK) or Public Key Infrastructure (PKI) needs
 to be configured before any network traffic starts to flow. For Servers, this
-has to be done before the Endpoint is created, for Clients, this is done
-during the Client Session set up.
+has to be done before the Endpoint is created.
 
-For Servers, all the encryption information is held internally by the TLS
-Context level and the CoAP Context level as the Server is listening for new
-incoming traffic based on the Endpoint definition.  The TLS and CoAP session
-will not get built until the new traffic starts, which is done by the libcoap
-library.
+For Servers, all the encryption information is held internally by the (D)TLS
+context level and the CoAP _context_ level as the Server is listening for new
+incoming traffic based on the Endpoint definition.  The (D)TLS and CoAP
+_session_ will not get built until the new traffic starts, which is done by the
+libcoap library.
 
 In principle the set-up sequence for CoAP Servers looks like
 ----
 coap_new_context()
-coap_context_set_pki_root_cas() - if the root CAs need to be updated and PKI
+coap_context_set_pki_root_cas() - if the root CAs need to be updated and using PKI
 coap_context_set_pki() and/or coap_context_set_psk2() - if encryption is required
 coap_new_endpoint()
 ----
 
-Multiple endpoints can be set up per Context, each listening for a new traffic
-flow with different TCP/UDP protocols, TLS protocols, port numbers etc. When a
-new traffic flow is started, then the CoAP library will create and start a new
-server session.
+Multiple endpoints can be set up per _context_, each listening for a new traffic
+flow with different TCP/UDP protocols, (D)TLS protocols, port numbers etc. When
+a new traffic flow is started, then the CoAP library will create and start a new
+server _session_.
 
 FUNCTIONS
 ---------
@@ -101,7 +102,7 @@ FUNCTIONS
 *Function: coap_context_set_pki()*
 
 The *coap_context_set_pki*() function, for a specific _context_, is used to
-configure the TLS context using the _setup_data_ PKI variables as defined in
+configure the (D)TLS context using the _setup_data_ PKI variables as defined in
 the coap_dtls_pki_t structure  - see *coap_encryption*(3).
 
 *Function: coap_context_set_pki_root_cas()*
@@ -109,18 +110,18 @@ the coap_dtls_pki_t structure  - see *coap_encryption*(3).
 The *coap_context_set_pki_root_cas*() function is used to define a set of
 root CAs to be used instead of the default set of root CAs provided as a part
 of the TLS library.  _ca_file_ points to a PEM encoded file containing the
-list of CAs.  _ca_file can be NULL.  _ca_dir_ points to a directory
+list of CAs.  _ca_file_ can be NULL.  _ca_dir_ points to a directory
 containing a set of PEM encoded files containing rootCAs.  _ca_dir_ can be
 NULL. One or both of _ca_file_ and _ca_dir_ must be set. +
 *NOTE:* Some TLS libraries send the full list of CAs added by this function
 during the (D)TLS session setup handshakes. To stop this, either provide a
 single CA using the _ca_file_ definition in _pki_key_ in _setup_data_ variable
-when calling *coap_context_set_pki*(), or set _check_common_ca to 0 in
+when calling *coap_context_set_pki*(), or set _check_common_ca_ to 0 in
 _setup_data_ variable. See *coap_encryption*(3).
 
 *Function: coap_context_set_psk2()*
 
-The *coap_context_set_psk2*() function is used to configure the TLS context
+The *coap_context_set_psk2*() function is used to configure the (D)TLS context
 using the _setup_data_ PSK variables as defined in the
 coap_dtls_spsk_t structure  - see *coap_encryption*(3).
 This function can only be used for servers as _setup_data_ provides
@@ -129,8 +130,11 @@ a _hint_, not an _identity_.
 *Function: coap_new_endpoint()*
 
 The *coap_new_endpoint*() function creates a new endpoint for _context_ that
-is listening for new traffic on the IP address and port number defined by
-_listen_addr_. If the port number is 0, then the default CoAP port is used.
+is listening for new traffic as defined in _listen_addr_
+(see *coap_address_t*(3)). If the address family is AF_INET or AF_INET6, then it
+listens on the IP address and port number defined by _listen_addr_. If the
+port number is 0, then the default CoAP port is used.
+
 Different CoAP protocols can be defined for _proto_ - the current supported
 list is:
 
@@ -142,13 +146,13 @@ COAP_PROTO_TCP
 COAP_PROTO_TLS
 ----
 
-*coap_tcp_is_supported*(), *coap_dtls_is_supported*() and
-*coap_tls_is_supported*() can be used for checking whether the underlying
+*coap_tcp_is_supported*(3), *coap_dtls_is_supported*(3) and
+*coap_tls_is_supported*(3) can be used for checking whether the underlying
 TCP or (D)TLS protocol support is available.  See *coap_tls_library*(3) for
 further information.
 
-When traffic starts to come in from a client, a server CoAP Session is created
-associated with this endpoint. This CoAP Session is created with a reference
+When traffic starts to come in from a client, a server CoAP session is created
+associated with this endpoint. This CoAP session is created with a reference
 count of 0. This means that if the server session is not used for 5 minutes,
 then it will get completely freed off.  See *coap_session_reference*(3) and
 *coap_session_release*(3) for further information.
@@ -214,6 +218,7 @@ setup_server_context (void) {
                               COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
 
 
+  /* See coap_address(3) */
   coap_address_init(&listen_addr);
   listen_addr.addr.sa.sa_family = AF_INET;
   listen_addr.addr.sin.sin_port = htons (5683);
@@ -358,6 +363,7 @@ setup_server_context_pki (const char *public_cert_file,
     return NULL;
   }
 
+  /* See coap_address(3) */
   coap_address_init(&listen_addr);
   listen_addr.addr.sa.sa_family = AF_INET;
   listen_addr.addr.sin.sin_port = htons (5684);
@@ -485,6 +491,7 @@ setup_server_context_psk (const char *hint,
     return NULL;
   }
 
+  /* See coap_address(3) */
   coap_address_init(&listen_addr);
   listen_addr.addr.sa.sa_family = AF_INET;
   listen_addr.addr.sin.sin_port = htons (5684);
@@ -501,90 +508,9 @@ setup_server_context_psk (const char *hint,
 }
 ----
 
-*CoAP Client DTLS PSK Setup*
-[source, c]
-----
-#include <coap@LIBCOAP_API_VERSION@/coap.h>
-
-#include <stdio.h>
-
-#ifndef min
-#define min(a,b) ((a) < (b) ? (a) : (b))
-#endif
-
-static const coap_dtls_cpsk_info_t *
-verify_ih_callback(coap_str_const_t *hint,
-                   coap_session_t *c_session,
-                   void *arg
-) {
-  coap_dtls_cpsk_info_t *psk_info = (coap_dtls_cpsk_info_t *)arg;
-  char lhint[COAP_DTLS_HINT_LENGTH];
-  /* Remove (void) definition if variable is used */
-  (void)c_session;
-
-  snprintf(lhint, sizeof(lhint), "%.*s", (int)hint->length, hint->s);
-  coap_log_info("Identity Hint '%s' provided\n", lhint);
-
-  /* Just use the defined information for now as passed in by arg */
-  return psk_info;
-}
-
-static coap_dtls_cpsk_t dtls_psk;
-static char client_sni[256];
-
-static coap_session_t *
-setup_client_session_psk (const char *uri,
-                          struct in_addr ip_address,
-                          const uint8_t *identity,
-                          unsigned int identity_len,
-                          const uint8_t *key,
-                          unsigned int key_len
-) {
-  coap_session_t *session;
-  coap_address_t server;
-  coap_context_t *context = coap_new_context(NULL);
-
-  if (!context)
-    return NULL;
-  /* See coap_block(3) */
-  coap_context_set_block_mode(context,
-                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
-
-
-  coap_address_init(&server);
-  server.addr.sa.sa_family = AF_INET;
-  server.addr.sin.sin_addr = ip_address;
-  server.addr.sin.sin_port = htons (5684);
-
-  /* See coap_encryption(3) */
-  memset (&dtls_psk, 0, sizeof(dtls_psk));
-  dtls_psk.version = COAP_DTLS_CPSK_SETUP_VERSION;
-  dtls_psk.validate_ih_call_back = verify_ih_callback;
-  dtls_psk.ih_call_back_arg = &dtls_psk.psk_info;
-  if (uri)
-    memcpy(client_sni, uri, min(strlen(uri), sizeof(client_sni)-1));
-  else
-    memcpy(client_sni, "localhost", 9);
-  dtls_psk.client_sni = client_sni;
-  dtls_psk.psk_info.identity.s = identity;
-  dtls_psk.psk_info.identity.length = identity_len;
-  dtls_psk.psk_info.key.s = key;
-  dtls_psk.psk_info.key.length = key_len;
-  session = coap_new_client_session_psk2(context, NULL, &server,
-                                        COAP_PROTO_DTLS, &dtls_psk);
-  if (!session) {
-    coap_free_context(context);
-    return NULL;
-  }
-  /* The context is in session->context */
-  return session;
-}
-
-----
-
 SEE ALSO
 --------
-*coap_block*(3), *coap_context*(3), *coap_encryption*(3),
+*coap_address*(3), *coap_block*(3), *coap_context*(3), *coap_encryption*(3),
 *coap_endpoint_client*(3), *coap_resource*(3), *coap_session*(3) and
 *coap_tls_library*(3)
 
@@ -593,6 +519,8 @@ FURTHER INFORMATION
 See
 
 "https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+"https://rfc-editor.org/rfc/rfc8323[RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets]"
 
 for further information.
 

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -15,7 +15,7 @@ coap_resource_set_get_observable,
 coap_resource_notify_observers,
 coap_cancel_observe,
 coap_session_set_no_observe_cancel
-- work with CoAP observe
+- Work with CoAP observe
 
 SYNOPSIS
 --------

--- a/man/coap_oscore.txt.in
+++ b/man/coap_oscore.txt.in
@@ -19,8 +19,8 @@ coap_delete_oscore_recipient,
 coap_new_client_session_oscore,
 coap_new_client_session_oscore_pki,
 coap_new_client_session_oscore_psk,
-coap_context_oscore_server,
-- Configuring and using OSCORE
+coap_context_oscore_server
+- Work with CoAP OSCORE
 
 SYNOPSIS
 --------

--- a/man/coap_uri.txt.in
+++ b/man/coap_uri.txt.in
@@ -54,7 +54,7 @@ A CoAP URI is of the form
 
 <scheme><host><(optional):port><(optional)path><(optional)?query>
 
-where scheme can be one of coap://, coaps://, coap+tcp:// and coaps+tcp://.
+where _scheme_ can be one of coap://, coaps://, coap+tcp:// and coaps+tcp://.
 
 The parsed uri structure is of the form
 


### PR DESCRIPTION
Add in new coap_address(3) man page.
Tidy up endpoint documentation.
Fix other minor nits in the documentation.