### PR TITLE
coap-client: Make retransmission give up more visible

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1568,7 +1568,7 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
   }
 
   /* no more retransmissions, remove node from system */
-  coap_log_debug("** %s: mid=0x%x: give up after %d attempts\n",
+  coap_log_warn("** %s: mid=0x%x: give up after %d attempts\n",
            coap_session_str(node->session), node->id, node->retransmit_cnt);
 
 #if COAP_SERVER_SUPPORT


### PR DESCRIPTION
Useful when coap-client is used to send block transfers.

Without this, users have to run coap-client with `-v 7` before they can see why coap-client ends earlier than expected.

Logging at warning level to match the default log level set by coap-client source code.