### PR TITLE
DTLS Libraries: Replace HAVE_<dtlslib> defines with COAP_WITH_<dtls_lib>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,14 +448,14 @@ if(ENABLE_DTLS)
     if(GnuTLS_FOUND)
       set(WITH_GNUTLS ON)
       message(STATUS "compiling with gnutls support")
-      set(HAVE_LIBGNUTLS 1)
+      set(COAP_WITH_LIBGNUTLS 1)
     else()
       # gnutls not found
       find_package(OpenSSL)
       if(OpenSSL_FOUND)
         set(WITH_OPENSSL ON)
         message(STATUS "compiling with openssl support")
-        set(HAVE_OPENSSL 1)
+        set(COAP_WITH_LIBOPENSSL 1)
       else()
         # openssl not found
         # libmbedtls (e.g. debian libmbedtls-dev)
@@ -463,7 +463,7 @@ if(ENABLE_DTLS)
         if(MbedTLS_FOUND)
           set(WITH_MBEDTLS ON)
           message(STATUS "compiling with mbedtls support")
-          set(HAVE_MBEDTLS 1)
+          set(COAP_WITH_LIBMBEDTLS 1)
         else()
           # mbedtls not found
           if(USE_VENDORED_TINYDTLS)
@@ -484,7 +484,7 @@ if(ENABLE_DTLS)
 
           set(WITH_TINYDTLS ON)
           message(STATUS "compiling with tinydtls support")
-          set(HAVE_LIBTINYDTLS 1)
+          set(COAP_WITH_LIBTINYDTLS 1)
 
         endif()
 
@@ -506,7 +506,7 @@ if(ENABLE_DTLS)
       find_package(GnuTLS REQUIRED)
       set(WITH_GNUTLS ON)
       message(STATUS "compiling with gnutls support")
-      set(HAVE_LIBGNUTLS 1)
+      set(COAP_WITH_LIBGNUTLS 1)
     endif()
 
     if(DTLS_BACKEND
@@ -516,7 +516,7 @@ if(ENABLE_DTLS)
       find_package(OpenSSL REQUIRED)
       set(WITH_OPENSSL ON)
       message(STATUS "compiling with openssl support")
-      set(HAVE_OPENSSL 1)
+      set(COAP_WITH_LIBOPENSSL 1)
     endif()
 
     if(DTLS_BACKEND
@@ -526,7 +526,7 @@ if(ENABLE_DTLS)
       find_package(MbedTLS REQUIRED)
       set(WITH_MBEDTLS ON)
       message(STATUS "compiling with mbedtls support")
-      set(HAVE_MBEDTLS 1)
+      set(COAP_WITH_LIBMBEDTLS 1)
     endif()
 
     if(DTLS_BACKEND
@@ -541,7 +541,7 @@ if(ENABLE_DTLS)
 
       message(STATUS "compiling with tinydtls support")
       set(WITH_TINYDTLS ON)
-      set(HAVE_LIBTINYDTLS 1)
+      set(COAP_WITH_LIBTINYDTLS 1)
 
     endif()
 
@@ -591,10 +591,10 @@ message(STATUS "WITH_GNUTLS:.....................${WITH_GNUTLS}")
 message(STATUS "WITH_TINYDTLS:...................${WITH_TINYDTLS}")
 message(STATUS "WITH_OPENSSL:....................${WITH_OPENSSL}")
 message(STATUS "WITH_MBEDTLS:....................${WITH_MBEDTLS}")
-message(STATUS "HAVE_LIBTINYDTLS:................${HAVE_LIBTINYDTLS}")
-message(STATUS "HAVE_LIBGNUTLS:..................${HAVE_LIBGNUTLS}")
-message(STATUS "HAVE_OPENSSL:....................${HAVE_OPENSSL}")
-message(STATUS "HAVE_MBEDTLS:....................${HAVE_MBEDTLS}")
+message(STATUS "COAP_WITH_LIBTINYDTLS:................${COAP_WITH_LIBTINYDTLS}")
+message(STATUS "COAP_WITH_LIBGNUTLS:..................${COAP_WITH_LIBGNUTLS}")
+message(STATUS "COAP_WITH_LIBOPENSSL:....................${COAP_WITH_LIBOPENSSL}")
+message(STATUS "COAP_WITH_LIBMBEDTLS:....................${COAP_WITH_LIBMBEDTLS}")
 message(STATUS "WITH_EPOLL:......................${WITH_EPOLL}")
 message(STATUS "BUILD_SHARED_LIBS:...............${BUILD_SHARED_LIBS}")
 message(STATUS "MAX_LOGGING_LEVEL:...............${MAX_LOGGING_LEVEL}")
@@ -659,10 +659,10 @@ target_sources(
           ${CMAKE_CURRENT_LIST_DIR}/src/pdu.c
           ${CMAKE_CURRENT_LIST_DIR}/src/resource.c
           # no need to parse those files if we do not need them
-          $<$<BOOL:${HAVE_OPENSSL}>:${CMAKE_CURRENT_LIST_DIR}/src/coap_openssl.c>
-          $<$<BOOL:${HAVE_LIBTINYDTLS}>:${CMAKE_CURRENT_LIST_DIR}/src/coap_tinydtls.c>
-          $<$<BOOL:${HAVE_LIBGNUTLS}>:${CMAKE_CURRENT_LIST_DIR}/src/coap_gnutls.c>
-          $<$<BOOL:${HAVE_MBEDTLS}>:${CMAKE_CURRENT_LIST_DIR}/src/coap_mbedtls.c>
+          $<$<BOOL:${COAP_WITH_LIBOPENSSL}>:${CMAKE_CURRENT_LIST_DIR}/src/coap_openssl.c>
+          $<$<BOOL:${COAP_WITH_LIBTINYDTLS}>:${CMAKE_CURRENT_LIST_DIR}/src/coap_tinydtls.c>
+          $<$<BOOL:${COAP_WITH_LIBGNUTLS}>:${CMAKE_CURRENT_LIST_DIR}/src/coap_gnutls.c>
+          $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:${CMAKE_CURRENT_LIST_DIR}/src/coap_mbedtls.c>
           # needed for OSCORE is enabled
           $<$<BOOL:${COAP_OSCORE_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/src/oscore/oscore.c>
           $<$<BOOL:${COAP_OSCORE_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/src/oscore/oscore_cbor.c>
@@ -700,18 +700,18 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/>
          $<INSTALL_INTERFACE:include/>
-         $<$<AND:$<BOOL:${HAVE_LIBTINYDTLS}>,$<BOOL:${USE_VENDORED_TINYDTLS}>>:${CMAKE_BINARY_DIR}/include/tinydtls>
-         $<$<BOOL:${HAVE_LIBGNUTLS}>:${GNUTLS_INCLUDE_DIR}>
-         $<$<BOOL:${HAVE_MBEDTLS}>:${MBEDTLS_INCLUDE_DIRS}>)
+         $<$<AND:$<BOOL:${COAP_WITH_LIBTINYDTLS}>,$<BOOL:${USE_VENDORED_TINYDTLS}>>:${CMAKE_BINARY_DIR}/include/tinydtls>
+         $<$<BOOL:${COAP_WITH_LIBGNUTLS}>:${GNUTLS_INCLUDE_DIR}>
+         $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:${MBEDTLS_INCLUDE_DIRS}>)
 target_link_libraries(
   ${COAP_LIBRARY_NAME}
-  PUBLIC $<$<BOOL:${HAVE_OPENSSL}>:OpenSSL::SSL>
-         $<$<BOOL:${HAVE_OPENSSL}>:OpenSSL::Crypto>
-         $<$<BOOL:${HAVE_LIBGNUTLS}>:${GNUTLS_LIBRARIES}>
-         $<$<BOOL:${HAVE_LIBTINYDTLS}>:tinydtls>
-         $<$<BOOL:${HAVE_MBEDTLS}>:${MBEDTLS_LIBRARY}>
-         $<$<BOOL:${HAVE_MBEDTLS}>:${MBEDX509_LIBRARY}>
-         $<$<BOOL:${HAVE_MBEDTLS}>:${MBEDCRYPTO_LIBRARY}>
+  PUBLIC $<$<BOOL:${COAP_WITH_LIBOPENSSL}>:OpenSSL::SSL>
+         $<$<BOOL:${COAP_WITH_LIBOPENSSL}>:OpenSSL::Crypto>
+         $<$<BOOL:${COAP_WITH_LIBGNUTLS}>:${GNUTLS_LIBRARIES}>
+         $<$<BOOL:${COAP_WITH_LIBTINYDTLS}>:tinydtls>
+         $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:${MBEDTLS_LIBRARY}>
+         $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:${MBEDX509_LIBRARY}>
+         $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:${MBEDCRYPTO_LIBRARY}>
          $<$<BOOL:${MINGW}>:ws2_32>)
 
 target_compile_options(

--- a/cmake_coap_config.h.in
+++ b/cmake_coap_config.h.in
@@ -81,16 +81,16 @@
 #cmakedefine HAVE_ERRNO_H @HAVE_ERRNO_H@
 
 /* Define to 1 if the system has openssl */
-#cmakedefine HAVE_OPENSSL @HAVE_OPENSSL@
+#cmakedefine COAP_WITH_LIBOPENSSL @COAP_WITH_LIBOPENSSL@
 
 /* Define to 1 if the system has libgnutls28 */
-#cmakedefine HAVE_LIBGNUTLS @HAVE_LIBGNUTLS@
+#cmakedefine COAP_WITH_LIBGNUTLS @COAP_WITH_LIBGNUTLS@
 
 /* Define to 1 if the system has libtinydtls */
-#cmakedefine HAVE_LIBTINYDTLS @HAVE_LIBTINYDTLS@
+#cmakedefine COAP_WITH_LIBTINYDTLS @COAP_WITH_LIBTINYDTLS@
 
 /* Define to 1 if the system has libmbedtls */
-#cmakedefine HAVE_MBEDTLS @HAVE_MBEDTLS@
+#cmakedefine COAP_WITH_LIBMBEDTLS @COAP_WITH_LIBMBEDTLS@
 
 /* Define to 1 if you have the <limits.h> header file. */
 #cmakedefine HAVE_LIMITS_H @HAVE_LIMITS_H@

--- a/coap_config.h.riot
+++ b/coap_config.h.riot
@@ -194,9 +194,9 @@
 #endif /* COAP_DISABLE_TCP */
 
 #ifdef MODULE_TINYDTLS
-#ifndef HAVE_LIBTINYDTLS
-#define HAVE_LIBTINYDTLS 1
-#endif /* ! HAVE_LIBTINYDTLS */
+#ifndef COAP_WITH_LIBTINYDTLS
+#define COAP_WITH_LIBTINYDTLS 1
+#endif /* ! COAP_WITH_LIBTINYDTLS */
 #endif /* MODULE_TINYDTLS */
 
 /* Define if building universal (internal helper macro) */

--- a/coap_config.h.riot.in
+++ b/coap_config.h.riot.in
@@ -194,9 +194,9 @@
 #endif /* COAP_DISABLE_TCP */
 
 #ifdef MODULE_TINYDTLS
-#ifndef HAVE_LIBTINYDTLS
-#define HAVE_LIBTINYDTLS 1
-#endif /* ! HAVE_LIBTINYDTLS */
+#ifndef COAP_WITH_LIBTINYDTLS
+#define COAP_WITH_LIBTINYDTLS 1
+#endif /* ! COAP_WITH_LIBTINYDTLS */
 #endif /* MODULE_TINYDTLS */
 
 /* Define if building universal (internal helper macro) */

--- a/configure.ac
+++ b/configure.ac
@@ -615,22 +615,22 @@ if test "x$build_dtls" = "xyes"; then
     if test "x$with_gnutls" = "xyes" -o "x$with_gnutls_auto" = "xyes"; then
         DTLS_CFLAGS="$GnuTLS_CFLAGS"
         DTLS_LIBS="$GnuTLS_LIBS"
-        AC_DEFINE(HAVE_LIBGNUTLS, [1], [Define to 1 if the system has libgnutls28.])
+        AC_DEFINE(COAP_WITH_LIBGNUTLS, [1], [Define to 1 if the system has libgnutls28.])
     fi
     if test "x$with_openssl" = "xyes" -o "x$with_openssl_auto" = "xyes"; then
         DTLS_CFLAGS="$OpenSSL_CFLAGS"
         DTLS_LIBS="$OpenSSL_LIBS"
-        AC_DEFINE(HAVE_OPENSSL, [1], [Define to 1 if the system has libssl1.1.])
+        AC_DEFINE(COAP_WITH_LIBOPENSSL, [1], [Define to 1 if the system has libssl1.1.])
     fi
     if test "x$with_mbedtls" = "xyes" -o "x$with_mbedtls_auto" = "xyes"; then
         DTLS_CFLAGS="$MbedTLS_CFLAGS"
         DTLS_LIBS="$MbedTLS_LIBS"
-        AC_DEFINE(HAVE_MBEDTLS, [1], [Define to 1 if the system has libmbedtls2.7.10.])
+        AC_DEFINE(COAP_WITH_LIBMBEDTLS, [1], [Define to 1 if the system has libmbedtls2.7.10.])
     fi
     if test "x$with_tinydtls" = "xyes" -o "x$with_tinydtls_auto" = "xyes"; then
         DTLS_CFLAGS="$TinyDTLS_CFLAGS"
         DTLS_LIBS="$TinyDTLS_LIBS"
-        AC_DEFINE(HAVE_LIBTINYDTLS, [1], [Define to 1 if the system has libtinydtls.])
+        AC_DEFINE(COAP_WITH_LIBTINYDTLS, [1], [Define to 1 if the system has libtinydtls.])
     fi
     AC_SUBST(DTLS_CFLAGS)
     AC_SUBST(DTLS_LIBS)

--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -168,7 +168,7 @@ SD_COAP_OBJ =$(patsubst %.c,lib-server-dtls/%.o,$(COAP_SRC))
 
 vpath %.c $(libcoap_dir)/ext/tinydtls $(libcoap_dir)/ext/tinydtls/sha2 $(libcoap_dir)/ext/tinydtls/aes $(libcoap_dir)/ext/tinydtls/ecc
 
-TINYDTLS_CFLAGS = -I. -I$(libcoap_dir)/ext -I$(libcoap_dir)/ext/tinydtls -DDTLSv12 -DWITH_SHA256 -DSHA2_USE_INTTYPES_H -DDTLS_CHECK_CONTENTTYPE -DHAVE_LIBTINYDTLS -DHAVE_DTLS_SET_LOG_HANDLER=1
+TINYDTLS_CFLAGS = -I. -I$(libcoap_dir)/ext -I$(libcoap_dir)/ext/tinydtls -DDTLSv12 -DWITH_SHA256 -DSHA2_USE_INTTYPES_H -DDTLS_CHECK_CONTENTTYPE -DCOAP_WITH_LIBTINYDTLS -DHAVE_DTLS_SET_LOG_HANDLER=1
 
 DTLS_SRC = dtls.c \
            dtls_debug.c \

--- a/examples/lwip/config/lwippools.h
+++ b/examples/lwip/config/lwippools.h
@@ -15,7 +15,7 @@
 #include "coap3/coap_net.h"
 #include "coap3/resource.h"
 #include "coap3/coap_subscribe.h"
-#ifdef HAVE_LIBTINYDTLS
+#ifdef COAP_WITH_LIBTINYDTLS
 #ifndef LWIP_TINYDTLS_LOCAL_FIX
 #define LWIP_TINYDTLS_LOCAL_FIX
 #include <lwip/ip_addr.h>
@@ -36,18 +36,18 @@ typedef struct l_coap_tiny_context_t {
 } l_coap_tiny_context_t;
 
 #endif /* LWIP_TINYDTLS_LOCAL_FIX */
-#endif /* HAVE_LIBTINYDTLS */
+#endif /* COAP_WITH_LIBTINYDTLS */
 
 #ifndef MEMP_NUM_COAPCONTEXT
 #define MEMP_NUM_COAPCONTEXT 1
 #endif
 
 #ifndef MEMP_NUM_COAPENDPOINT
-#ifdef HAVE_LIBTINYDTLS
+#ifdef COAP_WITH_LIBTINYDTLS
 #define MEMP_NUM_COAPENDPOINT 2
-#else /* ! HAVE_LIBTINYDTLS */
+#else /* ! COAP_WITH_LIBTINYDTLS */
 #define MEMP_NUM_COAPENDPOINT 1
-#endif /* ! HAVE_LIBTINYDTLS */
+#endif /* ! COAP_WITH_LIBTINYDTLS */
 #endif
 
 /* 1 is sufficient as this is very short-lived */
@@ -163,7 +163,7 @@ LWIP_MEMPOOL(COAP_LG_CRCV, MEMP_NUM_COAPLGCRCV, sizeof(coap_lg_crcv_t), "COAP_LG
 LWIP_MEMPOOL(COAP_LG_SRCV, MEMP_NUM_COAPLGSRCV, sizeof(coap_lg_srcv_t), "COAP_LG_SRCV")
 LWIP_MEMPOOL(COAP_DIGEST_CTX, MEMP_NUM_COAPDIGESTCTX, sizeof(coap_digest_t) + sizeof(size_t), "COAP_DIGEST_CTX")
 #endif /* COAP_SERVER_SUPPORT */
-#ifdef HAVE_LIBTINYDTLS
+#ifdef COAP_WITH_LIBTINYDTLS
 LWIP_MEMPOOL(COAP_DTLS_SESSION, MEMP_NUM_COAPDTLS_SESSION, sizeof(l_session_t), "COAP_DTLS_SESSION")
 LWIP_MEMPOOL(COAP_DTLS_CONTEXT, MEMP_NUM_COAPDTLS_CONTEXT, sizeof(l_coap_tiny_context_t), "COAP_DTLS_CONTEXT")
-#endif /* HAVE_LIBTINYDTLS */
+#endif /* COAP_WITH_LIBTINYDTLS */

--- a/examples/riot/pkg_libcoap/Makefile.libcoap
+++ b/examples/riot/pkg_libcoap/Makefile.libcoap
@@ -34,7 +34,7 @@ SRC := coap_address.c \
   coap_ws.c
 
 ifneq (,$(filter libcoap_tinydtls,$(USEMODULE)))
-CFLAGS += -DHAVE_LIBTINYDTLS
+CFLAGS += -DCOAP_WITH_LIBTINYDTLS
 endif
 
 include $(RIOTBASE)/Makefile.base

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -12,7 +12,7 @@
 
 /**
  * @file coap_gnutls.c
- * @brief GndTLS interafe functions
+ * @brief GnuTLS interafe functions
  */
 
 /*
@@ -50,7 +50,7 @@
 
 #include "coap3/coap_internal.h"
 
-#ifdef HAVE_LIBGNUTLS
+#ifdef COAP_WITH_LIBGNUTLS
 
 #define MIN_GNUTLS_VERSION "3.3.0"
 
@@ -3304,7 +3304,7 @@ fail:
 
 #endif /* COAP_OSCORE_SUPPORT */
 
-#else /* !HAVE_LIBGNUTLS */
+#else /* !COAP_WITH_LIBGNUTLS */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -3315,4 +3315,4 @@ fail:
 static inline void dummy(void) {
 }
 
-#endif /* !HAVE_LIBGNUTLS */
+#endif /* !COAP_WITH_LIBGNUTLS */

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -27,7 +27,7 @@
 
 #include "coap3/coap_internal.h"
 
-#ifdef HAVE_MBEDTLS
+#ifdef COAP_WITH_LIBMBEDTLS
 
 /*
  * This code can be conditionally compiled to remove some components if
@@ -3036,7 +3036,7 @@ error:
 
 #endif /* COAP_OSCORE_SUPPORT */
 
-#else /* !HAVE_MBEDTLS */
+#else /* !COAP_WITH_LIBMBEDTLS */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -3047,4 +3047,4 @@ error:
 static inline void dummy(void) {
 }
 
-#endif /* HAVE_MBEDTLS */
+#endif /* COAP_WITH_LIBMBEDTLS */

--- a/src/coap_mem.c
+++ b/src/coap_mem.c
@@ -267,12 +267,12 @@ static coap_resource_t resource_storage_data[COAP_MAX_RESOURCES];
 static memarray_t resource_storage;
 #endif /* COAP_SERVER_SUPPORT */
 
-#ifdef HAVE_LIBTINYDTLS
+#ifdef COAP_WITH_LIBTINYDTLS
 #undef PACKAGE_BUGREPORT
 #include <session.h>
 static session_t dtls_storage_data[COAP_MAX_DTLS_SESSIONS];
 static memarray_t dtls_storage;
-#endif /* HAVE_LIBTINYDTLS */
+#endif /* COAP_WITH_LIBTINYDTLS */
 
 static coap_session_t session_storage_data[COAP_MAX_SESSIONS];
 static memarray_t session_storage;
@@ -327,7 +327,7 @@ coap_memory_init(void) {
   INIT_STORAGE(resource, COAP_MAX_RESOURCES);
   INIT_STORAGE(resattr, COAP_MAX_ATTRIBUTES);
 #endif /* COAP_SERVER_SUPPORT */
-#ifdef HAVE_LIBTINYDTLS
+#ifdef COAP_WITH_LIBTINYDTLS
   INIT_STORAGE(dtls, COAP_MAX_DTLS_SESSIONS);
 #endif
   INIT_STORAGE(session, COAP_MAX_SESSIONS);
@@ -365,7 +365,7 @@ get_container(coap_memory_tag_t type) {
   case COAP_RESOURCE:        return &resource_storage;
   case COAP_RESOURCEATTR:    return &resattr_storage;
 #endif /* COAP_SERVER_SUPPORT */
-#ifdef HAVE_LIBTINYDTLS
+#ifdef COAP_WITH_LIBTINYDTLS
   case COAP_DTLS_SESSION:    return &dtls_storage;
 #endif
   case COAP_SESSION:         return &session_storage;

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -17,7 +17,7 @@
 
 #include "coap3/coap_internal.h"
 
-#if !defined(HAVE_LIBTINYDTLS) && !defined(HAVE_OPENSSL) && !defined(HAVE_LIBGNUTLS) && !defined(HAVE_MBEDTLS)
+#if !defined(COAP_WITH_LIBTINYDTLS) && !defined(COAP_WITH_LIBOPENSSL) && !defined(COAP_WITH_LIBGNUTLS) && !defined(COAP_WITH_LIBMBEDTLS)
 
 int
 coap_dtls_is_supported(void) {
@@ -383,7 +383,7 @@ coap_crypto_hmac(cose_hmac_alg_t hmac_alg,
 
 #endif /* COAP_OSCORE_SUPPORT */
 
-#else /* !HAVE_LIBTINYDTLS && !HAVE_OPENSSL && !HAVE_LIBGNUTLS */
+#else /* !COAP_WITH_LIBTINYDTLS && !COAP_WITH_LIBOPENSSL && !COAP_WITH_LIBGNUTLS */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -394,4 +394,4 @@ coap_crypto_hmac(cose_hmac_alg_t hmac_alg,
 static inline void dummy(void) {
 }
 
-#endif /* !HAVE_LIBTINYDTLS && !HAVE_OPENSSL && !HAVE_LIBGNUTLS && !HAVE_MBEDTLS */
+#endif /* !COAP_WITH_LIBTINYDTLS && !COAP_WITH_LIBOPENSSL && !COAP_WITH_LIBGNUTLS && !COAP_WITH_LIBMBEDTLS */

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -17,7 +17,7 @@
 
 #include "coap3/coap_internal.h"
 
-#ifdef HAVE_OPENSSL
+#ifdef COAP_WITH_LIBOPENSSL
 
 /*
  * OpenSSL 1.1.0 has support for making decisions during receipt of
@@ -3976,7 +3976,7 @@ coap_crypto_hmac(cose_hmac_alg_t hmac_alg,
 
 #endif /* COAP_OSCORE_SUPPORT */
 
-#else /* !HAVE_OPENSSL */
+#else /* !COAP_WITH_LIBOPENSSL */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -3987,4 +3987,4 @@ coap_crypto_hmac(cose_hmac_alg_t hmac_alg,
 static inline void dummy(void) {
 }
 
-#endif /* HAVE_OPENSSL */
+#endif /* COAP_WITH_LIBOPENSSL */

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -17,7 +17,7 @@
 
 #include "coap3/coap_internal.h"
 
-#ifdef HAVE_LIBTINYDTLS
+#ifdef COAP_WITH_LIBTINYDTLS
 
 /* We want TinyDTLS versions of these, not libcoap versions */
 #undef PACKAGE_BUGREPORT
@@ -1719,7 +1719,7 @@ coap_crypto_hmac(cose_hmac_alg_t hmac_alg, coap_bin_const_t *key,
 
 #endif /* COAP_OSCORE_SUPPORT */
 
-#else /* !HAVE_LIBTINYDTLS */
+#else /* !COAP_WITH_LIBTINYDTLS */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -1730,4 +1730,4 @@ coap_crypto_hmac(cose_hmac_alg_t hmac_alg, coap_bin_const_t *key,
 static inline void dummy(void) {
 }
 
-#endif /* HAVE_LIBTINYDTLS */
+#endif /* COAP_WITH_LIBTINYDTLS */

--- a/src/coap_ws.c
+++ b/src/coap_ws.c
@@ -36,12 +36,12 @@
 
 int
 coap_ws_is_supported(void) {
-#if defined(HAVE_OPENSSL) || defined(HAVE_LIBGNUTLS) || defined(HAVE_MBEDTLS)
+#if defined(COAP_WITH_LIBOPENSSL) || defined(COAP_WITH_LIBGNUTLS) || defined(COAP_WITH_LIBMBEDTLS)
   /* Have SHA1 hash support */
   return coap_tcp_is_supported();
-#else /* !HAVE_OPENSSL && !HAVE_LIBGNUTLS && !HAVE_MBEDTLS */
+#else /* !COAP_WITH_LIBOPENSSL && !COAP_WITH_LIBGNUTLS && !COAP_WITH_LIBMBEDTLS */
   return 0;
-#endif /* !HAVE_OPENSSL && !HAVE_LIBGNUTLS && !HAVE_MBEDTLS */
+#endif /* !COAP_WITH_LIBOPENSSL && !COAP_WITH_LIBGNUTLS && !COAP_WITH_LIBMBEDTLS */
 }
 
 int

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -13,7 +13,7 @@
 
 #undef HAVE_DTLS
 
-#ifdef HAVE_LIBTINYDTLS
+#ifdef COAP_WITH_LIBTINYDTLS
 #define HAVE_DTLS 1
 
 /* Need to #undef these to stop compiler warnings when tinydtls.h is included */
@@ -27,22 +27,22 @@
 #include <tinydtls.h>
 #include <dtls.h>
 #include <dtls_debug.h>
-#endif /* HAVE_LIBTINYDTLS */
+#endif /* COAP_WITH_LIBTINYDTLS */
 
-#ifdef HAVE_OPENSSL
+#ifdef COAP_WITH_LIBOPENSSL
 #define HAVE_DTLS 1
 #include <openssl/ssl.h>
-#endif /* HAVE_OPENSSL */
+#endif /* COAP_WITH_LIBOPENSSL */
 
-#ifdef HAVE_LIBGNUTLS
+#ifdef COAP_WITH_LIBGNUTLS
 #define HAVE_DTLS 1
 #include <gnutls/gnutls.h>
-#endif /* HAVE_LIBGNUTLS */
+#endif /* COAP_WITH_LIBGNUTLS */
 
-#ifdef HAVE_MBEDTLS
+#ifdef COAP_WITH_LIBMBEDTLS
 #define HAVE_DTLS 1
 #include <mbedtls/version.h>
-#endif /* HAVE_MBEDTLS */
+#endif /* COAP_WITH_LIBMBEDTLS */
 
 static void
 t_tls1(void) {
@@ -61,10 +61,10 @@ t_tls2(void) {
 
   memset(&version, 0, sizeof(coap_tls_version_t));
 
-#if defined(HAVE_OPENSSL)
+#if defined(COAP_WITH_LIBOPENSSL)
   version.version = SSLeay();
   version.type = COAP_TLS_LIBRARY_OPENSSL;
-#elif defined(HAVE_LIBTINYDTLS)
+#elif defined(COAP_WITH_LIBTINYDTLS)
   const char *vers = dtls_package_version();
   version.version = 0;
   if (vers) {
@@ -81,16 +81,16 @@ t_tls2(void) {
     version.version = (p1 << 16) | (p2 << 8) | p3;
   }
   version.type = COAP_TLS_LIBRARY_TINYDTLS;
-#elif defined(HAVE_LIBGNUTLS)
+#elif defined(COAP_WITH_LIBGNUTLS)
   version.version = GNUTLS_VERSION_NUMBER;
   version.type = COAP_TLS_LIBRARY_GNUTLS;
-#elif defined(HAVE_MBEDTLS)
+#elif defined(COAP_WITH_LIBMBEDTLS)
   version.version = MBEDTLS_VERSION_NUMBER;
   version.type = COAP_TLS_LIBRARY_MBEDTLS;
 #else /* no DTLS */
   version.version = 0;
   version.type = COAP_TLS_LIBRARY_NOTLS;
-#endif /* HAVE_OPENSSL || HAVE_LIBTINYDTLS */
+#endif /* COAP_WITH_LIBOPENSSL || COAP_WITH_LIBTINYDTLS */
 
   CU_ASSERT_PTR_NOT_NULL_FATAL(v);
   CU_ASSERT(version.version == v->version);

--- a/win32/libcoap.vcxproj
+++ b/win32/libcoap.vcxproj
@@ -360,7 +360,7 @@ TYPE %(FullPath) &gt;&gt; "$(IntDir)$(TargetName).def"</Command>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;HAVE_OPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;COAP_WITH_LIBOPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>../include;..;$(OpenSSLIncludeDirDbg)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
@@ -399,7 +399,7 @@ copy /Y ..\$(LibCoAPIncludeDir)\coap.h.windows ..\$(LibCoAPIncludeDir)\coap.h</C
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;HAVE_OPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;COAP_WITH_LIBOPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>../include;..;$(OpenSSLIncludeDirDbg)</AdditionalIncludeDirectories>
       <MinimalRebuild>false</MinimalRebuild>
@@ -442,7 +442,7 @@ copy /Y ..\$(LibCoAPIncludeDir)\coap.h.windows ..\$(LibCoAPIncludeDir)\coap.h</C
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;HAVE_OPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;COAP_WITH_LIBOPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>../include;..;$(OpenSSLIncludeDirDbg)</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
@@ -464,7 +464,7 @@ copy /Y ..\$(LibCoAPIncludeDir)\coap.h.windows ..\$(LibCoAPIncludeDir)\coap.h</C
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;HAVE_OPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_LIB;COAP_WITH_LIBOPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>../include;..;$(OpenSSLIncludeDirDbg)</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
@@ -491,7 +491,7 @@ copy /Y ..\$(LibCoAPIncludeDir)\coap.h.windows ..\$(LibCoAPIncludeDir)\coap.h</C
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;HAVE_OPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;COAP_WITH_LIBOPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include;..;$(OpenSSLIncludeDir)</AdditionalIncludeDirectories>
       <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <CompileAs>CompileAsC</CompileAs>
@@ -532,7 +532,7 @@ copy /Y ..\$(LibCoAPIncludeDir)\coap.h.windows ..\$(LibCoAPIncludeDir)\coap.h</C
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;HAVE_OPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;COAP_WITH_LIBOPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include;..;$(OpenSSLIncludeDir)</AdditionalIncludeDirectories>
       <CompileAs>CompileAsC</CompileAs>
     </ClCompile>
@@ -577,7 +577,7 @@ copy /Y ..\$(LibCoAPIncludeDir)\coap.h.windows ..\$(LibCoAPIncludeDir)\coap.h</C
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;HAVE_OPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;COAP_WITH_LIBOPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include;..;$(OpenSSLIncludeDir)</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <CompileAs>CompileAsC</CompileAs>
@@ -601,7 +601,7 @@ copy /Y ..\$(LibCoAPIncludeDir)\coap.h.windows ..\$(LibCoAPIncludeDir)\coap.h</C
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;HAVE_OPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;COAP_WITH_LIBOPENSSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include;..;$(OpenSSLIncludeDir)</AdditionalIncludeDirectories>
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <CompileAs>CompileAsC</CompileAs>


### PR DESCRIPTION
Prevents possibility of name clashes when integrating with other code / OS.