### PR TITLE
QNX: Add in build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,8 @@ check_function_exists(if_nametoindex HAVE_IF_NAMETOINDEX)
 if(WIN32 AND NOT MINGW)
   set(HAVE_STRUCT_CMSGHDR 1)
   message(STATUS "setting HAVE_STRUCT_CMSGHDR")
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL QNX)
+  set(HAVE_STRUCT_CMSGHDR 0)
 else()
   check_symbol_exists(
     CMSG_FIRSTHDR

--- a/configure.ac
+++ b/configure.ac
@@ -1120,6 +1120,11 @@ case $host in
     LIBS="${LIBS} -lws2_32"
     ;;
 
+    *-qnx*)
+    AC_MSG_RESULT([QNX])
+    ADDITIONAL_CFLAGS="-D_QNX_SOURCE"
+    ;;
+
     *xtensa-esp32-elf*)
     AC_MSG_RESULT([XtensaEsp32Elf])
     ADDITIONAL_CFLAGS="-D_GNU_SOURCE -DWITH_POSIX"

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -794,7 +794,7 @@ static __declspec(thread) LPFN_WSARECVMSG lpWSARecvMsg = NULL;
 #define iov_len_t size_t
 #endif
 
-#if defined(_CYGWIN_ENV)
+#if defined(_CYGWIN_ENV) || defined(__QNXNTO__)
 #define ipi_spec_dst ipi_addr
 #endif
 

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4333,6 +4333,7 @@ coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
                         "cannot get interface index for '%s'\n",
                         ifname);
         }
+#elif defined(__QNXNTO__)
 #else /* !HAVE_IF_NAMETOINDEX */
         result = ioctl(ctx->endpoint->sock.fd, SIOCGIFINDEX, &ifr);
         if (result != 0) {


### PR DESCRIPTION
Support compiling QNX 7 SDK.

Replaces #1334.  Changes are identical.