### PR TITLE
coap_tinydtls.c: Fix recent removal of DTLS_EVENT_RENEGOTIATE from TinyDTLS

### DIFF
--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -348,11 +348,13 @@ dtls_event(struct dtls_context_t *dtls_context,
     coap_event_dtls = COAP_EVENT_DTLS_CONNECTED;
     break;
   }
+#ifdef DTLS_EVENT_RENEGOTIATE
   case DTLS_EVENT_RENEGOTIATE:
   {
     coap_event_dtls = COAP_EVENT_DTLS_RENEGOTIATE;
     break;
   }
+#endif
   default:
     ;
   }


### PR DESCRIPTION
LwIP test build uses latest tinydtls source for DTLS builds.