### PR TITLE
cmake_coap_config.h.in: Add missing HAVE_ definitions

### DIFF
--- a/cmake_coap_config.h.in
+++ b/cmake_coap_config.h.in
@@ -17,14 +17,8 @@
 #define _GNU_SOURCE
 #endif
 
-/* Define to 1 if you have <ws2tcpip.h> header file. */
-#cmakedefine HAVE_WS2TCPIP_H @HAVE_WS2TCPIP_H@
-
 /* Define to 1 if the system has small stack size. */
 #cmakedefine COAP_CONSTRAINED_STACK @COAP_CONSTRAINED_STACK@
-
-/* Define to 1 if you have <winsock2.h> header file. */
-#cmakedefine HAVE_WINSOCK2_H @HAVE_WINSOCK2_H@
 
 /* Define to 1 if the library has client support. */
 #cmakedefine COAP_CLIENT_SUPPORT @COAP_CLIENT_SUPPORT@
@@ -71,24 +65,6 @@
 /* Define to 1 to build with Q-Block (RFC 9177) support. */
 #cmakedefine COAP_Q_BLOCK_SUPPORT @COAP_Q_BLOCK_SUPPORT@
 
-/* Define to 1 if you have the <arpa/inet.h> header file. */
-#cmakedefine HAVE_ARPA_INET_H @HAVE_ARPA_INET_H@
-
-/* Define to 1 if you have the <assert.h> header file. */
-#cmakedefine HAVE_ASSERT_H @HAVE_ASSERT_H@
-
-/* Define to 1 if you have the <dlfcn.h> header file. */
-#cmakedefine HAVE_DLFCN_H @HAVE_DLFCN_H@
-
-/* Define to 1 if you have the `getaddrinfo' function. */
-#cmakedefine HAVE_GETADDRINFO @HAVE_GETADDRINFO@
-
-/* Define to 1 if you have the <inttypes.h> header file. */
-#cmakedefine HAVE_INTTYPES_H @HAVE_INTTYPES_H@
-
-/* Define to 1 if you have the <erno.h> header file. */
-#cmakedefine HAVE_ERRNO_H @HAVE_ERRNO_H@
-
 /* Define to 1 if the system has openssl */
 #cmakedefine COAP_WITH_LIBOPENSSL @COAP_WITH_LIBOPENSSL@
 
@@ -101,6 +77,42 @@
 /* Define to 1 if the system has libmbedtls */
 #cmakedefine COAP_WITH_LIBMBEDTLS @COAP_WITH_LIBMBEDTLS@
 
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#cmakedefine HAVE_ARPA_INET_H @HAVE_ARPA_INET_H@
+
+/* Define to 1 if you have the <assert.h> header file. */
+#cmakedefine HAVE_ASSERT_H @HAVE_ASSERT_H@
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+#cmakedefine HAVE_BYTESWAP_H @HAVE_BYTESWAP_H@
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#cmakedefine HAVE_DLFCN_H @HAVE_DLFCN_H@
+
+/* Define to 1 if you have the <sys/epoll.h> header file. */
+#cmakedefine HAVE_EPOLL_H @HAVE_EPOLL_H@
+
+/* Define to 1 if you have the <errno.h> header file. */
+#cmakedefine HAVE_ERRNO_H @HAVE_ERRNO_H@
+
+/* Define to 1 if you have the <float.h> header file. */
+#cmakedefine HAVE_FLOAT_H @HAVE_FLOAT_H@
+
+/* Define to 1 if you have the `getaddrinfo' function. */
+#cmakedefine HAVE_GETADDRINFO @HAVE_GETADDRINFO@
+
+/* Define to 1 if you have the `getrandom' function. */
+#cmakedefine HAVE_GETRANDOM @HAVE_GETRANDOM@
+
+/* Define to 1 if you have the <ifaddrs.h> header file. */
+#cmakedefine HAVE_IFADDRS_H @HAVE_IFADDRS_H@
+
+/* Define to 1 if you have the `if_nametoindex' function. */
+#cmakedefine HAVE_IF_NAMETOINDEX @HAVE_IF_NAMETOINDEX@
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H @HAVE_INTTYPES_H@
+
 /* Define to 1 if you have the <limits.h> header file. */
 #cmakedefine HAVE_LIMITS_H @HAVE_LIMITS_H@
 
@@ -112,9 +124,6 @@
 
 /* Define to 1 if you have the `memset' function. */
 #cmakedefine HAVE_MEMSET @HAVE_MEMSET@
-
-/* Define to 1 if you have the `if_nametoindex' function. */
-#cmakedefine HAVE_IF_NAMETOINDEX @HAVE_IF_NAMETOINDEX@
 
 /* Define to 1 if you have the <netdb.h> header file. */
 #cmakedefine HAVE_NETDB_H @HAVE_NETDB_H@
@@ -137,6 +146,12 @@
 /* Define to 1 if you have the `socket' function. */
 #cmakedefine HAVE_SOCKET @HAVE_SOCKET@
 
+/* Define to 1 if you have the <stdbool.h> header file. */
+#cmakedefine HAVE_STDBOOL_H @HAVE_STDBOOL_H@
+
+/* Define to 1 if you have the <stddef.h> header file. */
+#cmakedefine HAVE_STDDEF_H @HAVE_STDDEF_H@
+
 /* Define to 1 if you have the <stdint.h> header file. */
 #cmakedefine HAVE_STDINT_H @HAVE_STDINT_H@
 
@@ -158,9 +173,6 @@
 /* Define to 1 if you have the `strrchr' function. */
 #cmakedefine HAVE_STRRCHR @HAVE_STRRCHR@
 
-/* Define to 1 if you have the `getrandom' function. */
-#cmakedefine HAVE_GETRANDOM @HAVE_GETRANDOM@
-
 /* Define to 1 if you have the `randon' function. */
 #cmakedefine HAVE_RANDOM @HAVE_RANDOM@
 
@@ -176,6 +188,9 @@
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #cmakedefine HAVE_SYS_STAT_H @HAVE_SYS_STAT_H@
 
+/* Define to 1 if you have the <sys/sysctl.h> header file. */
+#cmakedefine HAVE_SYS_SYSCTL_H @HAVE_SYS_SYSCTL_H@
+
 /* Define to 1 if you have the <sys/time.h> header file. */
 #cmakedefine HAVE_SYS_TIME_H @HAVE_SYS_TIME_H@
 
@@ -188,8 +203,17 @@
 /* Define to 1 if you have the <time.h> header file. */
 #cmakedefine HAVE_TIME_H @HAVE_TIME_H@
 
+/* Define to 1 if you have the <sys/timerfd.h> header file. */
+#cmakedefine HAVE_TIMERFD_H @HAVE_TIMERFD_H@
+
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD_H @HAVE_UNISTD_H@
+
+/* Define to 1 if you have <winsock2.h> header file. */
+#cmakedefine HAVE_WINSOCK2_H @HAVE_WINSOCK2_H@
+
+/* Define to 1 if you have <ws2tcpip.h> header file. */
+#cmakedefine HAVE_WS2TCPIP_H @HAVE_WS2TCPIP_H@
 
 /* Define to the address where bug reports for this package should be sent. */
 #cmakedefine PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"


### PR DESCRIPTION
HAVE_ entries sorted to aid future additions.