### PR TITLE
workflows: Revert #1073 to add OpenSSL dev environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
 env:
   PLATFORM: posix
   TESTS: yes
-  OPENSSL_INSTALL_PATH: C:\Program Files\OpenSSL\
+  OPENSSL_INSTALL_PATH: C:\Program Files\OpenSSL-Win64\
 
 jobs:
   build-linux:
@@ -155,6 +155,11 @@ jobs:
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v1
 
+      - name: Install OpenSSL on Windows (choco)
+        run: |
+          choco install openssl
+        shell: cmd
+
       - name: Build sln
         shell: cmd
         run: call .\scripts\msbuild.sln.cmd
@@ -162,6 +167,11 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
+
+    - name: Install OpenSSL on Windows (choco)
+      run: |
+        choco install openssl
+      shell: cmd
 
     - name: MS CMake setup
       run: |

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -75,6 +75,11 @@
 /* Ignore OpenSSL 3.0 deprecated warnings for now */
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
+#if defined(_WIN32)
+#if !defined(__MINGW32__)
+#pragma warning(disable : 4996)
+#endif /* ! __MINGW32__ */
+#endif /* _WIN32 */
 #endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
 
 #ifdef COAP_EPOLL_SUPPORT


### PR DESCRIPTION
OpenSSL dev environment is no longer included in windows-latest builds.

Disable Windows build OpenSSL 3 deprecation warnings