### PR TITLE
coap_config.h*: Make the various OS coap_config.h more consistent

### DIFF
--- a/coap_config.h.contiki.in
+++ b/coap_config.h.contiki.in
@@ -99,32 +99,32 @@
 
 #ifndef PACKAGE_BUGREPORT
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "libcoap-developers@lists.sourceforge.net"
+#define PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
 #endif /* PACKAGE_BUGREPORT */
 
 #ifndef PACKAGE_NAME
 /* Define to the full name of this package. */
-#define PACKAGE_NAME "libcoap"
+#define PACKAGE_NAME "@PACKAGE_NAME@"
 #endif /* PACKAGE_NAME */
 
 #ifndef PACKAGE_STRING
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libcoap 4.3.4"
+#define PACKAGE_STRING "@PACKAGE_STRING@"
 #endif /* PACKAGE_STRING */
 
 #ifndef PACKAGE_TARNAME
 /* Define to the one symbol short name of this package. */
-#define PACKAGE_TARNAME "libcoap"
+#define PACKAGE_TARNAME "@PACKAGE_TARNAME@"
 #endif /* PACKAGE_TARNAME */
 
 #ifndef PACKAGE_URL
 /* Define to the home page for this package. */
-#define PACKAGE_URL "https://libcoap.net/"
+#define PACKAGE_URL "@PACKAGE_URL@"
 #endif /* PACKAGE_URL */
 
 #ifndef PACKAGE_VERSION
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3.4"
+#define PACKAGE_VERSION "@PACKAGE_VERSION@"
 #endif /* PACKAGE_VERSION */
 
 #define WITH_CONTIKI 1

--- a/coap_config.h.riot
+++ b/coap_config.h.riot
@@ -1,6 +1,10 @@
 /*
  * coap_config.h.riot -- RIOT configuration for libcoap
  *
+ * [coap_config.h.riot is re-built from coap_config.h.riot.in by the
+ *  libcoap ./configure command, so make any permanent changes to libcoap's
+ *  coap_config.h.riot.in for a libcoap Pull Request]
+ *
  * Copyright (C) 2021-2024 Olaf Bergmann <bergmann@tzi.org> and others
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -346,17 +350,35 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H 1
 
+#ifndef PACKAGE_BUGREPORT
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "libcoap-developers@lists.sourceforge.net"
+#endif /* PACKAGE_BUGREPORT */
 
+#ifndef PACKAGE_NAME
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "libcoap"
+#endif /* PACKAGE_NAME */
 
-/* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3.4"
-
+#ifndef PACKAGE_STRING
 /* Define to the full name and version of this package. */
 #define PACKAGE_STRING "libcoap 4.3.4"
+#endif /* PACKAGE_STRING */
+
+#ifndef PACKAGE_TARNAME
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libcoap"
+#endif /* PACKAGE_TARNAME */
+
+#ifndef PACKAGE_URL
+/* Define to the home page for this package. */
+#define PACKAGE_URL "https://libcoap.net/"
+#endif /* PACKAGE_URL */
+
+#ifndef PACKAGE_VERSION
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "4.3.4"
+#endif /* PACKAGE_VERSION */
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1

--- a/coap_config.h.riot.in
+++ b/coap_config.h.riot.in
@@ -1,6 +1,10 @@
 /*
  * coap_config.h.riot -- RIOT configuration for libcoap
  *
+ * [coap_config.h.riot is re-built from coap_config.h.riot.in by the
+ *  libcoap ./configure command, so make any permanent changes to libcoap's
+ *  coap_config.h.riot.in for a libcoap Pull Request]
+ *
  * Copyright (C) 2021-2024 Olaf Bergmann <bergmann@tzi.org> and others
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -346,17 +350,35 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #define HAVE_UNISTD_H 1
 
+#ifndef PACKAGE_BUGREPORT
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
+#endif /* PACKAGE_BUGREPORT */
 
+#ifndef PACKAGE_NAME
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "@PACKAGE_NAME@"
+#endif /* PACKAGE_NAME */
 
-/* Define to the version of this package. */
-#define PACKAGE_VERSION "@PACKAGE_VERSION@"
-
+#ifndef PACKAGE_STRING
 /* Define to the full name and version of this package. */
 #define PACKAGE_STRING "@PACKAGE_STRING@"
+#endif /* PACKAGE_STRING */
+
+#ifndef PACKAGE_TARNAME
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "@PACKAGE_TARNAME@"
+#endif /* PACKAGE_TARNAME */
+
+#ifndef PACKAGE_URL
+/* Define to the home page for this package. */
+#define PACKAGE_URL "@PACKAGE_URL@"
+#endif /* PACKAGE_URL */
+
+#ifndef PACKAGE_VERSION
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@PACKAGE_VERSION@"
+#endif /* PACKAGE_VERSION */
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1

--- a/coap_config.h.windows
+++ b/coap_config.h.windows
@@ -1,6 +1,10 @@
 /*
  * coap_config.h.windows -- Windows configuration for libcoap
  *
+ * [coap_config.h.windows is re-built from coap_config.h.windows.in by the
+ *  libcoap ./configure command, so make any permanent changes to libcoap's
+ *  coap_config.h.windows.in for a libcoap Pull Request]
+ *
  * Copyright (C) 2017-2024 Olaf Bergmann <bergmann@tzi.org> and others
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -148,23 +152,35 @@
 #define COAP_THREAD_RECURSIVE_CHECK 0
 #endif
 
+#ifndef PACKAGE_BUGREPORT
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "libcoap-developers@lists.sourceforge.net"
+#endif /* PACKAGE_BUGREPORT */
 
+#ifndef PACKAGE_NAME
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "libcoap"
+#endif /* PACKAGE_NAME */
 
+#ifndef PACKAGE_STRING
 /* Define to the full name and version of this package. */
 #define PACKAGE_STRING "libcoap 4.3.4"
+#endif /* PACKAGE_STRING */
 
+#ifndef PACKAGE_TARNAME
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libcoap"
+#endif /* PACKAGE_TARNAME */
 
+#ifndef PACKAGE_URL
 /* Define to the home page for this package. */
 #define PACKAGE_URL "https://libcoap.net/"
+#endif /* PACKAGE_URL */
 
+#ifndef PACKAGE_VERSION
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "4.3.4"
+#endif /* PACKAGE_VERSION */
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1

--- a/coap_config.h.windows.in
+++ b/coap_config.h.windows.in
@@ -1,6 +1,10 @@
 /*
  * coap_config.h.windows -- Windows configuration for libcoap
  *
+ * [coap_config.h.windows is re-built from coap_config.h.windows.in by the
+ *  libcoap ./configure command, so make any permanent changes to libcoap's
+ *  coap_config.h.windows.in for a libcoap Pull Request]
+ *
  * Copyright (C) 2017-2024 Olaf Bergmann <bergmann@tzi.org> and others
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -148,23 +152,35 @@
 #define COAP_THREAD_RECURSIVE_CHECK 0
 #endif
 
+#ifndef PACKAGE_BUGREPORT
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
+#endif /* PACKAGE_BUGREPORT */
 
+#ifndef PACKAGE_NAME
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "@PACKAGE_NAME@"
+#endif /* PACKAGE_NAME */
 
+#ifndef PACKAGE_STRING
 /* Define to the full name and version of this package. */
 #define PACKAGE_STRING "@PACKAGE_STRING@"
+#endif /* PACKAGE_STRING */
 
+#ifndef PACKAGE_TARNAME
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "@PACKAGE_TARNAME@"
+#endif /* PACKAGE_TARNAME */
 
+#ifndef PACKAGE_URL
 /* Define to the home page for this package. */
 #define PACKAGE_URL "@PACKAGE_URL@"
+#endif /* PACKAGE_URL */
 
+#ifndef PACKAGE_VERSION
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "@PACKAGE_VERSION@"
+#endif /* PACKAGE_VERSION */
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1

--- a/configure.ac
+++ b/configure.ac
@@ -1151,6 +1151,7 @@ CFLAGS="$CFLAGS $ADDITIONAL_CFLAGS"
 #
 AC_CONFIG_FILES([
 Makefile
+coap_config.h.contiki
 coap_config.h.riot
 coap_config.h.windows
 doc/Makefile

--- a/examples/lwip/config/coap_config.h
+++ b/examples/lwip/config/coap_config.h
@@ -1,5 +1,9 @@
 /*
- * coap_config.h.lwip -- LwIP configuration for libcoap
+ * coap_config.h -- LwIP configuration for libcoap
+ *
+ * [coap_config.h is re-built from coap_config.h.in by the
+ *  libcoap ./configure command, so make any permanent changes to libcoap's
+ *  examples/lwip/config/coap_config.h.in for a libcoap Pull Request]
  *
  * Copyright (C) 2021-2024 Olaf Bergmann <bergmann@tzi.org> and others
  *
@@ -70,17 +74,35 @@
 #define COAP_THREAD_RECURSIVE_CHECK 0
 #endif
 
+#ifndef PACKAGE_BUGREPORT
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "libcoap-developers@lists.sourceforge.net"
+#endif /* PACKAGE_BUGREPORT */
+
 #ifndef PACKAGE_NAME
+/* Define to the full name of this package. */
 #define PACKAGE_NAME "libcoap"
 #endif /* PACKAGE_NAME */
 
-#ifndef PACKAGE_VERSION
-#define PACKAGE_VERSION "4.3.4"
-#endif /* PACKAGE_VERSION */
-
 #ifndef PACKAGE_STRING
+/* Define to the full name and version of this package. */
 #define PACKAGE_STRING "libcoap 4.3.4"
 #endif /* PACKAGE_STRING */
+
+#ifndef PACKAGE_TARNAME
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libcoap"
+#endif /* PACKAGE_TARNAME */
+
+#ifndef PACKAGE_URL
+/* Define to the home page for this package. */
+#define PACKAGE_URL "https://libcoap.net/"
+#endif /* PACKAGE_URL */
+
+#ifndef PACKAGE_VERSION
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "4.3.4"
+#endif /* PACKAGE_VERSION */
 
 #ifndef assert
 #define assert(x) LWIP_ASSERT("CoAP assert failed", x)

--- a/examples/lwip/config/coap_config.h.in
+++ b/examples/lwip/config/coap_config.h.in
@@ -1,5 +1,9 @@
 /*
- * coap_config.h.lwip -- LwIP configuration for libcoap
+ * coap_config.h -- LwIP configuration for libcoap
+ *
+ * [coap_config.h is re-built from coap_config.h.in by the
+ *  libcoap ./configure command, so make any permanent changes to libcoap's
+ *  examples/lwip/config/coap_config.h.in for a libcoap Pull Request]
  *
  * Copyright (C) 2021-2024 Olaf Bergmann <bergmann@tzi.org> and others
  *
@@ -70,17 +74,35 @@
 #define COAP_THREAD_RECURSIVE_CHECK 0
 #endif
 
+#ifndef PACKAGE_BUGREPORT
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
+#endif /* PACKAGE_BUGREPORT */
+
 #ifndef PACKAGE_NAME
+/* Define to the full name of this package. */
 #define PACKAGE_NAME "@PACKAGE_NAME@"
 #endif /* PACKAGE_NAME */
 
-#ifndef PACKAGE_VERSION
-#define PACKAGE_VERSION "@PACKAGE_VERSION@"
-#endif /* PACKAGE_VERSION */
-
 #ifndef PACKAGE_STRING
+/* Define to the full name and version of this package. */
 #define PACKAGE_STRING "@PACKAGE_STRING@"
 #endif /* PACKAGE_STRING */
+
+#ifndef PACKAGE_TARNAME
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "@PACKAGE_TARNAME@"
+#endif /* PACKAGE_TARNAME */
+
+#ifndef PACKAGE_URL
+/* Define to the home page for this package. */
+#define PACKAGE_URL "@PACKAGE_URL@"
+#endif /* PACKAGE_URL */
+
+#ifndef PACKAGE_VERSION
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@PACKAGE_VERSION@"
+#endif /* PACKAGE_VERSION */
 
 #ifndef assert
 #define assert(x) LWIP_ASSERT("CoAP assert failed", x)

--- a/src/coap_mem.c
+++ b/src/coap_mem.c
@@ -278,6 +278,7 @@ static memarray_t resource_storage;
 
 #ifdef COAP_WITH_LIBTINYDTLS
 #undef PACKAGE_BUGREPORT
+#undef PACKAGE_URL
 #include <session.h>
 static session_t dtls_storage_data[COAP_MAX_DTLS_SESSIONS];
 static memarray_t dtls_storage;


### PR DESCRIPTION
Add in coap_config.h.contiki.in to aid versioning updates.

Make the PACKAGE_ definitions consistent.