### PR TITLE
WebSockets: Add in support for WebSockets layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,10 @@ option(
   "Enable building with TCP support"
   ON)
 option(
+  ENABLE_WS
+  "Enable building with WebSockets support"
+  ON)
+option(
   ENABLE_TESTS
   "build also tests"
   OFF)
@@ -202,6 +206,13 @@ if(${ENABLE_OSCORE})
   message(STATUS "compiling with OSCORE support")
 else()
   message(STATUS "compiling without OSCORE support")
+endif()
+
+if(${ENABLE_WS})
+  set(COAP_WS_SUPPORT "1")
+  message(STATUS "compiling with WebSockets support")
+else()
+  message(STATUS "compiling without WebSockets support")
 endif()
 
 if(${WITH_EPOLL}
@@ -424,6 +435,7 @@ message(STATUS "PACKAGE VERSION..................${PACKAGE_VERSION}")
 message(STATUS "PACKAGE BUILD....................${LIBCOAP_PACKAGE_BUILD}")
 message(STATUS "ENABLE_DTLS:.....................${ENABLE_DTLS}")
 message(STATUS "ENABLE_TCP:......................${ENABLE_TCP}")
+message(STATUS "ENABLE_WEBSOCKETS:...............${ENABLE_WS}")
 message(STATUS "ENABLE_CLIENT_MODE:..............${ENABLE_CLIENT_MODE}")
 message(STATUS "ENABLE_SERVER_MODE:..............${ENABLE_SERVER_MODE}")
 message(STATUS "ENABLE_OSCORE:...................${ENABLE_OSCORE}")

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ The following RFCs are supported
 * RFC8132: PATCH and FETCH Methods for the Constrained Application Protocol (CoAP)
 
 * RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets
-  [No WebSockets support]
 
 * RFC8516: "Too Many Requests" Response Code for the Constrained Application Protocol
 

--- a/cmake_coap_config.h.in
+++ b/cmake_coap_config.h.in
@@ -38,6 +38,9 @@
 /* Define if the library has OSCORE support */
 #cmakedefine HAVE_OSCORE @HAVE_OSCORE@
 
+/* Define if the library has WebSockets support */
+#cmakedefine COAP_WS_SUPPORT @COAP_WS_SUPPORT@
+
 /* Define to 1 if you have the <arpa/inet.h> header file. */
 #cmakedefine HAVE_ARPA_INET_H @HAVE_ARPA_INET_H@
 

--- a/configure.ac
+++ b/configure.ac
@@ -765,6 +765,18 @@ AS_IF([test "x$build_tcp" != "xyes"], [AC_DEFINE(COAP_DISABLE_TCP, [1])])
 AC_SUBST(COAP_DISABLE_TCP)
 
 # configure options
+# __websockets__
+AC_ARG_ENABLE([websockets],
+              [AS_HELP_STRING([--enable-websockets],
+                              [Enable building with WebSockets support [default=yes]])],
+              [build_ws="$enableval"],
+              [build_ws="yes"])
+
+AC_DEFINE(COAP_WS_SUPPORT, [1], [Define to 1 to build with WebScockets support.])
+AS_IF([test "x$build_ws" = "xyes"], [AC_DEFINE(COAP_WS_SUPPORT, [1])])
+AC_SUBST(COAP_WS_SUPPORT)
+
+# configure options
 # __async__
 AC_ARG_ENABLE([async],
               [AS_HELP_STRING([--enable-async],

--- a/doc/main.md
+++ b/doc/main.md
@@ -34,7 +34,6 @@ The following RFCs are supported
 * RFC8132: PATCH and FETCH Methods for the Constrained Application Protocol (CoAP)
 
 * RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets
-  [No WebSockets support]
 
 * RFC8516: "Too Many Requests" Response Code for the Constrained Application Protocol
 

--- a/include/coap3/coap_event.h
+++ b/include/coap3/coap_event.h
@@ -115,7 +115,16 @@ typedef enum {
   /** Triggered when there is an OSCORE internal error i.e malloc failed */
   COAP_EVENT_OSCORE_INTERNAL_ERROR,
   /** Triggered when there is an OSCORE decode of OSCORE option failure */
-  COAP_EVENT_OSCORE_DECODE_ERROR
+  COAP_EVENT_OSCORE_DECODE_ERROR,
+/*
+ * WebSocket events
+ */
+  /** Triggered when there is an oversize WebSockets packet */
+  COAP_EVENT_WS_PACKET_SIZE = 0x7001,
+  /** Triggered when the WebSockets layer is up */
+  COAP_EVENT_WS_CONNECTED,
+  /** Triggered when the WebSockets layer is closed */
+  COAP_EVENT_WS_CLOSED,
 } coap_event_t;
 
 /**

--- a/include/coap3/coap_io.h
+++ b/include/coap3/coap_io.h
@@ -74,6 +74,8 @@ typedef enum {
   COAP_NACK_ICMP_ISSUE,
   COAP_NACK_BAD_RESPONSE,
   COAP_NACK_TLS_LAYER_FAILED,
+  COAP_NACK_WS_LAYER_FAILED,
+  COAP_NACK_WS_FAILED
 } coap_nack_reason_t;
 
 #endif /* COAP_IO_H_ */

--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -32,6 +32,7 @@ struct uip_udp_conn;
 
 typedef enum {
   COAP_LAYER_SESSION,
+  COAP_LAYER_WS,
   COAP_LAYER_TLS,
   COAP_LAYER_LAST
 } coap_layer_t;

--- a/include/coap3/coap_session.h
+++ b/include/coap3/coap_session.h
@@ -34,7 +34,8 @@ typedef struct coap_fixed_point_t {
 } coap_fixed_point_t;
 
 #define COAP_PROTO_NOT_RELIABLE(p) ((p)==COAP_PROTO_UDP || (p)==COAP_PROTO_DTLS)
-#define COAP_PROTO_RELIABLE(p) ((p)==COAP_PROTO_TCP || (p)==COAP_PROTO_TLS)
+#define COAP_PROTO_RELIABLE(p) ((p)==COAP_PROTO_TCP || (p)==COAP_PROTO_TLS || \
+                                (p)==COAP_PROTO_WS || (p)==COAP_PROTO_WSS)
 
 /**
  * coap_session_type_t values

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -176,6 +176,10 @@ struct coap_session_t {
                                            associations */
   uint64_t oscore_r2;             /**< R2 for RFC8613 Appendix B.2 */
 #endif /* HAVE_OSCORE */
+#if COAP_WS_SUPPORT
+  coap_ws_state_t *ws;            /**< WS state */
+  coap_str_const_t *ws_host;      /**< Host to use in WS Request */
+#endif /* COAP_WS_SUPPORT */
   volatile uint8_t max_token_checked; /**< Check for max token size
                                            coap_ext_token_check_t */
   uint16_t max_token_mid;         /**< mid used for checking ext token

--- a/include/coap3/coap_uri.h
+++ b/include/coap3/coap_uri.h
@@ -32,7 +32,9 @@ typedef enum coap_uri_scheme_t {
   COAP_URI_SCHEME_COAPS_TCP, /* 3 */
   COAP_URI_SCHEME_HTTP,      /* 4 Proxy-Uri only */
   COAP_URI_SCHEME_HTTPS,     /* 5 Proxy-Uri only */
-  COAP_URI_SCHEME_LAST       /* 6 Size of scheme */
+  COAP_URI_SCHEME_COAP_WS,   /* 6 */
+  COAP_URI_SCHEME_COAPS_WS,  /* 7 */
+  COAP_URI_SCHEME_LAST       /* 8 Size of scheme */
 } coap_uri_scheme_t;
 
 /** This mask can be used to check if a parsed URI scheme is secure. */
@@ -44,11 +46,15 @@ typedef enum coap_uri_scheme_t {
 #define COAP_URI_SCHEME_COAPS_TCP_BIT  (1 << COAP_URI_SCHEME_COAPS_TCP)
 #define COAP_URI_SCHEME_HTTP_BIT       (1 << COAP_URI_SCHEME_HTTP)
 #define COAP_URI_SCHEME_HTTPS_BIT      (1 << COAP_URI_SCHEME_HTTPS)
+#define COAP_URI_SCHEME_COAP_WS_BIT    (1 << COAP_URI_SCHEME_COAP_WS)
+#define COAP_URI_SCHEME_COAPS_WS_BIT   (1 << COAP_URI_SCHEME_COAPS_WS)
 
 #define COAP_URI_SCHEME_ALL_COAP_BITS (COAP_URI_SCHEME_COAP_BIT | \
                                        COAP_URI_SCHEME_COAPS_BIT | \
                                        COAP_URI_SCHEME_COAP_TCP_BIT | \
-                                       COAP_URI_SCHEME_COAPS_TCP_BIT)
+                                       COAP_URI_SCHEME_COAPS_TCP_BIT | \
+                                       COAP_URI_SCHEME_COAP_WS_BIT | \
+                                       COAP_URI_SCHEME_COAPS_WS_BIT)
 
 /**
  * Representation of parsed URI. Components may be filled from a string with

--- a/include/coap3/coap_ws_internal.h
+++ b/include/coap3/coap_ws_internal.h
@@ -27,6 +27,129 @@
  * @{
  */
 
+
+/* Frame size:  Min Header + (Opt) Ext payload length + (Opt) Masking key */
+#define COAP_MAX_FS (2 + 8 + 4)
+
+/**
+ * WebSockets session state
+ */
+typedef struct coap_ws_state_t {
+  coap_session_type_t state; /**< Client or Server */
+  uint8_t up;           /**< Websockets established */
+  uint8_t seen_first;   /**< Seen first request/response HTTP header */
+  uint8_t seen_host;    /**< Seen Host: HTTP header (server) */
+  uint8_t seen_upg;     /**< Seen Upgrade: HTTP header */
+  uint8_t seen_conn;    /**< Seen Connection: HTTP header */
+  uint8_t seen_key;     /**< Seen Key: HTTP header */
+  uint8_t seen_proto;   /**< Seen Protocol: HTTP header */
+  uint8_t seen_ver;     /**< Seen version: HTTP header (server) */
+  uint8_t sent_close;   /**< Close has been sent */
+  uint8_t recv_close;   /**< Close has been received */
+  uint16_t close_reason; /**< Reason for closing */
+  int all_hdr_in;       /**< Frame header available */
+  int hdr_ofs;          /**< Current offset into rd_header */
+  uint8_t rd_header[COAP_MAX_FS]; /**< (Partial) frame */
+  uint8_t mask_key[4];  /**< Masking key */
+  uint32_t http_ofs;    /**< Current offset into http_hdr */
+  uint8_t http_hdr[80]; /**< (Partial) HTTP header */
+  size_t data_ofs;      /**< Offset into user provided buffer */
+  size_t data_size;     /**< Data size as indicated by WebSocket frame */
+  uint8_t key[16];      /**< Random, but agreed key value */
+} coap_ws_state_t;
+
+/*
+ * WebSockets Frame
+ *
+ *    0                   1                   2                   3
+ *    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ *   +-+-+-+-+-------+-+-------------+-------------------------------+
+ *   |F|R|R|R| opcode|M| Payload len |    Extended payload length    |
+ *   |I|S|S|S|  (4)  |A|     (7)     |             (16/64)           |
+ *   |N|V|V|V|       |S|             |   (if payload len==126/127)   |
+ *   | |1|2|3|       |K|             |                               |
+ *   +-+-+-+-+-------+-+-------------+ - - - - - - - - - - - - - - - +
+ *   |     Extended payload length continued, if payload len == 127  |
+ *   + - - - - - - - - - - - - - - - +-------------------------------+
+ *   |                               |Masking-key, if MASK set to 1  |
+ *   +-------------------------------+-------------------------------+
+ *   | Masking-key (continued)       |          Payload Data         |
+ *   +-------------------------------- - - - - - - - - - - - - - - - +
+ *   :                     Payload Data continued ...                :
+ *   + - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - +
+ *   |                     Payload Data continued ...                |
+ *   +---------------------------------------------------------------+
+ */
+
+#define WS_B0_FIN_BIT  0x80
+#define WS_B0_RSV_MASK 0x70
+#define WS_B0_OP_MASK  0x0f
+
+#define WS_B1_MASK_BIT 0x80
+#define WS_B1_LEN_MASK 0x7f
+
+typedef enum {
+  WS_OP_CONT = 0x0,
+  WS_OP_TEXT,
+  WS_OP_BINARY,
+  WS_OP_CLOSE = 0x8,
+  WS_OP_PING,
+  WS_OP_PONG
+} coap_ws_opcode_t;
+
+/**
+ * Function interface for websockets data transmission. This function returns
+ * the number of bytes that have been transmitted, or a value less than zero
+ * on error. The number of bytes written may be less than datalen because of
+ * congestion control.
+ *
+ * @param session          Session to send data on.
+ * @param data             The data to send.
+ * @param datalen          The actual length of @p data.
+ *
+ * @return                 The number of bytes written on success, or a value
+ *                         less than zero on error.
+ */
+ssize_t coap_ws_write(coap_session_t *session,
+                      const uint8_t *data, size_t datalen);
+
+/**
+ * Function interface for websockets data receiving. This function returns
+ * the number of bytes that have been read, or a value less than zero
+ * on error. The number of bytes read may be less than datalen because of
+ * congestion control.
+ *
+ * @param session          Session to receive data on.
+ * @param data             The data to receive.
+ * @param datalen          The maximum length of @p data.
+ *
+ * @return                 The number of bytes read on success, or a value
+ *                         less than zero on error.
+ */
+ssize_t coap_ws_read(coap_session_t *session, uint8_t *data,
+                     size_t datalen);
+
+/**
+ * Layer function interface for layer below WebSockets accept/connect being
+ * established. This function initiates the Websockets layer.
+ *
+ * If this layer is properly established on invocation, then the next layer
+ * must get called by calling
+ *   session->lfunc[COAP_LAYER_WS].establish(session)
+ * (or done at any point when WebSockets is established).
+ *
+ * @param session Session that the lower layer accept/connect was done on.
+ *
+ */
+void coap_ws_establish(coap_session_t *session);
+
+/**
+ * Layer function interface for Websockets close for a session.
+ *
+ * @param session  Session to do the Websockets close on.
+ */
+void coap_ws_close(coap_session_t *session);
+
 /** @} */
 
 #endif /* COAP_WS_INTERNAL_H */

--- a/include/coap3/pdu.h
+++ b/include/coap3/pdu.h
@@ -305,6 +305,8 @@ typedef enum coap_proto_t {
   COAP_PROTO_DTLS,
   COAP_PROTO_TCP,
   COAP_PROTO_TLS,
+  COAP_PROTO_WS,
+  COAP_PROTO_WSS,
   COAP_PROTO_LAST
 } coap_proto_t;
 

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -20,9 +20,9 @@ coap-server-notls
 SYNOPSIS
 --------
 *coap-server* [*-d* max] [*-e*] [*-g* group] [*-l* loss] [*-p* port] [-r]
-              [*-v* num] [*-A* address] [*-E* oscore_conf_file[,seq_file]]
-              [*-G* group_if] [*-L* value] [*-N*]
-              [*-P* scheme://addr[:port],[name1[,name2..]]]
+              [*-v* num] [*-w* [port][,secure_port]] [*-A* address]
+              [*-E* oscore_conf_file[,seq_file]] [*-G* group_if] [*-L* value]
+              [*-N*] [*-P* scheme://addr[:port],[name1[,name2..]]]
               [*-T* max_token_size] [*-U* type] [*-V* num] [*-X* size]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
               [*-s* match_psk_sni_file] [*-u* user]]
@@ -76,6 +76,10 @@ OPTIONS - General
 *-v* num::
    The verbosity level to use (default 4, maximum is 8) for general
    CoAP logging.
+
+*-w* [port][,secure_port]::
+   Enable WebSockets support support on port (WS) and/or secure_port (WSS),
+   comma separated.
 
 *-A* address::
    The local address of the interface which the server has to listen on.

--- a/man/coap_uri.txt.in
+++ b/man/coap_uri.txt.in
@@ -191,6 +191,14 @@ parse_and_send_uri(coap_session_t *session, const char *do_uri) {
     if (proto != COAP_PROTO_TLS)
       return 0;
     break;
+  case COAP_URI_SCHEME_COAP_WS:
+    if (proto != COAP_PROTO_WS)
+      return 0;
+    break;
+  case COAP_URI_SCHEME_COAPS_WS:
+    if (proto != COAP_PROTO_WSS)
+      return 0;
+    break;
   /* Proxy support only */
   case COAP_URI_SCHEME_HTTP:
   case COAP_URI_SCHEME_HTTPS:

--- a/src/coap_address.c
+++ b/src/coap_address.c
@@ -274,6 +274,18 @@ coap_resolve_address_info(const coap_str_const_t *server,
             if (ainfo->ai_socktype != SOCK_STREAM)
               continue;
             break;
+          case COAP_URI_SCHEME_COAP_WS:
+            if (!coap_ws_is_supported())
+              continue;
+            if (ainfo->ai_socktype != SOCK_STREAM)
+              continue;
+            break;
+          case COAP_URI_SCHEME_COAPS_WS:
+            if (!coap_wss_is_supported())
+              continue;
+            if (ainfo->ai_socktype != SOCK_STREAM)
+              continue;
+            break;
           case COAP_URI_SCHEME_LAST:
           default:
             continue;
@@ -341,6 +353,12 @@ coap_resolve_address_info(const coap_str_const_t *server,
             update_port(&info->addr, port, 80);
             break;
           case COAP_URI_SCHEME_HTTPS:
+            update_port(&info->addr, secure_port, 443);
+            break;
+          case COAP_URI_SCHEME_COAP_WS:
+            update_port(&info->addr, port, 80);
+            break;
+          case COAP_URI_SCHEME_COAPS_WS:
             update_port(&info->addr, secure_port, 443);
             break;
           case COAP_URI_SCHEME_LAST:

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -1034,20 +1034,22 @@ char *coap_string_tls_support(char *buffer, size_t bufsize)
   const int have_pkcs11 = coap_dtls_pkcs11_is_supported();
   const int have_rpk = coap_dtls_rpk_is_supported();
   const int have_oscore = coap_oscore_is_supported();
+  const int have_ws = coap_ws_is_supported();
 
   if (have_dtls == 0 && have_tls == 0) {
     snprintf(buffer, bufsize, "(No DTLS or TLS support)");
     return buffer;
   }
   snprintf(buffer, bufsize,
-           "(%sDTLS and %sTLS support; %sPSK, %sPKI, %sPKCS11, and %sRPK support)\n(%sOSCORE)",
+           "(%sDTLS and %sTLS support; %sPSK, %sPKI, %sPKCS11, and %sRPK support)\n(%sOSCORE)\n(%sWebSockets)",
            have_dtls ? "" : "No ",
            have_tls ? "" : "no ",
            have_psk ? "" : "no ",
            have_pki ? "" : "no ",
            have_pkcs11 ? "" : "no ",
            have_rpk ? "" : "no ",
-           have_oscore ? "Have " : "No ");
+           have_oscore ? "Have " : "No ",
+           have_ws ? "Have " : "No ");
   return buffer;
 }
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -98,34 +98,74 @@
 coap_layer_func_t coap_layers_coap[COAP_PROTO_LAST][COAP_LAYER_LAST] = {
   { /* COAP_PROTO_NONE */
     { NULL, NULL, NULL, NULL }, /* SESSION */
+    { NULL, NULL, NULL, NULL }, /* WS */
     { NULL, NULL, NULL, NULL }  /* TLS */
   },
   { /* COAP_PROTO_UDP */
     { NULL,                 coap_netif_dgrm_write, coap_session_establish, coap_netif_close }, /* SESSION */
+    { NULL,                 NULL,                  NULL,                   NULL             }, /* WS */
     { NULL,                 NULL,                  NULL,                   NULL             }  /* TLS */
   },
   { /* COAP_PROTO_DTLS */
     { NULL,                 coap_dtls_send,        coap_dtls_establish,    coap_dtls_close  }, /* SESSION */
+    { NULL,                 NULL,                  NULL,                   NULL             }, /* WS */
     { NULL,                 coap_netif_dgrm_write, coap_session_establish, coap_netif_close }  /* TLS */
   },
 #if !COAP_DISABLE_TCP
   { /* COAP_PROTO_TCP */
     { coap_netif_strm_read, coap_netif_strm_write, coap_session_establish, coap_netif_close }, /* SESSION */
+    { NULL,                 NULL,                  NULL,                   NULL             }, /* WS */
     { NULL,                 NULL,                  NULL,                   NULL             }  /* TLS */
   },
   { /* COAP_PROTO_TLS */
     { coap_tls_read,        coap_tls_write,        coap_tls_establish,     coap_tls_close   }, /* SESSION */
+    { NULL,                 NULL,                  NULL,                   NULL             }, /* WS */
     { coap_netif_strm_read, coap_netif_strm_write, coap_session_establish, coap_netif_close }  /* TLS */
   },
+#if COAP_WS_SUPPORT
+  { /* COAP_PROTO_WS */
+    { coap_ws_read,         coap_ws_write,         coap_ws_establish,      coap_ws_close    }, /* SESSION */
+    { coap_netif_strm_read, coap_netif_strm_write, coap_session_establish, coap_netif_close }, /* WS */
+    { NULL,                 NULL,                  NULL,                   NULL             }  /* TLS */
+  },
+  { /* COAP_PROTO_WSS */
+    { coap_ws_read,         coap_ws_write,         coap_tls_establish,     coap_ws_close    }, /* SESSION */
+    { coap_tls_read,        coap_tls_write,        coap_session_establish, coap_tls_close   }, /* WS */
+    { coap_netif_strm_read, coap_netif_strm_write, coap_ws_establish,      coap_netif_close }  /* TLS */
+  }
+#else /* !COAP_WS_SUPPORT */
+  { /* COAP_PROTO_WS */
+    { NULL, NULL, NULL, NULL }, /* SESSION */
+    { NULL, NULL, NULL, NULL }, /* WS */
+    { NULL, NULL, NULL, NULL }  /* TLS */
+  },
+  { /* COAP_PROTO_WSS */
+    { NULL, NULL, NULL, NULL }, /* SESSION */
+    { NULL, NULL, NULL, NULL }, /* WS */
+    { NULL, NULL, NULL, NULL }  /* TLS */
+  }
+#endif /* !COAP_WS_SUPPORT */
 #else /* COAP_DISABLE_TCP */
   { /* COAP_PROTO_TCP */
     { NULL, NULL, NULL, NULL }, /* SESSION */
+    { NULL, NULL, NULL, NULL }, /* WS */
     { NULL, NULL, NULL, NULL }  /* TLS */
   },
   { /* COAP_PROTO_TLS */
     { NULL, NULL, NULL, NULL }, /* SESSION */
+    { NULL, NULL, NULL, NULL }, /* WS */
     { NULL, NULL, NULL, NULL }  /* TLS */
   },
+  { /* COAP_PROTO_WS */
+    { NULL, NULL, NULL, NULL }, /* SESSION */
+    { NULL, NULL, NULL, NULL }, /* WS */
+    { NULL, NULL, NULL, NULL }  /* TLS */
+  },
+  { /* COAP_PROTO_WSS */
+    { NULL, NULL, NULL, NULL }, /* SESSION */
+    { NULL, NULL, NULL, NULL }, /* WS */
+    { NULL, NULL, NULL, NULL }  /* TLS */
+  }
 #endif /* COAP_DISABLE_TCP */
 };
 

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -1214,7 +1214,8 @@ static int setup_client_ssl_session(coap_session_t *c_session,
       return ret;
     }
 #if defined(MBEDTLS_SSL_SRV_C) && defined(MBEDTLS_SSL_ALPN)
-    if (c_session->proto == COAP_PROTO_TLS) {
+    if (c_session->proto == COAP_PROTO_TLS ||
+        c_session->proto == COAP_PROTO_WSS) {
       static const char *alpn_list[] = { "coap", NULL };
 
       ret = mbedtls_ssl_conf_alpn_protocols(&m_env->conf, alpn_list);

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -3646,6 +3646,20 @@ coap_digest_final(coap_digest_ctx_t *digest_ctx,
 }
 #endif /* COAP_SERVER_SUPPORT */
 
+#if COAP_WS_SUPPORT || HAVE_OSCORE
+static void
+coap_crypto_output_errors(const char *prefix) {
+  unsigned long e;
+
+  while ((e = ERR_get_error()))
+    coap_log_warn(
+             "%s: %s%s\n",
+             prefix,
+             ERR_reason_error_string(e),
+             ssl_function_definition(e));
+}
+#endif /* COAP_WS_SUPPORT || HAVE_OSCORE */
+
 #if COAP_WS_SUPPORT
 /*
  * The struct hash_algs and the function get_hash_alg() are used to
@@ -3796,18 +3810,6 @@ coap_crypto_check_hkdf_alg(cose_hkdf_alg_t hkdf_alg) {
   if (1 != (Func)) {                                                           \
     goto error;                                                                \
   }
-
-static void
-coap_crypto_output_errors(const char *prefix) {
-  unsigned long e;
-
-  while ((e = ERR_get_error()))
-    coap_log_warn(
-             "%s: %s%s\n",
-             prefix,
-             ERR_reason_error_string(e),
-             ssl_function_definition(e));
-}
 
 int
 coap_crypto_aead_encrypt(const coap_crypto_param_t *params,

--- a/src/coap_ws.c
+++ b/src/coap_ws.c
@@ -18,6 +18,907 @@
 #include "coap3/coap_internal.h"
 
 #if COAP_WS_SUPPORT
+#include <stdio.h>
+#include <ctype.h>
+
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#endif
+
+#define COAP_WS_RESPONSE \
+"HTTP/1.1 101 Switching Protocols\r\n" \
+"Upgrade: websocket\r\n" \
+"Connection: Upgrade\r\n" \
+"Sec-WebSocket-Accept: %s\r\n" \
+"Sec-WebSocket-Protocol: coap\r\n" \
+"\r\n"
+
+int
+coap_ws_is_supported(void) {
+#if defined(HAVE_OPENSSL) || defined(HAVE_GNUTLS) || defined(HAVE_MBEDTLS)
+  /* Have SHA1 hash support */
+  return coap_tcp_is_supported();
+#else /* !HAVE_OPENSSL && !HAVE_GNUTLS && !HAVE_MBEDTLS */
+  return 0;
+#endif /* !HAVE_OPENSSL && !HAVE_GNUTLS && !HAVE_MBEDTLS */
+}
+
+int
+coap_wss_is_supported(void) {
+  return coap_tls_is_supported();
+}
+
+static const char
+basis_64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+static int
+coap_base64_encode_buffer(const uint8_t *string, size_t len, char *encoded,
+                          const size_t max_encoded_len) {
+  size_t i;
+  char *p;
+
+  if ((((len + 2) / 3 * 4) + 1) > max_encoded_len) {
+    assert(0);
+    return 0;
+  }
+
+  p = encoded;
+  for (i = 0; i < len - 2; i += 3) {
+    *p++ = basis_64[(string[i] >> 2) & 0x3F];
+    *p++ = basis_64[((string[i] & 0x3) << 4) |
+                    ((int) (string[i + 1] & 0xF0) >> 4)];
+    *p++ = basis_64[((string[i + 1] & 0xF) << 2) |
+                    ((int) (string[i + 2] & 0xC0) >> 6)];
+    *p++ = basis_64[string[i + 2] & 0x3F];
+  }
+  if (i < len) {
+    *p++ = basis_64[(string[i] >> 2) & 0x3F];
+    if (i == (len - 1)) {
+            *p++ = basis_64[((string[i] & 0x3) << 4)];
+            *p++ = '=';
+    } else {
+            *p++ = basis_64[((string[i] & 0x3) << 4) |
+                    ((int) (string[i + 1] & 0xF0) >> 4)];
+            *p++ = basis_64[((string[i + 1] & 0xF) << 2)];
+    }
+    *p++ = '=';
+  }
+
+  *p++ = '\0';
+  return 1;
+}
+
+static int
+coap_base64_decode_buffer(const char *bufcoded, size_t *len, uint8_t *bufplain,
+                          const size_t max_decoded_len) {
+  size_t nbytesdecoded;
+  const uint8_t *bufin;
+  uint8_t *bufout;
+  size_t nprbytes;
+  static const uint8_t pr2six[256] = {
+    /* ASCII table */
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
+    64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
+    64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64
+  };
+
+  bufin = (const uint8_t *)bufcoded;
+  while (pr2six[*(bufin++)] <= 63);
+  nprbytes = (bufin - (const unsigned char *) bufcoded) - 1;
+  nbytesdecoded = ((nprbytes + 3) / 4) * 3;
+  if ((nbytesdecoded - ((4 - nprbytes) & 3)) > max_decoded_len)
+    return 0;
+
+  bufout = bufplain;
+  bufin = (const uint8_t *)bufcoded;
+
+  while (nprbytes > 4) {
+    *(bufout++) =
+            (uint8_t) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
+    *(bufout++) =
+            (uint8_t) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
+    *(bufout++) =
+            (uint8_t) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
+    bufin += 4;
+    nprbytes -= 4;
+  }
+
+  /* Note: (nprbytes == 1) would be an error, so just ignore that case */
+  if (nprbytes > 1) {
+    *(bufout++) = (uint8_t) (pr2six[*bufin] << 2 | pr2six[bufin[1]] >> 4);
+  }
+  if (nprbytes > 2) {
+    *(bufout++) = (uint8_t) (pr2six[bufin[1]] << 4 | pr2six[bufin[2]] >> 2);
+  }
+  if (nprbytes > 3) {
+    *(bufout++) = (uint8_t) (pr2six[bufin[2]] << 6 | pr2six[bufin[3]]);
+  }
+
+  if (len)
+    *len = nbytesdecoded - ((4 - nprbytes) & 3);
+  return 1;
+}
+
+static void
+coap_ws_log_header(const coap_session_t *session, const uint8_t *header) {
+  char buf[3*COAP_MAX_FS + 1];
+  int i;
+  ssize_t bytes_size;
+  int extra_hdr_len = 2;
+
+  bytes_size = header[1] & WS_B1_LEN_MASK;
+  if (bytes_size == 127) {
+    extra_hdr_len += 8;
+  } else if (bytes_size == 126) {
+    extra_hdr_len += 2;
+  }
+  if (header[1] & WS_B1_MASK_BIT) {
+    extra_hdr_len +=4;
+  }
+  for (i = 0; i < extra_hdr_len; i++) {
+    snprintf(&buf[i*3], 4, " %02x", header[i]);
+  }
+  coap_log_debug("*  %s: WS header:%s\n", coap_session_str(session), buf);
+}
+
+static void
+coap_ws_log_key(const coap_session_t *session) {
+  char buf[3*16 + 1];
+  size_t i;
+
+  for (i = 0; i < sizeof(session->ws->key); i++) {
+    snprintf(&buf[i*3], 4, " %02x", session->ws->key[i]);
+  }
+  coap_log_debug("WS: key:%s\n", buf);
+}
+
+static void
+coap_ws_mask_data(coap_session_t *session, uint8_t *data, size_t data_len) {
+  coap_ws_state_t *ws = session->ws;
+  size_t i;
+
+  for (i = 0; i < data_len; i++) {
+    data[i] ^= ws->mask_key[i%4];
+  }
+}
+
+ssize_t
+coap_ws_write(coap_session_t *session, const uint8_t *data, size_t datalen) {
+  uint8_t ws_header[COAP_MAX_FS];
+  ssize_t hdr_len = 2;
+  ssize_t ret;
+
+  /* If lower layer not yet up, return error */
+  if (!session->ws) {
+    session->ws = coap_malloc_type(COAP_STRING, sizeof(coap_ws_state_t));
+    if (!session->ws) {
+      coap_session_disconnected(session, COAP_NACK_WS_LAYER_FAILED);
+      return -1;
+    }
+    memset(session->ws, 0, sizeof(coap_ws_state_t));
+  }
+
+  if (!session->ws->up) {
+    coap_log_debug("WS: Layer not up\n");
+    return 0;
+  }
+  if (session->ws->sent_close)
+    return 0;
+
+  ws_header[0] = WS_B0_FIN_BIT | WS_OP_BINARY;
+  if (datalen <= 125) {
+    ws_header[1] = datalen & WS_B1_LEN_MASK;
+  } else if (datalen <= 0xffff) {
+    ws_header[1] = 126;
+    ws_header[2] = (datalen >>  8) & 0xff;
+    ws_header[3] = datalen & 0xff;
+    hdr_len += 2;
+  } else {
+    ws_header[1] = 127;
+    ws_header[2] = (datalen >> 56) & 0xff;
+    ws_header[3] = (datalen >> 48) & 0xff;
+    ws_header[4] = (datalen >> 40) & 0xff;
+    ws_header[5] = (datalen >> 32) & 0xff;
+    ws_header[6] = (datalen >> 24) & 0xff;
+    ws_header[7] = (datalen >> 16) & 0xff;
+    ws_header[8] = (datalen >>  8) & 0xff;
+    ws_header[9] = datalen & 0xff;
+    hdr_len += 8;
+  }
+  if (session->ws->state == COAP_SESSION_TYPE_CLIENT) {
+    /* Need to set the Mask bit, and set the masking key */
+    ws_header[1] |= WS_B1_MASK_BIT;
+    /* TODO Masking Key and mask provided data */
+    coap_prng(&ws_header[hdr_len], 4);
+    memcpy(session->ws->mask_key, &ws_header[hdr_len], 4);
+    hdr_len += 4;
+  }
+  coap_ws_log_header(session, ws_header);
+  ret = session->sock.lfunc[COAP_LAYER_WS].write(session, ws_header, hdr_len);
+  if (ret != hdr_len) {
+    return -1;
+  }
+  if (session->ws->state == COAP_SESSION_TYPE_CLIENT) {
+    /* Need to mask the data */
+    uint8_t *wdata = coap_malloc_type(COAP_STRING, datalen);
+
+    if (!wdata) {
+      errno = ENOMEM;
+      return -1;
+    }
+    session->ws->data_size = datalen;
+    memcpy(wdata, data, datalen);
+    coap_ws_mask_data(session, wdata, datalen);
+    ret = session->sock.lfunc[COAP_LAYER_WS].write(session, wdata, datalen);
+    coap_free_type(COAP_STRING, wdata);
+  } else {
+    ret = session->sock.lfunc[COAP_LAYER_WS].write(session, data, datalen);
+  }
+  if (ret <= 0) {
+    return ret;
+  }
+  if (ret == (ssize_t)datalen)
+    coap_log_debug("*  %s: ws:    sent %4zd bytes\n",
+                   coap_session_str(session), ret);
+  else
+    coap_log_debug("*  %s: ws:    sent %4zd of %4zd bytes\n",
+                   coap_session_str(session), ret, datalen);
+  return datalen;
+}
+
+static char *
+coap_ws_split_rd_header(coap_session_t *session) {
+  char *cp = strchr((char*)session->ws->http_hdr, ' ');
+
+  if (!cp)
+    cp = strchr((char*)session->ws->http_hdr, '\t');
+
+  if (!cp)
+    return NULL;
+
+  *cp = '\000';
+  cp++;
+  while (isblank(*cp)) cp++;
+  return cp;
+}
+
+static int
+coap_ws_rd_http_header_server(coap_session_t *session) {
+  coap_ws_state_t *ws = session->ws;
+  char *value;
+
+  if (!ws->seen_first) {
+    if (strcasecmp((char*)ws->http_hdr,
+                    "GET /.well-known/coap HTTP/1.1") != 0) {
+      coap_log_info("WS: Invalid GET request %s\n", (char*)ws->http_hdr);
+      return 0;
+    }
+    ws->seen_first = 1;
+    return 1;
+  }
+  /* Process the individual header */
+  value = coap_ws_split_rd_header(session);
+  if (!value)
+    return 0;
+
+  if (strcasecmp((char*)ws->http_hdr, "Host:") == 0) {
+    if (ws->seen_host) {
+      coap_log_debug("WS: Duplicate Host: header\n");
+      return 0;
+    }
+    ws->seen_host = 1;
+  }
+  else if (strcasecmp((char*)ws->http_hdr, "Upgrade:") == 0) {
+    if (ws->seen_upg) {
+      coap_log_debug("WS: Duplicate Upgrade: header\n");
+      return 0;
+    }
+    if (strcasecmp(value, "websocket") != 0) {
+      coap_log_debug("WS: Invalid Upgrade: header\n");
+      return 0;
+    }
+    ws->seen_upg = 1;
+  }
+  else if (strcasecmp((char*)ws->http_hdr, "Connection:") == 0) {
+    if (ws->seen_conn) {
+      coap_log_debug("WS: Duplicate Connection: header\n");
+      return 0;
+    }
+    if (strcasecmp(value, "Upgrade") != 0) {
+      coap_log_debug("WS: Invalid Connection: header\n");
+      return 0;
+    }
+    ws->seen_conn = 1;
+  } else if (strcasecmp((char*)ws->http_hdr, "Sec-WebSocket-Key:") == 0) {
+    size_t len;
+
+    if (ws->seen_key) {
+      coap_log_debug("WS: Duplicate Sec-WebSocket-Key: header\n");
+      return 0;
+    }
+    if (!coap_base64_decode_buffer(value, &len, ws->key,
+                                   sizeof(ws->key)) ||
+        len != sizeof(ws->key)) {
+      coap_log_info("WS: Invalid Sec-WebSocket-Key: %s\n", value);
+      return 0;
+    }
+    coap_ws_log_key(session);
+    ws->seen_key = 1;
+  } else if (strcasecmp((char*)ws->http_hdr, "Sec-WebSocket-Protocol:") == 0) {
+    if (ws->seen_proto) {
+      coap_log_debug("WS: Duplicate Sec-WebSocket-Protocol: header\n");
+      return 0;
+    }
+    if (strcasecmp(value, "coap") != 0) {
+      coap_log_debug("WS: Invalid Sec-WebSocket-Protocol: header\n");
+      return 0;
+    }
+    ws->seen_proto = 1;
+  } else if (strcasecmp((char*)ws->http_hdr, "Sec-WebSocket-Version:") == 0) {
+    if (ws->seen_ver) {
+      coap_log_debug("WS: Duplicate Sec-WebSocket-Version: header\n");
+      return 0;
+    }
+    if (strcasecmp(value, "13") != 0) {
+      coap_log_debug("WS: Invalid Sec-WebSocket-Version: header\n");
+      return 0;
+    }
+    ws->seen_ver = 1;
+  }
+  return 1;
+}
+
+#define COAP_WS_KEY_EXT "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+static int
+coap_ws_build_key_hash(coap_session_t *session, char *hash, size_t max_hash_len) {
+  char buf[28 + sizeof(COAP_WS_KEY_EXT)];
+  coap_bin_const_t info;
+  coap_bin_const_t *hashed = NULL;
+
+  if (max_hash_len < 29)
+    return 0;
+  if (!coap_base64_encode_buffer(session->ws->key, sizeof(session->ws->key),
+                                 buf, sizeof(buf)))
+    return 0;
+  if (strlen(buf) >= 28)
+    return 0;
+  strcat(buf, COAP_WS_KEY_EXT);
+  info.s = (uint8_t *)buf;
+  info.length = strlen(buf);
+  if (!coap_crypto_hash(COSE_ALGORITHM_SHA_1, &info, &hashed))
+    return 0;
+
+  if (!coap_base64_encode_buffer(hashed->s, hashed->length,
+                                 hash, max_hash_len)) {
+    coap_delete_bin_const(hashed);
+    return 0;
+  }
+  coap_delete_bin_const(hashed);
+  return 1;
+}
+
+static int
+coap_ws_rd_http_header_client(coap_session_t *session) {
+  coap_ws_state_t *ws = session->ws;
+  char *value;
+
+  if (!ws->seen_first) {
+    value = coap_ws_split_rd_header(session);
+
+    if (strcmp((char*)ws->http_hdr, "HTTP/1.1") != 0 ||
+        atoi(value) != 101) {
+      coap_log_info("WS: Invalid GET response %s\n", (char*)ws->http_hdr);
+      return 0;
+    }
+    ws->seen_first = 1;
+    return 1;
+  }
+  /* Process the individual header */
+  value = coap_ws_split_rd_header(session);
+  if (!value)
+    return 0;
+
+  if (strcasecmp((char*)ws->http_hdr, "Upgrade:") == 0) {
+    if (ws->seen_upg) {
+      coap_log_debug("WS: Duplicate Upgrade: header\n");
+      return 0;
+    }
+    if (strcasecmp(value, "websocket") != 0) {
+      coap_log_debug("WS: Invalid Upgrade: header\n");
+      return 0;
+    }
+    ws->seen_upg = 1;
+  }
+  else if (strcasecmp((char*)ws->http_hdr, "Connection:") == 0) {
+    if (ws->seen_conn) {
+      coap_log_debug("WS: Duplicate Connection: header\n");
+      return 0;
+    }
+    if (strcasecmp(value, "Upgrade") != 0) {
+      coap_log_debug("WS: Invalid Connection: header\n");
+      return 0;
+    }
+    ws->seen_conn = 1;
+  } else if (strcasecmp((char*)ws->http_hdr, "Sec-WebSocket-Accept:") == 0) {
+    char hash[30];
+
+    if (ws->seen_key) {
+      coap_log_debug("WS: Duplicate Sec-WebSocket-Accept: header\n");
+      return 0;
+    }
+    if (!coap_ws_build_key_hash(session, hash, sizeof(hash))) {
+      return 0;
+    }
+    if (strcmp(hash, value) != 0) {
+      return 0;
+    }
+    ws->seen_key = 1;
+  } else if (strcasecmp((char*)ws->http_hdr, "Sec-WebSocket-Protocol:") == 0) {
+    if (ws->seen_proto) {
+      coap_log_debug("WS: Duplicate Sec-WebSocket-Protocol: header\n");
+      return 0;
+    }
+    if (strcasecmp(value, "coap") != 0) {
+      coap_log_debug("WS: Invalid Sec-WebSocket-Protocol: header\n");
+      return 0;
+    }
+    ws->seen_proto = 1;
+  }
+  return 1;
+}
+
+/*
+ * Read in and parse WebSockets setup HTTP headers
+ *
+ * return 0 failure
+ *        1 success
+ */
+static int
+coap_ws_rd_http_header(coap_session_t *session) {
+  coap_ws_state_t *ws = session->ws;
+  ssize_t bytes;
+  ssize_t rem;
+  char *cp;
+
+  while (!ws->up) {
+    /*
+     * Can only read in up to COAP_MAX_FS at a time in case there is
+     * some frame info that needs to be subsequently processed
+     */
+    rem = ws->http_ofs > (sizeof(ws->http_hdr) - 1 - COAP_MAX_FS) ?
+                           sizeof(ws->http_hdr) - ws->http_ofs : COAP_MAX_FS;
+    bytes = session->sock.lfunc[COAP_LAYER_WS].read(session,
+                                                    &ws->http_hdr[ws->http_ofs],
+                                                    rem);
+    if (bytes < 0)
+      return 0;
+    if (bytes == 0)
+      return 1;
+
+    ws->http_ofs += bytes;
+    ws->http_hdr[ws->http_ofs] = '\000';
+    /* Force at least one check */
+    cp = (char *)ws->http_hdr;
+    while (cp) {
+      cp = strchr((char *)ws->http_hdr, '\n');
+      if (cp) {
+        /* Whole header record in */
+        *cp = '\000';
+        if (cp != (char *)ws->http_hdr) {
+          if (cp[-1] == '\r')
+            cp[-1] = '\000';
+        }
+
+        coap_log_debug("WS: HTTP: %s\n", ws->http_hdr);
+        if (ws->http_hdr[0] != '\000') {
+          if (ws->state == COAP_SESSION_TYPE_SERVER) {
+            if (!coap_ws_rd_http_header_server(session)) {
+              return 0;
+            }
+          } else {
+            if (!coap_ws_rd_http_header_client(session)) {
+              return 0;
+            }
+          }
+        }
+
+        rem = ws->http_ofs - ((uint8_t*)cp + 1 - ws->http_hdr);
+        if (ws->http_hdr[0] == '\000') {
+          /* Found trailing empty header line */
+          if (ws->state == COAP_SESSION_TYPE_SERVER) {
+            if (!(ws->seen_first && ws->seen_host && ws->seen_upg &&
+                  ws->seen_conn && ws->seen_key && ws->seen_proto &&
+                  ws->seen_ver)) {
+              coap_log_info("WS: Missing protocol header(s)\n");
+              return 0;
+            }
+          } else {
+            if (!(ws->seen_first && ws->seen_upg && ws->seen_conn &&
+                  ws->seen_key && ws->seen_proto)) {
+              coap_log_info("WS: Missing protocol header(s)\n");
+              return 0;
+            }
+          }
+          ws->up = 1;
+          ws->hdr_ofs = rem;
+          if (rem > 0)
+            memcpy(ws->rd_header, cp + 1, rem);
+          return 1;
+        }
+        ws->http_ofs = rem;
+        memmove(ws->http_hdr, cp + 1, rem);
+        ws->http_hdr[ws->http_ofs] = '\000';
+      }
+    }
+  }
+  return 1;
+}
+
+/*
+ * return >=0 Number of bytes processed.
+ *         -1 Error (error in errno).
+ */
+ssize_t
+coap_ws_read(coap_session_t *session, uint8_t *data, size_t datalen) {
+  ssize_t bytes_size = 0;
+  ssize_t extra_hdr_len = 0;
+  ssize_t ret;
+  uint8_t op_code;
+
+  if (!session->ws) {
+    session->ws = coap_malloc_type(COAP_STRING, sizeof(coap_ws_state_t));
+    if (!session->ws) {
+      coap_session_disconnected(session, COAP_NACK_WS_LAYER_FAILED);
+      return -1;
+    }
+    memset(session->ws, 0, sizeof(coap_ws_state_t));
+  }
+
+  if (!session->ws->up) {
+    char buf[250];
+
+    if (!coap_ws_rd_http_header(session)) {
+      snprintf(buf, sizeof(buf), "HTTP/1.1 400 Invalid request\r\n\r\n");
+      coap_log_debug("WS: Response (Fail)\n%s", buf);
+      if (coap_netif_available(session)) {
+        session->sock.lfunc[COAP_LAYER_WS].write(session, (uint8_t*)buf,
+                                                 strlen(buf));
+      }
+      coap_session_disconnected(session, COAP_NACK_WS_LAYER_FAILED);
+      return -1;
+    }
+
+    if (!session->ws->up)
+      return 0;
+
+    if (session->ws->state == COAP_SESSION_TYPE_SERVER) {
+      char hash[30];
+
+      if (!coap_ws_build_key_hash(session, hash, sizeof(hash))) {
+        return 0;
+      }
+      snprintf(buf, sizeof(buf), COAP_WS_RESPONSE, hash);
+      coap_log_debug("WS: Response\n%s", buf);
+      session->sock.lfunc[COAP_LAYER_WS].write(session, (uint8_t*)buf,
+                                                   strlen(buf));
+
+      coap_handle_event(session->context, COAP_EVENT_WS_CONNECTED, session);
+      coap_log_debug("WS: established\n");
+    } else {
+      /* TODO Process the GET response - error on failure */
+
+      coap_handle_event(session->context, COAP_EVENT_WS_CONNECTED, session);
+    }
+    session->sock.lfunc[COAP_LAYER_WS].establish(session);
+    if (session->ws->hdr_ofs == 0)
+      return 0;
+  }
+
+  /* Get Websockets frame if not already completely in */
+  if (!session->ws->all_hdr_in) {
+    ret = session->sock.lfunc[COAP_LAYER_WS].read(session,
+                         &session->ws->rd_header[session->ws->hdr_ofs],
+                         sizeof(session->ws->rd_header) - session->ws->hdr_ofs);
+    if (ret < 0)
+      return ret;
+    session->ws->hdr_ofs += ret;
+    /* Enough of the header in ? */
+    if (session->ws->hdr_ofs < 2)
+      return 0;
+
+    if (session->ws->state == COAP_SESSION_TYPE_SERVER &&
+        !(session->ws->rd_header[1] & WS_B1_MASK_BIT)) {
+        /* Client has failed to mask the data */
+         session->ws->close_reason = 1002;
+        coap_ws_close(session);
+        return 0;
+    }
+
+    bytes_size = session->ws->rd_header[1] & WS_B1_LEN_MASK;
+    if (bytes_size == 127) {
+      extra_hdr_len += 8;
+    } else if (bytes_size == 126) {
+      extra_hdr_len += 2;
+    }
+    if (session->ws->rd_header[1] & WS_B1_MASK_BIT) {
+      memcpy(session->ws->mask_key, &session->ws->rd_header[2 + extra_hdr_len], 4);
+      extra_hdr_len +=4;
+    }
+    if (session->ws->hdr_ofs < 2 + extra_hdr_len)
+      return 0;
+
+    coap_ws_log_header(session, session->ws->rd_header);
+
+    op_code = session->ws->rd_header[0] & WS_B0_OP_MASK;
+    if (op_code != WS_OP_BINARY && op_code != WS_OP_CLOSE) {
+      /* Remote has failed to use correct opcode */
+       session->ws->close_reason = 1003;
+      coap_ws_close(session);
+      return 0;
+      if (op_code == WS_OP_CLOSE) {
+        coap_log_debug("WS: Close received\n");
+        session->ws->recv_close = 1;
+        coap_ws_close(session);
+        return 0;
+      }
+    }
+
+    session->ws->all_hdr_in = 1;
+
+    /* Get Websockets frame size */
+    if (bytes_size == 127) {
+      bytes_size = ((uint64_t)session->ws->rd_header[2] << 56) +
+                   ((uint64_t)session->ws->rd_header[3] << 48) +
+                   ((uint64_t)session->ws->rd_header[4] << 40) +
+                   ((uint64_t)session->ws->rd_header[5] << 32) +
+                   ((uint64_t)session->ws->rd_header[6] << 24) +
+                   ((uint64_t)session->ws->rd_header[7] << 16) +
+                   ((uint64_t)session->ws->rd_header[8] <<  8) +
+                   session->ws->rd_header[9];
+    } else if (bytes_size == 126) {
+      bytes_size = ((uint16_t)session->ws->rd_header[2] << 8) +
+                   session->ws->rd_header[3];
+    }
+    session->ws->data_size = bytes_size;
+    if ((size_t)bytes_size > datalen) {
+      coap_log_err("coap_ws_read: packet size bigger than provided data space"
+                   " (%zu > %zu)\n", bytes_size, datalen);
+      coap_handle_event(session->context, COAP_EVENT_WS_PACKET_SIZE, session);
+      session->ws->close_reason = 1009;
+      coap_ws_close(session);
+      return 0;
+    }
+    coap_log_debug("*  %s: Packet size %zu\n", coap_session_str(session),
+                   bytes_size);
+
+    /* Handle any data read in as a part of the header */
+    ret = session->ws->hdr_ofs - 2 - extra_hdr_len;
+    if (ret > 0) {
+      /* data in latter part of header */
+      if (ret <= bytes_size) {
+        /* copy across all the available data */
+        memcpy(data, &session->ws->rd_header[2 + extra_hdr_len], ret);
+        session->ws->data_ofs = ret;
+        if (ret == bytes_size) {
+          if (session->ws->state == COAP_SESSION_TYPE_SERVER) {
+            /* Need to unmask the data */
+            coap_ws_mask_data(session, data, bytes_size);
+          }
+          session->ws->all_hdr_in = 0;
+          session->ws->hdr_ofs = 0;
+          op_code = session->ws->rd_header[0] & WS_B0_OP_MASK;
+          if (op_code == WS_OP_CLOSE) {
+            session->ws->close_reason = (data[0] << 8) + data[1];
+            coap_log_debug("*  %s: WS: Close received (%u)\n",
+                           coap_session_str(session),
+                           session->ws->close_reason);
+            session->ws->recv_close = 1;
+            if (!session->ws->sent_close)
+              coap_ws_close(session);
+            return 0;
+          }
+          return bytes_size;
+        }
+      } else {
+        /* more information in header than given data size */
+        memcpy(data, &session->ws->rd_header[2 + extra_hdr_len], bytes_size);
+        session->ws->data_ofs = bytes_size;
+        /* set up partial header for the next read */
+        memmove(session->ws->rd_header,
+                &session->ws->rd_header[2 + extra_hdr_len + bytes_size],
+                ret - bytes_size);
+        session->ws->all_hdr_in = 0;
+        session->ws->hdr_ofs = ret - bytes_size;
+        return bytes_size;
+      }
+    } else {
+      session->ws->data_ofs = 0;
+    }
+  }
+
+  /* Get in (remaining) data */
+  ret = session->sock.lfunc[COAP_LAYER_WS].read(session,
+                               &data[session->ws->data_ofs],
+                               session->ws->data_size - session->ws->data_ofs);
+  if (ret <= 0)
+    return ret;
+  session->ws->data_ofs += ret;
+  if (session->ws->data_ofs == session->ws->data_size) {
+    if (session->ws->state == COAP_SESSION_TYPE_SERVER) {
+      /* Need to unmask the data */
+      coap_ws_mask_data(session, data, session->ws->data_size);
+    }
+    session->ws->all_hdr_in = 0;
+    session->ws->hdr_ofs = 0;
+    session->ws->data_ofs = 0;
+    coap_log_debug("*  %s: ws:    recv %4zd bytes\n",
+                   coap_session_str(session), session->ws->data_size);
+    return session->ws->data_size;
+  }
+  /* Need to get in all of the data */
+  coap_log_debug("*  %s: Waiting Packet size %zu (got %zu)\n", coap_session_str(session),
+                 session->ws->data_size, session->ws->data_ofs);
+  return 0;
+}
+
+#define COAP_WS_REQUEST \
+"GET /.well-known/coap HTTP/1.1\r\n" \
+"Host: %s\r\n" \
+"Upgrade: websocket\r\n" \
+"Connection: Upgrade\r\n" \
+"Sec-WebSocket-Key: %s\r\n" \
+"Sec-WebSocket-Protocol: coap\r\n" \
+"Sec-WebSocket-Version: 13\r\n" \
+"\r\n"
+
+void
+coap_ws_establish(coap_session_t *session) {
+  if (!session->ws) {
+    session->ws = coap_malloc_type(COAP_STRING, sizeof(coap_ws_state_t));
+    if (!session->ws) {
+      coap_session_disconnected(session, COAP_NACK_WS_LAYER_FAILED);
+      return;
+    }
+    memset(session->ws, 0, sizeof(coap_ws_state_t));
+  }
+  if (session->type == COAP_SESSION_TYPE_CLIENT) {
+    char buf[270];
+    char base64[28];
+    char host[80];
+    int port = 0;
+
+    session->ws->state = COAP_SESSION_TYPE_CLIENT;
+    if (!session->ws_host) {
+      coap_log_err("WS Host not defined\n");
+      coap_session_disconnected(session, COAP_NACK_WS_LAYER_FAILED);
+      return;
+    }
+    coap_prng(session->ws->key, sizeof(session->ws->key));
+    coap_ws_log_key(session);
+    if (!coap_base64_encode_buffer(session->ws->key, sizeof(session->ws->key),
+                                   base64, sizeof(base64)))
+      return;
+    if (session->proto == COAP_PROTO_WS &&
+        coap_address_get_port(&session->addr_info.remote) != 80) {
+      port = coap_address_get_port(&session->addr_info.remote);
+    } else if (session->proto == COAP_PROTO_WSS &&
+               coap_address_get_port(&session->addr_info.remote) != 443) {
+      port = coap_address_get_port(&session->addr_info.remote);
+    }
+    if (strchr((const char*)session->ws_host->s, ':')) {
+      if (port) {
+        snprintf(host, sizeof(host), "[%s]:%d", session->ws_host->s, port);
+      } else {
+        snprintf(host, sizeof(host), "[%s]", session->ws_host->s);
+      }
+    } else {
+      if (port) {
+        snprintf(host, sizeof(host), "%s:%d", session->ws_host->s, port);
+      } else {
+        snprintf(host, sizeof(host), "%s", session->ws_host->s);
+      }
+    }
+    snprintf(buf, sizeof(buf), COAP_WS_REQUEST, host, base64);
+    coap_log_debug("WS Request\n%s", buf);
+    session->sock.lfunc[COAP_LAYER_WS].write(session, (uint8_t*)buf,
+                                                   strlen(buf));
+  } else {
+    session->ws->state = COAP_SESSION_TYPE_SERVER;
+  }
+}
+
+void
+coap_ws_close(coap_session_t *session) {
+  if (!coap_netif_available(session) ||
+      session->state == COAP_SESSION_STATE_NONE) {
+    session->sock.lfunc[COAP_LAYER_WS].close(session);
+    return;
+  }
+  if (session->ws && session->ws->up) {
+    int count;
+
+    if (!session->ws->sent_close) {
+      size_t hdr_len = 2;
+      uint8_t ws_header[COAP_MAX_FS];
+      size_t ret;
+
+      ws_header[0] = WS_B0_FIN_BIT | WS_OP_CLOSE;
+      ws_header[1] = 2;
+      if (session->ws->state == COAP_SESSION_TYPE_CLIENT) {
+        /* Need to set the Mask bit, and set the masking key */
+        ws_header[1] |= WS_B1_MASK_BIT;
+        coap_prng(&ws_header[hdr_len], 4);
+        memcpy(session->ws->mask_key, &ws_header[hdr_len], 4);
+        hdr_len += 4;
+      }
+      coap_ws_log_header(session, ws_header);
+      if (session->ws->close_reason == 0)
+        session->ws->close_reason = 1000;
+
+      ws_header[hdr_len] =  session->ws->close_reason >> 8;
+      ws_header[hdr_len+1] =  session->ws->close_reason & 0xff;
+      if (session->ws->state == COAP_SESSION_TYPE_CLIENT) {
+        coap_ws_mask_data(session, &ws_header[hdr_len], 2);
+      }
+      session->ws->sent_close = 1;
+      coap_log_debug("*  %s: WS: Close sent (%u)\n",
+                     coap_session_str(session),
+                     session->ws->close_reason);
+      ret = session->sock.lfunc[COAP_LAYER_WS].write(session, ws_header, hdr_len+2);
+      if (ret != hdr_len+2) {
+        return;
+      }
+    }
+    count = 5;
+    while (!session->ws->recv_close && count > 0 && coap_netif_available(session)) {
+      uint8_t buf[100];
+      fd_set readfds;
+      int result;
+      struct timeval tv;
+
+      FD_ZERO(&readfds);
+      FD_SET(session->sock.fd, &readfds);
+      tv.tv_sec = 0;
+      tv.tv_usec = 1000;
+      result = select(session->sock.fd+1, &readfds, NULL, NULL, &tv);
+
+      if (result < 0) {
+        break;
+      } else if (result > 0) {
+        coap_ws_read(session, buf, sizeof(buf));
+      }
+      count --;
+    }
+    coap_handle_event(session->context, COAP_EVENT_WS_CLOSED, session);
+  }
+  session->sock.lfunc[COAP_LAYER_WS].close(session);
+}
+
+int
+coap_ws_set_host_request(coap_session_t *session, coap_str_const_t *ws_host) {
+  if (!session | !ws_host)
+    return 0;
+
+  session->ws_host = coap_new_str_const(ws_host->s, ws_host->length);
+  if (!session->ws_host)
+    return 0;
+  return 1;
+}
 
 #else /* !COAP_WS_SUPPORT */
 


### PR DESCRIPTION
Follows RFC6455, as specified in RFC8323.

Make support configurable.

Add in example support.

Update other code to be aware of WebSockets as a CoAP protocol.