### PR TITLE
logging: Support defining maximum logging level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,25 @@ option(
   WARNING_TO_ERROR
   "force all compiler warnings to be errors"
   OFF)
+set(MAX_LOGGING_LEVEL
+    "8"
+    CACHE
+      STRING
+      "\
+Only build logging code up to and including the specified logging level (0 - 8)[default=8]]
+    ")
+set_property(
+  CACHE DTLS_BACKEND
+  PROPERTY STRINGS
+           "0"
+           "1"
+           "2"
+           "3"
+           "4"
+           "5"
+           "6"
+           "7"
+           "8")
 
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 11)
@@ -227,6 +246,13 @@ endif()
 if(ENABLE_SMALL_STACK)
   set(ENABLE_SMALL_STACK "${ENABLE_SMALL_STACK}")
   message(STATUS "compiling with small stack support")
+endif()
+
+if(${MAX_LOGGING_LEVEL} MATCHES "[0-7]")
+  set(COAP_AX_LOGGING_LEVEL ${MAX_LOGGING_LEVEL})
+  message(STATUS "compiling with max logging level set to ${MAX_LOGGING_LEVEL}")
+else()
+  message(STATUS "compiling with max logging level set to none")
 endif()
 
 set(WITH_GNUTLS OFF)
@@ -455,6 +481,7 @@ message(STATUS "CMAKE_C_COMPILER:................${CMAKE_C_COMPILER}")
 message(STATUS "BUILD_SHARED_LIBS:...............${BUILD_SHARED_LIBS}")
 message(STATUS "CMAKE_BUILD_TYPE:................${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_SYSTEM_PROCESSOR:..........${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "MAX_LOGGING_LEVEL:...............${MAX_LOGGING_LEVEL}")
 message(STATUS "WARNING_TO_ERROR:................${WARNING_TO_ERROR}")
 
 set(top_srcdir "${CMAKE_CURRENT_LIST_DIR}")

--- a/configure.ac
+++ b/configure.ac
@@ -897,6 +897,29 @@ if test "x$enable_server_mode" != "xyes" -a "x$enable_client_mode" != "xyes" ; t
     AC_MSG_ERROR([==> One or both of '--enable-server-mode' and '--enable-client-mode' need to be set!])
 fi
 
+AC_ARG_ENABLE([max-logging-level],
+        [AS_HELP_STRING([--enable-max-logging-level],
+                        [Only build logging code up to and including the specified logging level [default=8]])],
+        [enable_max_logging_level="$enableval"],
+        [enable_max_logging_level="8"])
+
+if test "x$enable_max_logging_level" != "x8"; then
+    case x$enable_max_logging_level in
+        x0) ;;
+        x1) ;;
+        x2) ;;
+        x3) ;;
+        x4) ;;
+        x5) ;;
+        x6) ;;
+        x7) ;;
+        *)
+        AC_MSG_ERROR([--emable-max-logging-level must have a value of 0 through 8 inclusive])
+        ;;
+    esac
+    AC_DEFINE_UNQUOTED([COAP_MAX_LOGGING_LEVEL], [$enable_max_logging_level], [Define if max logging level is not 8])
+fi
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T
@@ -1104,6 +1127,11 @@ if test "x$build_oscore" != "xno"; then
     AC_MSG_RESULT([      enable OSCORE support    : "yes"])
 else
     AC_MSG_RESULT([      enable OSCORE support    : "no"])
+fi
+if test "x$enable_max_logging_level" != "x8"; then
+    AC_MSG_RESULT([      enable max logging level : "$enable_max_logging_level"])
+else
+    AC_MSG_RESULT([      enable max logging level : "none"])
 fi
 if test "x$build_doxygen" = "xyes"; then
     AC_MSG_RESULT([      build doxygen pages      : "yes"])

--- a/include/coap3/coap_debug.h
+++ b/include/coap3/coap_debug.h
@@ -38,15 +38,9 @@
 #define COAP_ERR_FD stderr
 #endif
 
-#define coap_log_emerg(...) coap_log(COAP_LOG_EMERG, __VA_ARGS__)
-#define coap_log_alert(...) coap_log(COAP_LOG_ALERT, __VA_ARGS__)
-#define coap_log_crit(...) coap_log(COAP_LOG_CRIT, __VA_ARGS__)
-#define coap_log_err(...) coap_log(COAP_LOG_ERR, __VA_ARGS__)
-#define coap_log_warn(...) coap_log(COAP_LOG_WARN, __VA_ARGS__)
-#define coap_log_info(...) coap_log(COAP_LOG_INFO, __VA_ARGS__)
-#define coap_log_notice(...) coap_log(COAP_LOG_NOTICE, __VA_ARGS__)
-#define coap_log_debug(...) coap_log(COAP_LOG_DEBUG, __VA_ARGS__)
-#define coap_log_oscore(...) coap_log(COAP_LOG_OSCORE, __VA_ARGS__)
+#ifndef COAP_MAX_LOGGING_LEVEL
+#define COAP_MAX_LOGGING_LEVEL 8
+#endif /* ! COAP_MAX_LOGGING_LEVEL */
 
 /**
  * Logging type.  These should be used where possible in the code instead
@@ -54,18 +48,84 @@
  * to reduce line length.
  */
 typedef enum {
-  COAP_LOG_EMERG = 0,
-  COAP_LOG_ALERT,
-  COAP_LOG_CRIT,
-  COAP_LOG_ERR,
-  COAP_LOG_WARN,
-  COAP_LOG_NOTICE,
-  COAP_LOG_INFO,
-  COAP_LOG_DEBUG,
-  COAP_LOG_OSCORE,
+  COAP_LOG_EMERG = 0,  /* 0 */
+  COAP_LOG_ALERT,      /* 1 */
+  COAP_LOG_CRIT,       /* 2 */
+  COAP_LOG_ERR,        /* 3 */
+  COAP_LOG_WARN,       /* 4 */
+  COAP_LOG_NOTICE,     /* 5 */
+  COAP_LOG_INFO,       /* 6 */
+  COAP_LOG_DEBUG,      /* 7 */
+  COAP_LOG_OSCORE,     /* 8 */
   COAP_LOG_DTLS_BASE,
 #define COAP_LOG_CIPHERS COAP_LOG_DTLS_BASE /* For backward compatability */
 } coap_log_t;
+
+/*
+ * These have the same values, but can be used in #if tests for better
+ * readability
+ */
+#define _COAP_LOG_EMERG  0
+#define _COAP_LOG_ALERT  1
+#define _COAP_LOG_CRIT   2
+#define _COAP_LOG_ERR    3
+#define _COAP_LOG_WARN   4
+#define _COAP_LOG_NOTICE 5
+#define _COAP_LOG_INFO   6
+#define _COAP_LOG_DEBUG  7
+#define _COAP_LOG_OSCORE 8
+
+COAP_STATIC_INLINE void coap_no_log(void) { }
+
+#define coap_log_emerg(...) coap_log(COAP_LOG_EMERG, __VA_ARGS__)
+
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_ALERT)
+#define coap_log_alert(...) coap_log(COAP_LOG_ALERT, __VA_ARGS__)
+#else
+#define coap_log_alert(...) coap_no_log()
+#endif
+
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_CRIT)
+#define coap_log_crit(...) coap_log(COAP_LOG_CRIT, __VA_ARGS__)
+#else
+#define coap_log_crit(...) coap_no_log()
+#endif
+
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_ERR)
+#define coap_log_err(...) coap_log(COAP_LOG_ERR, __VA_ARGS__)
+#else
+#define coap_log_err(...) coap_no_log()
+#endif
+
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_WARN)
+#define coap_log_warn(...) coap_log(COAP_LOG_WARN, __VA_ARGS__)
+#else
+#define coap_log_warn(...) coap_no_log()
+#endif
+
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_INFO)
+#define coap_log_info(...) coap_log(COAP_LOG_INFO, __VA_ARGS__)
+#else
+#define coap_log_info(...) coap_no_log()
+#endif
+
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_NOTICE)
+#define coap_log_notice(...) coap_log(COAP_LOG_NOTICE, __VA_ARGS__)
+#else
+#define coap_log_notice(...) coap_no_log()
+#endif
+
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_DEBUG)
+#define coap_log_debug(...) coap_log(COAP_LOG_DEBUG, __VA_ARGS__)
+#else
+#define coap_log_debug(...) coap_no_log()
+#endif
+
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_OSCORE)
+#define coap_log_oscore(...) coap_log(COAP_LOG_OSCORE, __VA_ARGS__)
+#else
+#define coap_log_oscore(...) coap_no_log()
+#endif
 
 /*
  * These entries are left here for backward compatability in applications

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -133,6 +133,10 @@ With additional level:
 *COAP_LOG_OSCORE*::
 Debug OSCORE information (8).
 
+*NOTE:* The maximum logging level in the libcoap library may have been updated
+by the use of './configure --enable-max-logging-level=X' (where X is 0 to 8 inclusive)
+which may disable some of the higher logging levels to save code space.
+
 FUNCTIONS
 ---------
 
@@ -140,6 +144,7 @@ FUNCTIONS
 
 The *coap_log*() function is used to log information at the appropriate _level_.
 The rest of the parameters follow the standard *printf*() function format.
+Where possible, the coap_log_*() functions should be used instead.
 
 *Function: coap_log_emerg()*
 

--- a/man/coap_oscore.txt.in
+++ b/man/coap_oscore.txt.in
@@ -269,7 +269,7 @@ setup_client_session (struct in_addr ip_address) {
         /* Try creating it */
         oscore_seq_num_fp = fopen(oscore_seq_save_file, "w+");
         if (oscore_seq_num_fp == NULL) {
-          coap_log(COAP_LOG_ERR, "OSCORE save restart info file error: %s\n",
+          coap_log_err("OSCORE save restart info file error: %s\n",
                    oscore_seq_save_file);
           return NULL;
         }
@@ -349,7 +349,7 @@ setup_context (void) {
         /* Try creating it */
         oscore_seq_num_fp = fopen(oscore_seq_save_file, "w+");
         if (oscore_seq_num_fp == NULL) {
-          coap_log(COAP_LOG_ERR, "OSCORE save restart info file error: %s\n",
+          coap_log_err("OSCORE save restart info file error: %s\n",
                    oscore_seq_save_file);
           return 0;
         }

--- a/src/block.c
+++ b/src/block.c
@@ -1283,6 +1283,9 @@ coap_block_delete_lg_crcv(coap_session_t *session,
                                coap_lg_crcv_t *lg_crcv) {
   size_t i;
 
+#if (COAP_MAX_LOGGING_LEVEL < _COAP_LOG_DEBUG)
+  (void)session;
+#endif
   if (lg_crcv == NULL)
     return;
 
@@ -1304,6 +1307,9 @@ coap_block_delete_lg_crcv(coap_session_t *session,
 void
 coap_block_delete_lg_srcv(coap_session_t *session,
                                coap_lg_srcv_t *lg_srcv) {
+#if (COAP_MAX_LOGGING_LEVEL < _COAP_LOG_DEBUG)
+  (void)session;
+#endif
   if (lg_srcv == NULL)
     return;
 

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -91,6 +91,8 @@ coap_get_log_level(void) {
 
 void
 coap_set_log_level(coap_log_t level) {
+  if (level > COAP_MAX_LOGGING_LEVEL)
+    level = COAP_MAX_LOGGING_LEVEL;
   maxlog = level;
 }
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -472,6 +472,10 @@ coap_epoll_ctl_add(coap_socket_t *sock,
   struct epoll_event event;
   coap_context_t *context;
 
+#if COAP_MAX_LOGGING_LEVEL < _COAP_LOG_ERR
+  (void)func;
+#endif
+
   if (sock == NULL)
     return;
 
@@ -506,6 +510,10 @@ coap_epoll_ctl_mod(coap_socket_t *sock,
   struct epoll_event event;
   coap_context_t *context;
 
+#if COAP_MAX_LOGGING_LEVEL < _COAP_LOG_ERR
+  (void)func;
+#endif
+
   if (sock == NULL)
     return;
 
@@ -523,6 +531,9 @@ coap_epoll_ctl_mod(coap_socket_t *sock,
 
   ret = epoll_ctl(context->epfd, EPOLL_CTL_MOD, sock->fd, &event);
   if (ret == -1) {
+#if (COAP_MAX_LOGGING_LEVEL < COAP_LOG_ERR)
+    (void)func;
+#endif
      coap_log_err(
               "%s: epoll_ctl MOD failed: %s (%d)\n",
               func,

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -3649,6 +3649,9 @@ coap_digest_final(coap_digest_ctx_t *digest_ctx,
 #if COAP_WS_SUPPORT || HAVE_OSCORE
 static void
 coap_crypto_output_errors(const char *prefix) {
+#if COAP_MAX_LOGGING_LEVEL < _COAP_LOG_WARN
+  (void)prefix;
+#else /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_WARN */
   unsigned long e;
 
   while ((e = ERR_get_error()))
@@ -3657,6 +3660,7 @@ coap_crypto_output_errors(const char *prefix) {
              prefix,
              ERR_reason_error_string(e),
              ssl_function_definition(e));
+#endif /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_WARN */
 }
 #endif /* COAP_WS_SUPPORT || HAVE_OSCORE */
 

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -241,6 +241,10 @@ error:
 
 static void
 dump_cose(cose_encrypt0_t *cose, const char *message) {
+#if COAP_MAX_LOGGING_LEVEL < _COAP_LOG_OSCORE
+  (void)cose;
+  (void)message;
+#else /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_OSCORE */
   if (coap_get_log_level() >= COAP_LOG_OSCORE) {
     char buffer[30];
 
@@ -258,6 +262,7 @@ dump_cose(cose_encrypt0_t *cose, const char *message) {
     oscore_log_hex_value(COAP_LOG_OSCORE, "external_aad", &cose->external_aad);
     oscore_log_hex_value(COAP_LOG_OSCORE, "aad", &cose->aad);
   }
+#endif /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_OSCORE */
 }
 
 /*

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -574,6 +574,7 @@ coap_session_connected(coap_session_t *session) {
   }
 }
 
+#if COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_DEBUG
 static const char*
 coap_nack_name(coap_nack_reason_t reason) {
   switch (reason) {
@@ -599,6 +600,7 @@ coap_nack_name(coap_nack_reason_t reason) {
     return "???";
   }
 }
+#endif /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_DEBUG */
 
 void
 coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reason) {

--- a/src/coap_ws.c
+++ b/src/coap_ws.c
@@ -155,6 +155,10 @@ coap_base64_decode_buffer(const char *bufcoded, size_t *len, uint8_t *bufplain,
 
 static void
 coap_ws_log_header(const coap_session_t *session, const uint8_t *header) {
+#if COAP_MAX_LOGGING_LEVEL < _COAP_LOG_DEBUG
+  (void)session;
+  (void)header;
+#else /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_DEBUG */
   char buf[3*COAP_MAX_FS + 1];
   int i;
   ssize_t bytes_size;
@@ -173,6 +177,7 @@ coap_ws_log_header(const coap_session_t *session, const uint8_t *header) {
     snprintf(&buf[i*3], 4, " %02x", header[i]);
   }
   coap_log_debug("*  %s: WS header:%s\n", coap_session_str(session), buf);
+#endif /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_DEBUG */
 }
 
 static void

--- a/src/net.c
+++ b/src/net.c
@@ -3020,7 +3020,9 @@ skip_handler:
   }
   respond = no_response(pdu, response, session, resource);
   if (respond != RESPONSE_DROP) {
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_DEBUG)
     coap_mid_t mid = pdu->mid;
+#endif
     if (COAP_RESPONSE_CLASS(response->code) != 2) {
       if (observe) {
         coap_remove_option(response, COAP_OPTION_OBSERVE);
@@ -3587,6 +3589,7 @@ cleanup:
 #endif /* HAVE_OSCORE */
 }
 
+#if COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_DEBUG
 static const char*
 coap_event_name(coap_event_t event) {
   switch (event) {
@@ -3644,6 +3647,7 @@ coap_event_name(coap_event_t event) {
     return "???";
   }
 }
+#endif /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_DEBUG */
 
 int
 coap_handle_event(coap_context_t *context, coap_event_t event, coap_session_t *session) {

--- a/src/oscore/oscore.c
+++ b/src/oscore/oscore.c
@@ -399,8 +399,7 @@ oscore_validate_sender_seq(oscore_recipient_ctx_t *ctx, cose_encrypt0_t *cose) {
     uint64_t pattern;
 
     if (shift > ctx->osc_ctx->replay_window_size || shift > 63) {
-      coap_log(
-          COAP_LOG_WARN,
+      coap_log_warn(
           "OSCORE: Replay protection, SEQ outside of replay window (%"
             PRIu64 " %" PRIu64 ")\n",
           ctx->last_seq,

--- a/src/oscore/oscore_context.c
+++ b/src/oscore/oscore_context.c
@@ -339,6 +339,10 @@ oscore_build_key(oscore_ctx_t *osc_ctx,
 
 static void
 oscore_log_context(oscore_ctx_t *osc_ctx, const char *heading) {
+#if COAP_MAX_LOG_LEVEL < _COAP_LOG_OSCORE
+  (void)osc_ctx;
+  (void)heading;
+#else /* COAP_MAX_LOG_LEVEL >= _COAP_LOG_OSCORE */
   if (coap_get_log_level() >= COAP_LOG_OSCORE) {
     char buffer[30];
     oscore_recipient_ctx_t *next = osc_ctx->recipient_chain;
@@ -376,6 +380,7 @@ oscore_log_context(oscore_ctx_t *osc_ctx, const char *heading) {
       next = next->next_recipient;
     }
   }
+#endif /* COAP_MAX_LOG_LEVEL >= _COAP_LOG_OSCORE */
 }
 
 void

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -1218,7 +1218,9 @@ coap_pdu_parse_opt(coap_pdu_t *pdu) {
     size_t length = pdu->used_size - pdu->e_token_length;
 
     while (length > 0 && *opt != COAP_PAYLOAD_START) {
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_WARN)
       coap_opt_t *opt_last = opt;
+#endif
       size_t optsize = next_option_safe(&opt, &length, &pdu->max_opt);
       const uint32_t len =
         optsize ? coap_opt_length((const uint8_t *)opt - optsize) : 0;


### PR DESCRIPTION
This allows for code reduction if not all logging levels are required.

Done by defining ./configure --enable-max-logging-level=X, where X can have the value of 0 through 8 inclusive.

COAP_LOG_EMERG is always logged.

Can save up to 40k bytes.