### PR TITLE
Client fails to ACK a retransmitted CON message

### DIFF
--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -210,6 +210,8 @@ struct coap_session_t {
                                        been processed */
   coap_mid_t last_con_mid;        /**< The last CON mid that has been
                                        been processed */
+  coap_response_t last_con_handler_res; /**< The result of calling the response handler
+                                       of the last CON */
 };
 
 #if COAP_SERVER_SUPPORT

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -3434,7 +3434,11 @@ handle_response(coap_context_t *context, coap_session_t *session,
   if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
     if (rcvd->type == COAP_MESSAGE_CON) {
       if (rcvd->mid == session->last_con_mid) {
-        /* Duplicate response */
+        /* Duplicate response: send ACK/RST, but don't process */
+        if (session->last_con_handler_res == COAP_RESPONSE_OK)
+          coap_send_ack(session, rcvd);
+        else
+          coap_send_rst(session, rcvd);
         return;
       }
       session->last_con_mid = rcvd->mid;
@@ -3512,11 +3516,14 @@ handle_response(coap_context_t *context, coap_session_t *session,
                                                      rcvd->mid));
     if (ret == COAP_RESPONSE_FAIL && rcvd->type != COAP_MESSAGE_ACK) {
       coap_send_rst(session, rcvd);
+      session->last_con_handler_res = COAP_RESPONSE_FAIL;
     } else {
       coap_send_ack(session, rcvd);
+      session->last_con_handler_res = COAP_RESPONSE_OK;
     }
   } else {
     coap_send_ack(session, rcvd);
+    session->last_con_handler_res = COAP_RESPONSE_OK;
   }
 }
 #endif /* COAP_CLIENT_SUPPORT */

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -449,6 +449,7 @@ coap_make_session(coap_proto_t proto, coap_session_type_t type,
   session->last_ping_mid = COAP_INVALID_MID;
   session->last_ack_mid = COAP_INVALID_MID;
   session->last_con_mid = COAP_INVALID_MID;
+  session->last_con_handler_res = COAP_RESPONSE_OK;
   session->max_token_size = context->max_token_size; /* RFC8974 */
   if (session->type != COAP_SESSION_TYPE_CLIENT)
     session->max_token_checked = COAP_EXT_T_CHECKED;


### PR DESCRIPTION
This fixes the issue of a client not ACKing a duplicate CON message from the server.
A duplicate CON message is sent by the server if the client's ACK to the original confirmable message did not reach it.
See issue #1306 for full description.