### PR TITLE
Contiki-NG: Remove call to clock_init as Contiki-NG already does it

### DIFF
--- a/include/coap3/coap_time.h
+++ b/include/coap3/coap_time.h
@@ -76,7 +76,6 @@ typedef int coap_tick_diff_t;
 
 COAP_STATIC_INLINE void
 coap_clock_init(void) {
-  clock_init();
 }
 
 COAP_STATIC_INLINE void


### PR DESCRIPTION
Calling `clock_init` is unnecessary and potentially harmful.