### PR TITLE
Use `grep -E` instead of deprecated `egrep`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -67,11 +67,11 @@ If get_config,sh exists, please copy the output from (do in the top level libcoa
 ```
 Else if using ./configure, please copy the output from (do in the top level libcoap directory) :-
 ```
-cat config.log | egrep "result:   |      libcoap|      host s" | cut -d\  -f3-
+cat config.log | grep -E "result:   |      libcoap|      host s" | cut -d\  -f3-
 ```
 Else if using cmake, please copy the output from (do in the cmake build directory) :-
 ```
-cmake -LH . | cut -d\  -f2- | egrep "\.\." | egrep "^[A-Z][A-Z]"
+cmake -LH . | cut -d\  -f2- | grep -E "\.\." | grep -E "^[A-Z][A-Z]"
 ```
 Else please copy the output from (do from within the libcoap directory) :-
 ```

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -82,10 +82,10 @@ man-page-build: upg-page-build man-page-start
 	##
 	for FILE in $${MAN_FILES} ; do \
 		BASE=`basename $${FILE} | cut -d. -f 1` ;\
-		MANUAL=`egrep -B 1 "^====" $${FILE} | head -1` ;\
-		SUMMARY=`egrep -B 2 "^SYNOPSIS" $${FILE} | ${SED} 's/coap-//g' | cut -d\- -f2 | cut -c2- | head -1` ;\
+		MANUAL=`${EGREP} -B 1 "^====" $${FILE} | head -1` ;\
+		SUMMARY=`${EGREP} -B 2 "^SYNOPSIS" $${FILE} | ${SED} 's/coap-//g' | cut -d\- -f2 | cut -c2- | head -1` ;\
 		if [ -z "$${SUMMARY}" ] ; then \
-			SUMMARY=`egrep -B 2 "^DESCRIPTION" $${FILE} | ${SED} 's/coap-//g' | cut -d\- -f2 | cut -c2- | head -1` ;\
+			SUMMARY=`${EGREP} -B 2 "^DESCRIPTION" $${FILE} | ${SED} 's/coap-//g' | cut -d\- -f2 | cut -c2- | head -1` ;\
 		fi ;\
 		##
 		## Fix and copy .html file across
@@ -126,7 +126,7 @@ man-page-build: upg-page-build man-page-start
 	echo '     <tab  type="usergroup" visible="yes" url="@ref man_individual" title="Individual Man Pages">' >> $(top_builddir)/doc/insert_file ;\
 	for FILE in $${MAN3_FILES} ; do \
 		BASE=`basename $${FILE} | cut -d. -f 1` ;\
-		LIST=`${SED} -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $${FILE} | ${SED} -ne '/coap_/{ s/ *, *//g ; p }' | egrep -v "^$${BASE}$$"` ;\
+		LIST=`${SED} -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $${FILE} | ${SED} -ne '/coap_/{ s/ *, *//g ; p }' | ${EGREP} -v "^$${BASE}$$"` ;\
 		for ENTRY in $${LIST} ; do \
 			MANUAL="$${ENTRY}(3)" ;\
 			## Build the manual insert page

--- a/examples/oscore_testcases.sh
+++ b/examples/oscore_testcases.sh
@@ -126,9 +126,9 @@ timecheck () {
 
 NO_PASS=0
 NO_FAIL=0
-# passfail count egrep-expression
+# passfail count grep-expression
 passfail () {
-  PASS=`cat /tmp/client_out | egrep "$2" | wc -l`
+  PASS=`cat /tmp/client_out | grep -E "$2" | wc -l`
   if [ "$PASS" = "$1" ] ; then
     echo Pass
     let "NO_PASS=$NO_PASS+1"
@@ -139,7 +139,7 @@ passfail () {
   if [ "$FULL_LOGS" = yes ] ; then
     cat /tmp/client_out
   elif [ "$PARTIAL_LOGS" = yes ] ; then
-    cat /tmp/client_out | egrep -v " DEBG | OSC  "
+    cat /tmp/client_out | grep -E -v " DEBG | OSC  "
   fi
 }
 
@@ -155,7 +155,7 @@ fi
 
 if [ "$SERVERS_ONLY" = yes ] ; then
   echo Servers are running, output in /tmp/server_b, /tmp/server_d, and /tmp/server_n
-  ps -ef | grep oscore-interop-server | egrep -v "grep "
+  ps -ef | grep oscore-interop-server | grep -E -v "grep "
   exit 0
 fi
 
@@ -165,7 +165,7 @@ rm -f /tmp/client_c
 
 # Test 0 General checkout
 echo -n "Test 0 - "
-timecheck 10 $CLIENT -w -v8 coap://$TARGET_IP:$S_PORT_B/oscore/hello/coap 2>&1 | egrep -v " DEBG | OSC  " > /tmp/client_out
+timecheck 10 $CLIENT -w -v8 coap://$TARGET_IP:$S_PORT_B/oscore/hello/coap 2>&1 | grep -E -v " DEBG | OSC  " > /tmp/client_out
 passfail 1 "^Hello World"
 
 # Test 1

--- a/get_config.sh
+++ b/get_config.sh
@@ -8,8 +8,8 @@ TAGS=0
 if [ -f config.log ] ; then
   echo "Last ./configure build"
   echo ""
-  cat config.log | egrep "      libcoap|      host s" | cut -d\  -f7-
-  cat config.log | egrep "result:   " | cut -d\  -f3- | cut -d\  -f7-
+  cat config.log | grep -E "      libcoap|      host s" | cut -d\  -f7-
+  cat config.log | grep -E "result:   " | cut -d\  -f3- | cut -d\  -f7-
   echo ""
   TAGS=1
 fi
@@ -17,7 +17,7 @@ for f in `find . -name CMakeCache.txt -print` ; do
   DIR=`dirname $f`
   echo "Last cmake build in $DIR"
   echo ""
-  (cd $DIR ; cmake -LH . | cut -d\  -f2- | egrep "\.\." | egrep "^[A-Z][A-Z]")
+  (cd $DIR ; cmake -LH . | cut -d\  -f2- | grep -E "\.\." | grep -E "^[A-Z][A-Z]")
   echo ""
   TAGS=1
 done

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -69,12 +69,12 @@ man7_MANS = $(MAN7)
 
 .txt.3:
 	$(A2X) --doctype manpage --format manpage $<
-	@NEWLIST=`${SED} -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $< | ${SED} 's/^- /\\\\\\\- /g' | egrep -v 'NAME|----|SYNOPSIS|^\$$' | tr '\n' ' '` ;\
+	@NEWLIST=`${SED} -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $< | ${SED} 's/^- /\\\\\\\- /g' | ${EGREP} -v 'NAME|----|SYNOPSIS|^\$$' | tr '\n' ' '` ;\
 	NAME=`echo $< | ${SED} -ne 's/^\(coap_[a-zA-Z_0-9]\+\).*$$/\1.3/p'` ;\
 	${SED} -i '/.SH "NAME"/{n;d;}' $${NAME} ;\
 	${SED} -i "/\.SH \"NAME\"/a $${NEWLIST}" $${NAME}
 	$(A2X) --doctype manpage --format xhtml $<
-	@NEWLIST=`${SED} -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $< | ${SED} 's^/^\\\\/^g' | egrep -v 'NAME|----|SYNOPSIS|^\$$' | tr '\n' ' '` ;\
+	@NEWLIST=`${SED} -ne '/^NAME/,/^SYNOPSIS/p;/^SYNOPSIS/q' $< | ${SED} 's^/^\\\\/^g' | ${EGREP} -v 'NAME|----|SYNOPSIS|^\$$' | tr '\n' ' '` ;\
 	NAME=`echo $< | ${SED} -ne 's/^\(coap_[a-zA-Z_0-9]\+\).*$$/\1.html/p'` ;\
 	${SED} -i "s^Name</h2><p>.*</p></div>^Name</h2><p>$${NEWLIST}</p></div>^" $${NAME}
 


### PR DESCRIPTION
When building libcoap, the following warning is printed many times:
```
egrep: warning: egrep is obsolescent; using grep -E
```

This is because `egrep` is [deprecated](https://git.savannah.gnu.org/gitweb/?p=grep.git;a=blobdiff;f=NEWS;h=4a62fb7ff21168ca274c7ac9dda508f9eb219190;hp=39a0903829a92c4363b9e06f8adb0d14320b3a19;hb=a9515624709865d480e3142fd959bccd1c9372d1;hpb=e87ccc7038d4f44f4601b3e8775fef09b1420dff). (deprecated in grep 2.5.3, warning since grep 3.8)

This PR replaces `egrep` with `grep -E`.