### PR TITLE
layers: Update coap_layer_func_t function names to be prefixed with l_

### DIFF
--- a/include/coap3/coap_layers_internal.h
+++ b/include/coap3/coap_layers_internal.h
@@ -81,7 +81,7 @@ typedef ssize_t (*coap_layer_write_t)(coap_session_t *session,
  *
  * If this layer is properly established on invocation, then the next layer
  * must get called by calling
- *   session->lfunc[_this_layer_].establish(session)
+ *   session->lfunc[_this_layer_].l_establish(session)
  * (or done at any point when layer is established).
  * If the establishment of a layer fails, then
  *   coap_session_disconnected(session, COAP_NACK_xxx_LAYER_FAILED) must be
@@ -96,7 +96,7 @@ typedef void (*coap_layer_establish_t)(coap_session_t *session);
  *
  * When this layer is properly closed, then the next layer
  * must get called by calling
- *   session->lfunc[_this_layer_].close(session)
+ *   session->lfunc[_this_layer_].l_close(session)
  * (or done at any point when layer is closed).
  *
  * @param session Session being closed.
@@ -104,10 +104,10 @@ typedef void (*coap_layer_establish_t)(coap_session_t *session);
 typedef void (*coap_layer_close_t)(coap_session_t *session);
 
 typedef struct {
-  coap_layer_read_t read;   /* Get data from next layer (TCP) */
-  coap_layer_write_t write; /* Output data to next layer */
-  coap_layer_establish_t establish; /* Layer establish */
-  coap_layer_close_t close; /* Connection close */
+  coap_layer_read_t l_read;   /* Get data from next layer (TCP) */
+  coap_layer_write_t l_write; /* Output data to next layer */
+  coap_layer_establish_t l_establish; /* Layer establish */
+  coap_layer_close_t l_close; /* Connection close */
 } coap_layer_func_t;
 
 extern coap_layer_func_t coap_layers_coap[COAP_PROTO_LAST][COAP_LAYER_LAST];

--- a/src/coap_dtls.c
+++ b/src/coap_dtls.c
@@ -42,7 +42,7 @@ coap_dtls_close(coap_session_t *session) {
     coap_dtls_free_session(session);
     session->tls = NULL;
   }
-  session->sock.lfunc[COAP_LAYER_TLS].close(session);
+  session->sock.lfunc[COAP_LAYER_TLS].l_close(session);
 }
 
 #if !COAP_DISABLE_TCP
@@ -71,6 +71,6 @@ coap_tls_close(coap_session_t *session) {
     coap_tls_free_session(session);
     session->tls = NULL;
   }
-  session->sock.lfunc[COAP_LAYER_TLS].close(session);
+  session->sock.lfunc[COAP_LAYER_TLS].l_close(session);
 }
 #endif /* !COAP_DISABLE_TCP */

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -1938,8 +1938,8 @@ coap_dgram_write(gnutls_transport_ptr_t context, const void *send_buffer,
       errno = ECONNRESET;
       return -1;
     }
-    result = c_session->sock.lfunc[COAP_LAYER_TLS].write(c_session,
-                                                         send_buffer, send_buffer_length);
+    result = c_session->sock.lfunc[COAP_LAYER_TLS].l_write(c_session,
+                                                           send_buffer, send_buffer_length);
     if (result != (int)send_buffer_length) {
       coap_log_warn("coap_netif_dgrm_write failed (%zd != %zu)\n",
                     result, send_buffer_length);
@@ -2425,7 +2425,7 @@ coap_dtls_receive(coap_session_t *c_session, const uint8_t *data,
       coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
                         c_session);
       gnutls_transport_set_ptr(g_env->g_session, c_session);
-      c_session->sock.lfunc[COAP_LAYER_TLS].establish(c_session);
+      c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
     }
     ret = gnutls_record_recv(g_env->g_session, pdu, (int)sizeof(pdu));
     if (ret > 0) {
@@ -2592,7 +2592,7 @@ coap_sock_read(gnutls_transport_ptr_t context, void *out, size_t outl) {
   coap_session_t *c_session = (coap_session_t *)context;
 
   if (out != NULL) {
-    ret = (int)c_session->sock.lfunc[COAP_LAYER_TLS].read(c_session, out, outl);
+    ret = (int)c_session->sock.lfunc[COAP_LAYER_TLS].l_read(c_session, out, outl);
     /* Translate layer returns into what GnuTLS expects */
     if (ret == 0) {
       errno = EAGAIN;
@@ -2613,7 +2613,7 @@ coap_sock_write(gnutls_transport_ptr_t context, const void *in, size_t inl) {
   int ret = 0;
   coap_session_t *c_session = (coap_session_t *)context;
 
-  ret = (int)c_session->sock.lfunc[COAP_LAYER_TLS].write(c_session, in, inl);
+  ret = (int)c_session->sock.lfunc[COAP_LAYER_TLS].l_write(c_session, in, inl);
   /* Translate layer what returns into what GnuTLS expects */
   if (ret < 0) {
     if ((c_session->state == COAP_SESSION_STATE_CSM ||
@@ -2679,7 +2679,7 @@ coap_tls_new_client_session(coap_session_t *c_session) {
   ret = do_gnutls_handshake(c_session, g_env);
   if (ret == 1) {
     coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
-    c_session->sock.lfunc[COAP_LAYER_TLS].establish(c_session);
+    c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
   }
   return g_env;
 
@@ -2725,7 +2725,7 @@ coap_tls_new_server_session(coap_session_t *c_session) {
   ret = do_gnutls_handshake(c_session, g_env);
   if (ret == 1) {
     coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
-    c_session->sock.lfunc[COAP_LAYER_TLS].establish(c_session);
+    c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
   }
   return g_env;
 
@@ -2789,7 +2789,7 @@ coap_tls_write(coap_session_t *c_session, const uint8_t *data,
     if (ret == 1) {
       coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
                         c_session);
-      c_session->sock.lfunc[COAP_LAYER_TLS].establish(c_session);
+      c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
       ret = 0;
     } else {
       ret = -1;
@@ -2839,7 +2839,7 @@ coap_tls_read(coap_session_t *c_session, uint8_t *data, size_t data_len) {
     if (ret == 1) {
       coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
                         c_session);
-      c_session->sock.lfunc[COAP_LAYER_TLS].establish(c_session);
+      c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
       ret = 0;
     }
   }

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -233,8 +233,8 @@ coap_dgram_write(void *ctx, const unsigned char *send_buffer,
       errno = ECONNRESET;
       return -1;
     }
-    result = (int)c_session->sock.lfunc[COAP_LAYER_TLS].write(c_session,
-                                                              send_buffer, send_buffer_length);
+    result = (int)c_session->sock.lfunc[COAP_LAYER_TLS].l_write(c_session,
+                                                                send_buffer, send_buffer_length);
     if (result != (ssize_t)send_buffer_length) {
       coap_log_warn("coap_netif_dgrm_write failed (%zd != %zu)\n",
                     result, send_buffer_length);
@@ -1402,7 +1402,7 @@ coap_sock_read(void *ctx, unsigned char *out, size_t outl) {
   coap_session_t *c_session = (coap_session_t *)ctx;
 
   if (out != NULL) {
-    ret = (int)c_session->sock.lfunc[COAP_LAYER_TLS].read(c_session, out, outl);
+    ret = (int)c_session->sock.lfunc[COAP_LAYER_TLS].l_read(c_session, out, outl);
     /* Translate layer returns into what MbedTLS expects */
     if (ret == -1) {
       if (errno == ECONNRESET) {
@@ -1430,9 +1430,9 @@ coap_sock_write(void *context, const unsigned char *in, size_t inl) {
   int ret = 0;
   coap_session_t *c_session = (coap_session_t *)context;
 
-  ret = c_session->sock.lfunc[COAP_LAYER_TLS].write(c_session,
-                                                    (const uint8_t *)in,
-                                                    inl);
+  ret = c_session->sock.lfunc[COAP_LAYER_TLS].l_write(c_session,
+                                                      (const uint8_t *)in,
+                                                      inl);
   /* Translate layer what returns into what MbedTLS expects */
   if (ret < 0) {
     if ((c_session->state == COAP_SESSION_STATE_CSM ||
@@ -2081,7 +2081,7 @@ coap_dtls_receive(coap_session_t *c_session,
     if (c_session->state == COAP_SESSION_STATE_HANDSHAKE) {
       coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
                         c_session);
-      c_session->sock.lfunc[COAP_LAYER_TLS].establish(c_session);
+      c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
     }
 
     ret = mbedtls_ssl_read(&m_env->ssl, pdu, sizeof(pdu));
@@ -2266,7 +2266,7 @@ coap_tls_new_client_session(coap_session_t *c_session) {
   ret = do_mbedtls_handshake(c_session, m_env);
   if (ret == 1) {
     coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
-    c_session->sock.lfunc[COAP_LAYER_TLS].establish(c_session);
+    c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
   }
   return m_env;
 #endif /* MBEDTLS_SSL_CLI_C */
@@ -2297,7 +2297,7 @@ coap_tls_new_server_session(coap_session_t *c_session) {
   ret = do_mbedtls_handshake(c_session, m_env);
   if (ret == 1) {
     coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
-    c_session->sock.lfunc[COAP_LAYER_TLS].establish(c_session);
+    c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
   }
   return m_env;
 #endif /* MBEDTLS_SSL_SRV_C */
@@ -2366,7 +2366,7 @@ coap_tls_write(coap_session_t *c_session, const uint8_t *data,
     if (ret == 1) {
       coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
                         c_session);
-      c_session->sock.lfunc[COAP_LAYER_TLS].establish(c_session);
+      c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
     } else {
       ret = -1;
     }
@@ -2416,7 +2416,7 @@ coap_tls_read(coap_session_t *c_session, uint8_t *data, size_t data_len) {
     if (ret == 1) {
       coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
                         c_session);
-      c_session->sock.lfunc[COAP_LAYER_TLS].establish(c_session);
+      c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
     }
   }
 

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -782,7 +782,7 @@ coap_session_send_pdu(coap_session_t *session, coap_pdu_t *pdu) {
   assert(pdu->hdr_size > 0);
 
   /* Caller handles partial writes */
-  bytes_written = session->sock.lfunc[COAP_LAYER_SESSION].write(session,
+  bytes_written = session->sock.lfunc[COAP_LAYER_SESSION].l_write(session,
                   pdu->token - pdu->hdr_size,
                   pdu->used_size + pdu->hdr_size);
   coap_show_pdu(COAP_LOG_DEBUG, pdu);
@@ -1734,7 +1734,7 @@ coap_connect_session(coap_session_t *session, coap_tick_t now) {
   if (coap_netif_strm_connect2(session)) {
     session->last_rx_tx = now;
     coap_handle_event(session->context, COAP_EVENT_TCP_CONNECTED, session);
-    session->sock.lfunc[COAP_LAYER_SESSION].establish(session);
+    session->sock.lfunc[COAP_LAYER_SESSION].l_establish(session);
   } else {
     coap_handle_event(session->context, COAP_EVENT_TCP_FAILED, session);
     coap_session_disconnected(session, COAP_NACK_NOT_DELIVERABLE);
@@ -1754,7 +1754,7 @@ coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now
     coap_log_debug("** %s: mid=0x%04x: transmitted after delay\n",
                    coap_session_str(session), (int)q->pdu->mid);
     assert(session->partial_write < q->pdu->used_size + q->pdu->hdr_size);
-    bytes_written = session->sock.lfunc[COAP_LAYER_SESSION].write(session,
+    bytes_written = session->sock.lfunc[COAP_LAYER_SESSION].l_write(session,
                     q->pdu->token - q->pdu->hdr_size + session->partial_write,
                     q->pdu->used_size + q->pdu->hdr_size - session->partial_write);
     if (bytes_written > 0)
@@ -1813,9 +1813,9 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
     ssize_t bytes_read = 0;
 
     /* WebSocket layer passes us the whole packet */
-    bytes_read = session->sock.lfunc[COAP_LAYER_SESSION].read(session,
-                                                              packet->payload,
-                                                              packet->length);
+    bytes_read = session->sock.lfunc[COAP_LAYER_SESSION].l_read(session,
+                                                                packet->payload,
+                                                                packet->length);
     if (bytes_read < 0) {
       coap_session_disconnected(session, COAP_NACK_NOT_DELIVERABLE);
     } else if (bytes_read > 2) {
@@ -1854,9 +1854,9 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
     int retry;
 
     do {
-      bytes_read = session->sock.lfunc[COAP_LAYER_SESSION].read(session,
-                                                                packet->payload,
-                                                                packet->length);
+      bytes_read = session->sock.lfunc[COAP_LAYER_SESSION].l_read(session,
+                                                                  packet->payload,
+                                                                  packet->length);
       if (bytes_read > 0) {
         session->last_rx_tx = now;
       }

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -373,9 +373,9 @@ coap_dgram_write(BIO *a, const char *in, int inl) {
       errno = ECONNRESET;
       return -1;
     }
-    ret = (int)data->session->sock.lfunc[COAP_LAYER_TLS].write(data->session,
-                                                               (const uint8_t *)in,
-                                                               inl);
+    ret = (int)data->session->sock.lfunc[COAP_LAYER_TLS].l_write(data->session,
+          (const uint8_t *)in,
+          inl);
     BIO_clear_retry_flags(a);
     if (ret <= 0)
       BIO_set_retry_write(a);
@@ -722,8 +722,8 @@ coap_sock_read(BIO *a, char *out, int outl) {
   coap_session_t *session = (coap_session_t *)BIO_get_data(a);
 
   if (out != NULL) {
-    ret =(int)session->sock.lfunc[COAP_LAYER_TLS].read(session, (u_char *)out,
-                                                       outl);
+    ret =(int)session->sock.lfunc[COAP_LAYER_TLS].l_read(session, (u_char *)out,
+                                                         outl);
     /* Translate layer returns into what OpenSSL expects */
     if (ret == 0) {
       BIO_set_retry_read(a);
@@ -746,9 +746,9 @@ coap_sock_write(BIO *a, const char *in, int inl) {
   int ret = 0;
   coap_session_t *session = (coap_session_t *)BIO_get_data(a);
 
-  ret = (int)session->sock.lfunc[COAP_LAYER_TLS].write(session,
-                                                       (const uint8_t *)in,
-                                                       inl);
+  ret = (int)session->sock.lfunc[COAP_LAYER_TLS].l_write(session,
+                                                         (const uint8_t *)in,
+                                                         inl);
   /* Translate layer what returns into what OpenSSL expects */
   BIO_clear_retry_flags(a);
   if (ret == 0) {
@@ -3174,7 +3174,7 @@ coap_dtls_receive(coap_session_t *session, const uint8_t *data, size_t data_len)
         coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                       coap_session_str(session), SSL_get_cipher_name(ssl));
         coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
-        session->sock.lfunc[COAP_LAYER_TLS].establish(session);
+        session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
       }
       r = 0;
     } else {
@@ -3316,7 +3316,7 @@ coap_tls_new_client_session(coap_session_t *session) {
   session->tls = ssl;
   if (SSL_is_init_finished(ssl)) {
     coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
-    session->sock.lfunc[COAP_LAYER_TLS].establish(session);
+    session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
   return ssl;
@@ -3386,7 +3386,7 @@ coap_tls_new_server_session(coap_session_t *session) {
   session->tls = ssl;
   if (SSL_is_init_finished(ssl)) {
     coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
-    session->sock.lfunc[COAP_LAYER_TLS].establish(session);
+    session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
   return ssl;
@@ -3438,7 +3438,7 @@ coap_tls_write(coap_session_t *session, const uint8_t *data, size_t data_len) {
         coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                       coap_session_str(session), SSL_get_cipher_name(ssl));
         coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
-        session->sock.lfunc[COAP_LAYER_TLS].establish(session);
+        session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
       }
       if (err == SSL_ERROR_WANT_READ)
         session->sock.flags |= COAP_SOCKET_WANT_READ;
@@ -3466,7 +3466,7 @@ coap_tls_write(coap_session_t *session, const uint8_t *data, size_t data_len) {
     coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                   coap_session_str(session), SSL_get_cipher_name(ssl));
     coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
-    session->sock.lfunc[COAP_LAYER_TLS].establish(session);
+    session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
   if (session->dtls_event >= 0) {
@@ -3516,7 +3516,7 @@ coap_tls_read(coap_session_t *session, uint8_t *data, size_t data_len) {
         coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                       coap_session_str(session), SSL_get_cipher_name(ssl));
         coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
-        session->sock.lfunc[COAP_LAYER_TLS].establish(session);
+        session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
       }
       if (err == SSL_ERROR_WANT_READ)
         session->sock.flags |= COAP_SOCKET_WANT_READ;
@@ -3542,7 +3542,7 @@ coap_tls_read(coap_session_t *session, uint8_t *data, size_t data_len) {
     coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                   coap_session_str(session), SSL_get_cipher_name(ssl));
     coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
-    session->sock.lfunc[COAP_LAYER_TLS].establish(session);
+    session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
   if (session->dtls_event >= 0) {

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -492,7 +492,7 @@ coap_session_mfree(coap_session_t *session) {
 
   if (session->partial_pdu)
     coap_delete_pdu(session->partial_pdu);
-  session->sock.lfunc[COAP_LAYER_SESSION].close(session);
+  session->sock.lfunc[COAP_LAYER_SESSION].l_close(session);
   if (session->psk_identity)
     coap_delete_bin_const(session->psk_identity);
   if (session->psk_key)
@@ -944,7 +944,7 @@ coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reason) {
       session->doing_first = 0;
   }
 #endif /* !COAP_DISABLE_TCP */
-  session->sock.lfunc[COAP_LAYER_SESSION].close(session);
+  session->sock.lfunc[COAP_LAYER_SESSION].l_close(session);
 }
 
 #if COAP_SERVER_SUPPORT
@@ -1229,7 +1229,7 @@ error:
 static void
 coap_session_check_connect(coap_session_t *session) {
   if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
-    session->sock.lfunc[COAP_LAYER_SESSION].establish(session);
+    session->sock.lfunc[COAP_LAYER_SESSION].l_establish(session);
   }
 #if !COAP_DISABLE_TCP
   if (COAP_PROTO_RELIABLE(session->proto)) {
@@ -1242,7 +1242,7 @@ coap_session_check_connect(coap_session_t *session) {
       }
     } else {
       /* Initial connect worked immediately */
-      session->sock.lfunc[COAP_LAYER_SESSION].establish(session);
+      session->sock.lfunc[COAP_LAYER_SESSION].l_establish(session);
     }
   }
 #endif /* !COAP_DISABLE_TCP */
@@ -1539,7 +1539,7 @@ coap_new_server_session(coap_context_t *ctx, coap_endpoint_t *ep) {
     coap_handle_event(session->context, COAP_EVENT_TCP_CONNECTED, session);
     coap_handle_event(session->context, COAP_EVENT_SERVER_SESSION_NEW, session);
     session->state = COAP_SESSION_STATE_CONNECTING;
-    session->sock.lfunc[COAP_LAYER_SESSION].establish(session);
+    session->sock.lfunc[COAP_LAYER_SESSION].l_establish(session);
   }
   return session;
 

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -300,8 +300,8 @@ dtls_send_to_peer(struct dtls_context_t *dtls_context,
     coap_log_warn("dtls_send_to_peer: cannot find local interface\n");
     return -3;
   }
-  return (int)coap_session->sock.lfunc[COAP_LAYER_TLS].write(coap_session,
-                                                             data, len);
+  return (int)coap_session->sock.lfunc[COAP_LAYER_TLS].l_write(coap_session,
+         data, len);
 }
 
 static int


### PR DESCRIPTION
Prevents issues with things such as '#define write lwip_write'.