### PR TITLE
CMakeLists.txt: Set compiler options for both the library and examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,57 @@ option(
   "Build shared libs"
   OFF)
 
+#
+# global compiler options
+# (need to do it before add_library())
+#
+
+add_compile_options(
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-pedantic>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wcast-qual>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wextra>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wformat-security>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Winline>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wmissing-declarations>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wmissing-prototypes>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wnested-externs>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wpointer-arith>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wshadow>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wstrict-prototypes>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wswitch-default>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wswitch-enum>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wunused>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wwrite-strings>)
+
+if(MINGW)
+add_compile_options(
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wno-format>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wno-format-security>)
+endif()
+
+if(${WARNING_TO_ERROR})
+add_compile_options(
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Werror>)
+endif()
+
+if(CMAKE_GENERATOR MATCHES "Visual Studio")
+  option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols when compiling to a .dll" ON)
+  # add_compile_options(/Wall /wd4100 /wd4820 /wd4668 /wd4061)
+  if(${WARNING_TO_ERROR})
+    add_compile_options(/WX)
+  endif()
+endif()
+
+#
+# The libcoap library
+#
+
 add_library(${COAP_LIBRARY_NAME})
 set_property(TARGET ${COAP_LIBRARY_NAME} PROPERTY C_STANDARD 99)
-cmake_policy(SET CMP0115 OLD) # Supresses libcoap configuration warning
+if(${CMAKE_VERSION} VERSION_GREATER "3.20.0")
+  cmake_policy(SET CMP0115 OLD) # Supresses libcoap configuration warning
+endif()
 
 #
 # options to tweak the library
@@ -492,13 +540,15 @@ message(STATUS "HAVE_LIBGNUTLS:..................${HAVE_LIBGNUTLS}")
 message(STATUS "HAVE_OPENSSL:....................${HAVE_OPENSSL}")
 message(STATUS "HAVE_MBEDTLS:....................${HAVE_MBEDTLS}")
 message(STATUS "WITH_EPOLL:......................${WITH_EPOLL}")
-message(STATUS "CMAKE_C_COMPILER:................${CMAKE_C_COMPILER}")
 message(STATUS "BUILD_SHARED_LIBS:...............${BUILD_SHARED_LIBS}")
+message(STATUS "MAX_LOGGING_LEVEL:...............${MAX_LOGGING_LEVEL}")
+message(STATUS "WARNING_TO_ERROR:................${WARNING_TO_ERROR}")
+message(STATUS "CMAKE_C_COMPILER:................${CMAKE_C_COMPILER}")
+message(STATUS "CMAKE_CXX_COMPILER_ID:...........${CMAKE_CXX_COMPILER_ID}")
 message(STATUS "CMAKE_BUILD_TYPE:................${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_SYSTEM_PROCESSOR:..........${CMAKE_SYSTEM_PROCESSOR}")
-message(STATUS "MAX_LOGGING_LEVEL:...............${MAX_LOGGING_LEVEL}")
 message(STATUS "CMAKE_HOST_SYSTEM_NAME:..........${CMAKE_HOST_SYSTEM_NAME}")
-message(STATUS "WARNING_TO_ERROR:................${WARNING_TO_ERROR}")
+message(STATUS "CMAKE_GENERATOR:.................${CMAKE_GENERATOR}")
 
 set(top_srcdir "${CMAKE_CURRENT_LIST_DIR}")
 set(top_builddir "${CMAKE_CURRENT_BINARY_DIR}")
@@ -616,42 +666,6 @@ add_library(
   ${PROJECT_NAME}::${COAP_LIBRARY_NAME}
   ALIAS
   ${COAP_LIBRARY_NAME})
-
-#
-# compiler options
-#
-
-add_compile_options(
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-pedantic>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wcast-qual>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wextra>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wformat-security>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Winline>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wmissing-declarations>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wmissing-prototypes>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wnested-externs>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wpointer-arith>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wshadow>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wstrict-prototypes>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wswitch-default>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wswitch-enum>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wunused>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wwrite-strings>)
-
-if(${WARNING_TO_ERROR})
-add_compile_options(
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Werror>
-  $<$<CXX_COMPILER_ID:AppleClang>:-Werror>)
-endif()
-
-if(CMAKE_GENERATOR MATCHES "Visual Studio")
-  option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols when compiling to a .dll" ON)
-  # add_compile_options(-Wall -wd4100)
-  if(${WARNING_TO_ERROR})
-    add_compile_options(-WX)
-  endif()
-endif()
 
 #
 # tests

--- a/src/coap_ws.c
+++ b/src/coap_ws.c
@@ -515,7 +515,7 @@ coap_ws_rd_http_header(coap_session_t *session) {
     if (bytes == 0)
       return 1;
 
-    ws->http_ofs += bytes;
+    ws->http_ofs += (uint32_t)bytes;
     ws->http_hdr[ws->http_ofs] = '\000';
     /* Force at least one check */
     cp = (char *)ws->http_hdr;
@@ -560,12 +560,12 @@ coap_ws_rd_http_header(coap_session_t *session) {
             }
           }
           ws->up = 1;
-          ws->hdr_ofs = rem;
+          ws->hdr_ofs = (int)rem;
           if (rem > 0)
             memcpy(ws->rd_header, cp + 1, rem);
           return 1;
         }
-        ws->http_ofs = rem;
+        ws->http_ofs = (uint32_t)rem;
         memmove(ws->http_hdr, cp + 1, rem);
         ws->http_hdr[ws->http_ofs] = '\000';
       }
@@ -641,7 +641,7 @@ coap_ws_read(coap_session_t *session, uint8_t *data, size_t datalen) {
                          sizeof(session->ws->rd_header) - session->ws->hdr_ofs);
     if (ret < 0)
       return ret;
-    session->ws->hdr_ofs += ret;
+    session->ws->hdr_ofs += (int)ret;
     /* Enough of the header in ? */
     if (session->ws->hdr_ofs < 2)
       return 0;
@@ -748,7 +748,7 @@ coap_ws_read(coap_session_t *session, uint8_t *data, size_t datalen) {
                 &session->ws->rd_header[2 + extra_hdr_len + bytes_size],
                 ret - bytes_size);
         session->ws->all_hdr_in = 0;
-        session->ws->hdr_ofs = ret - bytes_size;
+        session->ws->hdr_ofs = (int)(ret - bytes_size);
         return bytes_size;
       }
     } else {
@@ -900,7 +900,7 @@ coap_ws_close(coap_session_t *session) {
       FD_SET(session->sock.fd, &readfds);
       tv.tv_sec = 0;
       tv.tv_usec = 1000;
-      result = select(session->sock.fd+1, &readfds, NULL, NULL, &tv);
+      result = select((int)(session->sock.fd+1), &readfds, NULL, NULL, &tv);
 
       if (result < 0) {
         break;


### PR DESCRIPTION
Fix some reported Windows errors now that "treat all warnings as errors" is correctly set in the github workflows.