### PR TITLE
Contiki-NG: Fix compilation on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,6 +112,23 @@ jobs:
       run: |
         cd build_test
         cmake --build .
+  contiki-build-macos:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: install macOS software
+      run: |
+        brew install make automake
+    - name: setup
+      run: |
+        ./autogen.sh
+    - name: configure
+      run: |
+        ./configure --disable-doxygen --disable-manpages --disable-dtls --without-epoll --disable-examples --disable-examples-source --disable-tcp --disable-oscore --disable-q-block
+    - name: compile
+      run: |
+        gmake -C examples/contiki
   other-build:
     runs-on: ubuntu-latest
     strategy:

--- a/coap_config.h.contiki
+++ b/coap_config.h.contiki
@@ -96,8 +96,6 @@
 
 #define WITH_CONTIKI 1
 
-#define ntohs uip_ntohs
-
 #define HASH_NONFATAL_OOM 1
 
 #ifndef HEAPMEM_CONF_ARENA_SIZE

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -228,14 +228,14 @@ coap_print_addr(const coap_address_t *addr, unsigned char *buf, size_t len) {
   case AF_INET:
     snprintf((char *)buf, len, "%s:%d",
              coap_print_ip_addr(addr, scratch, sizeof(scratch)),
-             ntohs(addr->addr.sin.sin_port));
+             coap_address_get_port(addr));
     break;
 #endif /* COAP_IPV4_SUPPORT */
 #if COAP_IPV6_SUPPORT
   case AF_INET6:
     snprintf((char *)buf, len, "[%s]:%d",
              coap_print_ip_addr(addr, scratch, sizeof(scratch)),
-             ntohs(addr->addr.sin6.sin6_port));
+             coap_address_get_port(addr));
     break;
 #endif /* COAP_IPV6_SUPPORT */
 #if COAP_AF_UNIX_SUPPORT

--- a/src/coap_time.c
+++ b/src/coap_time.c
@@ -134,7 +134,12 @@ coap_ticks_from_rt_us(uint64_t t) {
 
 #else /* HAVE_TIME_H */
 
-/* make compilers happy that do not like empty modules */
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 COAP_STATIC_INLINE void
 dummy(void) {
 }


### PR DESCRIPTION
This PR fixes that Contiki-NG fails to compile on macOS due to an unused function and a redefinition of `ntohs`.