### PR TITLE
man: Correct man page errors

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -152,8 +152,8 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_pdu_setup.3" > coap_pdu_set_type.3
 	@echo ".so man3/coap_recovery.3" > coap_session_set_nstart.3
 	@echo ".so man3/coap_recovery.3" > coap_session_get_nstart.3
-	@echo ".so man3/coap_recovery.3" > coap_session_set_probing_wait.3
-	@echo ".so man3/coap_recovery.3" > coap_session_get_probing_wait.3
+	@echo ".so man3/coap_recovery.3" > coap_session_set_probing_rate.3
+	@echo ".so man3/coap_recovery.3" > coap_session_get_probing_rate.3
 	@echo ".so man3/coap_recovery.3" > coap_debug_set_packet_loss.3
 	@echo ".so man3/coap_resource.3" > coap_resource_set_mode.3
 	@echo ".so man3/coap_resource.3" > coap_resource_set_userdata.3

--- a/man/coap_address.txt.in
+++ b/man/coap_address.txt.in
@@ -12,11 +12,11 @@ NAME
 ----
 coap_address,
 coap_address_t,
-coap_address_un,
 coap_address_init,
 coap_get_available_scheme_hint_bits,
 coap_resolve_address_info,
 coap_free_address_info,
+coap_sockaddr_un,
 coap_address_set_unix_domain
 - Work with CoAP Socket Address Types
 
@@ -184,7 +184,7 @@ or'd together based on the supported libcoap functionality.
 *coap_resolve_address_info*() returns a linked list of addresses that can be
 used for session setup or NULL if there is a failure.
 
-*coap_address_set_unix_domain*() function returns 1 on success or 0 on failure.
+*coap_address_set_unix_domain*() returns 1 on success or 0 on failure.
 
 EXAMPLES
 --------

--- a/man/coap_attribute.txt.in
+++ b/man/coap_attribute.txt.in
@@ -87,13 +87,13 @@ specified _attribute_.
 
 RETURN VALUES
 -------------
-*coap_add_attr*() function returns a pointer to
+*coap_add_attr*() returns a pointer to
 the attribute that was created or NULL if there is a malloc failure.
 
-*coap_find_attr*() function returns a pointer to the first matching
+*coap_find_attr*() returns a pointer to the first matching
 attribute or NULL if the _name_ was not found.
 
-*coap_attr_get_value*() function returns a pointer to the value held within
+*coap_attr_get_value*() returns a pointer to the value held within
 the attribute. The pointer can be NULL if the _value_ id NULL, or NULL if
 _attribute_ does not exist.
 

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -280,10 +280,10 @@ body dropped.
 
 RETURN VALUES
 -------------
-The *coap_add_data_large_request*(), *coap_add_data_large_response*(), and
-*coap_get_data_large*() functions return 0 on failure, 1 on success.
+*coap_add_data_large_request*(), *coap_add_data_large_response*(), and
+*coap_get_data_large*() return 0 on failure, 1 on success.
 
-The  *coap_block_build_body*() returns the current state of the body's data
+*coap_block_build_body*() returns the current state of the body's data
 (which may have some missing gaps) or NULL on error.
 
 EXAMPLES

--- a/man/coap_cache.txt.in
+++ b/man/coap_cache.txt.in
@@ -216,17 +216,20 @@ _data_ in the _cache_entry_.
 
 RETURN VALUES
 -------------
-*coap_cache_derive_key*() and *coap_cache_derive_key_w_ignore*() functions
+*coap_cache_derive_key*() and *coap_cache_derive_key_w_ignore*()
 returns a newly created Cache Key or NULL if there is a creation failure.
 
-*coap_cache_ignore_options*() function returns 1 if success, 0 on failure.
+*coap_cache_ignore_options*() returns 1 if success, 0 on failure.
 
 *coap_new_cache_entry*(), *coap_cache_get_by_key*() and
-*coap_cache_get_by_pdu*() functions return the Cache Entry or NULL if there
+*coap_cache_get_by_pdu*() return the Cache Entry or NULL if there
 is a failure.
 
-*coap_cache_get_pdu*() function the PDU that is held within the Cache Entry or
+*coap_cache_get_pdu*() returns the PDU that is held within the Cache Entry or
 NULL if there is no PDU available.
+
+*coap_cache_get_app_data*() returns the application data value
+previously set by the *coap_cache_set_app_data*() function or NULL.
 
 EXAMPLES
 --------

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -157,7 +157,7 @@ supports the requested extended token size as per
 
 RETURN VALUES
 -------------
-*coap_new_context*() function returns a newly created context or
+*coap_new_context*() returns a newly created context or
 NULL if there is a creation failure.
 
 *coap_context_get_max_idle_sessions*() returns the maximum number of idle

--- a/man/coap_endpoint_client.txt.in
+++ b/man/coap_endpoint_client.txt.in
@@ -201,10 +201,10 @@ size of the data for the client endpoint's _session_.
 RETURN VALUES
 -------------
 *coap_new_client_session*(), *coap_new_client_session_psk2*(),
-*coap_new_client_session_pki*() functions returns a newly created client
+*coap_new_client_session_pki*() return a newly created client.
 session or NULL if there is a creation failure.
 
-*coap_session_max_pdu_size*() function returns the MTU size.
+*coap_session_max_pdu_size*() returns the MTU size.
 
 EXAMPLES
 --------

--- a/man/coap_endpoint_server.txt.in
+++ b/man/coap_endpoint_server.txt.in
@@ -198,9 +198,9 @@ definitions when setting up each resource. See *coap_resource*(3).
 RETURN VALUES
 -------------
 *coap_context_set_pki*(), *coap_context_set_pki_root_cas*() and
-*coap_context_set_psk2*() functions return 1 on success, 0 on failure.
+*coap_context_set_psk2*() return 1 on success, 0 on failure.
 
-*coap_new_endpoint*() function returns a newly created endpoint or
+*coap_new_endpoint*() returns a newly created endpoint or
 NULL if there is a creation failure.
 
 *coap_join_mcast_group_intf*() returns 0 on success, -1 on failure.

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -203,14 +203,14 @@ have been responded to.
 
 RETURN VALUES
 -------------
-*coap_io_process*() and *coap_io_process_with_fds*() returns the time, in
+*coap_io_process*() and *coap_io_process_with_fds*() return the time, in
 milli-seconds, that was spent in the function. If -1 is returned, there was
 an unexpected error.
 
 *coap_context_get_coap_fd*() returns a non-negative number as the file
 descriptor to monitor, or -1 if epoll is not configured in libcoap.
 
-*coap_io_prepare_io*() and *coap_io_prepare_epoll*() returns the number of
+*coap_io_prepare_io*() and *coap_io_prepare_epoll*() return the number of
 milli-seconds that need to be waited before the function should next be called.
 
 *coap_io_pending*() returns 1 if there is outstanding i/o else returns 0.

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -15,7 +15,7 @@ coap_log,
 coap_log_emerg,
 coap_log_alert,
 coap_log_crit,
-coap_logi_err,
+coap_log_err,
 coap_log_warn,
 coap_log_info,
 coap_log_notice,
@@ -300,25 +300,25 @@ _length_.
 RETURN VALUES
 -------------
 
-The *coap_package_name*(), *coap_package_version*() and
+*coap_package_name*(), *coap_package_version*() and
 *coap_package_build*() return the appropriate zero-terminated character
 string.
 
-The *coap_get_log_level*() function returns the current logging level.
+*coap_get_log_level*() returns the current logging level.
 
-The *coap_dtls_get_log_level*() function returns the current logging level
+*coap_dtls_get_log_level*() returns the current logging level
 for the DTLS library specifics.
 
-The *coap_endpoint_str*() function returns a description string of the
+*coap_endpoint_str*() returns a description string of the
 _endpoint_.
 
-The *coap_session_str*() function returns a description string of the
+*coap_session_str*() returns a description string of the
 _session_.
 
-The *coap_print_addr*() function returns the length of _buffer_ that has been
+*coap_print_addr*() returns the length of _buffer_ that has been
 updated with an ascii readable IP address and port for _address_.
 
-The *coap_print_ip_addr*() function returns a pointer to the ascii readable
+*coap_print_ip_addr*() returns a pointer to the ascii readable
 IP address only for _address_.
 
 SEE ALSO

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -146,10 +146,10 @@ by the client application.
 
 RETURN VALUES
 -------------
-The *coap_resource_set_get_observable*() function return 0 on failure, 1 on
-success.
+*coap_resource_notify_observers*() returns 0 if not observable or
+no observers, 1 on success.
 
-The *coap_cancel_observe*() function return 0 on failure, 1 on success.
+*coap_cancel_observe*() returns 0 on failure, 1 on success.
 
 EXAMPLES
 --------

--- a/man/coap_oscore.txt.in
+++ b/man/coap_oscore.txt.in
@@ -193,16 +193,16 @@ configure _oscore_conf_ (which is freed off by this call).
 
 RETURN VALUES
 -------------
-The *coap_new_client_session_oscore*(), *coap_new_client_session_oscore_psk*()
-and *coap_new_client_session_oscore_pki*() functions return a newly created
+*coap_new_client_session_oscore*(), *coap_new_client_session_oscore_psk*()
+and *coap_new_client_session_oscore_pki*() return a newly created
 client session or NULL if there is a malloc or parameter failure.
 
-The *coap_new_oscore_conf*() function returns a _coap_oscore_conf_t_
+*coap_new_oscore_conf*() returns a _coap_oscore_conf_t_
 or NULL on failure.
 
-The *coap_oscore_is_supported*(), *coap_context_oscore_server*(),
-*coap_delete_oscore_conf*(), *coap_add_oscore_recipient*() and
-*coap_delete_oscore_context*() functions return 0 on failure, 1 on success.
+*coap_oscore_is_supported*(), *coap_context_oscore_server*(),
+*coap_delete_oscore_conf*(), *coap_new_oscore_recipient*() and
+*coap_delete_oscore_recipient*() return 0 on failure, 1 on success.
 
 EXAMPLES
 --------

--- a/man/coap_pdu_access.txt.in
+++ b/man/coap_pdu_access.txt.in
@@ -328,7 +328,7 @@ value.
 *coap_pdu_get_code*(), *coap_pdu_get_mid*(), *coap_pdu_get_type*() return
 the appropriate value.
 
-*coap_option_filter_set*(), *coap_option_filter_set*() and
+*coap_option_filter_get*(), *coap_option_filter_set*() and
 *coap_option_filter_unset*() return 1 on success or 0 on failure.
 
 *coap_get_data*() returns 1 if data, else 0.

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -530,30 +530,31 @@ the response PDU to be transmitted as appropriate and there is no need to call
 
 RETURN VALUES
 -------------
-The *coap_new_pdu*() and *coap_pdu_init*() function returns a newly created
+*coap_new_pdu*() and *coap_pdu_init*() return a newly created
 _PDU_ or NULL if there is a malloc or parameter failure.
 
-The *coap_new_optlist*() function returns a newly created _optlist_ or NULL
+*coap_new_optlist*() returns a newly created _optlist_ or NULL
 if there is a malloc failure.
 
-The *coap_add_token*(), *coap_insert_optlist*(), *coap_delete_optlist*(),
-*coap_add_optlist_pdu*() and *coap_add_data*()
-functions return 0 on failure, 1 on success.
+*coap_add_token*(), *coap_insert_optlist*(), *coap_add_optlist_pdu*()
+and *coap_add_data*() return 0 on failure, 1 on success.
 
-The *coap_add_optlist*() function returns either the length of the option
-or 0 on failure.
-
-The *coap_encode_var_safe*() function returns either the length of bytes
+*coap_encode_var_safe*() returns either the length of bytes
 encoded (which can be 0 when encoding 0) or 0 on failure.
 
-The *coap_encode_var_safe8*() function returns either the length of bytes
+*coap_encode_var_safe8*() returns either the length of bytes
 encoded (which can be 0 when encoding 0) or 0 on failure.
 
-The *coap_send*() function returns the CoAP message ID on success or
+*coap_add_option*() returns the size of option added, or 0 on
+failure.
+
+*coap_send*() returns the CoAP message ID on success or
 COAP_INVALID_MID on failure.
 
-The *coap_split_path*() and *coap_split_query*() functions return the number
+*coap_split_path*() and *coap_split_query*() return the number
 of components found.
+
+*coap_new_message_id*() returns the next CoAP message ID to use.
 
 EXAMPLES
 --------

--- a/man/coap_persist.txt.in
+++ b/man/coap_persist.txt.in
@@ -191,9 +191,9 @@ instead of 0,
 
 RETURN VALUES
 -------------
-The *coap_persist_startup*() returns 1 on success else 0.
+*coap_persist_startup*() returns 1 on success else 0.
 
-The *coap_persist_observe_add*() function returns a newly created observe
+*coap_persist_observe_add*() returns a newly created observe
 subscription or NULL on failure.
 
 EXAMPLES

--- a/man/coap_recovery.txt.in
+++ b/man/coap_recovery.txt.in
@@ -21,8 +21,8 @@ coap_session_set_max_retransmit,
 coap_session_get_max_retransmit,
 coap_session_set_nstart,
 coap_session_get_nstart,
-coap_session_set_probing_wait,
-coap_session_get_probing_wait,
+coap_session_set_probing_rate,
+coap_session_get_probing_rate,
 coap_debug_set_packet_loss
 - Work with CoAP packet transmissions
 

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -284,18 +284,18 @@ the _resource_ definion.
 
 RETURN VALUES
 -------------
-The *coap_resource_init*(), *coap_resource_unknown_init*(),
+*coap_resource_init*(), *coap_resource_unknown_init*(),
 *coap_resource_unknown_init2*(), *coap_resource_proxy_uri_init*() and
-*coap_resource_proxy_uri_init2*() functions return a newly created resource
+*coap_resource_proxy_uri_init2*() return a newly created resource
 or NULL if there is a malloc failure.
 
-The *coap_delete_resource*() function return 0 on failure (_resource_ not
+*coap_delete_resource*() returns 0 on failure (_resource_ not
 found), 1 on success.
 
-The *coap_resource_get_userdata*() function returns the value previously set
+*coap_resource_get_userdata*() returns the value previously set
 by the *coap_resource_set_userdata*() function or NULL.
 
-The *coap_resource_get_uri_path*() function returns the uri_path or NULL if
+*coap_resource_get_uri_path*() returns the uri_path or NULL if
 there was a failure.
 
 EXAMPLES

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -223,11 +223,11 @@ _session_'s pre-shared-key key information.
 RETURN VALUES
 -------------
 
-*coap_session_reference*() function returns a pointer to the session.
+*coap_session_reference*() returns a pointer to the session.
 
-*coap_session_set_type_client*() function returns 1 on success, otherwise 0.
+*coap_session_set_type_client*() returns 1 on success, otherwise 0.
 
-*coap_session_get_app_data*() function return a previously defined pointer.
+*coap_session_get_app_data*() returns a previously defined pointer.
 
 *coap_session_get_addr_local*() and *coap_session_get_addr_remote*() return
 a pointer to the IP address / port or NULL on error.

--- a/man/coap_string.txt.in
+++ b/man/coap_string.txt.in
@@ -174,25 +174,25 @@ objects _binary1_ and _binary2_.
 
 RETURN VALUES
 -------------
-The *coap_new_string*() function returns a pointer to an allocated
+*coap_new_string*() returns a pointer to an allocated
 coap_string_t or NULL if there was a failure.
 
-The *coap_new_str_const*() function returns a pointer to an allocated
+*coap_new_str_const*() returns a pointer to an allocated
 coap_str_const_t or NULL if there was a failure.
 
-The *coap_make_str_const*() function returns a pointer to a structure in
+*coap_make_str_const*() returns a pointer to a structure in
 static memory that has a pointer to the provided string.
 
-The *coap_new_binary*() function returns a pointer to an allocated
+*coap_new_binary*() returns a pointer to an allocated
 coap_binary_t or NULL if there was a failure.
 
-The *coap_resize_binary*() function returns a pointer to an re-allocated
+*coap_resize_binary*() returns a pointer to an re-allocated
 coap_binary_t or NULL if there was a failure.
 
-The *coap_new_bin_const*() function returns a pointer to an allocated
+*coap_new_bin_const*() returns a pointer to an allocated
 coap_bin_const_t or NULL if there was a failure.
 
-The *coap_string_equal*() and *coap_binary_equal*() functions return 1 on
+*coap_string_equal*() and *coap_binary_equal*() return 1 on
 a precise match, else 0.
 
 SEE ALSO

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -173,16 +173,17 @@ RETURN VALUES
 -------------
 *coap_dtls_is_supported*(), *coap_tls_is_supported*(),
 *coap_dtls_psk_is_supported*(), *coap_dtls_pki_is_supported*(),
-*coap_dtls_pkcs11_is_supported*() and *coap_dtls_rpk_is_supported*() functions
+*coap_dtls_pkcs11_is_supported*() and *coap_dtls_rpk_is_supported*()
 return 0 if there is no support, 1 if support is available.
 
-*coap_get_tls_library_version*() function returns the TLS implementation type
+*coap_get_tls_library_version*() returns the TLS implementation type
 and library version in a coap_tls_version_t* structure.
 
-*coap_tcp_is_supported*() function returns 1 if support for TCP is
+*coap_tcp_is_supported*() returns 1 if support for TCP is
 available, otherwise 0.
 
-*coap_string_tls_version*() function returns a pointer to the provided buffer.
+*coap_string_tls_version*() and *coap_string_tls_support*() return
+a pointer to the provided buffer.
 
 SEE ALSO
 --------

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -74,16 +74,38 @@ const char *define_list[] = {
   "coap_dtls_log(",
 };
 
-const char *struct_list[] = {
+/* xxx *function */
+const char *pointer_list[] = {
+  "char ",
+  "coap_addr_info_t ",
+  "coap_async_t ",
+  "coap_attr_t ",
+  "coap_bin_const_t ",
+  "coap_binary_t ",
+  "coap_cache_entry_t ",
+  "coap_cache_key_t ",
+  "coap_endpoint_t ",
+  "coap_context_t ",
   "coap_fixed_point_t ",
+  "coap_oscore_conf_t ",
+  "coap_optlist_t ",
+  "coap_session_t ",
   "coap_string_t ",
   "coap_str_const_t ",
-  "coap_binary_t ",
-  "coap_bin_const_t ",
   "coap_opt_iterator_t ",
   "coap_opt_t ",
+  "coap_pdu_t ",
+  "coap_resource_t ",
+  "coap_subscription_t ",
+  "coap_tls_version_t ",
+  "coap_uri_t ",
+  "const char ",
+  "const coap_address_t ",
+  "const coap_bin_const_t ",
+  "const coap_pdu_t ",
 };
 
+/* xxx function */
 const char *number_list[] = {
   "coap_log_t ",
   "coap_pdu_type_t ",
@@ -101,9 +123,21 @@ const char *number_list[] = {
   "const uint8_t ",
 };
 
+const char *return_void_list[] = {
+  "coap_option_filter_set",
+  "coap_resource_set_userdata",
+  "coap_cache_set_app_data",
+};
+
 int exit_code = 0;
 
-static void check_synopsis(const char* file) {
+static char name_list[100][100];
+static unsigned int name_cnt = 0;
+static char return_list[100][100];
+static unsigned int return_cnt = 0;
+
+static void
+check_synopsis(const char* file) {
   char buffer[1024];
   char file_name[300];
   FILE *fpcode;
@@ -136,11 +170,221 @@ static void check_synopsis(const char* file) {
   return;
 }
 
+static void
+dump_name_synopsis_mismatch(void) {
+  unsigned int i;
+
+  for (i = 0; i < name_cnt; i++) {
+    if (name_list[i][0] != '\000') {
+      fprintf(stderr, "NAME: %s not in SYNOPSIS or pointer_list[]\n", name_list[i]);
+      exit_code = 1;
+    }
+  }
+  name_cnt = 0;
+}
+
+static void
+dump_return_synopsis_mismatch(void) {
+  unsigned int i;
+
+  for (i = 0; i < return_cnt; i++) {
+    if (return_list[i][0] != '\000') {
+      fprintf(stderr, "SYNOPSIS: %s not in RETURN VALUES\n", return_list[i]);
+      exit_code = 1;
+    }
+  }
+  return_cnt = 0;
+}
+
+/*
+ * It is assumed for a definition that a leading * and trailing * have been
+ * added to buffer.
+ */
+static void
+decode_synopsis_definition(FILE *fpheader, const char *buffer, int in_synopsis) {
+  size_t len;
+  char outbuf[1024];
+  const char *cp;
+  const char *ecp;
+  int is_void_func = 0;
+  int is_number_func = 0;
+  int is_inline_func = 0;
+  int is_struct_func = 0;
+  const char *func_start = NULL;
+  int is_struct = 0;
+  unsigned int i;
+
+  if (strncmp(buffer, "*void ", sizeof("*void ")-1) == 0) {
+    if (strncmp(buffer, "*void *", sizeof("*void *")-1) == 0) {
+      func_start = &buffer[sizeof("*void *")-1];
+    }
+    else {
+      is_void_func = 1;
+      func_start = &buffer[sizeof("*void ")-1];
+    }
+  }
+
+  for (i = 0; i < sizeof(number_list)/sizeof(number_list[0]); i++) {
+    if (strncmp(&buffer[1], number_list[i],
+                strlen(number_list[i])) == 0) {
+      if (buffer[1 + strlen(number_list[i])] == '*') {
+        func_start = &buffer[2 + strlen(number_list[i])];
+      }
+      else {
+        is_number_func = 1;
+        func_start = &buffer[1 + strlen(number_list[i])];
+      }
+      break;
+    }
+  }
+
+  for (i = 0; i < sizeof(pointer_list)/sizeof(pointer_list[0]); i++) {
+    if (strncmp(&buffer[1], pointer_list[i],
+                strlen(pointer_list[i])) == 0) {
+      if (buffer[1 + strlen(pointer_list[i])] == '*') {
+        func_start = &buffer[2 + strlen(pointer_list[i])];
+      }
+      else {
+        is_struct_func = i + 1;
+        func_start = &buffer[1 + strlen(pointer_list[i])];
+      }
+      break;
+    }
+  }
+
+  if (strncmp(buffer, "*struct ", sizeof("*struct ")-1) == 0) {
+    is_struct = 1;
+    func_start = &buffer[sizeof("*struct ")-1];
+  }
+
+  if (func_start) {
+    /* see if COAP_STATIC_INLINE function */
+    for (i = 0; i < sizeof(inline_list)/sizeof(inline_list[0]); i++) {
+      if (strncmp(func_start, inline_list[i],
+                  strlen(inline_list[i])) == 0) {
+        is_inline_func = 1;
+        break;
+      }
+    }
+    /* see if #define function */
+    for (i = 0; i < sizeof(define_list)/sizeof(define_list[0]); i++) {
+      if (strncmp(func_start, define_list[i], strlen(define_list[i])) == 0) {
+        break;
+      }
+    }
+    if (i != sizeof(define_list)/sizeof(define_list[0]))
+      goto cleanup;
+  }
+
+  /* Need to include use of U for unused parameters just before comma */
+  cp = buffer;
+  ecp = strchr(cp, ',');
+  if (!ecp) ecp = strchr(cp, ')');
+  outbuf[0] = '\000';
+  while (ecp) {
+    len = strlen(outbuf);
+    if (strncmp(cp, "void", ecp-cp) == 0)
+      snprintf(&outbuf[len], sizeof(outbuf)-len, "%*.*s%c",
+              (int)(ecp-cp), (int)(ecp-cp), cp, *ecp);
+    else
+      snprintf(&outbuf[len], sizeof(outbuf)-len, "%*.*s U%c",
+              (int)(ecp-cp), (int)(ecp-cp), cp, *ecp);
+    cp = ecp+1;
+    if(*cp) {
+      ecp = strchr(cp, ',');
+      if (!ecp) ecp = strchr(cp, ')');
+    }
+    else {
+      ecp = NULL;
+    }
+  }
+  if (*cp) {
+    len = strlen(outbuf);
+    snprintf(&outbuf[len], sizeof(outbuf)-len, "%s", cp);
+  }
+
+  len = strlen(outbuf);
+  if (len > 3 && ((outbuf[len-3] == ';' && outbuf[len-2] == '*') ||
+                  (outbuf[len-3] == '*' && outbuf[len-2] == ';'))) {
+    if (is_inline_func) {
+      strcpy(&outbuf[len-3], ";\n");
+    }
+    /* Replace ;* or *; with simple function definition */
+    else if (is_void_func) {
+      strcpy(&outbuf[len-3], "{}\n");
+    }
+    else if (is_number_func) {
+      strcpy(&outbuf[len-3], "{return 0;}\n");
+    }
+    else if (is_struct_func) {
+      snprintf(&outbuf[len-3], sizeof(outbuf)-(len-3),
+             "{%s v; memset(&v, 0, sizeof(v)); return v;}\n",
+             pointer_list[is_struct_func - 1]);
+    }
+    else if (is_struct) {
+      strcpy(&outbuf[len-3], ";\n");
+    }
+    else {
+      strcpy(&outbuf[len-3], "{return NULL;}\n");
+    }
+  }
+  if (outbuf[0] == '*') {
+    fprintf(fpheader, "%s", &outbuf[1]);
+  }
+  else {
+    fprintf(fpheader, "%s", outbuf);
+  }
+cleanup:
+  if (in_synopsis && func_start) {
+    char* wcp = strchr(func_start, '(');
+
+    if (!wcp && is_struct)
+      wcp = strchr(func_start, ';');
+    if (!wcp) {
+      wcp = strchr(func_start, '\n');
+      if (wcp)
+        *wcp = '\000';
+      fprintf(stderr, "SYNOPSIS: function %s issue\n", func_start);
+      return;
+    }
+    *wcp = '\000';
+    for (i = 0; i < name_cnt; i++) {
+      if (strcmp(name_list[i], func_start) == 0) {
+        name_list[i][0] = '\000';
+        break;
+      }
+    }
+    if (i == name_cnt) {
+      fprintf(stderr, "SYNOPSIS: %s not in NAME\n", func_start);
+      exit_code = 1;
+    }
+    if (!is_void_func && !is_struct) {
+      for (i = 0; i < return_cnt; i++) {
+        if (strcmp(func_start, return_list[i]) == 0) {
+          fprintf(stderr, "SYNOPSIS: %s duplicated\n", func_start);
+          break;
+        }
+      }
+      if (i != return_cnt)
+        return;
+      if (i >= (int)(sizeof(return_list)/sizeof(return_list[0]))) {
+        fprintf(stderr, "SYNOPSIS: %s insufficient space (%u >= %u)\n", func_start,
+                i, (int)(sizeof(return_list)/sizeof(return_list[0])));
+        return;
+      }
+      strncpy(return_list[i], func_start, sizeof(return_list[i])-1);
+      return_cnt++;
+    }
+  }
+  return;
+}
+
 int main(int argc, char* argv[])
 {
   DIR *pdir;
   struct dirent *pdir_ent;
   char buffer[1024];
+  char man_name[1024];
   int  status;
 
   if (argc != 2) {
@@ -176,30 +420,51 @@ int main(int argc, char* argv[])
       int skip = 1;
       int in_examples = 0;
       int in_synopsis = 0;
+      int in_functions = 0;
+      int in_name = 0;
+      int in_return = 0;
       int count = 1;
       char keep_line[1024] = {0};
       FILE* fpcode = NULL;
       FILE* fpheader = NULL;
       char file_name[300];
-      int is_void_func = 0;
-      int is_number_func = 0;
-      int is_inline_func = 0;
-      int is_struct_func = 0;
-      char *func_start = NULL;
-      int is_struct = 0;
+      char *cp;
       unsigned int i;
 
       fprintf(stderr, "Processing: %s\n", pdir_ent->d_name);
 
-      snprintf(buffer, sizeof (buffer), "%s", pdir_ent->d_name);
-      fp = fopen(buffer, "r");
+      snprintf(man_name, sizeof (man_name), "%s", pdir_ent->d_name);
+      fp = fopen(man_name, "r");
       if (fp == NULL) {
-        fprintf(stderr, "fopen: %s: %s (%d)\n", buffer, strerror(errno), errno);
+        fprintf(stderr, "fopen: %s: %s (%d)\n", man_name, strerror(errno), errno);
         continue;
       }
+      cp = strstr(man_name, ".txt.in");
+      if (cp)
+        *cp = '\000';
+      name_cnt = 0;
       while (fgets(buffer, sizeof (buffer), fp) != NULL) {
+        if (strncmp(buffer, "NAME", sizeof("NAME")-1) == 0) {
+          in_name = 1;
+          continue;
+        }
         if (strncmp(buffer, "SYNOPSIS", sizeof("SYNOPSIS")-1) == 0) {
+          in_name = 0;
           in_synopsis = 1;
+          snprintf(file_name, sizeof (file_name), "tmp/%s.h",
+                   pdir_ent->d_name);
+          fpheader = fopen(file_name, "w");
+          if (!fpheader) {
+            fprintf(stderr, "fopen: %s: %s (%d)\n", file_name,
+                    strerror(errno), errno);
+            goto bad;
+          }
+          continue;
+        }
+        if (strncmp(buffer, "FUNCTIONS", sizeof("FUNCTIONS")-1) == 0) {
+          in_synopsis = 0;
+          dump_name_synopsis_mismatch();
+          in_functions = 1;
           snprintf(file_name, sizeof (file_name), "tmp/%s.h",
                    pdir_ent->d_name);
           fpheader = fopen(file_name, "w");
@@ -212,27 +477,128 @@ int main(int argc, char* argv[])
         }
         if (strncmp(buffer, "DESCRIPTION", sizeof("DESCRIPTION")-1) == 0) {
           in_synopsis = 0;
+          dump_name_synopsis_mismatch();
           if (fpheader)
             fclose(fpheader);
           fpheader = NULL;
           check_synopsis(pdir_ent->d_name);
           continue;
         }
-        if (strncmp(buffer, "EXAMPLES", sizeof("EXAMPLES")-1) == 0) {
+        if (strncmp(buffer, "RETURN VALUES", sizeof("RETURN VALUES")-1) == 0) {
+          if (in_functions) {
+            if (fpheader)
+              fclose(fpheader);
+            fpheader = NULL;
+            check_synopsis(pdir_ent->d_name);
+          }
+          in_name = 0;
           in_synopsis = 0;
+          dump_name_synopsis_mismatch();
+          in_functions = 0;
+          in_return = 1;
+          continue;
+        }
+        if (strncmp(buffer, "TESTING", sizeof("TESTING")-1) == 0) {
+          if (in_functions) {
+            if (fpheader)
+              fclose(fpheader);
+            fpheader = NULL;
+            check_synopsis(pdir_ent->d_name);
+          }
+          in_name = 0;
+          in_synopsis = 0;
+          in_functions = 0;
+          in_return = 0;
+          continue;
+        }
+        if (strncmp(buffer, "EXAMPLES", sizeof("EXAMPLES")-1) == 0) {
+          if (in_functions) {
+            if (fpheader)
+              fclose(fpheader);
+            fpheader = NULL;
+            check_synopsis(pdir_ent->d_name);
+          }
+          in_name = 0;
+          in_synopsis = 0;
+          in_return = 0;
+          dump_name_synopsis_mismatch();
+          dump_return_synopsis_mismatch();
+          in_functions = 0;
           in_examples = 1;
           continue;
         }
         if (strncmp(buffer, "SEE ALSO", sizeof("SEE ALSO")-1) == 0) {
+          if (in_functions) {
+            if (fpheader)
+              fclose(fpheader);
+            fpheader = NULL;
+            check_synopsis(pdir_ent->d_name);
+          }
+          in_name = 0;
+          in_synopsis = 0;
+          in_return = 0;
+          dump_name_synopsis_mismatch();
+          dump_return_synopsis_mismatch();
+          in_functions = 0;
+          in_examples = 1;
           break;
         }
+
+        if (in_name) {
+          /* Working in NAME section */
+          if (buffer[0] == '\n')
+            continue;
+          if (buffer[0] == '-')
+            continue;
+          cp = strchr(buffer, '\n');
+          if (cp)
+            *cp = '\000';
+          cp = strchr(buffer, ',');
+          if (cp)
+            *cp = '\000';
+          if (strcmp(man_name, buffer) == 0)
+            continue;
+          if (strlen(buffer) >= sizeof(name_list[0])) {
+            fprintf(stderr, "NAME: %s is too long (%u >= %u)\n", buffer,
+                    (int)strlen(buffer), (int)sizeof(name_list[0]));
+            continue;
+          }
+          for (i = 0; i < name_cnt; i++) {
+            if (strcmp(buffer, name_list[i]) == 0) {
+              fprintf(stderr, "NAME: %s duplicated\n", buffer);
+              break;
+            }
+          }
+          if (i != name_cnt)
+            continue;
+          if (i >= (int)(sizeof(name_list)/sizeof(name_list[0]))) {
+            fprintf(stderr, "NAME: %s insufficient space (%u >= %u)\n", buffer,
+                    i, (int)(sizeof(name_list)/sizeof(name_list[0])));
+            continue;
+          }
+          snprintf(name_list[i], sizeof(name_list[i]), "%s", buffer);
+          name_cnt++;
+        }
+
         if (in_synopsis) {
           /* Working in SYNOPSIS section */
           size_t len;
           char outbuf[1024];
-          char *cp;
-          char *ecp;
 
+          if (buffer[0] == '*' && buffer[1] != '#') {
+            /* Start of a new entry */
+            snprintf(outbuf, sizeof(outbuf), "%s", buffer);
+            while (fgets(buffer, sizeof (buffer), fp) != NULL) {
+              if (buffer[0] == '\n') {
+                break;
+              }
+              len = strlen(outbuf);
+              outbuf[len-1] = ' ';
+              snprintf(&outbuf[len], sizeof(outbuf) - len, "%s", buffer);
+            }
+            decode_synopsis_definition(fpheader, outbuf, 1);
+            continue;
+          }
           if (buffer[0] == '\n')
             continue;
           if (buffer[0] == '-')
@@ -246,138 +612,65 @@ int main(int argc, char* argv[])
             check_synopsis(pdir_ent->d_name);
             continue;
           }
-          if (buffer[0] == '*' && buffer[1] == '#')
+        }
+
+        if (in_functions) {
+          /* Working in FUNCTIONS section */
+          size_t len;
+          char outbuf[1024];
+
+          if (strncmp(buffer, "Prototype:\n", sizeof("Prototype:\n")-1)== 0) {
+            /* Start of a new entry */
+            outbuf[0] = '*';
+            outbuf[1] = '\000';
+            while (fgets(buffer, sizeof (buffer), fp) != NULL) {
+              if (buffer[0] == '\n') {
+                break;
+              }
+              len = strlen(outbuf);
+              if (outbuf[len-1] == '\n')
+                outbuf[len-1] = ' ';
+              snprintf(&outbuf[len], sizeof(outbuf) - len, "%s", buffer);
+            }
+            len = strlen(outbuf);
+            len--;
+            snprintf(&outbuf[len], sizeof(outbuf) - len, "*\n");
+            decode_synopsis_definition(fpheader, outbuf, 0);
             continue;
-          if (buffer[0] == '*') {
-            /* start of a new function */
-            is_void_func = 0;
-            is_number_func = 0;
-            is_struct_func = 0;
-            is_inline_func = 0;
-            is_struct = 0;
-            func_start = NULL;
+          }
+        }
 
-            if (strncmp(buffer, "*void ", sizeof("*void ")-1) == 0) {
-              if (strncmp(buffer, "*void *", sizeof("*void *")-1) == 0) {
-                func_start = &buffer[sizeof("*void *")-1];
-              }
-              else {
-                is_void_func = 1;
-                func_start = &buffer[sizeof("*void ")-1];
-              }
+        if (in_return) {
+          cp = strstr(buffer, "*coap_");
+          while (cp) {
+            char *ecp = strchr(cp+1, '*');
+
+            if (!ecp) {
+              fprintf(stderr, "RETURN VALUES: %s undecipherable\n", cp + 1);
+              exit_code = 1;
+              break;
             }
-
-            for (i = 0; i < sizeof(number_list)/sizeof(number_list[0]); i++) {
-              if (strncmp(&buffer[1], number_list[i],
-                          strlen(number_list[i])) == 0) {
-                if (buffer[1 + strlen(number_list[i])] == '*') {
-                  func_start = &buffer[2 + strlen(number_list[i])];
-                }
-                else {
-                  is_number_func = 1;
-                  func_start = &buffer[1 + strlen(number_list[i])];
-                }
+            *ecp = '\000';
+            for (i = 0; i < return_cnt; i++) {
+              if (strcmp(cp+1, return_list[i]) == 0) {
+                return_list[i][0] = '\000';
                 break;
               }
             }
-
-            for (i = 0; i < sizeof(struct_list)/sizeof(struct_list[0]); i++) {
-              if (strncmp(&buffer[1], struct_list[i],
-                          strlen(struct_list[i])) == 0) {
-                if (buffer[1 + strlen(struct_list[i])] == '*') {
-                  func_start = &buffer[2 + strlen(struct_list[i])];
-                }
-                else {
-                  is_struct_func = i + 1;
-                  func_start = &buffer[1 + strlen(struct_list[i])];
-                }
-                break;
+            if (i == return_cnt) {
+              for (i = 0;
+                   i < sizeof(return_void_list)/sizeof(return_void_list[0]);
+                   i++) {
+                if (strcmp(cp+1, return_void_list[i]) == 0)
+                  break;
+              }
+              if (i == sizeof(return_void_list)/sizeof(return_void_list[0])) {
+                fprintf(stderr, "RETURN VALUES: %s not defined in SYNOPSIS\n", cp + 1);
+                exit_code = 1;
               }
             }
-
-            if (strncmp(buffer, "*struct ", sizeof("*struct ")-1) == 0) {
-              is_struct = 1;
-            }
+            cp = strstr(ecp+1, "*coap_");
           }
-
-          if (func_start) {
-            /* see if COAP_STATIC_INLINE function */
-            for (i = 0; i < sizeof(inline_list)/sizeof(inline_list[0]); i++) {
-              if (strncmp(func_start, inline_list[i],
-                          strlen(inline_list[i])) == 0) {
-                is_inline_func = 1;
-                break;
-              }
-            }
-            /* see if #define function */
-            for (i = 0; i < sizeof(define_list)/sizeof(define_list[0]); i++) {
-              if (strncmp(func_start, define_list[i], strlen(define_list[i])) == 0) {
-                break;
-              }
-            }
-            if (i != sizeof(define_list)/sizeof(define_list[0]))
-              continue;
-          }
-
-          /* Need to include use of U for unused parameters just before comma */
-          cp = buffer;
-          ecp = strchr(cp, ',');
-          if (!ecp) ecp = strchr(cp, ')');
-          outbuf[0] = '\000';
-          while (ecp) {
-            len = strlen(outbuf);
-            if (strncmp(cp, "void", ecp-cp) == 0)
-              snprintf(&outbuf[len], sizeof(outbuf)-len, "%*.*s%c",
-                      (int)(ecp-cp), (int)(ecp-cp), cp, *ecp);
-            else
-              snprintf(&outbuf[len], sizeof(outbuf)-len, "%*.*s U%c",
-                      (int)(ecp-cp), (int)(ecp-cp), cp, *ecp);
-            cp = ecp+1;
-            if(*cp) {
-              ecp = strchr(cp, ',');
-              if (!ecp) ecp = strchr(cp, ')');
-            }
-            else {
-              ecp = NULL;
-            }
-          }
-          if (*cp) {
-            len = strlen(outbuf);
-            snprintf(&outbuf[len], sizeof(outbuf)-len, "%s", cp);
-          }
-
-          len = strlen(outbuf);
-          if (len > 3 && ((outbuf[len-3] == ';' && outbuf[len-2] == '*') ||
-                          (outbuf[len-3] == '*' && outbuf[len-2] == ';'))) {
-            if (is_inline_func) {
-              strcpy(&outbuf[len-3], ";\n");
-            }
-            /* Replace ;* or ;* with simple function definition */
-            else if (is_void_func) {
-              strcpy(&outbuf[len-3], "{}\n");
-            }
-            else if (is_number_func) {
-              strcpy(&outbuf[len-3], "{return 0;}\n");
-            }
-            else if (is_struct_func) {
-              snprintf(&outbuf[len-3], sizeof(outbuf)-(len-3),
-                     "{%s v; memset(&v, 0, sizeof(v)); return v;}\n",
-                     struct_list[is_struct_func - 1]);
-            }
-            else if (is_struct) {
-              strcpy(&outbuf[len-3], ";\n");
-            }
-            else {
-              strcpy(&outbuf[len-3], "{return NULL;}\n");
-            }
-          }
-          if (outbuf[0] == '*') {
-            fprintf(fpheader, "%s", &outbuf[1]);
-          }
-          else {
-            fprintf(fpheader, "%s", outbuf);
-          }
-          continue;
         }
 
         if (!in_examples) {


### PR DESCRIPTION
Update examples-code-check.c to cross-check NAME and SYNOPSIS entries.

Update examples-code-check.c to cross-check SYNOPSIS and RETURN VALUE entries.

Make the formating style of RETURN VALUES consistent.