### PR TITLE
RIOT: Stop objdump analyzing the examples

### DIFF
--- a/examples/riot/Makefile
+++ b/examples/riot/Makefile
@@ -30,10 +30,10 @@ examples:
 	cd examples_libcoap_server && cp -r * ../RIOT/examples/libcoap-server
 
 client:	RIOT pkg examples
-	$(MAKE) -C RIOT/examples/libcoap-client/
+	$(MAKE) -C RIOT/examples/libcoap-client/ RIOT_CI_BUILD=1
 
 server:	RIOT pkg examples
-	$(MAKE) -C RIOT/examples/libcoap-server/
+	$(MAKE) -C RIOT/examples/libcoap-server/ RIOT_CI_BUILD=1
 
 clean:
 	rm -rf RIOT/pkg/libcoap

--- a/examples/riot/README
+++ b/examples/riot/README
@@ -14,9 +14,10 @@ This will
 * build the client application
 * build the server application
 
-To run the server application
+To run (and/or rebuild) the server application
 
 * cd RIOT/examples-libcoap-server
+* make RIOT_CI_BUILD=1
 * make term
 * (at the shell prompt) coaps start
 
@@ -24,9 +25,10 @@ The server creates a resource for 'time' with a query 'ticks'.  This is
 reported for `.well-known/core`. The work flow for adding more resources does
 not differ from regular libcoap usage.
 
-To run the client application
+To run (and/or rebuild) the client application
 
 * cd RIOT/examples-libcoap-client
+* make RIOT_CI_BUILD=1
 * make term
 * (at the shell prompt) coapc
 


### PR DESCRIPTION
See [9920d3e2](https://github.com/RIOT-OS/RIOT/pull/19745) which introduced running objdump which will take many minutes of CPU time when running a GitHub workflow without RIOT_CI_BUILD=1 set.