### PR TITLE
man: Document deprecated functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1083,6 +1083,7 @@ man/coap_attribute.txt
 man/coap_block.txt
 man/coap_cache.txt
 man/coap_context.txt
+man/coap_deprecated.txt
 man/coap_encryption.txt
 man/coap_endpoint_client.txt
 man/coap_endpoint_server.txt

--- a/include/coap3/coap_event.h
+++ b/include/coap3/coap_event.h
@@ -173,7 +173,7 @@ void coap_set_event_handler(coap_context_t *context,
 /**
  * Clears the event handler registered with @p context.
  *
- * @deprecated Use coap_register_event_handler() instead with NULL for hnd.
+ * @deprecated Use coap_register_event_handler() instead with NULL for handler.
  *
  * @param context The CoAP context whose event handler is to be removed.
  */

--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -162,6 +162,8 @@ coap_context_t *coap_new_context(const coap_address_t *listen_addr);
 /**
  * Set the context's default PSK hint and/or key for a server.
  *
+ * @deprecated Use coap_context_set_psk2() instead.
+ *
  * @param context The current coap_context_t object.
  * @param hint    The default PSK server hint sent to a client. If NULL, PSK
  *                authentication is disabled. Empty string is a valid hint.

--- a/include/coap3/coap_session.h
+++ b/include/coap3/coap_session.h
@@ -253,6 +253,9 @@ coap_session_t *coap_new_client_session(
 
 /**
 * Creates a new client session to the designated server with PSK credentials
+ *
+ * @deprecated Use coap_new_client_session_psk2() instead.
+ *
 * @param ctx The CoAP context.
 * @param local_if Address of local interface. It is recommended to use NULL to let the operating system choose a suitable local interface. If an address is specified, the port number should be zero, which means that a free port is automatically selected.
 * @param server The server's address. If the port number is zero, the default port for the protocol will be used.

--- a/include/coap3/resource.h
+++ b/include/coap3/resource.h
@@ -179,8 +179,8 @@ coap_resource_t *coap_resource_init(coap_str_const_t *uri_path,
  * for PUT.
  *
  * In the same way that additional handlers can be added to the resource
- * created by coap_resource_init() by using coap_register_handler(), POST,
- * GET, DELETE etc. handlers can be added to this resource. It is the
+ * created by coap_resource_init() by using coap_register_request_handler(),
+ * POST, GET, DELETE etc. handlers can be added to this resource. It is the
  * responsibility of the application to manage the unknown resources by either
  * creating new resources with coap_resource_init() (which should have a
  * DELETE handler specified for the resource removal) or by maintaining an
@@ -207,8 +207,8 @@ coap_resource_t *coap_resource_unknown_init(coap_method_handler_t put_handler);
  * for PUT and configurable control over multicast requests packets.
  *
  * In the same way that additional handlers can be added to the resource
- * created by coap_resource_init() by using coap_register_handler(), POST,
- * GET, DELETE etc. handlers can be added to this resource. It is the
+ * created by coap_resource_init() by using coap_register_request_handler(),
+ * POST, GET, DELETE etc. handlers can be added to this resource. It is the
  * responsibility of the application to manage the unknown resources by either
  * creating new resources with coap_resource_init() (which should have a
  * DELETE handler specified for the resource removal) or by maintaining an
@@ -367,6 +367,8 @@ int coap_delete_resource(coap_context_t *context, coap_resource_t *resource);
 /**
  * Registers the specified @p handler as message handler for the request type
  * @p method
+ *
+ * @deprecated use coap_register_request_handler() instead.
  *
  * @param resource The resource for which the handler shall be registered.
  * @param method   The CoAP request method to handle.

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -24,6 +24,7 @@ TXT3 = coap_address.txt \
 	coap_block.txt \
 	coap_cache.txt \
 	coap_context.txt \
+	coap_deprecated.txt \
 	coap_endpoint_server.txt \
 	coap_encryption.txt \
 	coap_endpoint_client.txt \
@@ -106,6 +107,11 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_set_csm_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_get_csm_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_set_max_token_size.3
+	@echo ".so man3/coap_deprecated.3" > coap_register_handler.3
+	@echo ".so man3/coap_deprecated.3" > coap_resource_set_dirty.3
+	@echo ".so man3/coap_deprecated.3" > coap_run_once.3
+	@echo ".so man3/coap_deprecated.3" > coap_set_event_handler.3
+	@echo ".so man3/coap_deprecated.3" > coap_write.3
 	@echo ".so man3/coap_io.3" > coap_can_exit.3
 	@echo ".so man3/coap_logging.3" > coap_log_info.3
 	@echo ".so man3/coap_logging.3" > coap_log_debug.3

--- a/man/coap_deprecated.txt.in
+++ b/man/coap_deprecated.txt.in
@@ -1,0 +1,194 @@
+// -*- mode:doc; -*-
+// vim: set syntax=asciidoc tw=0
+
+coap_deprecated(3)
+==================
+:doctype: manpage
+:man source:   coap_deprecated
+:man version:  @PACKAGE_VERSION@
+:man manual:   libcoap Manual
+
+NAME
+----
+coap_deprecated,
+coap_clear_event_handler,
+coap_context_set_psk,
+coap_encode_var_bytes,
+coap_new_client_session_psk,
+coap_option_clrb,
+coap_option_getb,
+coap_option_setb,
+coap_read,
+coap_register_handler,
+coap_resource_set_dirty,
+coap_run_once,
+coap_set_event_handler,
+coap_write
+- Work with CoAP deprecated functions
+
+SYNOPSIS
+--------
+*#include <coap@LIBCOAP_API_VERSION@/coap.h>*
+
+*void coap_clear_event_handler(coap_context_t *_context_);*
+
+*int coap_context_set_psk(coap_context_t *_context_, const char *_hint_,
+const uint8_t *_key_, size_t _key_len_);*
+
+*int coap_encode_var_bytes(uint8_t *_buffer_, unsigned int _value_);*
+
+*coap_session_t *coap_new_client_session_psk(coap_context_t *_context_,
+const coap_address_t *_local_if_, const coap_address_t *_server_,
+coap_proto_t _proto_, const char *_identity_, const uint8_t *_key_,
+unsigned _key_len_);*
+
+*int coap_option_clrb(coap_opt_filter_t *_filter_, uint16_t _type_);*
+
+*int coap_option_getb(coap_opt_filter_t *_filter_, uint16_t _type_);*
+
+*int coap_option_setb(coap_opt_filter_t *_filter_, uint16_t _type_);*
+
+*void coap_read(coap_context_t *_context_, coap_tick_t _now_);*
+
+*void coap_register_handler(coap_resource_t *_resource_,
+coap_request_t _method_, coap_method_handler_t _handler_);*
+
+*int coap_resource_set_dirty(coap_resource_t *_resource_,
+const coap_string_t *_query_);*
+
+*int coap_run_once(coap_context_t *_context_, uint32_t _timeout_ms_);*
+
+*void coap_set_event_handler(coap_context_t *_context_,
+coap_event_handler_t _handler_);*
+
+*unsigned int coap_write(coap_context_t *_context_, coap_socket_t *_sockets_[],
+unsigned int _max_sockets_, unsigned int *_num_sockets_, coap_tick_t _now_);*
+
+For specific (D)TLS library support, link with
+*-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
+*-lcoap-@LIBCOAP_API_VERSION@* to get the default (D)TLS library support.
+
+DESCRIPTION
+-----------
+
+Several of the existing CoAP API functions have been deprecated.  These are
+listed here, along with the functions that should now be used instead.
+
+FUNCTIONS
+---------
+
+*Function: coap_clear_event_handler()*
+
+The *coap_clear_event_handler*() function is replaced by
+*coap_register_event_handler*(3), using NULL for _handler_.
+
+*Function: coap_context_set_psk()*
+
+The *coap_context_set_psk*() function is replaced by
+*coap_context_set_psk2*(3) which gives additional PSK configuration capability
+by the use of the coap_dtls_spsk_t structure.
+
+*Function: coap_encode_var_bytes()*
+
+The *coap_encode_var_bytes*() function is replaced by
+*coap_encode_var_safe*(3).
+
+*Function: coap_new_client_session_psk()*
+
+The *coap_new_client_session_psk*() function is replaced by
+*coap_new_client_session_psk2*(3) which gives additional PSK configuration capability
+by the use of the coap_dtls_cpsk_t structure.
+
+*Function: coap_option_clrb()*
+
+The *coap_option_clrb*() function is replaced by
+*coap_option_filter_unset*(3).
+
+*Function: coap_option_getb()*
+
+The *coap_option_getb*() function is replaced by
+*coap_option_filter_get*(3).
+
+*Function: coap_option_setb()*
+
+The *coap_option_setb*() function is replaced by
+*coap_option_filter_set*(3).
+
+*Function: coap_read()*
+
+The *coap_read*() function is replaced by
+*coap_io_do_io*(3).
+
+*Function: coap_register_handler()*
+
+The *coap_register_handler*() function is replaced by
+*coap_register_request_handler*(3).
+
+*Function: coap_resource_set_dirty()*
+
+The *coap_resource_set_dirty*() function is replaced by
+*coap_resource_notify_observers*(3).
+
+*Function: coap_run_once()*
+
+The *coap_run_once*() function is replaced by
+*coap_io_process*(3).
+
+*Function: coap_set_event_handler()*
+
+The *coap_set_event_handler*() function is replaced by
+*coap_register_event_handler*(3).
+
+*Function: coap_clear_event_handler()*
+
+The *coap_write*() function is replaced by
+*coap_io_prepare_io*(3).
+
+RETURN VALUES
+-------------
+*coap_context_set_psk*() returns 1 if success, 0 on failure.
+
+*coap_encode_var_bytes*() returns either the length of bytes encoded (which can
+be 0 when encoding 0) or 0 on failure.
+
+*coap_new_client_session_psk*() returns a new session if success, NULL on
+failure.
+
+*coap_option_clrb*() returns  1 if bit was set, -1 otherwise.
+
+*coap_option_getb*() returns  1 if bit was set, 0 if not.
+
+*coap_option_setb*() returns  1 if bit was set, -1 otherwise.
+
+*coap_resource_set_dirty*() returns 1 if success, 0 on failure.
+
+*coap_run_once*() returns number of milliseconds spent in function or -1
+if there was an error.
+
+*coap_write*() returns the number of milli-seconds that need to be waited
+before the function should next be called.
+
+SEE ALSO
+--------
+*coap_endpoint_client*(3), *coap_endpoint_server*(3), *coap_handler*(3),
+*coap_io*(3), *coap_observe*(3), *coap_pdu_access*(3) and *coap_pdu_setup*(3).
+
+FURTHER INFORMATION
+-------------------
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
+
+BUGS
+----
+Please report bugs on the mailing list for libcoap:
+libcoap-developers@lists.sourceforge.net or raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues
+
+AUTHORS
+-------
+The libcoap project <libcoap-developers@lists.sourceforge.net>

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -54,8 +54,15 @@
 #endif /* ! _WIN32 */
 
 const char *inline_list[] = {
-  "coap_malloc(",
   "coap_free(",
+  "coap_malloc(",
+  "coap_encode_var_bytes(",
+  "coap_option_clrb(",
+  "coap_option_getb(",
+  "coap_option_setb(",
+  "coap_read(",
+  "coap_run_once(",
+  "coap_write(",
 };
 
 const char *define_list[] = {


### PR DESCRIPTION
New: man/coap_deprecated.txt.in