### PR TITLE
coap_net.c: Response PDU not set to CON if reliable protocol

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -3137,6 +3137,9 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
   if (async && pdu->type == COAP_MESSAGE_CON)
     response->type = COAP_MESSAGE_CON;
 #endif /* COAP_ASYNC_SUPPORT */
+  /* A lot of the reliable code assumes type is CON */
+  if (COAP_PROTO_RELIABLE(session->proto) && response->type != COAP_MESSAGE_CON)
+    response->type = COAP_MESSAGE_CON;
 
   if (!coap_add_token(response, pdu->actual_token.length,
                       pdu->actual_token.s)) {


### PR DESCRIPTION
Fix generated response PDU in handle_request() to be of type CON if reliable protocol (as a lot of code assumes it to be of pseudo type CON) to stop a warning in coap_show_pdu().