### PR TITLE
block.h/pdu.h: fix misspellings of "already"

### DIFF
--- a/include/coap3/block.h
+++ b/include/coap3/block.h
@@ -280,7 +280,7 @@ typedef void (*coap_release_large_data_t)(coap_session_t *session,
 /**
  * Associates given data with the @p pdu that is passed as second parameter.
  *
- * This function will fail if data has aready been added to the @p pdu.
+ * This function will fail if data has already been added to the @p pdu.
  *
  * If all the data can be transmitted in a single PDU, this is functionally
  * the same as coap_add_data() except @p release_func (if not NULL) will get
@@ -330,7 +330,7 @@ int coap_add_data_large_request(coap_session_t *session,
  * Associates given data with the @p response pdu that is passed as fourth
  * parameter.
  *
- * This function will fail if data has aready been added to the @p pdu.
+ * This function will fail if data has already been added to the @p pdu.
  *
  * If all the data can be transmitted in a single PDU, this is functionally
  * the same as coap_add_data() except @p release_func (if not NULL) will get

--- a/include/coap3/pdu.h
+++ b/include/coap3/pdu.h
@@ -457,7 +457,7 @@ int coap_add_token(coap_pdu_t *pdu,
  * Adds option of given @p number to @p pdu that is passed as first
  * parameter.
  *
- * This function will fail if data has aready been added to the @p pdu.
+ * This function will fail if data has already been added to the @p pdu.
  *
  * Hence data must be added after optional coap_add_option() has been called.
  *
@@ -482,7 +482,7 @@ size_t coap_add_option(coap_pdu_t *pdu,
 /**
  * Adds given data to the pdu that is passed as first parameter.
  *
- * This function will fail if data has aready been added to the @p pdu.
+ * This function will fail if data has already been added to the @p pdu.
  *
  * @param pdu    The PDU where the data is to be added.
  * @param len    The length of the data.
@@ -497,7 +497,7 @@ int coap_add_data(coap_pdu_t *pdu,
 /**
  * Adds given data to the pdu that is passed as first parameter but does not
  *
- * This function will fail if data has aready been added to the @p pdu.
+ * This function will fail if data has already been added to the @p pdu.
  *
  * The actual data must be copied at the returned location.
  *


### PR DESCRIPTION
Fixes misspellings of "already" in the block and pdu header files.