### PR TITLE
Suppress RST when the processing of a non-empty ACK fails

### DIFF
--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -57,7 +57,7 @@ typedef enum coap_response_t {
  * @param mid CoAP transaction ID.
 
  * @return @c COAP_RESPONSE_OK if successful, else @c COAP_RESPONSE_FAIL which
- *         triggers sending a RST packet.
+ *         triggers sending a RST packet if the received PDU is a CON or NON.
  */
 typedef coap_response_t (*coap_response_handler_t)(coap_session_t *session,
                                                    const coap_pdu_t *sent,

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -3406,8 +3406,9 @@ handle_response(coap_context_t *context, coap_session_t *session,
 
   /* Call application-specific response handler when available. */
   if (context->response_handler) {
-    if (context->response_handler(session, sent, rcvd,
-                                  rcvd->mid) == COAP_RESPONSE_FAIL)
+    if ((context->response_handler(session, sent, rcvd,
+                                   rcvd->mid) == COAP_RESPONSE_FAIL) &&
+        (rcvd->type != COAP_MESSAGE_ACK))
       coap_send_rst(session, rcvd);
     else
       coap_send_ack(session, rcvd);


### PR DESCRIPTION
Replying an RST in response to an ACK is not compliant, is it? Hence, we should sort out this case when, e.g., processing a piggybacked response.