### PR TITLE
Fix inconsistent tokens received by other servers

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1583,7 +1583,7 @@ void
 coap_session_new_token(coap_session_t *session, size_t *len,
                        uint8_t *data) {
   *len = coap_encode_var_safe8(data,
-                               sizeof(session->tx_token), ++session->tx_token);
+                               sizeof(session->tx_token), session->tx_token++);
 }
 
 uint16_t


### PR DESCRIPTION
When use `coap-client` with -T command, the other server received inconsistent.
```
coap-client send token "aaa", the other server received "aab"
coap-client send token "obstoken", the other server received "obstokeo"
```