### PR TITLE
Zephyr: Initial Zephyr integration setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: astyle_py
         files: '^.*\.(c|cpp|cxx|h|h.in|h.riot|h.riot.in|h.windows|h.windows.in|h.contiki|hpp|inc)$'
-        exclude: '^.*/(coap_uthash_internal.h|coap_utlist_internal.h)$|examples/riot/examples_libcoap_.*$|examples/riot/tests_pkg_libcoap/.*$'
+        exclude: '^.*/(coap_uthash_internal.h|coap_utlist_internal.h)$|examples/riot/examples_libcoap_.*$|examples/riot/tests_pkg_libcoap/.*$|zephyr/.*$'
         args: ['--style=google',
                '--align-pointer=name',
                '--align-reference=name',

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,14 @@ set(LIBCOAP_ABI_VERSION 3.1.1)
 
 set(COAP_LIBRARY_NAME "coap-${LIBCOAP_API_VERSION}")
 
+if(NOT ZEPHYR_BASE)
 option(
   BUILD_SHARED_LIBS
   "Build shared libs"
   OFF)
+else()
+  # provided by the zephyr build system
+endif()
 
 #
 # global compiler options
@@ -84,6 +88,7 @@ set_target_properties(${COAP_LIBRARY_NAME} PROPERTIES VERSION ${LIBCOAP_ABI_VERS
 # options to tweak the library
 #
 
+if(NOT ZEPHYR_BASE)
 option(
   ENABLE_DTLS
   "enable building with DTLS support"
@@ -207,6 +212,10 @@ set_property(
            "6"
            "7"
            "8")
+
+else() # ! ZEPHYR_BASE
+  # provided by zephyr/CMakeLists.txt and zephyr/Kconfig
+endif() # ! ZEPHYR_BASE
 
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 11)
@@ -766,6 +775,12 @@ target_compile_options(
   ${COAP_LIBRARY_NAME}
   PUBLIC -DLIBCOAP_PACKAGE_BUILD="${LIBCOAP_PACKAGE_BUILD}")
 
+if(ZEPHYR_BASE)
+target_compile_options(
+  ${COAP_LIBRARY_NAME}
+  PUBLIC -DMBEDTLS_CONFIG_FILE="${CONFIG_MBEDTLS_CFG_FILE}" -I${ZEPHYR_MBEDTLS_CMAKE_DIR}/configs)
+endif()
+
 add_library(
   ${PROJECT_NAME}::${COAP_LIBRARY_NAME}
   ALIAS
@@ -895,11 +910,13 @@ install(
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT lib)
 
+if(NOT ZEPHYR_BASE)
 install(
   EXPORT ${PROJECT_NAME}Targets
   DESTINATION ${LIBCOAP_CONFIG_INSTALL_DIR}
   NAMESPACE ${PROJECT_NAME}::
   COMPONENT dev)
+endif()
 
 configure_package_config_file(
   cmake/Config.cmake.in

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -510,6 +510,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
   }
   switch (setup_data->pki_key.key_type) {
   case COAP_PKI_KEY_PEM:
+#if defined(MBEDTLS_FS_IO)
     if (setup_data->pki_key.key.pem.public_cert &&
         setup_data->pki_key.key.pem.public_cert[0] &&
         setup_data->pki_key.key.pem.private_key &&
@@ -564,6 +565,10 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
       }
       mbedtls_ssl_conf_ca_chain(&m_env->conf, cacert, NULL);
     }
+#else /* ! MBEDTLS_FS_IO */
+    (void)m_context;
+    coap_log_err("mbedtls_x509_crt_parse_file: MBEDTLS_FS_IO not set, so cannot handle files\n");
+#endif /* ! MBEDTLS_FS_IO */
     break;
   case COAP_PKI_KEY_PEM_BUF:
     if (setup_data->pki_key.key.pem_buf.public_cert &&
@@ -750,6 +755,7 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
     return -1;
   }
 
+#if defined(MBEDTLS_FS_IO)
   if (m_context->root_ca_file) {
     ret = mbedtls_x509_crt_parse_file(cacert, m_context->root_ca_file);
     if (ret < 0) {
@@ -768,6 +774,9 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
     }
     mbedtls_ssl_conf_ca_chain(&m_env->conf, cacert, NULL);
   }
+#else /* ! MBEDTLS_FS_IO */
+  coap_log_err("mbedtls_x509_crt_parse_file: MBEDTLS_FS_IO not set, so cannot handle files\n");
+#endif /* ! MBEDTLS_FS_IO */
 
 #if defined(MBEDTLS_SSL_SRV_C)
   mbedtls_ssl_conf_cert_req_ca_list(&m_env->conf,

--- a/src/coap_uri.c
+++ b/src/coap_uri.c
@@ -702,7 +702,7 @@ coap_delete_uri(coap_uri_t *uri) {
   coap_free_type(COAP_STRING, uri);
 }
 
-COAP_STATIC_INLINE int
+static int
 is_unescaped_in_path(const uint8_t c) {
   return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
          (c >= '0' && c <= '9') || c == '-' || c == '.' || c == '_' ||
@@ -711,7 +711,7 @@ is_unescaped_in_path(const uint8_t c) {
          c=='=' || c==':' || c=='@' || c == '&';
 }
 
-COAP_STATIC_INLINE int
+static int
 is_unescaped_in_query(const uint8_t c) {
   return is_unescaped_in_path(c) || c=='/' || c=='?';
 }

--- a/src/oscore/oscore_cbor.c
+++ b/src/oscore/oscore_cbor.c
@@ -47,7 +47,7 @@
 #include "coap3/coap_internal.h"
 #include <string.h>
 
-static inline void
+static void
 util_write_byte(uint8_t **buffer, size_t *buf_size, uint8_t value) {
   assert(*buf_size >= 1);
   (*buf_size)--;
@@ -207,7 +207,7 @@ oscore_cbor_put_unsigned(uint8_t **buffer, size_t *buf_size, uint64_t value) {
   }
 }
 
-static inline uint8_t
+static uint8_t
 get_byte(const uint8_t **buffer, size_t *buf_len) {
 #if NDEBUG
   (void)buf_len;
@@ -216,7 +216,7 @@ get_byte(const uint8_t **buffer, size_t *buf_len) {
   return (*buffer)[0];
 }
 
-static inline uint8_t
+static uint8_t
 get_byte_inc(const uint8_t **buffer, size_t *buf_len) {
   assert((*buf_len) > 0);
   (*buf_len)--;

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,99 @@
+# zephyr/CMakeLists.txt for libcoap
+#
+# Copyright (C) 2023-2024 Jon Shallow <supjps-libcoap@jpshallow.com>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This file is part of the CoAP library libcoap. Please see README for terms
+# of use.
+#
+###############################################################################
+
+cmake_minimum_required(VERSION 3.20.0)
+
+if(CONFIG_LIBCOAP)
+  if(CONFIG_MBEDTLS)
+    set(ENABLE_DTLS ON)
+    set(DTLS_BACKEND "zephyr" CACHE STRING "Zephyr build")
+    set_property(
+      CACHE DTLS_BACKEND
+      PROPERTY STRINGS
+             zephyr)
+    set(COAP_WITH_LIBMBEDTLS 1)
+  else()
+    set(ENABLE_DTLS OFF)
+  endif()
+  if (CONFIG_LIBCOAP_CLIENT_SUPPORT)
+    set (ENABLE_CLIENT_MODE ON)
+  else()
+    set (ENABLE_CLIENT_MODE OFF)
+  endif()
+  if (CONFIG_LIBCOAP_SERVER_SUPPORT)
+    set (ENABLE_SERVER_MODE ON)
+  else()
+    set (ENABLE_SERVER_MODE OFF)
+  endif()
+  if (CONFIG_LIBCOAP_OSCORE_SUPPORT)
+    set (ENABLE_OSCORE ON)
+  else()
+    set (ENABLE_OSCORE OFF)
+  endif()
+  if (CONFIG_LIBCOAP_OBSERVE_PERSIST)
+    set (WITH_OBSERVE_PERSIST ON)
+  else()
+    set (WITH_OBSERVE_PERSIST OFF)
+  endif()
+  if (CONFIG_LIBCOAP_OBSERVE_PERSIST)
+    set (WITH_OBSERVE_PERSIST ON)
+  else()
+    set (WITH_OBSERVE_PERSIST OFF)
+  endif()
+  if (CONFIG_LIBCOAP_TCP_SUPPORT)
+    set (ENABLE_TCP ON)
+  else()
+    set (ENABLE_TCP OFF)
+  endif()
+  if (CONFIG_LIBCOAP_IPV4_SUPPORT)
+    set (ENABLE_IPV4 ON)
+  else()
+    set (ENABLE_IPV4 OFF)
+  endif()
+  if (CONFIG_LIBCOAP_IPV6_SUPPORT)
+    set (ENABLE_IPV6 ON)
+  else()
+    set (ENABLE_IPV6 OFF)
+  endif()
+  if (CONFIG_LIBCOAP_WS_SOCKET)
+    set (ENABLE_WS ON)
+  else()
+    set (ENABLE_WS OFF)
+  endif()
+  if (CONFIG_LIBCOAP_ASYNC_SUPPORT)
+    set (ENABLE_ASYNC ON)
+  else()
+    set (ENABLE_ASYNC OFF)
+  endif()
+  if (CONFIG_LIBCOAP_Q_BLOCK_SUPPORT)
+    set (ENABLE_Q_BLOCK ON)
+  else()
+    set (ENABLE_Q_BLOCK OFF)
+  endif()
+
+  set (ENABLE_SMALL_STACK ON)
+  set (ENABLE_AF_UNIX OFF)
+  set (WITH_EPOLL OFF)
+  set (ENABLE_TESTS OFF)
+  set (ENABLE_EXAMPLES OFF)
+  set (WARNING_TO_ERROR OFF)
+
+  if(CONFIG_MBEDTLS)
+    target_include_directories(mbedTLS INTERFACE ${ZEPHYR_LIBCOAP_MODULE_DIR}/include)
+  endif()
+
+  add_subdirectory(.. build)
+  target_compile_definitions(coap-3 PUBLIC WITH_ZEPHYR)
+  target_link_libraries(coap-3 PUBLIC zephyr_interface)
+  set_property(GLOBAL APPEND PROPERTY ZEPHYR_INTERFACE_LIBS coap-3)
+
+  target_link_libraries(app PUBLIC coap-3)
+endif()

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,185 @@
+# zephyr/Kconfig for libcoap
+#
+# Copyright (C) 2023-2024 Jon Shallow <supjps-libcoap@jpshallow.com>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This file is part of the CoAP library libcoap. Please see README for terms
+# of use.
+#
+###############################################################################
+
+menu "libcoap Settings"
+
+config LIBCOAP
+      bool "Enable libcoap"
+      help
+        This option enables libcoap as a Zephyr module.
+
+endmenu
+
+if LIBCOAP
+
+config LIBCOAP_IPV4_SUPPORT
+    bool "Enable IPv4 support within CoAP"
+    default y
+    help
+        Enable IPv4 functionality for CoAP.
+
+        If this option is disabled, redundant CoAP IPv4 code is removed.
+
+config LIBCOAP_IPV6_SUPPORT
+    bool "Enable IPv6 support within CoAP"
+    default y
+    help
+        Enable IPv6 functionality for CoAP.
+
+        If this option is disabled, redundant CoAP IPv6 code is removed.
+
+config LIBCOAP_TCP_SUPPORT
+    bool "Enable TCP support within CoAP"
+    default n
+    help
+        Enable TCP functionality for CoAP. This is required if TLS sessions
+        are to be used. Note that RIOT TCP support also needs to be enabled.
+
+        If this option is disabled, redundant CoAP TCP code is removed.
+
+config LIBCOAP_OSCORE_SUPPORT
+    bool "Enable OSCORE support within CoAP"
+    default n
+    help
+        Enable OSCORE functionality for CoAP.
+
+        If this option is disabled, redundant CoAP OSCORE code is removed.
+
+config LIBCOAP_OBSERVE_PERSIST
+    bool "Enable Observe persist support within CoAP"
+    default n
+    help
+        Enable Observe persist functionality for CoAP.
+
+        If this option is disabled, redundant CoAP Observe persist code is removed.
+
+config LIBCOAP_WS_SOCKET
+    bool "Enable WebSocket support within CoAP"
+    default n
+    help
+        Enable WebSocket functionality for CoAP.
+
+        If this option is disabled, redundant CoAP WebSocket code is removed.
+
+config LIBCOAP_Q_BLOCK_SUPPORT
+    bool "Enable Q-Block (RFC9177) support within CoAP"
+    default n
+    help
+        Enable Q-Block (RFC9177) functionality for CoAP.
+
+        If this option is disabled, redundant CoAP Q-Block code is removed.
+
+config LIBCOAP_ASYNC_SUPPORT
+    bool "Enable separate responses support within CoAP"
+    default y
+    help
+        Enable async separate responses functionality for CoAP.
+
+        If this option is disabled, redundent CoAP async separate responses code is removed.
+
+config LIBCOAP_CLIENT_SUPPORT
+    bool "Enable Client functionality within CoAP"
+    default n
+    help
+        Enable client functionality (ability to make requests and receive
+        responses) for CoAP. If the server is going to act as a proxy, then
+        this needs to be enabled to support the ongoing session going to
+        the next hop.
+
+        If this option is disabled, redundant CoAP client only code is
+        removed.
+        If both this option and LIBCOAP_SERVER_SUPPORT are disabled, then
+        both are automatically enabled for backwards compatability.
+
+config LIBCOAP_SERVER_SUPPORT
+    bool "Enable Server functionality within CoAP"
+    default n
+    help
+        Enable server functionality (ability to receive requests and send
+        responses) for CoAP.
+
+        If this option is disabled, redundant CoAP server only code is
+        removed.
+        If both this option and LIBCOAP_CLIENT_SUPPORT are disabled, then
+        both are automatically enabled for backwards compatability.
+
+if MBEDTLS
+
+config MBEDTLS_CIPHER_CCM_ENABLED
+    bool
+    default y
+config MBEDTLS_DEBUG
+    bool
+    default y
+config MBEDTLS_SERVER_NAME_INDICATION
+    bool
+    default y
+config MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+    bool
+    default y
+config MBEDTLS_ENTROPY_ENABLED
+    bool
+    default y
+config MBEDTLS_DTLS
+    bool
+    default y
+config MBEDTLS_SSL_DTLS_CONNECTION_ID
+    bool
+    default y
+config MBEDTLS_ZEPHYR_ENTROPY
+    bool
+    default y
+config MBEDTLS_TLS_VERSION_1_2
+    bool
+    default y
+config MBEDTLS_KEY_EXCHANGE_ALL_ENABLED
+    bool
+    default y
+config MBEDTLS_CIPHER_ALL_ENABLED
+    bool
+    default y
+config MBEDTLS_ECP_ALL_ENABLED
+    bool
+    default y
+config MBEDTLS_MAC_ALL_ENABLED
+    bool
+    default y
+config MBEDTLS_GENPRIME_ENABLED
+    bool
+    default y
+config MBEDTLS_HMAC_DRBG_ENABLED
+    bool
+    default y
+config MBEDTLS_ECDH_C
+    bool
+    default y
+config MBEDTLS_ECDSA_C
+    bool
+    default y
+config MBEDTLS_ECJPAKE_C
+    bool
+    default y
+config MBEDTLS_ECP_C
+    bool
+    default y
+config MBEDTLS_PEM_CERTIFICATE_FORMAT
+    bool
+    default y
+config MBEDTLS_SSL_EXTENDED_MASTER_SECRET
+    bool
+    default y
+
+endif # MBEDTLS
+
+module = LIBCOAP
+module-str = libcoap
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+endif # LIBCOAP

--- a/zephyr/config-mbedtls-libcoap.h
+++ b/zephyr/config-mbedtls-libcoap.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ * Copyright (c) 2017 Intel Corporation.
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * libcoap configuration for (D)TLS, manageable by Kconfig.
+ */
+
+#ifndef CONFIG_MBEDTLS_LIBCOAP_H
+#define CONFIG_MBEDTLS_LIBCOAP_H
+
+#ifndef MBEDTLS_TIMING_C
+#define MBEDTLS_TIMING_C
+#endif /* ! MBEDTLS_TIMING_C */
+
+#ifndef MBEDTLS_VERSION_C
+#define MBEDTLS_VERSION_C
+#endif /* ! MBEDTLS_VERSION_C */
+
+#endif /* CONFIG_MBEDTLS_LIBCOAP_H */

--- a/zephyr/libcoap.conf
+++ b/zephyr/libcoap.conf
@@ -1,0 +1,4 @@
+#
+CONFIG_MBEDTLS_USER_CONFIG_ENABLE=y
+CONFIG_MBEDTLS_USER_CONFIG_FILE="../zephyr/config-mbedtls-libcoap.h"
+#

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,5 @@
+name: libcoap
+
+build:
+  cmake: zephyr
+  kconfig: zephyr/Kconfig


### PR DESCRIPTION
zephyr/ Initial files added

Tested with
````
west build -p always -b native_posix samples/net/eth_native_posix -- -DCONF_FILE=prj.conf -DEXTRA_ZEPHYR_MODULES=//<libcoap path>/libcoap -DEXTRA_CONF_FILE=/<libcoap path>/libcoap/zephyr/libcoap.conf -DCONFIG_LIBCOAP=y
````
with `samples/net/eth_native_posix/src/main.c` updated to run a simple libcoap CoAP client.