### PR TITLE
coap_session.c: Make sure that lg_crcv is properly freed off

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -246,8 +246,6 @@ coap_session_mfree(coap_session_t *session) {
           }
           queue = queue->next;
         }
-        /* lg_crcv will be deleted when coap_cancel_observe() completes */
-        continue;
       }
     }
     LL_DELETE(session->lg_crcv, lg_crcv);


### PR DESCRIPTION
The response will never get seen as coap_session_mfree() continues to close down the socket.