### PR TITLE
Mutexes: Clean up / simplify use of mutexes

### DIFF
--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -2068,14 +2068,14 @@ coap_dtls_receive(coap_session_t *c_session,
 
   if (m_env->established) {
 #if COAP_CONSTRAINED_STACK
-    COAP_MUTEX_DEFINE(b_static_mutex);
+    /* pdu protected by mutex m_dtls_recv */
     static uint8_t pdu[COAP_RXBUFFER_SIZE];
 #else /* ! COAP_CONSTRAINED_STACK */
     uint8_t pdu[COAP_RXBUFFER_SIZE];
 #endif /* ! COAP_CONSTRAINED_STACK */
 
 #if COAP_CONSTRAINED_STACK
-    coap_mutex_lock(&b_static_mutex);
+    coap_mutex_lock(&m_dtls_recv);
 #endif /* COAP_CONSTRAINED_STACK */
 
     if (c_session->state == COAP_SESSION_STATE_HANDSHAKE) {
@@ -2088,7 +2088,7 @@ coap_dtls_receive(coap_session_t *c_session,
     if (ret > 0) {
       ret = coap_handle_dgram(c_session->context, c_session, pdu, (size_t)ret);
 #if COAP_CONSTRAINED_STACK
-      coap_mutex_unlock(&b_static_mutex);
+      coap_mutex_unlock(&m_dtls_recv);
 #endif /* COAP_CONSTRAINED_STACK */
       goto finish;
     }
@@ -2107,7 +2107,7 @@ coap_dtls_receive(coap_session_t *c_session,
       break;
     }
 #if COAP_CONSTRAINED_STACK
-    coap_mutex_unlock(&b_static_mutex);
+    coap_mutex_unlock(&m_dtls_recv);
 #endif /* COAP_CONSTRAINED_STACK */
     ret = -1;
   } else {

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -57,7 +57,7 @@ coap_persist_observe_add(coap_context_t *context,
   size_t data_len;
   coap_pdu_t *pdu = NULL;
 #if COAP_CONSTRAINED_STACK
-  COAP_MUTEX_DEFINE(e_static_mutex);
+  /* e_packet protected by mutex m_persist_add */
   static coap_packet_t e_packet;
 #else /* ! COAP_CONSTRAINED_STACK */
   coap_packet_t e_packet;
@@ -88,7 +88,7 @@ coap_persist_observe_add(coap_context_t *context,
   }
 
 #if COAP_CONSTRAINED_STACK
-  coap_mutex_lock(&e_static_mutex);
+  coap_mutex_lock(&m_persist_add);
 #endif /* COAP_CONSTRAINED_STACK */
 
   /* Build up packet */
@@ -277,7 +277,7 @@ oscore_fail:
 #endif /* ! COAP_OSCORE_SUPPORT */
   coap_delete_pdu(pdu);
 #if COAP_CONSTRAINED_STACK
-  coap_mutex_unlock(&e_static_mutex);
+  coap_mutex_unlock(&m_persist_add);
 #endif /* COAP_CONSTRAINED_STACK */
   return s;
 
@@ -285,7 +285,7 @@ malformed:
   coap_log_warn("coap_persist_observe_add: discard malformed PDU\n");
 fail:
 #if COAP_CONSTRAINED_STACK
-  coap_mutex_unlock(&e_static_mutex);
+  coap_mutex_unlock(&m_persist_add);
 #endif /* COAP_CONSTRAINED_STACK */
   coap_delete_string(uri_path);
   coap_delete_pdu(pdu);


### PR DESCRIPTION
Not all OS implementations properly support static initializations.