### PR TITLE
coap_session.c: Report COAP_NACK_ICMP_ISSUE for NON to NACK handler

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -345,10 +345,13 @@ static void
 nack_handler(coap_session_t *session COAP_UNUSED,
              const coap_pdu_t *sent,
              const coap_nack_reason_t reason,
-             const coap_mid_t id COAP_UNUSED) {
-  coap_bin_const_t token = coap_pdu_get_token(sent);
-  if (!track_check_token(&token)) {
-    coap_log_err("nack_handler: Unexpected token\n");
+             const coap_mid_t mid COAP_UNUSED) {
+  if (sent) {
+    coap_bin_const_t token = coap_pdu_get_token(sent);
+
+    if (!track_check_token(&token)) {
+      coap_log_err("nack_handler: Unexpected token\n");
+    }
   }
 
   switch (reason) {

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1720,7 +1720,7 @@ static void
 proxy_nack_handler(coap_session_t *session,
                    const coap_pdu_t *sent COAP_UNUSED,
                    const coap_nack_reason_t reason,
-                   const coap_mid_t id COAP_UNUSED) {
+                   const coap_mid_t mid COAP_UNUSED) {
 
   switch (reason) {
   case COAP_NACK_TOO_MANY_RETRIES:


### PR DESCRIPTION
Try to get the PDU information from session->lg_crcv, else call NACK handler with `sent == NULL` so client understands there are network related issues.