### PR TITLE
coap_address.c: do not enable IPV4 broadcast as multicast with Zephyr

### DIFF
--- a/src/coap_address.c
+++ b/src/coap_address.c
@@ -139,7 +139,7 @@ coap_is_mcast(const coap_address_t *a) {
   return 0;
 }
 
-#if !defined(WIN32)
+#if !defined(WIN32) && !defined(__ZEPHYR__)
 
 #ifndef COAP_BCST_CNT
 #define COAP_BCST_CNT 15
@@ -234,13 +234,13 @@ coap_is_bcast(const coap_address_t *a) {
   return 0;
 #endif /* COAP_IPV4_SUPPORT */
 }
-#else /* WIN32 */
+#else /* WIN32 || __ZEPHYR__ */
 int
 coap_is_bcast(const coap_address_t *a) {
   (void)a;
   return 0;
 }
-#endif /* WIN32 || ESPIDF_VERSION */
+#endif /* WIN32 || __ZEPHYR__ */
 
 #endif /* !defined(WITH_CONTIKI) && !defined(WITH_LWIP) */
 


### PR DESCRIPTION
Adds a check to ensure IPV4 broadcast as multicast is not enabled when using Zephyr as it will break builds with Zephyr's minimal libc, which is missing ifaddr.h.

Fixes #1217 