### PR TITLE
Coverity: Fix 1583538, 1583565 and 1583573

### DIFF
--- a/tests/test_common.h.in
+++ b/tests/test_common.h.in
@@ -8,5 +8,8 @@
  * README for terms of use.
  */
 
+/* We need to treat these tests as being an user application */
+#define COAP_THREAD_IGNORE_LOCKED_MAPPING
+
 #include "coap@LIBCOAP_API_VERSION@/coap_internal.h"
 

--- a/tests/test_oscore.c
+++ b/tests/test_oscore.c
@@ -1029,10 +1029,6 @@ static int
 t_oscore_tests_create(void) {
   ctx = coap_new_context(NULL);
 
-  if (ctx != NULL) {
-    coap_lock_lock(ctx, return 1);
-  }
-
   return (ctx == NULL);
 }
 

--- a/tests/test_sendqueue.c
+++ b/tests/test_sendqueue.c
@@ -284,7 +284,6 @@ t_sendqueue_tests_create(void) {
   addr.addr.sin6.sin6_port = htons(COAP_DEFAULT_PORT);
 
   ctx = coap_new_context(&addr);
-  coap_lock_lock(ctx, return 1);
 
   addr.addr.sin6.sin6_addr = in6addr_loopback;
   session = coap_new_client_session(ctx, NULL, &addr, COAP_PROTO_UDP);
@@ -308,7 +307,10 @@ t_sendqueue_tests_create(void) {
     /* destroy all test nodes and set entry to zero */
     for (n = 0; n < sizeof(node)/sizeof(coap_queue_t *); n++) {
       if (node[n]) {
+        /* As coap_delete_node() is not in the Public API, need to lock */
+        coap_lock_lock(ctx, continue);
         coap_delete_node(node[n]);
+        coap_lock_unlock(ctx);
         node[n] = NULL;
       }
     }
@@ -324,7 +326,10 @@ t_sendqueue_tests_remove(void) {
   size_t n;
   for (n = 0; n < sizeof(node)/sizeof(coap_queue_t *); n++) {
     if (node[n]) {
+      /* As coap_delete_node() is not in the Public API, need to lock */
+      coap_lock_lock(ctx, continue);
       coap_delete_node(node[n]);
+      coap_lock_unlock(ctx);
       node[n] = NULL;
     }
   }

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -182,7 +182,6 @@ t_session_tests_create(void) {
   ctx = coap_new_context(&addr);
 
   if (ctx != NULL) {
-    coap_lock_lock(ctx, return 1);
     addr.addr.sin6.sin6_addr = in6addr_loopback;
     session = coap_new_client_session(ctx, NULL, &addr, COAP_PROTO_UDP);
   }

--- a/tests/test_wellknown.c
+++ b/tests/test_wellknown.c
@@ -200,7 +200,6 @@ t_wkc_tests_create(void) {
   addr.addr.sin6.sin6_port = htons(COAP_DEFAULT_PORT);
 
   ctx = coap_new_context(&addr);
-  coap_lock_lock(ctx, return 1);
 
   addr.addr.sin6.sin6_addr = in6addr_loopback;
   session = coap_new_client_session(ctx, NULL, &addr, COAP_PROTO_UDP);


### PR DESCRIPTION
For the test suite, treat these tests as using the public API so locking is handled by the underlying libcoap.

The only exception is for coap_delete_node() which is an internal function and expects context to be locked on entry.