### PR TITLE
coap_block.c: Handle Block1 packets with random order block numbers

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2177,7 +2177,7 @@ usage(const char *program, const char *version) {
           "\t       \t\tif the -A option is used\n"
           "\t-L value\tSum of one or more COAP_BLOCK_* flag valuess for block\n"
           "\t       \t\thandling methods. Default is 1 (COAP_BLOCK_USE_LIBCOAP)\n"
-          "\t       \t\t(Sum of one or more of 1,2,4 and 64)\n"
+          "\t       \t\t(Sum of one or more of 1,2,4 64 and 128)\n"
           "\t-N     \t\tMake \"observe\" responses NON-confirmable. Even if set\n"
           "\t       \t\tevery fifth response will still be sent as a confirmable\n"
           "\t       \t\tresponse (RFC 7641 requirement)\n"

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -509,7 +509,7 @@ init_resources(coap_context_t *ctx) {
   coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_separate);
 
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
-  coap_add_attr(r, coap_make_str_const("rt"), coap_make_str_const("seperate"), 0);
+  coap_add_attr(r, coap_make_str_const("rt"), coap_make_str_const("separate"), 0);
   coap_add_resource(ctx, r);
 }
 

--- a/include/coap3/coap_block.h
+++ b/include/coap3/coap_block.h
@@ -65,28 +65,9 @@ typedef struct {
 #define COAP_BLOCK_NO_PREEMPTIVE_RTAG 0x10 /* (cl) Don't use pre-emptive Request-Tags */
 #define COAP_BLOCK_STLESS_FETCH  0x20 /* (cl) Assume server supports stateless FETCH */
 #define COAP_BLOCK_STLESS_BLOCK2 0x40 /* (svr)Server is stateless for handling Block2 */
-
-#if COAP_Q_BLOCK_SUPPORT
-#define COAP_BLOCK_SET_MASK (COAP_BLOCK_USE_LIBCOAP | \
-                             COAP_BLOCK_SINGLE_BODY | \
-                             COAP_BLOCK_TRY_Q_BLOCK | \
-                             COAP_BLOCK_USE_M_Q_BLOCK | \
-                             COAP_BLOCK_NO_PREEMPTIVE_RTAG | \
-                             COAP_BLOCK_STLESS_FETCH | \
-                             COAP_BLOCK_STLESS_BLOCK2)
-#else /* ! COAP_Q_BLOCK_SUPPORT */
-#define COAP_BLOCK_SET_MASK (COAP_BLOCK_USE_LIBCOAP | \
-                             COAP_BLOCK_SINGLE_BODY | \
-                             COAP_BLOCK_NO_PREEMPTIVE_RTAG | \
-                             COAP_BLOCK_STLESS_FETCH | \
-                             COAP_BLOCK_STLESS_BLOCK2)
-#endif /* ! COAP_Q_BLOCK_SUPPORT */
-
-#define COAP_BLOCK_MAX_SIZE_MASK 0x700 /* (svr)Mask to get the max supported block size */
-#define COAP_BLOCK_MAX_SIZE_SHIFT 8    /* (svr)Mask shift to get the max supported block size */
-#define COAP_BLOCK_MAX_SIZE_GET(a) (((a) & COAP_BLOCK_MAX_SIZE_MASK) >> COAP_BLOCK_MAX_SIZE_SHIFT)
-#define COAP_BLOCK_MAX_SIZE_SET(a) (((a) << COAP_BLOCK_MAX_SIZE_SHIFT) & COAP_BLOCK_MAX_SIZE_MASK)
-/* Note 0x4000 and 0x8000 are internally defined elsewhere */
+#define COAP_BLOCK_NOT_RANDOM_BLOCK1 0x80 /* (svr)Disable server handling random order
+                                             block1 */
+/* WARNING: Added defined values must not encroach into 0xff000000 which are defined elsewhere */
 
 /**
  * Returns @c 1 if libcoap was built with option Q-BlockX support,

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -31,9 +31,32 @@
  */
 
 #if COAP_Q_BLOCK_SUPPORT
+#define COAP_BLOCK_SET_MASK (COAP_BLOCK_USE_LIBCOAP | \
+                             COAP_BLOCK_SINGLE_BODY | \
+                             COAP_BLOCK_TRY_Q_BLOCK | \
+                             COAP_BLOCK_USE_M_Q_BLOCK | \
+                             COAP_BLOCK_NO_PREEMPTIVE_RTAG | \
+                             COAP_BLOCK_STLESS_FETCH | \
+                             COAP_BLOCK_STLESS_BLOCK2 | \
+                             COAP_BLOCK_NOT_RANDOM_BLOCK1)
+#else /* ! COAP_Q_BLOCK_SUPPORT */
+#define COAP_BLOCK_SET_MASK (COAP_BLOCK_USE_LIBCOAP | \
+                             COAP_BLOCK_SINGLE_BODY | \
+                             COAP_BLOCK_NO_PREEMPTIVE_RTAG | \
+                             COAP_BLOCK_STLESS_FETCH | \
+                             COAP_BLOCK_STLESS_BLOCK2 | \
+                             COAP_BLOCK_NOT_RANDOM_BLOCK1)
+#endif /* ! COAP_Q_BLOCK_SUPPORT */
+
+#define COAP_BLOCK_MAX_SIZE_MASK 0x7000000 /* (svr)Mask to get the max supported block size */
+#define COAP_BLOCK_MAX_SIZE_SHIFT 24    /* (svr)Mask shift to get the max supported block size */
+#define COAP_BLOCK_MAX_SIZE_GET(a) (((a) & COAP_BLOCK_MAX_SIZE_MASK) >> COAP_BLOCK_MAX_SIZE_SHIFT)
+#define COAP_BLOCK_MAX_SIZE_SET(a) (((a) << COAP_BLOCK_MAX_SIZE_SHIFT) & COAP_BLOCK_MAX_SIZE_MASK)
+
+#if COAP_Q_BLOCK_SUPPORT
 /* Internal use only and are dropped when setting block_mode */
-#define COAP_BLOCK_HAS_Q_BLOCK   0x4000 /* Set when Q_BLOCK supported */
-#define COAP_BLOCK_PROBE_Q_BLOCK 0x8000 /* Set when Q_BLOCK probing */
+#define COAP_BLOCK_HAS_Q_BLOCK   0x40000000 /* Set when Q_BLOCK supported */
+#define COAP_BLOCK_PROBE_Q_BLOCK 0x80000000 /* Set when Q_BLOCK probing */
 
 #define set_block_mode_probe_q(block_mode) \
   do { \
@@ -179,6 +202,7 @@ struct coap_lg_srcv_t {
   uint8_t observe[3];    /**< Observe data (if set) (only 24 bits) */
   uint8_t observe_length;/**< Length of observe data */
   uint8_t observe_set;   /**< Set if this is an observe receive PDU */
+  uint8_t no_more_seen;  /**< Set if block with more not set seen */
   uint8_t rtag_set;      /**< Set if RTag is in receive PDU */
   uint8_t rtag_length;   /**< RTag length */
   uint8_t rtag[8];       /**< RTag for block checking */
@@ -187,13 +211,10 @@ struct coap_lg_srcv_t {
   uint8_t szx;           /**< size of individual blocks */
   size_t total_len;      /**< Length as indicated by SIZE1 option */
   coap_binary_t *body_data; /**< Used for re-assembling entire body */
-  size_t amount_so_far;  /**< Amount of data seen so far */
   coap_resource_t *resource; /**< associated resource */
   coap_str_const_t *uri_path; /** set to uri_path if unknown resource */
   coap_rblock_t rec_blocks; /** < list of received blocks */
-#if COAP_Q_BLOCK_SUPPORT
   coap_bin_const_t *last_token; /**< last used token */
-#endif /* COAP_Q_BLOCK_SUPPORT */
   coap_mid_t last_mid;   /**< Last received mid for this set of packets */
   coap_tick_t last_used; /**< Last time data sent or 0 */
   uint16_t block_option; /**< Block option in use */

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -113,10 +113,11 @@ OPTIONS - General
    Sum of one or more COAP_BLOCK_* flag values for different block handling
    methods. Default is 1 (COAP_BLOCK_USE_LIBCOAP).
 
-     COAP_BLOCK_USE_LIBCOAP    1
-     COAP_BLOCK_SINGLE_BODY    2
-     COAP_BLOCK_TRY_Q_BLOCK    4
-     COAP_BLOCK_STLESS_BLOCK2 64
+     COAP_BLOCK_USE_LIBCOAP         1
+     COAP_BLOCK_SINGLE_BODY         2
+     COAP_BLOCK_TRY_Q_BLOCK         4
+     COAP_BLOCK_STLESS_BLOCK2      64
+     COAP_BLOCK_NOT_RANDOM_BLOCK1 128
 
 *-N* ::
    Send NON-confirmable message for "observe" responses. If option *-N* is

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -109,7 +109,8 @@ In RAM constrained environments, option 2 may be the preferred method.
 This man page focuses on getting libcoap to do all the work, not how to do it
 all in the application.
 
-However, if the client supplies a Block1 or Block2 Option in the PDU where the
+However, if the client supplies a Block1 or Block2 Option in a GET request type
+PDU where the
 block number is not 0, this is assumed to be a random access request and any
 other blocks will not be requested by libcoap even if instructed otherwise.
 
@@ -157,6 +158,7 @@ session _block_mode_.
 #define COAP_BLOCK_NO_PREEMPTIVE_RTAG 0x10 /* (Client) Don't use pre-emptive Request-Tags */
 #define COAP_BLOCK_STLESS_FETCH  0x20 /* (Client) Assume server supports stateless FETCH */
 #define COAP_BLOCK_STLESS_BLOCK2 0x40 /* (Server) Server is stateless for Block2 transfers */
+#define COAP_BLOCK_NOT_RANDOM_BLOCK1 0x80 /* (Server) Disable server handling random order block1 */
 ----
 _block_mode_ is an or'd set of zero or more COAP_BLOCK_* definitions.
 
@@ -213,6 +215,14 @@ If *COAP_BLOCK_STLESS_BLOCK2* is set, then the server does not maintain state
 for any data returned that uses Block2 to split up the data chunks.
 The application is called for every request to get the complete set of data which
 is then split into the separate Block2 responses as appropriate.
+
+If *COAP_BLOCK_NOT_RANDOM_BLOCK1* is set, then the server does not allow any
+Block1 packets arriving in the wrong block number order by returning
+4.08 error codes. Normally this should not be set as networks can re-order
+the arrival of UDP packets, in particular this may happen if NON is being used
+for Block1 by the client.
+
+*NOTE:* This is ignored if Q-Block1 is being used.
 
 *Function: coap_context_set_max_block_size()*
 

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -3307,7 +3307,7 @@ skip_handler:
     if (COAP_RESPONSE_CLASS(response->code) > 2) {
       if (observe)
         coap_delete_observer(resource, session, &pdu->actual_token);
-      if (added_block)
+      if (response->code != COAP_RESPONSE_CODE(413))
         coap_remove_option(response, COAP_OPTION_BLOCK1);
     }
 


### PR DESCRIPTION
Add in new COAP_BLOCK_NOT_RANDOM_BLOCK1 option for coap_context_set_block_mode(). This disables receipt of any Block1 packet (but not Q-BLock1) if the block numbers are not sequentially received starting with 0.  A 4.08 code is returned for every packet out of order and its data is ignored.

If COAP_BLOCK_SINGLE_BODY is set in coap_context_set_block_mode(), but not COAP_BLOCK_NOT_RANDOM_BLOCK1, then all Block1 packets are assembled in the correct order before passing the body up to the application.  The receive logic will timeout after MAX_TRANSMIT_WAIT (93 seconds) if there are any missing blocks, or 10 seconds if the last block is seen.

If COAP_BLOCK_SINGLE_BODY is not set in coap_context_set_block_mode(), and not COAP_BLOCK_NOT_RANDOM_BLOCK1, then the random order packets are passed up to the application layer where it is the application's responsibility to decide what to do with the randomly ordered packets, and what response code to send.