### PR TITLE
layers: Add in protocol layers support

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2303,6 +2303,7 @@ get_context(const char *node, const char *port) {
   case COAP_PROTO_DTLS: scheme_hint_bits = 1 << COAP_URI_SCHEME_COAPS; break;
   case COAP_PROTO_TLS:  scheme_hint_bits = 1 << COAP_URI_SCHEME_COAPS_TCP; break;
   case COAP_PROTO_NONE:
+  case COAP_PROTO_LAST:
   default:
     break;
   }

--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -271,7 +271,7 @@ int coap_dtls_hello(coap_session_t *coap_session,
  *
  * If this layer is properly established on invocation, then the next layer
  * must get called by calling
- *   coap_session_establish(session)
+ *   session->lfunc[COAP_LAYER_TLS].establish(session)
  * (or done at any point when DTLS is established).
  *
  * @param session Session that the lower layer connect was done on.
@@ -367,7 +367,7 @@ ssize_t coap_tls_read(coap_session_t *coap_session,
  *
  * If this layer is properly established on invocation, then the next layer
  * must get called by calling
- *   coap_session_establish(session)
+ *   session->lfunc[COAP_LAYER_TLS].establish(session)
  * (or done at any point when TLS is established).
  *
  * @param session Session that the lower layer accept/connect was done on.

--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -30,6 +30,98 @@ struct uip_udp_conn;
 #include "net/gnrc.h"
 #endif /* RIOT_VERSION */
 
+typedef enum {
+  COAP_LAYER_SESSION,
+  COAP_LAYER_TLS,
+  COAP_LAYER_LAST
+} coap_layer_t;
+
+/**
+ * Function read interface for layer data receiving.
+ *
+ * If a called lower layer returned value is 0 or less, this must get passed
+ * back to the caller.
+ *
+ * If the layer function consumes all the data (i.e. to handle the protocol
+ * layer requirements), then the function must return 0 to indicate no data.
+ *
+ * Otherwise data must get updated (limited by datalen) and the number of bytes
+ * available returned.
+ *
+ * Note: If the number of returned bytes is less that read in, then
+ * COAP_SOCKET_CAN_READ must be dropped from session->sock.flags.
+ *
+ * @param session  Session to receive data on.
+ * @param data     The data to receive.
+ * @param datalen  The maximum length of @p data.
+ *
+ * @return         >=0 Number of bytes read.
+ *                 -1  Error error in errno).
+ *                 -2  Recieved ICMP unreachable.
+ */
+typedef ssize_t (*coap_layer_read_t)(coap_session_t *session,
+                                      uint8_t *data, size_t datalen);
+
+/**
+ * Function write interface for layer data sending.
+ *
+ * If a called lower layer returned value is 0 or less, this must get passed
+ * back to the caller.
+ *
+ * If the layer function cannot transmit any data (congestion control etc.),
+ * then the function must return 0 to indicate no data sent.
+ *
+ * It is possible that not all the data is sent (congestion control etc.),
+ * and bytes written is less that datalen.
+ *
+ * Note: If the number of returned bytes is less that to be written,
+ * COAP_SOCKET_WANT_WRITE must be added to session->sock.flags.
+ *
+ * @param session  Session to receive data on.
+ * @param data     The data to write out.
+ * @param datalen  The maximum length of @p data.
+ *
+ * @return         >=0 Number of bytes written.
+ *                 -1  Error error in errno).
+ */
+typedef ssize_t (*coap_layer_write_t)(coap_session_t *session,
+                                      const uint8_t *data, size_t datalen);
+/**
+ * Function establish interface for layer establish handling.
+ *
+ * If this layer is properly established on invocation, then the next layer
+ * must get called by calling
+ *   session->lfunc[_this_layer_].establish(session)
+ * (or done at any point when layer is established).
+ * If the establishment of a layer fails, then
+ *   coap_session_disconnected(session, COAP_NACK_xxx_LAYER_FAILED) must be
+ *   called.
+ *
+ * @param session Session being established
+ */
+typedef void (*coap_layer_establish_t)(coap_session_t *session);
+
+/**
+ * Function close interface for layer closing.
+ *
+ * When this layer is properly closed, then the next layer
+ * must get called by calling
+ *   session->lfunc[_this_layer_].close(session)
+ * (or done at any point when layer is closed).
+ *
+ * @param session Session being closed.
+ */
+typedef void (*coap_layer_close_t)(coap_session_t *session);
+
+typedef struct {
+  coap_layer_read_t read;   /* Get data from next layer (TCP) */
+  coap_layer_write_t write; /* Output data to next layer */
+  coap_layer_establish_t establish; /* Layer establish */
+  coap_layer_close_t close; /* Connection close */
+} coap_layer_func_t;
+
+extern coap_layer_func_t coap_layers_coap[COAP_PROTO_LAST][COAP_LAYER_LAST];
+
 struct coap_socket_t {
 #if defined(WITH_LWIP)
   struct udp_pcb *pcb;
@@ -48,6 +140,7 @@ struct coap_socket_t {
   coap_endpoint_t *endpoint; /* Used by the epoll logic for a listening
                                 endpoint. */
 #endif /* COAP_SERVER_SUPPORT */
+  coap_layer_func_t lfunc[COAP_LAYER_LAST]; /* Layer functions to use */
 };
 
 /**
@@ -89,13 +182,37 @@ coap_socket_bind_udp(coap_socket_t *sock,
                      const coap_address_t *listen_addr,
                      coap_address_t *bound_addr );
 
+/**
+ * Function interface to close off a socket.
+ *
+ * @param sock             Socket to close.
+ *
+ */
 void coap_socket_close(coap_socket_t *sock);
 
-ssize_t
-coap_socket_write(coap_socket_t *sock, const uint8_t *data, size_t data_len);
+/**
+ * Function interface for data stream sending off a socket.
+ *
+ * @param sock             Socket to send data over.
+ * @param data             The data to send.
+ * @param data_len         The length of @p data.
+ *
+ * @return                 >=0 Number of bytes sent.
+ *                         -1 Error error in errno).
+ */
+ssize_t coap_socket_write(coap_socket_t *sock, const uint8_t *data, size_t data_len);
 
-ssize_t
-coap_socket_read(coap_socket_t *sock, uint8_t *data, size_t data_len);
+/**
+ * Function interface for data stream receiving off a socket.
+ *
+ * @param sock             Socket to receive data on.
+ * @param data             The data to receive.
+ * @param data_len         The maximum length of @p data.
+ *
+ * @return                 >=0 Number of bytes read.
+ *                         -1 Error error in errno).
+ */
+ssize_t coap_socket_read(coap_socket_t *sock, uint8_t *data, size_t data_len);
 
 /**
  * Epoll specific function to add the state of events that epoll is to track
@@ -188,7 +305,6 @@ struct coap_packet_t {
 #ifdef WITH_CONTIKI
 void coap_start_io_process(void);
 void coap_stop_io_process(void);
-#endif /* COAP_IO_INTERNAL_H_ */
+#endif /* WITH_CONTIKI */
 
 #endif /* COAP_IO_INTERNAL_H_ */
-

--- a/include/coap3/pdu.h
+++ b/include/coap3/pdu.h
@@ -305,6 +305,7 @@ typedef enum coap_proto_t {
   COAP_PROTO_DTLS,
   COAP_PROTO_TCP,
   COAP_PROTO_TLS,
+  COAP_PROTO_LAST
 } coap_proto_t;
 
 /**

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -74,6 +74,61 @@
 #endif /* IPV6_RECVPKTINFO */
 #endif /* !(WITH_CONTIKI || RIOT_VERSION) */
 
+/*
+ * Layer index table.  A whole protocol chunk gets copied into coap_socket_t.
+ * Each layer invokes the function defined at its layer to get the next layer
+ * (which could be above or below) to complete.
+ *
+ * The stack layers are (* managed by libcoap)
+ *   Application
+ *   CoAP *
+ *   CoAP-Session *
+ *   DTLS *
+ *   Netif *
+ *   Sockets *
+ *   Network Stack
+ *
+ * dgrm read currently handled separately.
+ * strm read works down the layers.
+ * write     works down the layers.
+ * establish is done after netif accept/connect completes by invoking SESSION
+ * and then works up the layers.
+ * close     works down the layers
+ */
+coap_layer_func_t coap_layers_coap[COAP_PROTO_LAST][COAP_LAYER_LAST] = {
+  { /* COAP_PROTO_NONE */
+    { NULL, NULL, NULL, NULL }, /* SESSION */
+    { NULL, NULL, NULL, NULL }  /* TLS */
+  },
+  { /* COAP_PROTO_UDP */
+    { NULL,                 coap_netif_dgrm_write, coap_session_establish, coap_netif_close }, /* SESSION */
+    { NULL,                 NULL,                  NULL,                   NULL             }  /* TLS */
+  },
+  { /* COAP_PROTO_DTLS */
+    { NULL,                 coap_dtls_send,        coap_dtls_establish,    coap_dtls_close  }, /* SESSION */
+    { NULL,                 coap_netif_dgrm_write, coap_session_establish, coap_netif_close }  /* TLS */
+  },
+#if !COAP_DISABLE_TCP
+  { /* COAP_PROTO_TCP */
+    { coap_netif_strm_read, coap_netif_strm_write, coap_session_establish, coap_netif_close }, /* SESSION */
+    { NULL,                 NULL,                  NULL,                   NULL             }  /* TLS */
+  },
+  { /* COAP_PROTO_TLS */
+    { coap_tls_read,        coap_tls_write,        coap_tls_establish,     coap_tls_close   }, /* SESSION */
+    { coap_netif_strm_read, coap_netif_strm_write, coap_session_establish, coap_netif_close }  /* TLS */
+  },
+#else /* COAP_DISABLE_TCP */
+  { /* COAP_PROTO_TCP */
+    { NULL, NULL, NULL, NULL }, /* SESSION */
+    { NULL, NULL, NULL, NULL }  /* TLS */
+  },
+  { /* COAP_PROTO_TLS */
+    { NULL, NULL, NULL, NULL }, /* SESSION */
+    { NULL, NULL, NULL, NULL }  /* TLS */
+  },
+#endif /* COAP_DISABLE_TCP */
+};
+
 #if COAP_SERVER_SUPPORT
 coap_endpoint_t *
   coap_malloc_endpoint(void) {

--- a/src/coap_netif.c
+++ b/src/coap_netif.c
@@ -219,8 +219,8 @@ coap_netif_strm_read(coap_session_t *session, uint8_t *data, size_t datalen) {
     coap_log_debug("*  %s: netif: received %zd bytes\n",
              coap_session_str(session), bytes_read);
   } else if (bytes_read == -1 && errno != EAGAIN) {
-    coap_log_debug( "*  %s: netif: failed to receive any bytes (%s)\n",
-             coap_session_str(session), coap_socket_strerror());
+    coap_log_debug( "*  %s: netif: failed to receive any bytes (%s) state %d\n",
+             coap_session_str(session), coap_socket_strerror(), session->state);
     errno = keep_errno;
   }
   return bytes_read;
@@ -257,7 +257,8 @@ coap_netif_strm_write(coap_session_t *session, const uint8_t *data,
 
 void
 coap_netif_close(coap_session_t *session) {
-  coap_socket_close(&session->sock);
+  if (coap_netif_available(session))
+    coap_socket_close(&session->sock);
 }
 
 #if COAP_SERVER_SUPPORT
@@ -265,5 +266,4 @@ void
 coap_netif_close_ep(coap_endpoint_t *endpoint) {
   coap_socket_close(&endpoint->sock);
 }
-
 #endif /* COAP_SERVER_SUPPORT */

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -260,7 +260,8 @@ dtls_send_to_peer(struct dtls_context_t *dtls_context,
     coap_log_warn("dtls_send_to_peer: cannot find local interface\n");
     return -3;
   }
-  return (int)coap_netif_dgrm_write(coap_session, data, len);
+  return (int)coap_session->sock.lfunc[COAP_LAYER_TLS].write(coap_session,
+                                                             data, len);
 }
 
 static int

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -1341,7 +1341,7 @@ coap_pdu_encode_header(coap_pdu_t *pdu, coap_proto_t proto) {
              "coap_add_token: Token size too large. PDU ignored\n");
     return 0;
   }
-  if (proto == COAP_PROTO_UDP || proto == COAP_PROTO_DTLS) {
+  if (COAP_PROTO_NOT_RELIABLE(proto)) {
     assert(pdu->max_hdr_size >= 4);
     if (pdu->max_hdr_size < 4) {
       coap_log_warn(
@@ -1355,7 +1355,7 @@ coap_pdu_encode_header(coap_pdu_t *pdu, coap_proto_t proto) {
     pdu->token[-2] = (uint8_t)(pdu->mid >> 8);
     pdu->token[-1] = (uint8_t)(pdu->mid);
     pdu->hdr_size = 4;
-  } else if (proto == COAP_PROTO_TCP || proto == COAP_PROTO_TLS) {
+  } else if (COAP_PROTO_RELIABLE(proto)) {
     size_t len;
     assert(pdu->used_size >= pdu->e_token_length);
     if (pdu->used_size < pdu->e_token_length) {


### PR DESCRIPTION
Current stack:-

Application
CoAP
CoAP-Session
DTLS
Netif
Sockets
Network Stack

Depending on the CoAP protocol, indexing functions through coap_layers_coap[] (in src/coap_io.c) will invoke the correct layer function when used at the CoAP and DTLS layers.

It is then easy to add in another protocol layer by updating coap_layers_coap[].