### PR TITLE
coap_address.[ch]: Add coap_resolve_address_info() and coap_free_address_info()

### DIFF
--- a/coap_config.h.contiki
+++ b/coap_config.h.contiki
@@ -131,6 +131,7 @@
 #define HAVE_STRNLEN 1
 #define HAVE_SNPRINTF 1
 #define HAVE_STRINGS_H 1
+#define HAVE_NETDB_H 1
 
 /* there is no file-oriented output */
 #define COAP_DEBUG_FD NULL

--- a/examples/lwip/config/coap_config.h
+++ b/examples/lwip/config/coap_config.h
@@ -39,6 +39,8 @@
 
 #define HAVE_LIMITS_H
 
+#define HAVE_NETDB_H
+
 #define HAVE_SNPRINTF
 
 #endif /* COAP_CONFIG_H_ */

--- a/examples/lwip/config/coap_config.h.in
+++ b/examples/lwip/config/coap_config.h.in
@@ -39,6 +39,8 @@
 
 #define HAVE_LIMITS_H
 
+#define HAVE_NETDB_H
+
 #define HAVE_SNPRINTF
 
 #endif /* COAP_CONFIG_H_ */

--- a/include/coap3/uri.h
+++ b/include/coap3/uri.h
@@ -38,6 +38,18 @@ typedef enum coap_uri_scheme_t {
 /** This mask can be used to check if a parsed URI scheme is secure. */
 #define COAP_URI_SCHEME_SECURE_MASK 0x01
 
+#define COAP_URI_SCHEME_COAP_BIT       (1 << COAP_URI_SCHEME_COAP)
+#define COAP_URI_SCHEME_COAPS_BIT      (1 << COAP_URI_SCHEME_COAPS)
+#define COAP_URI_SCHEME_COAP_TCP_BIT   (1 << COAP_URI_SCHEME_COAP_TCP)
+#define COAP_URI_SCHEME_COAPS_TCP_BIT  (1 << COAP_URI_SCHEME_COAPS_TCP)
+#define COAP_URI_SCHEME_HTTP_BIT       (1 << COAP_URI_SCHEME_HTTP)
+#define COAP_URI_SCHEME_HTTPS_BIT      (1 << COAP_URI_SCHEME_HTTPS)
+
+#define COAP_URI_SCHEME_ALL_COAP_BITS (COAP_URI_SCHEME_COAP_BIT | \
+                                       COAP_URI_SCHEME_COAPS_BIT | \
+                                       COAP_URI_SCHEME_COAP_TCP_BIT | \
+                                       COAP_URI_SCHEME_COAPS_TCP_BIT)
+
 /**
  * Representation of parsed URI. Components may be filled from a string with
  * coap_split_uri() or coap_split_proxy_uri() and can be used as input for

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -87,6 +87,7 @@ global:
   coap_find_attr;
   coap_fls;
   coap_flsll;
+  coap_free_address_info;
   coap_free_async;
   coap_free_context;
   coap_free_endpoint;
@@ -182,6 +183,7 @@ global:
   coap_register_request_handler;
   coap_register_response_handler;
   coap_resize_binary;
+  coap_resolve_address_info;
   coap_resource_get_uri_path;
   coap_resource_get_userdata;
   coap_resource_init;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -85,6 +85,7 @@ coap_find_async
 coap_find_attr
 coap_fls
 coap_flsll
+coap_free_address_info
 coap_free_async
 coap_free_context
 coap_free_endpoint
@@ -180,6 +181,7 @@ coap_register_pong_handler
 coap_register_request_handler
 coap_register_response_handler
 coap_resize_binary
+coap_resolve_address_info
 coap_resource_get_uri_path
 coap_resource_get_userdata
 coap_resource_init

--- a/man/coap_address.txt.in
+++ b/man/coap_address.txt.in
@@ -11,7 +11,7 @@ coap_address(3)
 NAME
 ----
 coap_address,
-coap_address_t,
+coap_address_t
 - Work with CoAP Socket Address Types
 
 SYNOPSIS
@@ -23,6 +23,12 @@ SYNOPSIS
 *struct coap_sockaddr_un;*
 
 *void coap_address_init(coap_address_t *_addr_);*
+
+*coap_addr_info_t *coap_resolve_address_info(const coap_str_const_t *_server_,
+uint16_t _port_, uint16_t _secure_port_, int _ai_hints_flags_,
+int _scheme_hint_bits_);*
+
+*void coap_free_address_info(coap_addr_info_t *_info_list_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -50,7 +56,7 @@ which are all handled by the *coap_address_t* structure.
 
 [source, c]
 ----
- /** multi-purpose address abstraction */
+/* Multi-purpose address abstraction */
 typedef struct coap_address_t {
   socklen_t size;           /* size of addr */
   union {
@@ -59,6 +65,21 @@ typedef struct coap_address_t {
     struct sockaddr_in6     sin6;
   } addr;
 } coap_address_t;
+----
+
+which is used in the *coap_addr_info_t* structure as returned by
+*coap_resolve_address_info()*.
+
+*Structure coap_addr_info_t*
+
+[source, c]
+----
+/* Resolved addresses information */
+typedef struct coap_addr_info_t {
+  struct coap_addr_info_t *next; /* Next entry in the chain */
+  coap_uri_scheme_t scheme;      /* CoAP scheme to use */
+  coap_address_t addr;           /* The address to connect / bind to */
+} coap_addr_info_t;
 ----
 
 FUNCTIONS
@@ -73,9 +94,53 @@ It is then the responsibility of the application to set the address family
 in addr.sa.sa_family and then fill in the the appropriate union structure
 based on the address family before the coap_address_t _addr_ is used.
 
+*Function: coap_resolve_address_info()*
+
+The *coap_resolve_address_info*() function resolves the address _server_ into
+a set of one or more coap_addr_info_t structures. Depending on the scheme as
+abstracted from _scheme_hint_bits_ either _port_ or _secure_port_ is used to
+update the addr variable of coap_addr_info_t. If _port_ (or _secure_port_) is
+0, then the default port for the scheme is used.  _ai_hints_flags_ is used for
+the internally called getaddrinfo(3) function. _scheme_hint_bits_ is a set of
+one or more COAP_URI_SCHEME_*_BIT or'd together.
+
+The returned set of coap_addr_info_t structures must be freed off by the
+caller using *coap_free_address_info*().
+
+*Function: coap_free_address_info()*
+
+The *coap_free_address_info*() function frees off all the _info_list_
+linked entries.
+
+RETURN VALUES
+-------------
+*coap_resolve_address_info*() returns a linked list of addresses that can be
+used for session setup or NULL if there is a failure.
+
+EXAMPLES
+--------
+*Get target address from uri*
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+static int
+get_address(coap_uri_t *uri, coap_address_t *dst) {
+  coap_addr_info_t *info_list;
+
+   info_list = coap_resolve_address_info(&uri->host, uri->port, uri->port, 0,
+                                         1 << uri->scheme);
+   if (info_list == NULL)
+     return 0;
+   memcpy(dst, &info_list->addr, sizeof(*dst));
+   coap_free_address_info(info_list);
+   return 1;
+}
+----
+
 SEE ALSO
 --------
-*coap_endpoint_client*(3) and *coap_endpoint_server*(3)
+*coap_endpoint_client*(3), *coap_endpoint_server*(3) and *coap_uri*(3)
 
 FURTHER INFORMATION
 -------------------


### PR DESCRIPTION
coap_resolve_address_info() emulates getaddrinfo() but has the extensibility to support other socket types based on the address to resolve.

coap-client and coap-server updated to use this new functionality.

coap_address(3) updated to include the new functions.