### PR TITLE
src/coap:debug.c: Fix broken printing of Content-Format:

### DIFF
--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -955,12 +955,11 @@ no_more:
         } else {
           encode = 1;
         }
+        buf_len = print_readable(coap_opt_value(option),
+                                 coap_opt_length(option),
+                                 buf, sizeof(buf), encode);
       }
     }
-
-    buf_len = print_readable(coap_opt_value(option),
-                             coap_opt_length(option),
-                             buf, sizeof(buf), encode);
     outbuflen = strlen(outbuf);
     snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
              " %s:%.*s", msg_option_string(pdu->code, opt_iter.number),


### PR DESCRIPTION
Fix location of terminating } following adding { to wrap a single line statement block that covered many lines in commit
ba69c7926226566b815b119a53266ebde9c6d75f.