### PR TITLE
Fix for piggybacked response answering request with No-Response

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -2543,6 +2543,7 @@ no_response(coap_pdu_t *request, coap_pdu_t *response,
           response->actual_token.length = 0;
           response->e_token_length = 0;
           response->used_size = 0;
+          response->data = NULL;
           return RESPONSE_SEND;
         }
         else {


### PR DESCRIPTION
Fix for piggybacked response answering to request with No-Response option set.

When No-Response option is interpreted in no_response function from net.c, for piggybacked response payload is removed to send only bare ACK. That means that used_size is set to 0. This causes an error in coap_get_data_large function from pdu.c, because when used_size is 0 then variable len has incorrect (and very large) value. This causes application to crash.