### PR TITLE
coap_session.c: Fix GCC array bounds warning for memcpy

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1756,6 +1756,7 @@ coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, co
   ep->context = context;
   ep->proto = proto;
   ep->sock.endpoint = ep;
+  assert(proto < COAP_PROTO_LAST);
   memcpy(&ep->sock.lfunc, coap_layers_coap[proto], sizeof(ep->sock.lfunc));
 
   if (COAP_PROTO_NOT_RELIABLE(proto)) {


### PR DESCRIPTION
Copying from the multidimensional coap_layers_coap array into the coap_layers of endpoint::sock.lfunc triggers a warning from GCC v13.2.0 as the global variable has no space for the end marker COAP_PROTO_LAST:

```
src/coap_session.c: In function 'coap_new_endpoint':
src/coap_session.c:1759:3: warning: 'memcpy' offset [672, 767] is out of the bounds [0, 672] of object 'coap_layers_coap' with type 'coap_layer_func_t[7][3]' [-Warray-bounds=]
 1759 |   memcpy(&ep->sock.lfunc, coap_layers_coap[proto], sizeof(ep->sock.lfunc));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./include/coap3/coap_io_internal.h:21,
                 from ./include/coap3/coap_internal.h:109,
                 from src/coap_session.c:17:
./include/coap3/coap_layers_internal.h:113:26: note: 'coap_layers_coap' declared here
  113 | extern coap_layer_func_t coap_layers_coap[COAP_PROTO_LAST][COAP_LAYER_LAST];
      |                          ^~~~~~~~~~~~~~~~
```

672 is the size of coap_layers_coap, and each entry is 96 bytes. If `proto` was `COAP_PROTO_LAST`, the entry would extend from byte index 672 to 767.

This change adds an assertion to indicate that proto is always less than COAP_PROTO_LAST to suppress the warning.