### PR TITLE
coap_cleanup: Allow coap_startup() to be called after coap_cleanup()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,6 +91,7 @@ EXTRA_DIST = \
   include/coap$(LIBCOAP_API_VERSION)/coap_block_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_cache_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_crypto_internal.h \
+  include/coap$(LIBCOAP_API_VERSION)/coap_debug_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_dtls_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_hashkey_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_io_internal.h \

--- a/include/coap3/coap_debug.h
+++ b/include/coap3/coap_debug.h
@@ -347,8 +347,6 @@ char *coap_string_tls_support(char *buffer, size_t bufsize);
 /**
  * Print the address into the defined buffer.
  *
- * Internal Function.
- *
  * @param address The address to print.
  * @param buffer The buffer to print into.
  * @param size The size of the buffer to print into.
@@ -360,8 +358,6 @@ size_t coap_print_addr(const coap_address_t *address,
 
 /**
  * Print the IP address into the defined buffer.
- *
- * Internal Function.
  *
  * @param address The address to print.
  * @param buffer The buffer to print into.
@@ -389,15 +385,5 @@ const char *coap_print_ip_addr(const coap_address_t *address,
  * @return @c 1 If loss level set, @c 0 if there is an error.
  */
 int coap_debug_set_packet_loss(const char *loss_level);
-
-/**
- * Check to see whether a packet should be sent or not.
- *
- * Internal function
- *
- * @return @c 1 if packet is to be sent, @c 0 if packet is to be dropped.
- */
-int coap_debug_send_packet(void);
-
 
 #endif /* COAP_DEBUG_H_ */

--- a/include/coap3/coap_debug_internal.h
+++ b/include/coap3/coap_debug_internal.h
@@ -1,0 +1,36 @@
+/*
+ * coap_debug_internal.h -- debug utilities
+ *
+ * Copyright (C) 2010-2011,2014-2023 Olaf Bergmann <bergmann@tzi.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_debug_internal.h
+ * @brief CoAP Logging support internal information
+ */
+
+#ifndef COAP_DEBUG_INTERNAL_H_
+#define COAP_DEBUG_INTERNAL_H_
+
+/**
+ * Check to see whether a packet should be sent or not.
+ *
+ * Internal function
+ *
+ * @return @c 1 if packet is to be sent, @c 0 if packet is to be dropped.
+ */
+int coap_debug_send_packet(void);
+
+/**
+ * Reset all the defined logging parameters.
+ *
+ * Internal function
+ */
+void coap_debug_reset(void);
+
+#endif /* COAP_DEBUG_INTERNAL_H_ */

--- a/include/coap3/coap_internal.h
+++ b/include/coap3/coap_internal.h
@@ -104,6 +104,7 @@ typedef struct oscore_ctx_t oscore_ctx_t;
 #if defined(COAP_OSCORE_SUPPORT) || defined(COAP_WS_SUPPORT)
 #include "coap_crypto_internal.h"
 #endif /* COAP_OSCORE_SUPPORT || COAP_WS_SUPPORT */
+#include "coap_debug_internal.h"
 #include "coap_dtls_internal.h"
 #include "coap_hashkey_internal.h"
 #include "coap_io_internal.h"

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -59,7 +59,6 @@ global:
   coap_context_set_psk2;
   coap_context_set_psk;
   coap_context_set_session_timeout;
-  coap_debug_send_packet;
   coap_debug_set_packet_loss;
   coap_decode_var_bytes8;
   coap_decode_var_bytes;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -57,7 +57,6 @@ coap_context_set_pki_root_cas
 coap_context_set_psk
 coap_context_set_psk2
 coap_context_set_session_timeout
-coap_debug_send_packet
 coap_debug_set_packet_loss
 coap_decode_var_bytes
 coap_decode_var_bytes8

--- a/man/coap_init.txt.in
+++ b/man/coap_init.txt.in
@@ -47,11 +47,18 @@ random number gererators, clocks, TLS libraries etc.
 *NOTE:* This should be called after any other lower layer is initialized.
 For example, for LwIP, lwip_init() must be called before *coap_startup*().
 
+*NOTE:* After the inital call to *coap_startup*(), subsequent calls are ignored
+until *coap_cleanup*() is called.
+
 *Function: coap_cleanup()*
 
 The *coap_cleanup*() function is used to cleanup / free any information set
 up by the *coap_startup*() function and should be the last *coap_**() function
-called.
+called. It is possible to call *coap_startup*() after *coap_cleanup*() to
+re-initialize the libcoap logic.
+
+*NOTE:* All other libcoap cleanups should called prior to *coap_cleanup*(), e.g.
+*coap_free_context*(3).
 
 FURTHER INFORMATION
 -------------------

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -1304,3 +1304,12 @@ coap_debug_send_packet(void) {
   }
   return 1;
 }
+
+void
+coap_debug_reset(void) {
+  maxlog = COAP_LOG_WARN;
+  use_fprintf_for_show_pdu = 1;
+  num_packet_loss_intervals = 0;
+  packet_loss_level = 0;
+  send_packet_count = 0;
+}

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -163,7 +163,7 @@ typedef enum coap_free_bye_t {
     G_CHECK(xx, func); \
   } while 0
 
-static coap_log_t dtls_log_level = 0;
+static coap_log_t dtls_log_level = COAP_LOG_EMERG;
 
 #if COAP_SERVER_SUPPORT
 static int post_client_hello_gnutls_pki(gnutls_session_t g_session);
@@ -434,6 +434,7 @@ coap_dtls_startup(void) {
 
 void
 coap_dtls_shutdown(void) {
+  coap_dtls_set_log_level(COAP_LOG_EMERG);
 }
 
 void *

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -2481,6 +2481,7 @@ coap_dtls_shutdown(void) {
   pki_ciphers = NULL;
   processed_ciphers = 0;
 #endif /* COAP_CLIENT_SUPPORT */
+  coap_dtls_set_log_level(COAP_LOG_EMERG);
 }
 
 void *

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4052,6 +4052,8 @@ coap_cleanup(void) {
   coap_mutex_destroy(&m_read_endpoint);
   coap_mutex_destroy(&m_persist_add);
 #endif /* COAP_CONSTRAINED_STACK */
+  coap_debug_reset();
+  coap_started = 0;
 }
 
 void

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -128,6 +128,7 @@ coap_dtls_get_tls(const coap_session_t *c_session COAP_UNUSED,
 
 void
 coap_dtls_shutdown(void) {
+  coap_dtls_set_log_level(COAP_LOG_EMERG);
 }
 
 void

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -270,6 +270,7 @@ coap_dtls_shutdown(void) {
     ssl_engine = NULL;
   }
   ERR_free_strings();
+  coap_dtls_set_log_level(COAP_LOG_EMERG);
 }
 
 void *

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -153,10 +153,12 @@ coap_dtls_startup(void) {
   /* Valid after TinyDTLS submodule has been updated */
   dtls_set_log_handler(dtls_logging);
 #endif /* HAVE_DTLS_SET_LOG_HANDLER */
+  coap_dtls_set_log_level(COAP_LOG_EMERG);
 }
 
 void
 coap_dtls_shutdown(void) {
+  coap_dtls_set_log_level(COAP_LOG_EMERG);
 }
 
 void *


### PR DESCRIPTION
After calling `coap_cleanup()`, allow another call to `coap_startup()` to re-initialize the libcoap library.