### PR TITLE
WebSockets: Add in libcoap infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,7 @@ target_sources(
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_tcp.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_time.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_uri.c
+          ${CMAKE_CURRENT_LIST_DIR}/src/coap_ws.c
           ${CMAKE_CURRENT_LIST_DIR}/src/block.c
           ${CMAKE_CURRENT_LIST_DIR}/src/net.c
           ${CMAKE_CURRENT_LIST_DIR}/src/pdu.c
@@ -529,7 +530,8 @@ target_sources(
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_str.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_subscribe.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_time.h
-          ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_uri.h)
+          ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_uri.h
+          ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_ws.h)
 target_include_directories(
   ${COAP_LIBRARY_NAME}
   PUBLIC # config headers are generated during configuration time

--- a/Makefile.am
+++ b/Makefile.am
@@ -85,6 +85,7 @@ EXTRA_DIST = \
   include/coap$(LIBCOAP_API_VERSION)/coap_uri_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_uthash_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_utlist_internal.h \
+  include/coap$(LIBCOAP_API_VERSION)/coap_ws_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap.h.in \
   include/coap$(LIBCOAP_API_VERSION)/coap.h.windows \
   include/coap$(LIBCOAP_API_VERSION)/coap.h.windows.in \
@@ -176,6 +177,7 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_SOURCES = \
   src/coap_time.c \
   src/coap_tinydtls.c \
   src/coap_uri.c \
+  src/coap_ws.c \
   src/net.c \
   src/pdu.c \
   src/resource.c
@@ -220,7 +222,8 @@ libcoap_include_HEADERS = \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_str.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_subscribe.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_time.h \
-  $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_uri.h
+  $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_uri.h \
+  $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_ws.h
 
 ## Instruct libtool to include API version information in the generated shared
 ## library file (.so). The library ABI version will later defined in configure.ac,

--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -351,13 +351,12 @@ nack_handler(coap_session_t *session COAP_UNUSED,
   case COAP_NACK_NOT_DELIVERABLE:
   case COAP_NACK_RST:
   case COAP_NACK_TLS_FAILED:
+  case COAP_NACK_TLS_LAYER_FAILED:
     coap_log_err("cannot send CoAP pdu\n");
     quit = 1;
     break;
   case COAP_NACK_ICMP_ISSUE:
   case COAP_NACK_BAD_RESPONSE:
-  case COAP_NACK_TLS_LAYER_FAILED:
-  case COAP_NACK_SESSION_LAYER_FAILED:
   default:
     ;
   }

--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -155,7 +155,8 @@ COAP_SRC = coap_address.c \
 	   coap_tinydtls.c \
 	   coap_str.c \
 	   coap_tcp.c \
-	   coap_uri.c
+	   coap_uri.c \
+	   coap_ws.c
 
 CN_COAP_OBJ =$(patsubst %.c,lib-client/%.o,$(COAP_SRC))
 SN_COAP_OBJ =$(patsubst %.c,lib-server/%.o,$(COAP_SRC))

--- a/include/coap3/coap.h.in
+++ b/include/coap3/coap.h.in
@@ -63,6 +63,7 @@ extern "C" {
 #include "coap@LIBCOAP_API_VERSION@/coap_subscribe.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_time.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_uri.h"
+#include "coap@LIBCOAP_API_VERSION@/coap_ws.h"
 
 #ifdef __cplusplus
 }

--- a/include/coap3/coap.h.windows
+++ b/include/coap3/coap.h.windows
@@ -58,6 +58,7 @@ extern "C" {
 #include "coap3/coap_time.h"
 #include "coap3/coap_str.h"
 #include "coap3/coap_uri.h"
+#include "coap3/coap_ws.h"
 
 #ifdef __cplusplus
 }

--- a/include/coap3/coap.h.windows.in
+++ b/include/coap3/coap.h.windows.in
@@ -58,6 +58,7 @@ extern "C" {
 #include "coap@LIBCOAP_API_VERSION@/coap_time.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_str.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_uri.h"
+#include "coap@LIBCOAP_API_VERSION@/coap_ws.h"
 
 #ifdef __cplusplus
 }

--- a/include/coap3/coap_crypto_internal.h
+++ b/include/coap3/coap_crypto_internal.h
@@ -137,6 +137,21 @@ int coap_crypto_hmac(cose_hmac_alg_t hmac_alg,
                      coap_bin_const_t *data,
                      coap_bin_const_t **hmac);
 
+/**
+ * Create a hash of the provided data.
+ *
+ * @param alg The hash algorithm.
+ * @param data The data to hash.
+ * @param hash Where to put the hash result if successful.
+ *
+ * @return @c 1 if the data was successfully hashed, else @c 0.
+ *         It is the responsibility of the caller to release the
+ *         created hash.
+ */
+int coap_crypto_hash(cose_alg_t alg,
+                     const coap_bin_const_t *data,
+                     coap_bin_const_t **hash);
+
 /** @} */
 
 #endif /* COAP_CRYPTO_INTERNAL_H_ */

--- a/include/coap3/coap_internal.h
+++ b/include/coap3/coap_internal.h
@@ -112,5 +112,6 @@ typedef struct oscore_ctx_t oscore_ctx_t;
 #include "coap_uri_internal.h"
 #include "coap_utlist_internal.h"
 #include "coap_uthash_internal.h"
+#include "coap_ws_internal.h"
 
 #endif /* COAP_INTERNAL_H_ */

--- a/include/coap3/coap_io.h
+++ b/include/coap3/coap_io.h
@@ -74,7 +74,6 @@ typedef enum {
   COAP_NACK_ICMP_ISSUE,
   COAP_NACK_BAD_RESPONSE,
   COAP_NACK_TLS_LAYER_FAILED,
-  COAP_NACK_SESSION_LAYER_FAILED,
 } coap_nack_reason_t;
 
 #endif /* COAP_IO_H_ */

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -200,7 +200,7 @@ size_t coap_pdu_parse_header_size(coap_proto_t proto,
  * @param data   The raw data to parse as CoAP PDU.
  * @param length The actual size of @p data.
  *
- * @return       A value greater than zero on success or @c 0 on error.
+ * @return       PDU size including token on success or @c 0 on error.
  */
 size_t coap_pdu_parse_size(coap_proto_t proto,
                            const uint8_t *data,

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -20,6 +20,7 @@
 
 #include "coap_internal.h"
 #include "coap_io_internal.h"
+#include "coap_ws_internal.h"
 
 #define COAP_DEFAULT_SESSION_TIMEOUT 300
 #define COAP_PARTIAL_SESSION_TIMEOUT_TICKS (30 * COAP_TICKS_PER_SECOND)

--- a/include/coap3/coap_ws.h
+++ b/include/coap3/coap_ws.h
@@ -1,0 +1,51 @@
+/*
+ * coap_ws.h -- WebSockets Transport Layer Support for libcoap
+ *
+ * Copyright (C) 2023 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2023 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_ws.h
+ * @brief CoAP WebSockets support
+ */
+
+#ifndef COAP_WS_H_
+#define COAP_WS_H_
+
+/**
+ * @ingroup application_api
+ * @defgroup ws WebSockets Support
+ * API for interfacing with WebSockets
+ * @{
+ */
+
+/**
+ * Check whether Websockets is available.
+ *
+ * @return @c 1 if support for WebSockets is available, or @c 0 otherwise.
+ */
+int coap_ws_is_supported(void);
+
+/**
+ * Check whether Secure WebSockets is available.
+ *
+ * @return @c 1 if support for Secure WebSockets is available, or @c 0 otherwise.
+ */
+int coap_wss_is_supported(void);
+
+/**
+ * Set the host for the HTTP Host: Header in the WebSockets Request.
+ *
+ * @return @c 1 if successful, else @c 0 if failure of some sort.
+ */
+int coap_ws_set_host_request(coap_session_t *session, coap_str_const_t *ws_host);
+
+/** @} */
+
+#endif /* COAP_WS_H */

--- a/include/coap3/coap_ws_internal.h
+++ b/include/coap3/coap_ws_internal.h
@@ -1,0 +1,32 @@
+/*
+ * coap_ws_internal.h -- WebSockets Transport Layer Support for libcoap
+ *
+ * Copyright (C) 2023 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2023 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_ws_internal.h
+ * @brief Internal CoAP WebSockets support
+ */
+
+#ifndef COAP_WS_INTERNAL_H_
+#define COAP_WS_INTERNAL_H_
+
+#include "coap_internal.h"
+
+/**
+ * @ingroup internal_api
+ * @defgroup ws_internal WebSockets Support
+ * Internal API for WebSockets Support
+ * @{
+ */
+
+/** @} */
+
+#endif /* COAP_WS_INTERNAL_H */

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -267,6 +267,9 @@ global:
   coap_uri_into_options;
   coap_write_block_b_opt;
   coap_write_block_opt;
+  coap_ws_is_supported;
+  coap_ws_set_host_request;
+  coap_wss_is_supported;
 local:
   *;
 };

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -265,3 +265,6 @@ coap_tls_is_supported
 coap_uri_into_options
 coap_write_block_b_opt
 coap_write_block_opt
+coap_ws_is_supported
+coap_ws_set_host_request
+coap_wss_is_supported

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -310,6 +310,18 @@ coap_digest_final(coap_digest_ctx_t *digest_ctx,
 }
 #endif /* COAP_SERVER_SUPPORT */
 
+#if COAP_WS_SUPPORT
+int
+coap_crypto_hash(cose_alg_t alg,
+                 const coap_bin_const_t *data,
+                 coap_bin_const_t **hash) {
+  (void)alg;
+  (void)data;
+  (void)hash;
+  return 0;
+}
+#endif /* COAP_WS_SUPPORT */
+
 #if HAVE_OSCORE
 
 int

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -310,6 +310,8 @@ void coap_session_free(coap_session_t *session) {
   assert(session->ref == 0);
   if (session->ref)
     return;
+  /* Make sure nothing gets deleted under our feet */
+  coap_session_reference(session);
   coap_session_mfree(session);
 #if COAP_SERVER_SUPPORT
   if (session->endpoint) {
@@ -327,6 +329,7 @@ void coap_session_free(coap_session_t *session) {
   coap_log_debug("***%s: session %p: closed\n", coap_session_str(session),
            (void *)session);
 
+  assert(session->ref == 1);
   coap_free_type(COAP_SESSION, session);
 }
 
@@ -586,8 +589,6 @@ coap_nack_name(coap_nack_reason_t reason) {
     return "COAP_NACK_BAD_RESPONSE";
   case COAP_NACK_TLS_LAYER_FAILED:
     return "COAP_NACK_TLS_LAYER_FAILED";
-  case COAP_NACK_SESSION_LAYER_FAILED:
-    return "COAP_NACK_SESSION_LAYER_FAILED";
   default:
     return "???";
   }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -1460,6 +1460,18 @@ coap_digest_final(coap_digest_ctx_t *digest_ctx,
 }
 #endif /* COAP_SERVER_SUPPORT */
 
+#if COAP_WS_SUPPORT
+int
+coap_crypto_hash(cose_alg_t alg,
+                 const coap_bin_const_t *data,
+                 coap_bin_const_t **hash) {
+  (void)alg;
+  (void)data;
+  (void)hash;
+  return 0;
+}
+#endif /* COAP_WS_SUPPORT */
+
 #if HAVE_OSCORE
 
 int

--- a/src/coap_ws.c
+++ b/src/coap_ws.c
@@ -1,0 +1,41 @@
+/*
+ * coap_ws.c -- WebSockets functions for libcoap
+ *
+ * Copyright (C) 2023 Olaf Bergmann <bergmann@tzi.org>
+ * Copyright (C) 2023 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_ws.c
+ * @brief CoAP WebSocket handling functions
+ */
+
+#include "coap3/coap_internal.h"
+
+#if COAP_WS_SUPPORT
+
+#else /* !COAP_WS_SUPPORT */
+
+int
+coap_ws_is_supported(void) {
+  return 0;
+}
+
+int
+coap_wss_is_supported(void) {
+  return 0;
+}
+
+int
+coap_ws_set_host_request(coap_session_t *session, coap_str_const_t *ws_host) {
+  (void)session;
+  (void)ws_host;
+  return 0;
+}
+
+#endif /* !COAP_WS_SUPPORT */

--- a/src/net.c
+++ b/src/net.c
@@ -1681,7 +1681,7 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
           }
         } else if (session->partial_read > 0) {
           size_t hdr_size = coap_pdu_parse_header_size(session->proto,
-            session->read_header);
+                                                       session->read_header);
           size_t tkl = session->read_header[0] & 0x0f;
           size_t tok_ext_bytes = tkl == COAP_TOKEN_EXT_1B_TKL ? 1 :
                                  tkl == COAP_TOKEN_EXT_2B_TKL ? 2 : 0;
@@ -3503,7 +3503,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
 
     if (!coap_is_mcast(&session->addr_info.local)) {
       if (COAP_PDU_IS_EMPTY(pdu)) {
-        if (session->proto != COAP_PROTO_TCP && session->proto != COAP_PROTO_TLS) {
+        if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
           coap_tick_t now;
           coap_ticks(&now);
           if (session->last_tx_rst + COAP_TICKS_PER_SECOND/4 < now) {

--- a/win32/libcoap.vcxproj
+++ b/win32/libcoap.vcxproj
@@ -65,6 +65,7 @@
     <ClCompile Include="..\src\coap_tcp.c" />
     <ClCompile Include="..\src\coap_tinydtls.c" />
     <ClCompile Include="..\src\coap_uri.c" />
+    <ClCompile Include="..\src\coap_ws.c" />
     <ClCompile Include="..\src\net.c" />
     <ClCompile Include="..\src\pdu.c" />
     <ClCompile Include="..\src\resource.c" />
@@ -115,6 +116,8 @@
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_uri_internal.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_uthash_internal.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_utlist_internal.h" />
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_ws.h" />
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_ws_internal.h" />
     <ClInclude Include="..\$(LibCoAPOSCOREIncludeDir)\oscore.h" />
     <ClInclude Include="..\$(LibCoAPOSCOREIncludeDir)\oscore_cbor.h" />
     <ClInclude Include="..\$(LibCoAPOSCOREIncludeDir)\oscore_context.h" />

--- a/win32/libcoap.vcxproj.filters
+++ b/win32/libcoap.vcxproj.filters
@@ -89,6 +89,9 @@
     <ClCompile Include="..\src\coap_uri.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\coap_ws.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\net.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -233,6 +236,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_utlist_internal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_ws.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_ws_internal.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\$(LibCoAPOSCOREIncludeDir)\oscore_cbor.h">


### PR DESCRIPTION
Add in stub Websockets files.

Add in coap_crypto_hash(0 function.

Actual WebSocket support for applications will follow.