### PR TITLE
fix memory leak in coap_async

### DIFF
--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -73,8 +73,8 @@ coap_register_async(coap_session_t *session,
     return NULL;
   }
 
-  LL_PREPEND(session->context->async_state, s);
   memset(s, 0, sizeof(coap_async_t));
+  LL_PREPEND(session->context->async_state, s);
 
   /* Note that this generates a new MID */
   s->pdu = coap_pdu_duplicate(request, session, request->actual_token.length,


### PR DESCRIPTION
This is a bug I encountered a while ago while ago.

LL_PREPEND was setting s as the first element in the linked list, and then memset was clearing it; resulting in any other pending async requests being lost
