### PR TITLE
debug.c: replace 'in_port_t' with 'uint16_t'

### DIFF
--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -210,7 +210,7 @@ size_t
 coap_print_addr(const coap_address_t *addr, unsigned char *buf, size_t len) {
 #if defined( HAVE_ARPA_INET_H ) || defined( HAVE_WS2TCPIP_H )
   const void *addrptr = NULL;
-  in_port_t port;
+  uint16_t port;
   unsigned char *p = buf;
   size_t need_buf;
 


### PR DESCRIPTION
`in_port_t` might be hidden under `_GNU_SOURCE` feature test macro, which
is not defined at the top of the file. This happens with newlib build with
Zephyr SDK and with Zephyr RTOS. As a result following build error occurs:

```
/libcoap/src/coap_debug.c: In function 'coap_print_addr':
/libcoap/src/coap_debug.c:189:3: error: unknown type name 'in_port_t'; did you mean 'io_port_t'?
  189 |   in_port_t port;
      |   ^~~~~~~~~
      |   io_port_t
```

Workaround that issue by replacing `in_port_t` with `uint16_t`, as that is
the only place where former typedef was used.

Alternative to: #1030
Closes: #1030