### PR TITLE
Contiki-NG: Fix retransmissions and simplify cleanup

### DIFF
--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -147,12 +147,13 @@ void coap_epoll_ctl_add(coap_socket_t *sock, uint32_t events, const char *func);
 void coap_epoll_ctl_mod(coap_socket_t *sock, uint32_t events, const char *func);
 
 /**
- * Update the epoll timer fd as to when it is to trigger.
+ * Update when to continue with I/O processing, unless packets come in in the
+ * meantime. Typically, this timeout triggers retransmissions.
  *
- * @param context The context to update the epoll timer on.
- * @param delay The time to delay before the epoll timer fires.
+ * @param context The CoAP context.
+ * @param delay The time to delay before continuing with I/O processing.
  */
-void coap_update_epoll_timer(coap_context_t *context, coap_tick_t delay);
+void coap_update_io_timer(coap_context_t *context, coap_tick_t delay);
 
 #ifdef WITH_LWIP
 ssize_t coap_socket_send_pdu(coap_socket_t *sock, coap_session_t *session,

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -80,7 +80,7 @@ struct coap_context_t {
 
 #ifdef WITH_CONTIKI
   struct uip_udp_conn *conn;      /**< uIP connection object */
-  struct ctimer prepare_timer;    /**< fires when it's time to call
+  struct ctimer io_timer;         /**< fires when it's time to call
                                        coap_io_prepare_io */
 #endif /* WITH_CONTIKI */
 

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -103,9 +103,7 @@ coap_async_trigger(coap_async_t *async) {
 
   coap_log_debug("   %s: Async request triggered\n",
                  coap_session_str(async->session));
-#ifdef COAP_EPOLL_SUPPORT
-  coap_update_epoll_timer(async->session->context, 0);
-#endif /* COAP_EPOLL_SUPPORT */
+  coap_update_io_timer(async->session->context, 0);
 }
 
 
@@ -118,9 +116,7 @@ coap_async_set_delay(coap_async_t *async, coap_tick_t delay) {
 
   if (delay) {
     async->delay = now + delay;
-#ifdef COAP_EPOLL_SUPPORT
-    coap_update_epoll_timer(async->session->context, delay);
-#endif /* COAP_EPOLL_SUPPORT */
+    coap_update_io_timer(async->session->context, delay);
     coap_log_debug("   %s: Async request delayed for %u.%03u secs\n",
                    coap_session_str(async->session),
                    (unsigned int)(delay / COAP_TICKS_PER_SECOND),

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -520,9 +520,14 @@ coap_epoll_ctl_mod(coap_socket_t *sock,
                  coap_socket_strerror(), errno);
   }
 }
+#endif /* COAP_EPOLL_SUPPORT */
 
+#endif /* ! WITH_CONTIKI && ! WITH_LWIP */
+
+#ifndef WITH_CONTIKI
 void
-coap_update_epoll_timer(coap_context_t *context, coap_tick_t delay) {
+coap_update_io_timer(coap_context_t *context, coap_tick_t delay) {
+#if COAP_EPOLL_SUPPORT
   if (context->eptimerfd != -1) {
     coap_tick_t now;
 
@@ -554,9 +559,14 @@ coap_update_epoll_timer(coap_context_t *context, coap_tick_t delay) {
 #endif /* COAP_DEBUG_WAKEUP_TIMES */
     }
   }
-}
-
+#else /* COAP_EPOLL_SUPPORT */
+  (void)context;
+  (void)delay;
 #endif /* COAP_EPOLL_SUPPORT */
+}
+#endif /* ! WITH_CONTIKI */
+
+#if !defined(WITH_CONTIKI) && !defined(WITH_LWIP)
 
 #ifdef _WIN32
 static void

--- a/src/coap_io_contiki.c
+++ b/src/coap_io_contiki.c
@@ -56,7 +56,7 @@ static void
 prepare_io(coap_context_t *ctx) {
   coap_tick_t now;
   coap_socket_t *sockets[1];
-  unsigned int max_sockets = sizeof(sockets)/sizeof(sockets[0]);
+  static const unsigned int max_sockets = sizeof(sockets)/sizeof(sockets[0]);
   unsigned int num_sockets;
   unsigned timeout;
 

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -935,9 +935,7 @@ coap_wait_ack(coap_context_t *context, coap_session_t *session,
                  (unsigned)((node->timeout << node->retransmit_cnt) * 1000 /
                             COAP_TICKS_PER_SECOND));
 
-#ifdef COAP_EPOLL_SUPPORT
-  coap_update_epoll_timer(context, node->t);
-#endif /* COAP_EPOLL_SUPPORT */
+  coap_update_io_timer(context, node->t);
 
   return node->id;
 }

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -1193,9 +1193,7 @@ coap_resource_notify_observers(coap_resource_t *r,
   }
 
   r->context->observe_pending = 1;
-#ifdef COAP_EPOLL_SUPPORT
-  coap_update_epoll_timer(r->context, 0);
-#endif /* COAP_EPOLL_SUPPORT */
+  coap_update_io_timer(r->context, 0);
   return 1;
 }
 


### PR DESCRIPTION
I noticed that retransmissions are sometimes sent only after receiving something. The reason was that no `tcpip_event` occurred after sending, which would have caused the retransmission timer to be re-scheduled. This PR fixes the issue. Besides, I added a commit that leverages Contiki-NG's `process_exit` function for simplifying the cleanup procedure in `coap_io_contiki.c`.