### PR TITLE
oscore.h: Fix misspelling of Environment

### DIFF
--- a/include/oscore/oscore.h
+++ b/include/oscore/oscore.h
@@ -33,7 +33,7 @@
 /**
  * @file oscore.h
  * @brief An implementation of the Object Security for Constrained RESTful
- * Enviornments (RFC 8613).
+ * Environments (RFC 8613).
  *
  * \author Martin Gunnarsson  <martin.gunnarsson@ri.se>
  * major rewrite for libcoap


### PR DESCRIPTION
Fixes a misspelling of Environment.