### PR TITLE
coap_netif.c: Update incoming packet addresses earlier for any logging

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -1889,8 +1889,7 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
         coap_session_disconnected(session, COAP_NACK_ICMP_ISSUE);
     } else if (bytes_read > 0) {
       session->last_rx_tx = now;
-      memcpy(&session->addr_info, &packet->addr_info,
-             sizeof(session->addr_info));
+      /* coap_netif_dgrm_read() updates session->addr_info from packet->addr_info */
       coap_handle_dgram_for_proto(ctx, session, packet);
     }
 #if !COAP_DISABLE_TCP

--- a/src/coap_netif.c
+++ b/src/coap_netif.c
@@ -82,6 +82,8 @@ coap_netif_dgrm_read(coap_session_t *session, coap_packet_t *packet) {
     errno = keep_errno;
   } else if (bytes_read > 0) {
     coap_ticks(&session->last_rx_tx);
+    memcpy(&session->addr_info, &packet->addr_info,
+           sizeof(session->addr_info));
     coap_log_debug("*  %s: netif: recv %4zd bytes\n",
                    coap_session_str(session), bytes_read);
   }


### PR DESCRIPTION
Update session->addr_info from packet->addr_info before logging incoming packet.  Only seen on the first incoming packet for a client as subsequent packets likely to be the same address..