### PR TITLE
block.h: Make COAP_OPT_BLOCK_* functions safe against NULL indirects

### DIFF
--- a/include/coap3/block.h
+++ b/include/coap3/block.h
@@ -70,13 +70,18 @@ typedef struct {
 #define COAP_OPT_BLOCK_LAST(opt) \
   (coap_opt_length(opt) ? (coap_opt_value(opt) + (coap_opt_length(opt)-1)) : 0)
 
+/** Returns the value of the last byte of @p opt. */
+#define COAP_OPT_BLOCK_END_BYTE(opt) \
+  ((coap_opt_length(opt) && coap_opt_value(opt)) ? \
+                         *(coap_opt_value(opt) + (coap_opt_length(opt)-1)) : 0)
+
 /** Returns the value of the More-bit of a Block option @p opt. */
 #define COAP_OPT_BLOCK_MORE(opt) \
-  (coap_opt_length(opt) ? (*COAP_OPT_BLOCK_LAST(opt) & 0x08) : 0)
+  (coap_opt_length(opt) ? (COAP_OPT_BLOCK_END_BYTE(opt) & 0x08) : 0)
 
 /** Returns the value of the SZX-field of a Block option @p opt. */
 #define COAP_OPT_BLOCK_SZX(opt)  \
-  (coap_opt_length(opt) ? (*COAP_OPT_BLOCK_LAST(opt) & 0x07) : 0)
+  (coap_opt_length(opt) ? (COAP_OPT_BLOCK_END_BYTE(opt) & 0x07) : 0)
 
 /**
  * Returns the value of field @c num in the given block option @p block_opt.

--- a/src/block.c
+++ b/src/block.c
@@ -39,7 +39,7 @@ coap_opt_block_num(const coap_opt_t *block_opt) {
                                 coap_opt_length(block_opt) - 1);
   }
 
-  return (num << 4) | ((*COAP_OPT_BLOCK_LAST(block_opt) & 0xF0) >> 4);
+  return (num << 4) | ((COAP_OPT_BLOCK_END_BYTE(block_opt) & 0xF0) >> 4);
 }
 
 int


### PR DESCRIPTION
`COAP_OPT_BLOCK_LAST(opt)` may return NULL, so doing `*COAP_OPT_BLOCK_LAST(opt)` is unsafe. Replace indirect with `COAP_OPT_BLOCK_END_BYTE(opt)`.