### PR TITLE
netif: Create netif layer, initially provide datagram read/write

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ include(TestBigEndian)
 # check for headers
 check_include_file(byteswap.h HAVE_BYTESWAP_H)
 check_include_file(inttypes.h HAVE_INTTYPES_H)
+check_include_file(errno.h HAVE_ERRNO_H)
 check_include_file(limits.h HAVE_LIMITS_H)
 check_include_file(memory.h HAVE_MEMORY_H)
 check_include_file(strings.h HAVE_STRINGS_H)
@@ -478,6 +479,7 @@ target_sources(
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_hashkey.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_io.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_mem.c
+          ${CMAKE_CURRENT_LIST_DIR}/src/coap_netif.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_notls.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_option.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_oscore.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,6 +75,7 @@ EXTRA_DIST = \
   include/coap$(LIBCOAP_API_VERSION)/coap_io_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_mutex_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_net_internal.h \
+  include/coap$(LIBCOAP_API_VERSION)/coap_netif_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_oscore_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_pdu_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_resource_internal.h \
@@ -161,6 +162,7 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_SOURCES = \
   src/coap_io.c \
   src/coap_mbedtls.c \
   src/coap_mem.c \
+  src/coap_netif.c \
   src/coap_notls.c \
   src/coap_openssl.c \
   src/coap_option.c \

--- a/cmake_coap_config.h.in
+++ b/cmake_coap_config.h.in
@@ -53,6 +53,9 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #cmakedefine HAVE_INTTYPES_H @HAVE_INTTYPES_H@
 
+/* Define to 1 if you have the <erno.h> header file. */
+#cmakedefine HAVE_ERRNO_H @HAVE_ERRNO_H@
+
 /* Define if the system has openssl */
 #cmakedefine HAVE_OPENSSL @HAVE_OPENSSL@
 

--- a/coap_config.h.contiki
+++ b/coap_config.h.contiki
@@ -10,6 +10,9 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #define HAVE_INTTYPES_H 1
 
+/* Define to 1 if you have the <errno.h> header file. */
+#define HAVE_ERRNO_H 1
+
 /* Define to 1 to build without TCP support. */
 #define COAP_DISABLE_TCP 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -824,7 +824,7 @@ fi
 
 # Checks for header files.
 AC_CHECK_HEADERS([assert.h arpa/inet.h limits.h netdb.h netinet/in.h \
-                  pthread.h \
+                  pthread.h errno.h \
                   stdlib.h string.h strings.h sys/socket.h sys/time.h \
                   time.h unistd.h sys/unistd.h syslog.h sys/ioctl.h net/if.h])
 

--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -143,6 +143,7 @@ COAP_SRC = coap_address.c \
 	   coap_io.c \
 	   coap_io_lwip.c \
 	   net.c \
+	   coap_netif.c \
 	   coap_notls.c \
 	   coap_option.c \
 	   coap_oscore.c \

--- a/examples/lwip/config/coap_config.h
+++ b/examples/lwip/config/coap_config.h
@@ -43,4 +43,6 @@
 
 #define HAVE_SNPRINTF
 
+#define HAVE_ERRNO_H
+
 #endif /* COAP_CONFIG_H_ */

--- a/examples/lwip/config/coap_config.h.in
+++ b/examples/lwip/config/coap_config.h.in
@@ -43,4 +43,6 @@
 
 #define HAVE_SNPRINTF
 
+#define HAVE_ERRNO_H
+
 #endif /* COAP_CONFIG_H_ */

--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -192,9 +192,9 @@ void coap_dtls_session_update_mtu(coap_session_t *coap_session);
  * @return @c 0 if this would be blocking, @c -1 if there is an error or the
  *         number of cleartext bytes sent.
  */
-int coap_dtls_send(coap_session_t *coap_session,
-                   const uint8_t *data,
-                   size_t data_len);
+ssize_t coap_dtls_send(coap_session_t *coap_session,
+                       const uint8_t *data,
+                       size_t data_len);
 
 /**
  * Check if timeout is handled per CoAP session or per CoAP context.

--- a/include/coap3/coap_internal.h
+++ b/include/coap3/coap_internal.h
@@ -46,6 +46,10 @@
 #endif /* ! PRIu32 */
 #endif /* ! HAVE_INTTYPES_H */
 
+#if defined(HAVE_ERRNO_H)
+# include <errno.h>
+#endif
+
 /* By default without either configured, these need to be set */
 #ifndef COAP_SERVER_SUPPORT
 #ifndef COAP_CLIENT_SUPPORT
@@ -90,6 +94,7 @@ typedef struct oscore_ctx_t oscore_ctx_t;
 #include "coap_io_internal.h"
 #include "coap_mutex_internal.h"
 #include "coap_net_internal.h"
+#include "coap_netif_internal.h"
 #if HAVE_OSCORE
 #include "coap_oscore_internal.h"
 #endif /* HAVE_OSCORE */

--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -91,9 +91,21 @@ coap_socket_bind_udp(coap_socket_t *sock,
 
 void coap_socket_close(coap_socket_t *sock);
 
+/**
+ * Function interface for data transmission. This function returns the number of
+ * bytes that have been transmitted, or a value less than zero on error.
+ *
+ * @param sock             Socket to send data with
+ * @param session          Addressing information for unconnected sockets, or NULL
+ * @param data             The data to send.
+ * @param datalen          The actual length of @p data.
+ *
+ * @return                 The number of bytes written on success, or a value
+ *                         less than zero on error.
+ */
 ssize_t
-coap_socket_send( coap_socket_t *sock, coap_session_t *session,
-                  const uint8_t *data, size_t data_len );
+coap_socket_send(coap_socket_t *sock, coap_session_t *session,
+                 const uint8_t *data, size_t datalen);
 
 ssize_t
 coap_socket_write(coap_socket_t *sock, const uint8_t *data, size_t data_len);
@@ -130,7 +142,8 @@ coap_socket_send_pdu( coap_socket_t *sock, coap_session_t *session,
  * @return                 The number of bytes written on success, or a value
  *                         less than zero on error.
  */
-ssize_t coap_network_send( coap_socket_t *sock, const coap_session_t *session, const uint8_t *data, size_t datalen );
+ssize_t coap_network_send(coap_socket_t *sock, const coap_session_t *session,
+                          const uint8_t *data, size_t datalen);
 
 /**
  * Function interface for reading data. This function returns the number of

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -107,11 +107,6 @@ struct coap_context_t {
    */
   coap_event_handler_t handle_event;
 
-  ssize_t (*network_send)(coap_socket_t *sock, const coap_session_t *session,
-                          const uint8_t *data, size_t datalen);
-
-  ssize_t (*network_read)(coap_socket_t *sock, coap_packet_t *packet);
-
   void *dtls_context;
 
 #if COAP_SERVER_SUPPORT

--- a/include/coap3/coap_netif_internal.h
+++ b/include/coap3/coap_netif_internal.h
@@ -1,0 +1,82 @@
+/*
+ * coap_netif_internal.h -- Netif Transport Layer Support for libcoap
+ *
+ * Copyright (C) 2023 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_netif_internal.h
+ * @brief Internal CoAP Netif support
+ */
+
+#ifndef COAP_NETIF_INTERNAL_H_
+#define COAP_NETIF_INTERNAL_H_
+
+#include "coap_internal.h"
+
+/**
+ * @ingroup internal_api
+ * @defgroup netif_internal Netif Support
+ * Internal API for Netif Support
+ * @{
+ */
+
+/**
+ * Function interface to check whether netif for session is still available.
+ *
+ *  @param session          Session to check against.
+ *
+ * @return 1                If netif is available, else 0.
+ */
+int coap_netif_available(coap_session_t *session);
+
+/**
+ * Function interface for layer data datagram receiving for endpoints. This
+ * function returns the number of bytes that have been read, or -1 on error.
+ *
+ * @param endpoint Endpoint to receive data on.
+ * @param packet   Where to put the received information
+ *
+ * @return                 >=0 Number of bytes read.
+ *                          -1 Error of some sort (see errno).
+ *                          -2 ICMP error response
+ */
+ssize_t coap_netif_dgrm_read_ep(coap_endpoint_t *endpoint,
+                                coap_packet_t *packet);
+
+/**
+ * Function interface for layer data datagram receiving for sessions. This
+ * function returns the number of bytes that have been read, or -1 on error.
+ *
+ * @param session  Session to receive data on.
+ * @param packet   Where to put the received information
+ *
+ * @return                 >=0 Number of bytes read.
+ *                          -1 Error of some sort (see errno).
+ *                          -2 ICMP error response
+ */
+ssize_t coap_netif_dgrm_read(coap_session_t *session, coap_packet_t *packet);
+
+/**
+ * Function interface for netif datagram data transmission. This function
+ * returns the number of bytes that have been transmitted, or a value less
+ * than zero on error.
+ *
+ * @param session          Session to send data on.
+ * @param data             The data to send.
+ * @param datalen          The actual length of @p data.
+ *
+ * @return                 The number of bytes written on success, or a value
+ *                         less than zero on error.
+ */
+ssize_t coap_netif_dgrm_write(coap_session_t *session, const uint8_t *data,
+                              size_t datalen);
+
+/** @} */
+
+#endif /* COAP_NETIF_INTERNAL_H */

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -275,21 +275,6 @@ coap_session_t *coap_new_server_session(
 #endif /* COAP_SERVER_SUPPORT */
 
 /**
- * Function interface for datagram data transmission. This function returns
- * the number of bytes that have been transmitted, or a value less than zero
- * on error.
- *
- * @param session          Session to send data on.
- * @param data             The data to send.
- * @param datalen          The actual length of @p data.
- *
- * @return                 The number of bytes written on success, or a value
- *                         less than zero on error.
- */
-ssize_t coap_session_send(coap_session_t *session,
-  const uint8_t *data, size_t datalen);
-
-/**
  * Function interface for stream data transmission. This function returns
  * the number of bytes that have been transmitted, or a value less than zero
  * on error. The number of bytes written may be less than datalen because of

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -46,7 +46,6 @@
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #endif
-#include <errno.h>
 #ifdef COAP_EPOLL_SUPPORT
 #include <sys/epoll.h>
 #include <sys/timerfd.h>
@@ -592,6 +591,11 @@ static __declspec(thread) LPFN_WSARECVMSG lpWSARecvMsg = NULL;
 #endif
 
 #if !defined(RIOT_VERSION) && !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ */
 ssize_t
 coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint8_t *data, size_t datalen) {
   ssize_t bytes_written = 0;
@@ -764,6 +768,12 @@ coap_packet_get_memmapped(coap_packet_t *packet, unsigned char **address, size_t
 }
 
 #if !defined(RIOT_VERSION) && !defined(WITH_LWIP) && !defined(WITH_CONTIKI)
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ *         -2 ICMP error response
+ */
 ssize_t
 coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
   ssize_t len = -1;
@@ -1503,10 +1513,15 @@ const char *coap_socket_strerror(void) {
 #endif /* _WIN32 */
 
 #if !defined(WITH_LWIP)
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ */
 ssize_t
 coap_socket_send(coap_socket_t *sock, coap_session_t *session,
   const uint8_t *data, size_t data_len) {
-  return session->context->network_send(sock, session, data, data_len);
+  return coap_network_send(sock, session, data, data_len);
 }
 #endif /* ! WITH_LWIP */
 

--- a/src/coap_io_contiki.c
+++ b/src/coap_io_contiki.c
@@ -151,6 +151,11 @@ void coap_socket_close(coap_socket_t *sock) {
   sock->flags = COAP_SOCKET_EMPTY;
 }
 
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ */
 ssize_t
 coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint8_t *data, size_t datalen) {
   ssize_t bytes_written = 0;
@@ -170,6 +175,12 @@ coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint
   return bytes_written;
 }
 
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ *         -2 ICMP error response
+ */
 ssize_t
 coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
   ssize_t len;

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -110,6 +110,17 @@ coap_io_process(coap_context_t *context, uint32_t timeout_ms) {
   return (int)(((now - before) * 1000) / COAP_TICKS_PER_SECOND);
 }
 
+/*
+ * Not used for LwIP (done with coap_recvc()), but need dummy function.
+ */
+ssize_t
+coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
+  (void)sock;
+  (void)packet;
+  assert(0);
+  return -1;
+}
+
 #if COAP_CLIENT_SUPPORT
 /** Callback from lwIP when a package was received for a client.
  *
@@ -289,6 +300,11 @@ coap_socket_send_pdu(coap_socket_t *sock, coap_session_t *session,
   return pdu->used_size;
 }
 
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ */
 ssize_t
 coap_socket_send(coap_socket_t *sock, coap_session_t *session,
                  const uint8_t *data, size_t data_len ) {

--- a/src/coap_io_riot.c
+++ b/src/coap_io_riot.c
@@ -36,7 +36,6 @@
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #endif
-#include <errno.h>
 
 #include "net/gnrc.h"
 #include "net/gnrc/ipv6.h"
@@ -45,6 +44,11 @@
 
 #include "coap_riot.h"
 
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ */
 ssize_t
 coap_network_send(coap_socket_t *sock,
                   const coap_session_t *session,
@@ -74,6 +78,12 @@ get_udp_header(gnrc_pktsnip_t *pkt) {
   return udp ? (udp_hdr_t *)udp->data : NULL;
 }
 
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ *         -2 ICMP error response
+ */
 ssize_t
 coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
   size_t len;

--- a/src/coap_netif.c
+++ b/src/coap_netif.c
@@ -1,0 +1,120 @@
+/*
+ * coap_netif.c -- Netif functions for libcoap
+ *
+ * Copyright (C) 2023 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_netif.c
+ * @brief CoAP Netif handling functions
+ */
+
+#include "coap3/coap_internal.h"
+#include "coap3/coap_session_internal.h"
+
+/*
+ * return 1 netif still in use.
+ *        0 netif no longer available.
+ */
+int
+coap_netif_available(coap_session_t *session) {
+  return session->sock.flags != COAP_SOCKET_EMPTY;
+}
+
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ */
+ssize_t
+coap_netif_dgrm_write(coap_session_t *session, const uint8_t *data,
+                      size_t datalen) {
+  ssize_t bytes_written;
+  int keep_errno;
+
+  coap_socket_t *sock = &session->sock;
+#if COAP_SERVER_SUPPORT
+  if (sock->flags == COAP_SOCKET_EMPTY) {
+    assert(session->endpoint != NULL);
+    sock = &session->endpoint->sock;
+  }
+#endif /* COAP_SERVER_SUPPORT */
+
+  bytes_written = coap_socket_send(sock, session, data, datalen);
+  keep_errno = errno;
+  if (bytes_written <= 0) {
+    coap_log_debug( "*  %s: failed to send %zd bytes (%s) state %d\n",
+                   coap_session_str(session), datalen,
+                   coap_socket_strerror(), session->state);
+  } else if (bytes_written == (ssize_t)datalen) {
+    coap_ticks(&session->last_rx_tx);
+    coap_log_debug("*  %s: sent %zd bytes\n",
+             coap_session_str(session), datalen);
+  } else {
+    coap_ticks(&session->last_rx_tx);
+    coap_log_debug("*  %s: sent %zd bytes of %zd\n",
+             coap_session_str(session), bytes_written, datalen);
+    errno = keep_errno;
+  }
+  return bytes_written;
+}
+
+#if COAP_SERVER_SUPPORT
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ *         -2 ICMP error response
+ */
+ssize_t
+coap_netif_dgrm_read_ep(coap_endpoint_t *endpoint, coap_packet_t *packet) {
+  ssize_t bytes_read;
+  int keep_errno;
+
+  bytes_read = coap_network_read(&endpoint->sock, packet);
+  keep_errno = errno;
+  if (bytes_read == -1) {
+    coap_log_debug( "*  %s: failed to read %zd bytes (%s)\n",
+                   coap_endpoint_str(endpoint), packet->length,
+                   coap_socket_strerror());
+    errno = keep_errno;
+  } else if (bytes_read > 0) {
+    coap_log_debug("*  %s: read %zd bytes\n",
+             coap_endpoint_str(endpoint), bytes_read);
+    errno = keep_errno;
+  }
+  return bytes_read;
+}
+#endif /* COAP_SERVER_SUPPORT */
+
+/*
+ * dgram
+ * return +ve Number of bytes written.
+ *         -1 Error error in errno).
+ *         -2 ICMP error response
+ */
+ssize_t
+coap_netif_dgrm_read(coap_session_t *session, coap_packet_t *packet) {
+  ssize_t bytes_read;
+  int keep_errno;
+
+  bytes_read = coap_network_read(&session->sock, packet);
+  keep_errno = errno;
+  if (bytes_read == -1) {
+    coap_log_debug( "*  %s: failed to read %zd bytes (%s) state %d\n",
+                   coap_session_str(session), packet->length,
+                   coap_socket_strerror(), session->state);
+    errno = keep_errno;
+  } else if (bytes_read > 0) {
+    coap_ticks(&session->last_rx_tx);
+    coap_log_debug("*  %s: read %zd bytes\n",
+             coap_session_str(session), bytes_read);
+    errno = keep_errno;
+  }
+  return bytes_read;
+}

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -166,11 +166,10 @@ void coap_dtls_free_session(coap_session_t *coap_session COAP_UNUSED) {
 void coap_dtls_session_update_mtu(coap_session_t *session COAP_UNUSED) {
 }
 
-int
+ssize_t
 coap_dtls_send(coap_session_t *session COAP_UNUSED,
-  const uint8_t *data COAP_UNUSED,
-  size_t data_len COAP_UNUSED
-) {
+               const uint8_t *data COAP_UNUSED,
+               size_t data_len COAP_UNUSED) {
   return -1;
 }
 

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -25,7 +25,6 @@
 #include <sys/epoll.h>
 #include <sys/timerfd.h>
 #endif /* COAP_EPOLL_SUPPORT */
-#include <errno.h>
 
 void
 coap_session_set_ack_timeout(coap_session_t *session, coap_fixed_point_t value) {
@@ -407,29 +406,6 @@ void coap_session_set_mtu(coap_session_t *session, unsigned mtu) {
     session->tls_overhead = session->mtu;
     coap_log_err("DTLS overhead exceeds MTU\n");
   }
-}
-
-ssize_t coap_session_send(coap_session_t *session, const uint8_t *data, size_t datalen) {
-  ssize_t bytes_written;
-
-  coap_socket_t *sock = &session->sock;
-#if COAP_SERVER_SUPPORT
-  if (sock->flags == COAP_SOCKET_EMPTY) {
-    assert(session->endpoint != NULL);
-    sock = &session->endpoint->sock;
-  }
-#endif /* COAP_SERVER_SUPPORT */
-
-  bytes_written = coap_socket_send(sock, session, data, datalen);
-  if (bytes_written == (ssize_t)datalen) {
-    coap_ticks(&session->last_rx_tx);
-    coap_log_debug("*  %s: sent %zd bytes\n",
-             coap_session_str(session), datalen);
-  } else {
-    coap_log_debug("*  %s: failed to send %zd bytes\n",
-             coap_session_str(session), datalen);
-  }
-  return bytes_written;
 }
 
 ssize_t coap_session_write(coap_session_t *session, const uint8_t *data, size_t datalen) {

--- a/src/coap_tcp.c
+++ b/src/coap_tcp.c
@@ -16,7 +16,6 @@
 
 #include "coap3/coap_internal.h"
 
-#include <errno.h>
 #include <sys/types.h>
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -260,7 +260,7 @@ dtls_send_to_peer(struct dtls_context_t *dtls_context,
     coap_log_warn("dtls_send_to_peer: cannot find local interface\n");
     return -3;
   }
-  return (int)coap_session_send(coap_session, data, len);
+  return (int)coap_netif_dgrm_write(coap_session, data, len);
 }
 
 static int
@@ -729,11 +729,10 @@ coap_dtls_free_session(coap_session_t *coap_session) {
   }
 }
 
-int
+ssize_t
 coap_dtls_send(coap_session_t *session,
-  const uint8_t *data,
-  size_t data_len
-) {
+               const uint8_t *data,
+               size_t data_len) {
   int res;
   uint8_t *data_rw;
   coap_tiny_context_t *t_context = (coap_tiny_context_t *)session->context->dtls_context;

--- a/src/resource.c
+++ b/src/resource.c
@@ -17,7 +17,6 @@
 
 #if COAP_SERVER_SUPPORT
 #include <stdio.h>
-#include <errno.h>
 
 #ifdef COAP_EPOLL_SUPPORT
 #include <sys/epoll.h>

--- a/win32/libcoap.vcxproj
+++ b/win32/libcoap.vcxproj
@@ -51,6 +51,7 @@
     <ClCompile Include="..\src\coap_io.c" />
     <ClCompile Include="..\src\coap_mbedtls.c" />
     <ClCompile Include="..\src\coap_mem.c" />
+    <ClCompile Include="..\src\coap_netif.c" />
     <ClCompile Include="..\src\coap_notls.c" />
     <ClCompile Include="..\src\coap_openssl.c" />
     <ClCompile Include="..\src\coap_option.c" />
@@ -92,8 +93,9 @@
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_internal.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_io.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_mem.h" />
-    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_net.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_mutex_internal.h" />
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_net.h" />
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_netif_internal.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_option.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\pdu.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_oscore.h" />

--- a/win32/libcoap.vcxproj.filters
+++ b/win32/libcoap.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="..\src\coap_mem.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\coap_netif.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\coap_notls.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -171,6 +174,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_net.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_netif_internal.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_option.h">


### PR DESCRIPTION
Add in skeleton coap_netif.c coap_netif_internal.h files, populated with coap_netif_dgrm_read(), coap_netif_dgrm_read_ep(), and coap_netif_dgrm_write() functions that are called by the CoAP and (D)TLS code which in turn call the appropriate coap_socket_*() functions.

The coap_dtls_send() function parameters are aligned with coap_netif_dgrm_write().