### PR TITLE
mcast_ips: Restore mcast ip for mcast sessions for each new coap_send()

### DIFF
--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -41,15 +41,18 @@ struct coap_socket_t {
   coap_fd_t fd;
 #endif /* WITH_LWIP */
 #if defined(RIOT_VERSION)
-  gnrc_pktsnip_t *pkt; /* pointer to received packet for processing */
+  gnrc_pktsnip_t *pkt; /**< pointer to received packet for processing */
 #endif /* RIOT_VERSION */
-  coap_socket_flags_t flags;
-  coap_session_t *session; /* Used to determine session owner. */
+  coap_socket_flags_t flags; /**< 1 or more of COAP_SOCKET* flag values */
+  coap_session_t *session; /**< Used to determine session owner. */
 #if COAP_SERVER_SUPPORT
-  coap_endpoint_t *endpoint; /* Used by the epoll logic for a listening
-                                endpoint. */
+  coap_endpoint_t *endpoint; /**< Used by the epoll logic for a listening
+                                  endpoint. */
 #endif /* COAP_SERVER_SUPPORT */
-  coap_layer_func_t lfunc[COAP_LAYER_LAST]; /* Layer functions to use */
+#if COAP_CLIENT_SUPPORT
+  coap_address_t mcast_addr; /**< remote address and port (multicast track) */
+#endif /* COAP_CLIENT_SUPPORT */
+  coap_layer_func_t lfunc[COAP_LAYER_LAST]; /**< Layer functions to use */
 };
 
 /**

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -215,6 +215,7 @@ global:
   coap_session_get_ack_random_factor;
   coap_session_get_ack_timeout;
   coap_session_get_addr_local;
+  coap_session_get_addr_mcast;
   coap_session_get_addr_remote;
   coap_session_get_app_data;
   coap_session_get_by_peer;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -213,6 +213,7 @@ coap_session_disconnected
 coap_session_get_ack_random_factor
 coap_session_get_ack_timeout
 coap_session_get_addr_local
+coap_session_get_addr_mcast
 coap_session_get_addr_remote
 coap_session_get_app_data
 coap_session_get_by_peer

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -158,6 +158,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_resource.3" > coap_resource_get_userdata.3
 	@echo ".so man3/coap_resource.3" > coap_resource_release_userdata_handler.3
 	@echo ".so man3/coap_resource.3" > coap_resource_get_uri_path.3
+	@echo ".so man3/coap_session.3" > coap_session_get_addr_remote.3
 	@echo ".so man3/coap_session.3" > coap_session_get_context.3
 	@echo ".so man3/coap_session.3" > coap_session_get_ifindex.3
 	@echo ".so man3/coap_session.3" > coap_session_get_proto.3

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -18,6 +18,7 @@ coap_session_set_type_client,
 coap_session_set_app_data,
 coap_session_get_app_data,
 coap_session_get_addr_local,
+coap_session_get_addr_mcast,
 coap_session_get_addr_remote,
 coap_session_get_context,
 coap_session_get_ifindex,
@@ -46,6 +47,9 @@ SYNOPSIS
 *void *coap_session_get_app_data(const coap_session_t *_session_);*
 
 *const coap_address_t *coap_session_get_addr_local(
+const coap_session_t *_session_);*
+
+*const coap_address_t *coap_session_get_addr_mcast(
 const coap_session_t *_session_);*
 
 *const coap_address_t *coap_session_get_addr_remote(
@@ -141,10 +145,19 @@ pointer previously defined by *coap_session_set_app_data*().
 The *coap_session_get_addr_local*() function is used to get the local IP
 address and port information from the _session_.
 
+*Function: coap_session_get_addr_mcast()*
+
+The *coap_session_get_addr_mcast*() function is used to get the remote (peer)
+multicast IP address and port information from the _session_ if the _session_
+was originally set up to send requests to a multicast IP.
+
 *Function: coap_session_get_addr_remote()*
 
 The *coap_session_get_addr_remote*() function is used to get the remote (peer)
-IP address and port information from the _session_.
+IP address and port information from the _session_.  If the _session_ was
+originally set up to send requests to a multicast IP, then the returned IP
+will be that of the unicast response from a peer. The returned IP will get
+set back to the multicast IP when the next *coap_send*(3) is called.
 
 *Function: coap_session_get_context()*
 
@@ -218,6 +231,9 @@ RETURN VALUES
 
 *coap_session_get_addr_local*() and *coap_session_get_addr_remote*() return
 a pointer to the IP address / port or NULL on error.
+
+*coap_session_get_addr_mcast*() returns a pointer to the remote multicast IP
+address / port or NULL on error or this is not a multicast session.
 
 *coap_session_get_context*() returns a pointer to the current CoAP Context or
 NULL on error.

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -287,6 +287,7 @@ coap_socket_connect_udp(coap_socket_t *sock,
               coap_socket_strerror());
     }
     coap_address_copy(remote_addr, &connect_addr);
+    coap_address_copy(&sock->mcast_addr, &connect_addr);
     sock->flags |= COAP_SOCKET_MULTICAST;
     return 1;
   }

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1372,6 +1372,18 @@ coap_session_get_addr_local(const coap_session_t *session) {
   return NULL;
 }
 
+const coap_address_t *
+coap_session_get_addr_mcast(const coap_session_t *session) {
+#if COAP_CLIENT_SUPPORT
+  if (session && session->type == COAP_SESSION_TYPE_CLIENT &&
+      session->sock.flags & COAP_SOCKET_MULTICAST)
+    return &session->sock.mcast_addr;
+#else /* ! COAP_CLIENT_SUPPORT */
+  (void)session;
+#endif /* ! COAP_CLIENT_SUPPORT */
+  return NULL;
+}
+
 coap_context_t *
 coap_session_get_context(const coap_session_t *session) {
   if (session)
@@ -1593,9 +1605,13 @@ coap_session_get_by_peer(const coap_context_t *ctx,
   coap_session_t *s, *rtmp;
 #if COAP_CLIENT_SUPPORT
   SESSIONS_ITER(ctx->sessions, s, rtmp) {
-    if (s->ifindex == ifindex && coap_address_equals(&s->addr_info.remote,
-                                                     remote_addr))
-      return s;
+    if (s->ifindex == ifindex) {
+      if (s->sock.flags & COAP_SOCKET_MULTICAST) {
+        if (coap_address_equals(&s->sock.mcast_addr, remote_addr))
+          return s;
+      } else if (coap_address_equals(&s->addr_info.remote, remote_addr))
+        return s;
+    }
   }
 #endif /* COAP_CLIENT_SUPPORT */
 #if COAP_SERVER_SUPPORT

--- a/src/net.c
+++ b/src/net.c
@@ -1208,6 +1208,8 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
       lg_xmit->b.b1.state_token = lg_crcv->state_token;
     }
   }
+  if (session->sock.flags & COAP_SOCKET_MULTICAST)
+    coap_address_copy(&session->addr_info.remote, &session->sock.mcast_addr);
 
 send_it:
 #endif /* COAP_CLIENT_SUPPORT */


### PR DESCRIPTION
If the server is responding to a mcast request with a packet that is a part of larger body (i.e. responding with Block2 option) the requests for the missing packets have to be using unicast, which continues to be supported.

The application can determine the unicast remote address before the next coap_send() by using coap_session_get_addr_remote().

Addresses #1096.