### PR TITLE
mutex: add COAP_MUTEX_DEFINE() and support Zepyr RTOS mutex

### DIFF
--- a/include/coap3/coap_mutex_internal.h
+++ b/include/coap3/coap_mutex_internal.h
@@ -70,7 +70,17 @@ typedef int coap_mutex_t;
 #define coap_mutex_trylock(a) *(a) = 1
 #define coap_mutex_unlock(a) *(a) = 0
 
-#else /* !WITH_CONTIKI && !WITH_LWIP && !RIOT_VERSION && !HAVE_PTHREAD_H && !HAVE_PTHREAD_MUTEX_LOCK */
+#elif defined(__ZEPHYR__)
+#include <zephyr/sys/mutex.h>
+
+typedef struct k_mutex coap_mutex_t;
+#define COAP_MUTEX_DEFINE(_name)			\
+	static SYS_MUTEX_DEFINE(_name)
+#define coap_mutex_lock(a) sys_mutex_lock(a, K_FOREVER)
+#define coap_mutex_trylock(a) sys_mutex_lock(a, K_NO_WAIT)
+#define coap_mutex_unlock(a) sys_mutex_unlock(a)
+
+#else /* !__ZEPYR__ && !WITH_CONTIKI && !WITH_LWIP && !RIOT_VERSION && !HAVE_PTHREAD_H && !HAVE_PTHREAD_MUTEX_LOCK */
 /* define stub mutex functions */
 #warning "stub mutex functions"
 typedef int coap_mutex_t;

--- a/include/coap3/coap_mutex_internal.h
+++ b/include/coap3/coap_mutex_internal.h
@@ -29,7 +29,8 @@
 #include <pthread.h>
 
 typedef pthread_mutex_t coap_mutex_t;
-#define COAP_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+#define COAP_MUTEX_DEFINE(_name)			\
+	static coap_mutex_t _name = PTHREAD_MUTEX_INITIALIZER
 #define coap_mutex_lock(a) pthread_mutex_lock(a)
 #define coap_mutex_trylock(a) pthread_mutex_trylock(a)
 #define coap_mutex_unlock(a) pthread_mutex_unlock(a)
@@ -39,7 +40,8 @@ typedef pthread_mutex_t coap_mutex_t;
 #include <mutex.h>
 
 typedef mutex_t coap_mutex_t;
-#define COAP_MUTEX_INITIALIZER MUTEX_INIT
+#define COAP_MUTEX_DEFINE(_name)			\
+	static coap_mutex_t _name = MUTEX_INIT
 #define coap_mutex_lock(a) mutex_lock(a)
 #define coap_mutex_trylock(a) mutex_trylock(a)
 #define coap_mutex_unlock(a) mutex_unlock(a)
@@ -50,7 +52,8 @@ typedef mutex_t coap_mutex_t;
 #if NO_SYS
 /* Single threaded, no-op'd in lwip/sys.h */
 typedef int coap_mutex_t;
-#define COAP_MUTEX_INITIALIZER 0
+#define COAP_MUTEX_DEFINE(_name)			\
+	static coap_mutex_t _name
 #define coap_mutex_lock(a) *(a) = 1
 #define coap_mutex_trylock(a) *(a) = 1
 #define coap_mutex_unlock(a) *(a) = 0
@@ -61,7 +64,8 @@ typedef int coap_mutex_t;
 #elif defined(WITH_CONTIKI)
 /* Contiki does not have a mutex API, used as single thread */
 typedef int coap_mutex_t;
-#define COAP_MUTEX_INITIALIZER 0
+#define COAP_MUTEX_DEFINE(_name)			\
+	static coap_mutex_t _name
 #define coap_mutex_lock(a) *(a) = 1
 #define coap_mutex_trylock(a) *(a) = 1
 #define coap_mutex_unlock(a) *(a) = 0
@@ -70,7 +74,8 @@ typedef int coap_mutex_t;
 /* define stub mutex functions */
 #warning "stub mutex functions"
 typedef int coap_mutex_t;
-#define COAP_MUTEX_INITIALIZER 0
+#define COAP_MUTEX_DEFINE(_name)			\
+	static coap_mutex_t _name
 #define coap_mutex_lock(a) *(a) = 1
 #define coap_mutex_trylock(a) *(a) = 1
 #define coap_mutex_unlock(a) *(a) = 0

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -602,7 +602,7 @@ is_binary(int content_format) {
 void
 coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
 #if COAP_CONSTRAINED_STACK
-  static coap_mutex_t static_show_pdu_mutex = COAP_MUTEX_INITIALIZER;
+  COAP_MUTEX_DEFINE(static_show_pdu_mutex);
   /* Proxy-Uri: can be 1034 bytes long */
   static unsigned char buf[min(COAP_DEBUG_BUF_SIZE, 1035)];
   static char outbuf[COAP_DEBUG_BUF_SIZE];
@@ -1062,7 +1062,7 @@ coap_log_impl(coap_log_t level, const char *format, ...) {
 
   if (log_handler) {
 #if COAP_CONSTRAINED_STACK
-    static coap_mutex_t static_log_mutex = COAP_MUTEX_INITIALIZER;
+    COAP_MUTEX_DEFINE(static_log_mutex);
     static char message[COAP_DEBUG_BUF_SIZE];
 #else /* ! COAP_CONSTRAINED_STACK */
     char message[COAP_DEBUG_BUF_SIZE];

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -2073,7 +2073,7 @@ int coap_dtls_receive(coap_session_t *c_session,
 
   if (m_env->established) {
 #if COAP_CONSTRAINED_STACK
-    static coap_mutex_t b_static_mutex = COAP_MUTEX_INITIALIZER;
+    COAP_MUTEX_DEFINE(b_static_mutex);
     static uint8_t pdu[COAP_RXBUFFER_SIZE];
 #else /* ! COAP_CONSTRAINED_STACK */
     uint8_t pdu[COAP_RXBUFFER_SIZE];

--- a/src/net.c
+++ b/src/net.c
@@ -1721,7 +1721,7 @@ coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now
 static void
 coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now) {
 #if COAP_CONSTRAINED_STACK
-  static coap_mutex_t s_static_mutex = COAP_MUTEX_INITIALIZER;
+  COAP_MUTEX_DEFINE(s_static_mutex);
   static unsigned char payload[COAP_RXBUFFER_SIZE];
   static coap_packet_t s_packet;
 #else /* ! COAP_CONSTRAINED_STACK */
@@ -1886,7 +1886,7 @@ coap_read_endpoint(coap_context_t *ctx, coap_endpoint_t *endpoint, coap_tick_t n
   ssize_t bytes_read = -1;
   int result = -1;                /* the value to be returned */
 #if COAP_CONSTRAINED_STACK
-  static coap_mutex_t e_static_mutex = COAP_MUTEX_INITIALIZER;
+  COAP_MUTEX_DEFINE(e_static_mutex);
   static unsigned char payload[COAP_RXBUFFER_SIZE];
   static coap_packet_t e_packet;
 #else /* ! COAP_CONSTRAINED_STACK */


### PR DESCRIPTION
Introduce new macro, which will be used for defining static mutex
objects, for use from COAP_CONSTRAINED_STACK enabled code. This macro
will automatically initialize mutex using platform/OS specific macro if
such exists.

Provide mutex implementation for Zephyr RTOS, so that libcoap inside Zephyr
can be used with COAP_CONSTRAINED_STACK enabled.

This PR is a minimal set of changes in-tree that allows to integrate `libcoap`
into Zephyr RTOS application. I/O, (D)TLS and time routines implementation can
be easily added out-of-tree, so that Zephyr socket layer (either UDP/TCP or
Zephyr specific DTLS/TLS) can be utilized. For reference, this work is for now
part of https://github.com/golioth/golioth-firmware-sdk/pull/76. There will be
possiblity to upstream libcoap integration with Zephyr in the future.