### PR TITLE
coap_debug.c: Split out coap_print_ip_addr() from coap_print_addr()

### DIFF
--- a/include/coap3/coap_debug.h
+++ b/include/coap3/coap_debug.h
@@ -355,6 +355,21 @@ char *coap_string_tls_support(char *buffer, size_t bufsize);
 size_t coap_print_addr(const coap_address_t *address,
                        unsigned char *buffer, size_t size);
 
+/**
+ * Print the IP address into the defined buffer.
+ *
+ * Internal Function.
+ *
+ * @param address The address to print.
+ * @param buffer The buffer to print into.
+ * @param size The size of the buffer to print into.
+ *
+ * @return The pointer to provided buffer with as much of the IP address added
+ *         as possible.
+ */
+const char* coap_print_ip_addr(const coap_address_t *address,
+                            char *buffer, size_t size);
+
 /** @} */
 
 /**

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -178,6 +178,7 @@ global:
   coap_persist_stop;
   coap_persist_track_funcs;
   coap_print_addr;
+  coap_print_ip_addr;
   coap_print_link;
   coap_prng;
   coap_prng_init;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -176,6 +176,7 @@ coap_persist_startup
 coap_persist_stop
 coap_persist_track_funcs
 coap_print_addr
+coap_print_ip_addr
 coap_print_link
 coap_prng
 coap_prng_init


### PR DESCRIPTION
Sometimes just the IP address is required, not the port as well.