### PR TITLE
block.c: Report 4.08 for missing Block1 chunks of data

### DIFF
--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -2726,7 +2726,6 @@ coap_handle_request_put_block(coap_context_t *context,
         p->uri_path = coap_new_str_const(uri_path->s, uri_path->length);
       p->content_format = fmt;
       p->total_len = total;
-      p->amount_so_far = length;
       p->szx = block.szx;
       p->block_option = block_option;
       if (observe) {
@@ -2749,6 +2748,19 @@ coap_handle_request_put_block(coap_context_t *context,
         response->code = COAP_RESPONSE_CODE(408);
         goto free_lg_srcv;
       }
+#if COAP_Q_BLOCK_SUPPORT
+      if (block_option != COAP_OPTION_Q_BLOCK1) {
+#endif /* COAP_Q_BLOCK_SUPPORT */
+        if (offset > p->amount_so_far) {
+          coap_add_data(response, sizeof("Missing block")-1,
+                        (const uint8_t *)"Missing block");
+          response->code = COAP_RESPONSE_CODE(408);
+          goto free_lg_srcv;
+        }
+        p->amount_so_far += length;
+#if COAP_Q_BLOCK_SUPPORT
+      }
+#endif /* COAP_Q_BLOCK_SUPPORT */
 #if COAP_Q_BLOCK_SUPPORT
       if (block_option == COAP_OPTION_Q_BLOCK1) {
         if (total != p->total_len) {
@@ -2845,7 +2857,16 @@ coap_handle_request_put_block(coap_context_t *context,
                                                     block.aszx),
                                buf);
             response->code = COAP_RESPONSE_CODE(231);
-            goto skip_app_handler;
+          } else {
+#if COAP_Q_BLOCK_SUPPORT
+            if (block_option != COAP_OPTION_Q_BLOCK1) {
+#endif /* COAP_Q_BLOCK_SUPPORT */
+              coap_add_data(response, sizeof("Missing interim block")-1,
+                            (const uint8_t *)"Missing interim block");
+              response->code = COAP_RESPONSE_CODE(408);
+#if COAP_Q_BLOCK_SUPPORT
+            }
+#endif /* COAP_Q_BLOCK_SUPPORT */
           }
           goto skip_app_handler;
         }


### PR DESCRIPTION
Not applied to RFC9177 Q-Block1 missing blocks which are handled in a different way.

Follows RFC7959 Section 2.5

A server MAY
   also return a 4.08 error code for any (final or non-final) Block1
   transfer that is not in sequence;

To remove the requirement of an application having to do this if COAP_BLOCK_SINGLE_BODY is not set.