### PR TITLE
oscore: Handle encrypt error return

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -782,7 +782,7 @@ get_oscore_conf(void) {
   /* Need a rw var to free off later and file_mem.s is a const */
   buf = read_file_mem(oscore_conf_file, &length);
   if (buf == NULL) {
-    fprintf(stderr, "OSCORE configuraton file error: %s\n", oscore_conf_file);
+    fprintf(stderr, "OSCORE configuration file error: %s\n", oscore_conf_file);
     return NULL;
   }
   file_mem.s = buf;
@@ -808,7 +808,7 @@ get_oscore_conf(void) {
                                      NULL, start_seq_num);
   coap_free(buf);
   if (oscore_conf == NULL) {
-    fprintf(stderr, "OSCORE configuraton file error: %s\n", oscore_conf_file);
+    fprintf(stderr, "OSCORE configuration file error: %s\n", oscore_conf_file);
     return NULL;
   }
   return oscore_conf;

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2460,7 +2460,7 @@ get_oscore_conf(coap_context_t *context) {
   /* Need a rw var to free off later and file_mem.s is a const */
   buf = read_file_mem(oscore_conf_file, &length);
   if (buf == NULL) {
-    fprintf(stderr, "OSCORE configuraton file error: %s\n", oscore_conf_file);
+    fprintf(stderr, "OSCORE configuration file error: %s\n", oscore_conf_file);
     return NULL;
   }
   file_mem.s = buf;
@@ -2486,7 +2486,7 @@ get_oscore_conf(coap_context_t *context) {
                                      NULL, start_seq_num);
   coap_free(buf);
   if (oscore_conf == NULL) {
-    fprintf(stderr, "OSCORE configuraton file error: %s\n", oscore_conf_file);
+    fprintf(stderr, "OSCORE configuration file error: %s\n", oscore_conf_file);
     return NULL;
   }
   coap_context_oscore_server(context, oscore_conf);

--- a/examples/oscore-interop-server.c
+++ b/examples/oscore-interop-server.c
@@ -512,7 +512,7 @@ get_oscore_conf(coap_context_t *context) {
 
   buf = read_file_mem(oscore_conf_file, &length);
   if (buf == NULL) {
-    fprintf(stderr, "OSCORE configuraton file error: %s\n", oscore_conf_file);
+    fprintf(stderr, "OSCORE configuration file error: %s\n", oscore_conf_file);
     return NULL;
   }
   file_mem.s = buf;
@@ -538,7 +538,7 @@ get_oscore_conf(coap_context_t *context) {
                                      NULL, start_seq_num);
   coap_free(buf);
   if (oscore_conf == NULL) {
-    fprintf(stderr, "OSCORE configuraton file error: %s\n", oscore_conf_file);
+    fprintf(stderr, "OSCORE configuration file error: %s\n", oscore_conf_file);
     return NULL;
   }
   coap_context_oscore_server(context, oscore_conf);

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -591,6 +591,12 @@ coap_oscore_new_pdu_encrypted(coap_session_t *session,
   ciphertext_len = cose_encrypt0_encrypt(cose,
                                          ciphertext_buffer,
                                          plain_pdu->used_size + AES_CCM_TAG);
+  if ((int)ciphertext_len <= 0) {
+    coap_log_warn(
+             "OSCORE: Encryption Failure, result code: %d \n",
+             (int)ciphertext_len);
+    goto error;
+  }
   assert(ciphertext_len < OSCORE_CRYPTO_BUFFER_SIZE);
 
   /* Add in OSCORE option (previously computed) */


### PR DESCRIPTION
Check return from cose_encrypt0_encrypt() and correct spelling error.