### PR TITLE
ESP32: Add platform support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1120,6 +1120,11 @@ case $host in
     LIBS="${LIBS} -lws2_32"
     ;;
 
+    *xtensa-esp32-elf*)
+    AC_MSG_RESULT([XtensaEsp32Elf])
+    ADDITIONAL_CFLAGS="-D_GNU_SOURCE -DWITH_POSIX"
+    ;;
+
     *)
     AC_MSG_WARN([==> Currently unsupported operating system '${host}' !])
     AC_MSG_ERROR([==> If you can provide patches to support your operating system please write to 'libcoap-developers@lists.sourceforge.net'.])


### PR DESCRIPTION
This allows the configuration of Libcoap for Expressif ESP32.

LE: I didn't do an exhaustive check related to the full support for adding a platform, but this helped me to configure Libcoap for ESP32.