### PR TITLE
Dockerfile.develop: Add package adduser

### DIFF
--- a/build-env/Dockerfile.develop
+++ b/build-env/Dockerfile.develop
@@ -19,6 +19,7 @@ FROM debian:testing-slim
 RUN apt-get update && apt-get install -y autoconf automake gcc g++ gdb libtool libtool-bin make \
  pkg-config libssl-dev libgnutls28-dev libmbedtls-dev
 RUN apt-get install -y iproute2 lsof net-tools inetutils-ping netcat-openbsd less vim
+RUN apt-get install -y adduser
 RUN apt-get clean
 
 COPY --from=0 /usr/local/include/coap3 /usr/local/include/coap3


### PR DESCRIPTION
Installs the package adduser where /sbin/adduser apparently has been moved.