### PR TITLE
debug.c: define _GNU_SOURCE before including any header

### DIFF
--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -13,11 +13,11 @@
  * @brief Debug utilities
  */
 
-#include "coap3/coap_internal.h"
-
-#if defined(HAVE_STRNLEN) && defined(__GNUC__) && !defined(_GNU_SOURCE)
-#define _GNU_SOURCE 1
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
 #endif
+
+#include "coap3/coap_internal.h"
 
 #include <stdarg.h>
 #include <stdio.h>


### PR DESCRIPTION
This is a fragment of feature_test_macros(7) man pages:

>  NOTE: In order to be effective, a feature test macro must be defined
>  before including any header files. This can be done either in the com‐
>  pilation command (cc -DMACRO=value) or by defining the macro within the
>  source code before including any headers. The requirement that the macro
>  must be defined before including any header file exists because header
>  files may freely include one another.

Just follow that guideline, as that is necessary in an effort to port
libcoap to Zephyr RTOS (where defining _GNU_SOURCE after first includes
breaks project build).