### PR TITLE
Reliable PDUs: coap_show_pdu(): Do not show all the non-reliable headers

### DIFF
--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -155,6 +155,7 @@ struct coap_pdu_t {
   size_t body_total;        /**< Holds body data total size */
   coap_lg_xmit_t *lg_xmit;  /**< Holds ptr to lg_xmit if sending a set of
                                  blocks */
+  coap_session_t *session;  /**< Session responsible for PDU or NULL */
 };
 
 /**

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -275,6 +275,10 @@ The *coap_show_pdu*() function is used to decode the _pdu_, outputting as
 appropriate for logging _level_.  Where the output goes is dependent on
 *coap_set_show_pdu_output*().
 
+*NOTE:* If _pdu_ has not been associated with a CoAP session (i.e. not a
+received PDU or coap_send() not yet called), then the output assumes that
+this _pdu_ is of type unreliable.
+
 *Function: coap_endpoint_str()*
 
 The *coap_endpoint_str*() function returns a description string of the

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -479,7 +479,10 @@ coap_session_send_csm(coap_session_t *session) {
   ) {
     coap_session_disconnected(session, COAP_NACK_NOT_DELIVERABLE);
   } else {
-    ssize_t bytes_written = coap_session_send_pdu(session, pdu);
+    ssize_t bytes_written;
+
+    pdu->session = session;
+    bytes_written = coap_session_send_pdu(session, pdu);
     if (bytes_written != (ssize_t)pdu->used_size + pdu->hdr_size) {
       coap_session_disconnected(session, COAP_NACK_NOT_DELIVERABLE);
     } else {

--- a/src/net.c
+++ b/src/net.c
@@ -1027,6 +1027,7 @@ coap_send(coap_session_t *session, coap_pdu_t *pdu) {
 
   assert(pdu);
 
+  pdu->session = session;
 #if COAP_CLIENT_SUPPORT
   if (session->type == COAP_SESSION_TYPE_CLIENT &&
       !coap_netif_available(session)) {
@@ -1236,6 +1237,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
   ssize_t bytes_written;
   coap_opt_iterator_t opt_iter;
 
+  pdu->session = session;
   if (pdu->code == COAP_RESPONSE_CODE(508)) {
     /*
      * Need to prepend our IP identifier to the data as per
@@ -2909,6 +2911,7 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
     resp = 500;
     goto fail_response;
   }
+  response->session = session;
 #if COAP_ASYNC_SUPPORT
   /* If handling a separate response, need CON, not ACK response */
   if (async && pdu->type == COAP_MESSAGE_CON)
@@ -3333,6 +3336,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
 #endif /* COAP_OSCORE_SUPPORT */
   int is_ext_token_rst;
 
+  pdu->session = session;
   coap_show_pdu(COAP_LOG_DEBUG, pdu);
 
   memset(&opt_filter, 0, sizeof(coap_opt_filter_t));

--- a/src/pdu.c
+++ b/src/pdu.c
@@ -61,6 +61,7 @@ coap_pdu_clear(coap_pdu_t *pdu, size_t size) {
   pdu->body_offset = 0;
   pdu->body_total = 0;
   pdu->lg_xmit = NULL;
+  pdu->session = NULL;
 }
 
 #ifdef WITH_LWIP


### PR DESCRIPTION
`v:1 t:xxx c:yyy i:zzzz` is shown as` v:Reliable c:yyy` or `v:WebSocket c:yyy` as appropriate.