### PR TITLE
Do not destroy mutexes in coap_cleanup()

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4043,15 +4043,6 @@ coap_cleanup(void) {
   coap_stop_io_process();
 #endif
   coap_dtls_shutdown();
-
-#if COAP_CONSTRAINED_STACK
-  coap_mutex_destroy(&m_show_pdu);
-  coap_mutex_destroy(&m_log_impl);
-  coap_mutex_destroy(&m_dtls_recv);
-  coap_mutex_destroy(&m_read_session);
-  coap_mutex_destroy(&m_read_endpoint);
-  coap_mutex_destroy(&m_persist_add);
-#endif /* COAP_CONSTRAINED_STACK */
 }
 
 void


### PR DESCRIPTION
If mutexes are destroyed in coap_cleanup() they can never be re-initialized as calling coap_startup() short-circuits after its first invocation. This updates to not destroy the mutexes on calls to coap_cleanup().

Fixes https://github.com/obgm/libcoap/issues/1225