### PR TITLE
netif: Replace coap_network_{send|read}() with coap_socket_{send|recv}()

### DIFF
--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -91,30 +91,33 @@ coap_socket_bind_udp(coap_socket_t *sock,
 
 void coap_socket_close(coap_socket_t *sock);
 
-/**
- * Function interface for data transmission. This function returns the number of
- * bytes that have been transmitted, or a value less than zero on error.
- *
- * @param sock             Socket to send data with
- * @param session          Addressing information for unconnected sockets, or NULL
- * @param data             The data to send.
- * @param datalen          The actual length of @p data.
- *
- * @return                 The number of bytes written on success, or a value
- *                         less than zero on error.
- */
-ssize_t
-coap_socket_send(coap_socket_t *sock, coap_session_t *session,
-                 const uint8_t *data, size_t datalen);
-
 ssize_t
 coap_socket_write(coap_socket_t *sock, const uint8_t *data, size_t data_len);
 
 ssize_t
 coap_socket_read(coap_socket_t *sock, uint8_t *data, size_t data_len);
 
-void
-coap_epoll_ctl_mod(coap_socket_t *sock, uint32_t events, const char *func);
+/**
+ * Epoll specific function to add the state of events that epoll is to track
+ * for the appropriate file descriptor.
+ *
+ * @param sock    Socket information.
+ * @param events  The Epoll events to update
+ * @param func    Function that this function was called from.
+ *
+ */
+void coap_epoll_ctl_add(coap_socket_t *sock, uint32_t events, const char *func);
+
+/**
+ * Epoll specific function to modify the state of events that epoll is tracking
+ * on the appropriate file descriptor.
+ *
+ * @param sock    Socket information.
+ * @param events  The Epoll events to update
+ * @param func    Function that this function was called from.
+ *
+ */
+void coap_epoll_ctl_mod(coap_socket_t *sock, uint32_t events, const char *func);
 
 /**
  * Update the epoll timer fd as to when it is to trigger.
@@ -134,29 +137,30 @@ coap_socket_send_pdu( coap_socket_t *sock, coap_session_t *session,
  * Function interface for data transmission. This function returns the number of
  * bytes that have been transmitted, or a value less than zero on error.
  *
- * @param sock             Socket to send data with
- * @param session          Addressing information for unconnected sockets, or NULL
- * @param data             The data to send.
- * @param datalen          The actual length of @p data.
+ * @param sock          Socket to send data over.
+ * @param session       Addressing information for unconnected sockets, or NULL
+ * @param data          The data to send.
+ * @param datalen       The actual length of @p data.
  *
- * @return                 The number of bytes written on success, or a value
- *                         less than zero on error.
+ * @return              The number of bytes written on success, or a value
+ *                      less than zero on error.
  */
-ssize_t coap_network_send(coap_socket_t *sock, const coap_session_t *session,
-                          const uint8_t *data, size_t datalen);
+ssize_t coap_socket_send(coap_socket_t *sock, const coap_session_t *session,
+                         const uint8_t *data, size_t datalen);
 
 /**
  * Function interface for reading data. This function returns the number of
  * bytes that have been read, or a value less than zero on error. In case of an
  * error, @p *packet is set to NULL.
  *
- * @param sock   Socket to read data from
- * @param packet Received packet metadata and payload. src and dst should be preset.
+ * @param sock   Socket to read data from.
+ * @param packet Received packet metadata and payload. src and dst
+ *               should be preset.
  *
  * @return       The number of bytes received on success, or a value less than
  *               zero on error.
  */
-ssize_t coap_network_read( coap_socket_t *sock, coap_packet_t *packet );
+ssize_t coap_socket_recv(coap_socket_t *sock, coap_packet_t *packet);
 
 #ifndef coap_mcast_interface
 # define coap_mcast_interface(Local) 0

--- a/src/coap_io_contiki.c
+++ b/src/coap_io_contiki.c
@@ -157,7 +157,7 @@ void coap_socket_close(coap_socket_t *sock) {
  *         -1 Error error in errno).
  */
 ssize_t
-coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint8_t *data, size_t datalen) {
+coap_socket_send(coap_socket_t *sock, const coap_session_t *session, const uint8_t *data, size_t datalen) {
   ssize_t bytes_written = 0;
 
   if (!coap_debug_send_packet()) {
@@ -169,7 +169,7 @@ coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint
   }
 
   if (bytes_written < 0) {
-    coap_log(LOG_CRIT, "coap_network_send: %s\n", coap_socket_strerror());
+    coap_log(LOG_CRIT, "coap_socket_send: %s\n", coap_socket_strerror());
   }
 
   return bytes_written;
@@ -182,7 +182,7 @@ coap_network_send(coap_socket_t *sock, const coap_session_t *session, const uint
  *         -2 ICMP error response
  */
 ssize_t
-coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
+coap_socket_recv(coap_socket_t *sock, coap_packet_t *packet) {
   ssize_t len;
 
   assert(sock);

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -114,7 +114,7 @@ coap_io_process(coap_context_t *context, uint32_t timeout_ms) {
  * Not used for LwIP (done with coap_recvc()), but need dummy function.
  */
 ssize_t
-coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
+coap_socket_recv(coap_socket_t *sock, coap_packet_t *packet) {
   (void)sock;
   (void)packet;
   assert(0);
@@ -306,7 +306,7 @@ coap_socket_send_pdu(coap_socket_t *sock, coap_session_t *session,
  *         -1 Error error in errno).
  */
 ssize_t
-coap_socket_send(coap_socket_t *sock, coap_session_t *session,
+coap_socket_send(coap_socket_t *sock, const coap_session_t *session,
                  const uint8_t *data, size_t data_len ) {
   struct pbuf *pbuf;
   int err;

--- a/src/coap_io_riot.c
+++ b/src/coap_io_riot.c
@@ -50,7 +50,7 @@
  *         -1 Error error in errno).
  */
 ssize_t
-coap_network_send(coap_socket_t *sock,
+coap_socket_send(coap_socket_t *sock,
                   const coap_session_t *session,
                   const uint8_t *data,
                   size_t datalen) {
@@ -67,7 +67,7 @@ coap_network_send(coap_socket_t *sock,
   }
 
   if (bytes_written < 0)
-    coap_log_crit("coap_network_send: %s\n", coap_socket_strerror());
+    coap_log_crit("coap_socket_send: %s\n", coap_socket_strerror());
 
   return bytes_written;
 }
@@ -85,7 +85,7 @@ get_udp_header(gnrc_pktsnip_t *pkt) {
  *         -2 ICMP error response
  */
 ssize_t
-coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
+coap_socket_recv(coap_socket_t *sock, coap_packet_t *packet) {
   size_t len;
   ipv6_hdr_t *ipv6_hdr;
   /* The GNRC API currently only supports UDP. */
@@ -97,7 +97,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
   assert(packet);
 
   if ((sock->flags & COAP_SOCKET_CAN_READ) == 0) {
-    coap_log_debug("coap_network_read: COAP_SOCKET_CAN_READ not set\n");
+    coap_log_debug("coap_socket_recv: COAP_SOCKET_CAN_READ not set\n");
     return -1;
   } else {
     /* clear has-data flag */
@@ -116,7 +116,7 @@ coap_network_read(coap_socket_t *sock, coap_packet_t *packet) {
   udp_hdr_print(udp_hdr);
 
   len = (size_t)gnrc_pkt_len_upto(sock->pkt, type) - sizeof(udp_hdr_t);
-  coap_log_debug("coap_network_read: recvfrom got %zd bytes\n", len);
+  coap_log_debug("coap_socket_recv: recvfrom got %zd bytes\n", len);
   if (len > COAP_RXBUFFER_SIZE) {
     coap_log_warn("packet exceeds buffer size, truncated\n");
     len = COAP_RXBUFFER_SIZE;

--- a/src/coap_netif.c
+++ b/src/coap_netif.c
@@ -76,7 +76,7 @@ coap_netif_dgrm_read_ep(coap_endpoint_t *endpoint, coap_packet_t *packet) {
   ssize_t bytes_read;
   int keep_errno;
 
-  bytes_read = coap_network_read(&endpoint->sock, packet);
+  bytes_read = coap_socket_recv(&endpoint->sock, packet);
   keep_errno = errno;
   if (bytes_read == -1) {
     coap_log_debug( "*  %s: failed to read %zd bytes (%s)\n",
@@ -103,7 +103,7 @@ coap_netif_dgrm_read(coap_session_t *session, coap_packet_t *packet) {
   ssize_t bytes_read;
   int keep_errno;
 
-  bytes_read = coap_network_read(&session->sock, packet);
+  bytes_read = coap_socket_recv(&session->sock, packet);
   keep_errno = errno;
   if (bytes_read == -1) {
     coap_log_debug( "*  %s: failed to read %zd bytes (%s) state %d\n",

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -872,43 +872,6 @@ coap_session_new_dtls_session(coap_session_t *session,
 }
 #endif /* COAP_SERVER_SUPPORT */
 
-#ifdef COAP_EPOLL_SUPPORT
-static void
-coap_epoll_ctl_add(coap_socket_t *sock,
-                   uint32_t events,
-                   const char *func
-) {
-  int ret;
-  struct epoll_event event;
-  coap_context_t *context;
-
-  if (sock == NULL)
-    return;
-
-#if COAP_SERVER_SUPPORT
-  context = sock->session ? sock->session->context :
-                            sock->endpoint ? sock->endpoint->context : NULL;
-#else /* ! COAP_SERVER_SUPPORT */
-  context = sock->session ? sock->session->context : NULL;
-#endif /* ! COAP_SERVER_SUPPORT */
-  if (context == NULL)
-    return;
-
-  /* Needed if running 32bit as ptr is only 32bit */
-  memset(&event, 0, sizeof(event));
-  event.events = events;
-  event.data.ptr = sock;
-
-  ret = epoll_ctl(context->epfd, EPOLL_CTL_ADD, sock->fd, &event);
-  if (ret == -1) {
-     coap_log_err(
-              "%s: epoll_ctl ADD failed: %s (%d)\n",
-              func,
-              coap_socket_strerror(), errno);
-  }
-}
-#endif /* COAP_EPOLL_SUPPORT */
-
 #if COAP_CLIENT_SUPPORT
 static coap_session_t *
 coap_session_create_client(


### PR DESCRIPTION
Replace coap_network_{send|read}() with coap_socket_{send|recv}().

Move coap_epoll_ctl_mod() into coap_io.c to be along with all the other epoll specific functions for consistency.