### PR TITLE
coap_resolve_address_info: Add in support for defining WebSocket ports

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -1541,7 +1541,7 @@ get_session(coap_context_t *ctx,
       local.s = (const uint8_t *)local_addr;
       local.length = strlen(local_addr);
       /* resolve local address where data should be sent from */
-      info_list = coap_resolve_address_info(&local, port, port,
+      info_list = coap_resolve_address_info(&local, port, port, port, port,
                                             AI_PASSIVE | AI_NUMERICHOST | AI_NUMERICSERV | AI_ALL,
                                             1 << scheme,
                                             COAP_RESOLVE_TYPE_LOCAL);
@@ -1806,7 +1806,7 @@ main(int argc, char **argv) {
   }
 
   /* resolve destination address where data should be sent */
-  info_list = coap_resolve_address_info(&server, port, port,
+  info_list = coap_resolve_address_info(&server, port, port, port, port,
                                         0,
                                         1 << scheme,
                                         COAP_RESOLVE_TYPE_REMOTE);

--- a/examples/coap-rd.c
+++ b/examples/coap-rd.c
@@ -716,6 +716,7 @@ get_context(const char *node, const char *port) {
       coap_get_available_scheme_hint_bits(cert_file != NULL || key_defined != 0,
                                           enable_ws, COAP_PROTO_NONE);
   info_list = coap_resolve_address_info(node ? &local : NULL, u_s_port, s_port,
+                                        ws_port, wss_port,
                                         AI_PASSIVE | AI_NUMERICHOST,
                                         scheme_hint_bits,
                                         COAP_RESOLVE_TYPE_LOCAL);

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -909,7 +909,7 @@ get_ongoing_proxy_session(coap_session_t *session,
   }
 
   /* resolve destination address where data should be sent */
-  info_list = coap_resolve_address_info(&server, port, port,
+  info_list = coap_resolve_address_info(&server, port, port, port, port,
                                         0,
                                         1 << scheme,
                                         COAP_RESOLVE_TYPE_REMOTE);
@@ -2327,6 +2327,7 @@ get_context(const char *node, const char *port) {
       coap_get_available_scheme_hint_bits(cert_file != NULL || key_defined != 0,
                                           enable_ws, use_unix_proto);
   info_list = coap_resolve_address_info(node ? &local : NULL, u_s_port, s_port,
+                                        ws_port, wss_port,
                                         AI_PASSIVE | AI_NUMERICHOST,
                                         scheme_hint_bits,
                                         COAP_RESOLVE_TYPE_LOCAL);

--- a/examples/lwip/client-coap.c
+++ b/examples/lwip/client-coap.c
@@ -86,8 +86,8 @@ resolve_address(const char *host, const char *service, coap_address_t *dst,
   str_host.s = (const uint8_t *)host;
   str_host.length = strlen(host);
 
-  addr_info = coap_resolve_address_info(&str_host, port, port, AF_UNSPEC,
-                                        scheme_hint_bits,
+  addr_info = coap_resolve_address_info(&str_host, port, port, port, port,
+                                        AF_UNSPEC, scheme_hint_bits,
                                         COAP_RESOLVE_TYPE_REMOTE);
   if (addr_info) {
     ret = 1;

--- a/examples/lwip/server-coap.c
+++ b/examples/lwip/server-coap.c
@@ -171,6 +171,7 @@ server_coap_init(coap_lwip_input_wait_handler_t input_wait,
       coap_get_available_scheme_hint_bits(use_psk[0],
                                           0, COAP_PROTO_NONE);
   info_list = coap_resolve_address_info(&node, 0, 0,
+                                        0, 0,
                                         0,
                                         scheme_hint_bits,
                                         COAP_RESOLVE_TYPE_LOCAL);

--- a/examples/riot/examples_libcoap_client/client-coap.c
+++ b/examples/riot/examples_libcoap_client/client-coap.c
@@ -105,8 +105,8 @@ resolve_address(const char *host, const char *service, coap_address_t *dst,
 
   str_host.s = (const uint8_t *)host;
   str_host.length = strlen(host);
-  addr_info = coap_resolve_address_info(&str_host, port, port, AF_UNSPEC,
-                                        scheme_hint_bits,
+  addr_info = coap_resolve_address_info(&str_host, port, port,  port, port,
+                                        AF_UNSPEC, scheme_hint_bits,
                                         COAP_RESOLVE_TYPE_REMOTE);
   if (addr_info) {
     ret = 1;

--- a/examples/riot/examples_libcoap_server/server-coap.c
+++ b/examples/riot/examples_libcoap_server/server-coap.c
@@ -166,6 +166,7 @@ init_coap_context_endpoints(const char *use_psk) {
   local.length = strlen(addr_str);
   info_list = coap_resolve_address_info(&local, COAP_DEFAULT_PORT,
                                         COAPS_DEFAULT_PORT,
+                                        0, 0,
                                         0,
                                         scheme_hint_bits,
                                         COAP_RESOLVE_TYPE_REMOTE);

--- a/examples/riot/pkg_libcoap/Makefile
+++ b/examples/riot/pkg_libcoap/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=libcoap
-PKG_URL=https://github.com/obgm/libcoap
-PKG_VERSION=cb78d5fd857c7bc244ca056ac3c989eeeb2954bf
+PKG_URL=https://github.com/mrdeep1/libcoap
+PKG_VERSION=6769f9f893e9143d33782ce3602f947a8f2cf521
 PKG_LICENSE=BSD-2-Clause
 
 LIBCOAP_BUILD_DIR=$(BINDIR)/pkg/$(PKG_NAME)

--- a/include/coap3/coap_address.h
+++ b/include/coap3/coap_address.h
@@ -175,6 +175,8 @@ typedef enum coap_resolve_type_t {
  * @param address The Address to resolve.
  * @param port    The unsecured protocol port to use.
  * @param secure_port The secured protocol port to use.
+ * @param ws_port The unsecured WebSockets port to use.
+ * @param ws_secure_port The secured WebSockets port to use.
  * @param ai_hints_flags AI_* Hint flags to use for internal getaddrinfo().
  * @param scheme_hint_bits Which schemes to return information for. One or
  *                         more of COAP_URI_SCHEME_*_BIT or'd together.
@@ -185,6 +187,8 @@ typedef enum coap_resolve_type_t {
 coap_addr_info_t *coap_resolve_address_info(const coap_str_const_t *address,
                                             uint16_t port,
                                             uint16_t secure_port,
+                                            uint16_t ws_port,
+                                            uint16_t ws_secure_port,
                                             int ai_hints_flags,
                                             int scheme_hint_bits,
                                             coap_resolve_type_t type);

--- a/man/coap_address.txt.in
+++ b/man/coap_address.txt.in
@@ -50,7 +50,8 @@ SYNOPSIS
 int _ws_check_, coap_proto_t _use_unix_proto_);*
 
 *coap_addr_info_t *coap_resolve_address_info(const coap_str_const_t *_address_,
-uint16_t _port_, uint16_t _secure_port_, int _ai_hints_flags_,
+uint16_t _port_, uint16_t _secure_port_, uint16_t _ws_port_,
+uint16_t _ws_secure_port_, int _ai_hints_flags_,
 int _scheme_hint_bits_, coap_resolve_type_t _type_);*
 
 *void coap_free_address_info(coap_addr_info_t *_info_list_);*
@@ -196,7 +197,8 @@ protocol to use over a Unix socket. The output is suitable for input for the
 
 The *coap_resolve_address_info*() function resolves the address _address_ into
 a set of one or more coap_addr_info_t structures. Depending on the scheme as
-abstracted from _scheme_hint_bits_ either _port_ or _secure_port_ is used to
+abstracted from _scheme_hint_bits_,  _port_, _secure_port_, _ws_port_
+(WebSockets) or _ws_secure_port_ (WebSockets) is used to
 update the addr variable of coap_addr_info_t. If _port_ (or _secure_port_) is
 0, then the default port for the scheme is used if _type_ is set to
 COAP_RESOLVE_TYPE_LOCAL.  _ai_hints_flags_ is used for
@@ -262,7 +264,7 @@ used for session setup or NULL if there is a failure.
 
 EXAMPLES
 --------
-*Get target address from uri*
+*Get client target address from uri*
 [source, c]
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
@@ -271,7 +273,8 @@ static int
 get_address(coap_uri_t *uri, coap_address_t *dst) {
   coap_addr_info_t *info_list;
 
-   info_list = coap_resolve_address_info(&uri->host, uri->port, uri->port, 0,
+   info_list = coap_resolve_address_info(&uri->host, uri->port, uri->port,
+                                         uri->port, uri->port,0,
                                          1 << uri->scheme, COAP_RESOLVE_TYPE_LOCAL);
    if (info_list == NULL)
      return 0;

--- a/src/coap_address.c
+++ b/src/coap_address.c
@@ -373,6 +373,8 @@ coap_addr_info_t *
 coap_resolve_address_info(const coap_str_const_t *address,
                           uint16_t port,
                           uint16_t secure_port,
+                          uint16_t ws_port,
+                          uint16_t ws_secure_port,
                           int ai_hints_flags,
                           int scheme_hint_bits,
                           coap_resolve_type_t type) {
@@ -612,11 +614,11 @@ coap_resolve_address_info(const coap_str_const_t *address,
                         type == COAP_RESOLVE_TYPE_LOCAL);
             break;
           case COAP_URI_SCHEME_COAP_WS:
-            update_port(&info->addr, port, 80,
+            update_port(&info->addr, ws_port, 80,
                         type == COAP_RESOLVE_TYPE_LOCAL);
             break;
           case COAP_URI_SCHEME_COAPS_WS:
-            update_port(&info->addr, secure_port, 443,
+            update_port(&info->addr, ws_secure_port, 443,
                         type == COAP_RESOLVE_TYPE_LOCAL);
             break;
           case COAP_URI_SCHEME_LAST:
@@ -758,11 +760,11 @@ coap_resolve_address_info(const coap_str_const_t *address,
                       type == COAP_RESOLVE_TYPE_LOCAL);
           break;
         case COAP_URI_SCHEME_HTTP:
-          update_port(&info->addr, port, 80,
+          update_port(&info->addr, port, ws_port,
                       type == COAP_RESOLVE_TYPE_LOCAL);
           break;
         case COAP_URI_SCHEME_HTTPS:
-          update_port(&info->addr, secure_port, 443,
+          update_port(&info->addr, secure_port, ws_secure_port,
                       type == COAP_RESOLVE_TYPE_LOCAL);
           break;
         case COAP_URI_SCHEME_LAST:


### PR DESCRIPTION
coap_resolve_address_info() was created post 4.3.1, so no API change going into 4.3.2.