### PR TITLE
OSCORE: Account for pseudo-token to prevent coap_pdu_resize

### DIFF
--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -494,7 +494,7 @@ coap_oscore_new_pdu_encrypted(coap_session_t *session,
   plain_pdu = coap_pdu_init(pdu->type,
                             pdu->code,
                             pdu->mid,
-                            pdu->used_size);
+                            pdu->used_size + 1 /* pseudo-token with actual code */);
   if (plain_pdu == NULL)
     goto error;
 


### PR DESCRIPTION
The memory that OSCORE reserves for accommodating the `plain_pdu` may be insufficient. This is because the subsequent `add_token` containing the unmasked code also consumes one byte. In effect, `coap_pdu_resize` may become necesary.