### PR TITLE
coap_response_handler: Tidy up sent parameter

### DIFF
--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -141,6 +141,12 @@ this is an ACK or RST response to the request.  In general, matching of
 Requests and Responses whould be done by generating unique Tokens for each
 Request and then matching up based on the Token in _received_ Response.
 
+*NOTE:* _sent_ (if not NULL) may not contain all or any of the data used for the
+initial request if block transfers are being used. For Block1 requests, the
+complete data will be lost once the data has been successfully transmitted as
+acknowledged by the first response. For Block2 responses, _sent_ gets re-used
+to request the next Block2 and so data information is lost.
+
 *NOTE:* If the returned value is COAP_RESPONSE_FAIL, then a CoAP RST packet
 will get sent to the server by libcoap.  The returned value of COAP_RESPONSE_OK
 indicates that all is OK.

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -3272,6 +3272,15 @@ lg_xmit_finished:
     coap_show_pdu(COAP_LOG_DEBUG, rcvd);
   }
 
+  if (sent) {
+    /* need to put back original token into sent */
+    if (p->b.b1.app_token)
+      coap_update_token(sent, p->b.b1.app_token->length,
+                        p->b.b1.app_token->s);
+    if (sent->lg_xmit)
+      coap_remove_option(sent, sent->lg_xmit->option);
+    sent->lg_xmit = NULL;
+  }
   LL_DELETE(session->lg_xmit, p);
   coap_block_delete_lg_xmit(session, p);
   return 0;
@@ -3645,6 +3654,14 @@ reinit:
 #endif /* ! COAP_Q_BLOCK_SUPPORT */
             coap_log_debug("Client app version of updated PDU\n");
             coap_show_pdu(COAP_LOG_DEBUG, rcvd);
+
+            if (sent) {
+              /* need to put back original token into sent */
+              if (p->app_token)
+                coap_update_token(sent, p->app_token->length,
+                                  p->app_token->s);
+              coap_remove_option(sent, p->block_option);
+            }
             goto call_app_handler;
           }
 #if COAP_Q_BLOCK_SUPPORT
@@ -3681,6 +3698,13 @@ give_to_app:
               coap_update_token(rcvd, p->app_token->length, p->app_token->s);
               coap_log_debug("Client app version of updated PDU\n");
               coap_show_pdu(COAP_LOG_DEBUG, rcvd);
+            }
+            if (sent) {
+              /* need to put back original token into sent */
+              if (p->app_token)
+                coap_update_token(sent, p->app_token->length,
+                                  p->app_token->s);
+              coap_remove_option(sent, p->block_option);
             }
             if (context->response_handler(session, sent, rcvd,
                                           rcvd->mid) == COAP_RESPONSE_FAIL)
@@ -3830,6 +3854,14 @@ expire_lg_crcv:
     coap_update_token(rcvd, p->app_token->length, p->app_token->s);
     coap_log_debug("Client app version of updated PDU\n");
     coap_show_pdu(COAP_LOG_DEBUG, rcvd);
+  }
+
+  if (sent) {
+    /* need to put back original token into sent */
+    if (p->app_token)
+      coap_update_token(sent, p->app_token->length,
+                        p->app_token->s);
+    coap_remove_option(sent, p->block_option);
   }
   /* Expire this entry */
   LL_DELETE(session->lg_crcv, p);


### PR DESCRIPTION
sent PDU passed to a response handler is now reset to initial sent PDU (token restored, Block options removed), but some or all of original data may be missing if Block operations were needed for the request or the repsonse.

Updated documentation to reflect this.