### PR TITLE
Define coap_mutex_t as sys_mutex on Zephyr

### DIFF
--- a/include/coap3/coap_mutex_internal.h
+++ b/include/coap3/coap_mutex_internal.h
@@ -85,7 +85,7 @@ typedef int coap_mutex_t;
 #elif defined(__ZEPHYR__)
 #include <zephyr/sys/mutex.h>
 
-typedef struct k_mutex coap_mutex_t;
+typedef struct sys_mutex coap_mutex_t;
 
 #define coap_mutex_init(a)    sys_mutex_init(a)
 #define coap_mutex_destroy(a)


### PR DESCRIPTION
Changes definition of coap_mutex_t as k_mutex to sys_mutex to build properly with Zephyr.

Fixes #1219 

See https://github.com/obgm/libcoap/pull/1033 and https://github.com/obgm/libcoap/pull/1197 for more information.