### PR TITLE
OpenSSL: Add in support for configuring an alternative TLS ENGINE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1257,6 +1257,7 @@ man/coap-client.txt
 man/coap-oscore-conf.txt
 man/coap-server.txt
 man/coap-rd.txt
+man/coap-tls-engine-conf.txt
 man/Makefile
 tests/test_common.h
 tests/Makefile

--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -43,6 +43,18 @@
 #define COAP_DTLS_CID_LENGTH 6
 #endif
 
+typedef enum {
+  COAP_DEFINE_KEY_CA,
+  COAP_DEFINE_KEY_PUBLIC,
+  COAP_DEFINE_KEY_PRIVATE
+} coap_define_issue_key_t;
+
+typedef enum {
+  COAP_DEFINE_FAIL_BAD,
+  COAP_DEFINE_FAIL_NOT_SUPPORTED,
+  COAP_DEFINE_FAIL_NONE
+} coap_define_issue_fail_t;
+
 /**
  * Creates a new DTLS context for the given @p coap_context. This function
  * returns a pointer to a new DTLS context object or @c NULL on error.
@@ -442,6 +454,30 @@ void coap_dtls_shutdown(void);
 void *coap_dtls_get_tls(const coap_session_t *session,
                         coap_tls_library_t *tls_lib);
 
+/**
+ * Map the PKI key definitions to the new DEFINE format.
+ *
+ * @param setup_data The PKI definition.
+ * @param key Updated with the DEFINE format of the key definitions.
+ *
+ */
+void coap_dtls_map_key_type_to_define(const coap_dtls_pki_t *setup_data,
+                                      coap_dtls_key_t *key);
+
+/**
+ * Report PKI DEFINE type issue
+ *
+ * @param type The type of key with the issue.
+ * @param fail Why the key is failing
+ * @param key The key with the issue.
+ * @param role Whether this is for the CLient or Server.
+ *
+ * @return @c 0 as there is a failure.
+ */
+int coap_dtls_define_issue(coap_define_issue_key_t type,
+                           coap_define_issue_fail_t fail,
+                           coap_dtls_key_t *key,
+                           const coap_dtls_role_t role);
 /** @} */
 
 #endif /* COAP_DTLS_INTERNAL_H */

--- a/include/coap3/coap_str.h
+++ b/include/coap3/coap_str.h
@@ -67,6 +67,14 @@ typedef struct coap_bin_const_t {
 } coap_bin_const_t;
 
 /**
+ * CoAP union for handling signed / unsigned chars
+ */
+typedef union {
+  const char *s_byte;    /**< signed char ptr */
+  const uint8_t *u_byte; /**< unsigned char ptr */
+} coap_const_char_ptr_t;
+
+/**
  * Returns a new string object with at least size+1 bytes storage allocated.
  * It is the responsibility of the caller to fill in all the appropriate
  * information.

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -289,6 +289,8 @@ global:
   coap_ticks_from_rt_us;
   coap_ticks_to_rt;
   coap_ticks_to_rt_us;
+  coap_tls_engine_configure;
+  coap_tls_engine_remove;
   coap_tls_is_supported;
   coap_uri_into_options;
   coap_write_block_b_opt;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -287,6 +287,8 @@ coap_ticks
 coap_ticks_from_rt_us
 coap_ticks_to_rt
 coap_ticks_to_rt_us
+coap_tls_engine_configure
+coap_tls_engine_remove
 coap_tls_is_supported
 coap_uri_into_options
 coap_write_block_b_opt

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -55,7 +55,8 @@ man3_MANS = $(MAN3)
 TXT5 = coap-client.txt \
        coap-rd.txt \
        coap-server.txt \
-       coap-oscore-conf.txt
+       coap-oscore-conf.txt \
+       coap-tls-engine-conf.txt
 
 MAN5 = $(TXT5:%.txt=%.5)
 
@@ -204,6 +205,8 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_tls_library.3" > coap_string_tls_support.3
 	@echo ".so man3/coap_tls_library.3" > coap_string_tls_version.3
 	@echo ".so man3/coap_tls_library.3" > coap_show_tls_version.3
+	@echo ".so man3/coap_tls_library.3" > coap_tls_engine_configure.3
+	@echo ".so man3/coap_tls_library.3" > coap_tls_engine_remove.3
 	$(INSTALL_DATA) $(A2X_EXTRA_PAGES_3) "$(DESTDIR)$(man3dir)"
 	$(INSTALL_DATA) $(A2X_EXTRA_PAGES_5) "$(DESTDIR)$(man5dir)"
 

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -20,7 +20,8 @@ coap-client-notls
 SYNOPSIS
 --------
 *coap-client* [*-a* addr] [*-b* [num,]size] [*-e* text] [*-f* file] [*-l* loss]
-              [*-m* method] [*-o* file] [*-p* port] [*-r*] [*-s duration*]
+              [*-m* method] [*-o* file] [*-p* port] [*-q* tls_engine_conf_file]
+              [*-r*] [*-s duration*]
               [*-t* type] [*-v* num] [*-w*] [*-A* type] [*-B* seconds]
               [*-E* oscore_conf_file[,seq_file]] [*-G* count] [*-H* hoplimit]
               [*-K* interval] [*-L* value] [*-N*] [*-O* num,text]
@@ -93,6 +94,11 @@ OPTIONS - General
 
 *-p* port::
    The port to send from.
+
+*-q* tls_engine_conf_file::
+   'tls_engine_conf_file' contains TLS ENGINE configuration. Only OpenSSL
+   is currently supported.
+   See *coap-tls-engine-conf*(5) for definitions.
 
 *-r*::
    Use reliable protocol (TCP or TLS).

--- a/man/coap-oscore-conf.txt.in
+++ b/man/coap-oscore-conf.txt.in
@@ -6,7 +6,7 @@ coap-oscore-conf(5)
 :doctype: manpage
 :man source:   coap-oscore-conf
 :man version:  @PACKAGE_VERSION@
-:man manual:   Coap OSCORE configuration file format
+:man manual:   CoAP OSCORE configuration file format
 
 NAME
 -----

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -20,7 +20,7 @@ coap-server-notls
 SYNOPSIS
 --------
 *coap-server* [*-a* priority] [*-b* max_block_size] [*-d* max] [*-e*]
-              [*-g* group] [*-l* loss] [*-p* port]
+              [*-g* group] [*-l* loss] [*-p* port] [*-q* tls_engine_conf_file]
               [*-r*] [*-t*]  [*-v* num] [*-w* [port][,secure_port]]
               [*-A* address] [*-E* oscore_conf_file[,seq_file]]
               [*-G* group_if] [*-L* value] [*-N*]
@@ -76,6 +76,11 @@ OPTIONS - General
    If (D)TLS is supported, then 'port' + 1 will also be listened on for
    (D)TLS connections.
    The default port is 5683 if not given any other value.
+
+*-q* tls_engine_conf_file::
+   'tls_engine_conf_file' contains TLS ENGINE configuration. Only OpenSSL
+   is currently supported.
+   See *coap-tls-engine-conf*(5) for definitions.
 
 *-r* ::
    Enable multicast per resource support.  If enabled, only '/', '/async'

--- a/man/coap-tls-engine-conf.txt.in
+++ b/man/coap-tls-engine-conf.txt.in
@@ -1,0 +1,113 @@
+// -*- mode:doc; -*-
+// vim: set syntax=asciidoc tw=0
+
+coap-tls-engine-conf(5)
+=======================
+:doctype: manpage
+:man source:   coap-tls-engine-conf
+:man version:  @PACKAGE_VERSION@
+:man manual:   CoAP TLS ENGINE configuration file format
+
+NAME
+-----
+coap-tls-engine-conf
+- CoAP TLS ENGINE configuration file format
+
+DESCRIPTION
+-----------
+The TLS ENGINE configuration file is read in and installed when using the
+_*-q* tls_engine_conf_file_ option for the *coap-client*(5) or *coap-server*(5)
+executables. This then allows a client or server to use the defined TLS
+ENGINE to do the appropriate TLS functions.
+
+*NOTE:* Currently only OpenSSL is supported.
+
+It is also read in, parsed and installed by *coap_tls_engine_configure*(3).
+
+This configuration file can be a configuration held in memory, the formatting
+of the memory region is same as that for a file as if the file was mapped
+into memory. The *coap_tls_engine_configure*(3) function uses the memory
+version of the file.
+
+The configuration file comprises of a set of keywords, one per line. Each
+keyword has a parameter with an optional second parameter.
+
+The format of each line is one of (colon separated)
+
+[source, c]
+----
+keyword:parameter_1:parameter_2
+keyword:parameter_1
+----
+
+For _parameter_2_, this can be a zero length string.  If the preceding character
+to _parameter_2_ is not a colon, then _parameter_2_ is treated as NULL (as in the
+second example).
+
+The keywords and parameters are case sensitive.  If a line starts with a *#*,
+then it is treated as a comment line and so is ignored. Empty lines are also
+valid and ignored.
+
+The possible keywords are:
+
+*engine* ::
+    _parameter_1_ containes the ENGINE name (ID). _parameter_2_ is ignored.
+
+*pre-cmd* ::
+    _parameter_1_ is the command that are to be issued to the ENGINE logic before
+    the ENGINE is initialized. If the command has a parameter, this is passed
+    passed in from _parameter_2_.  Some commands do not have a _parameter_2_ which
+    usually is enforced by the ENGINE.
+
+*post-cmd* ::
+    _parameter_1_ is the command that are to be issued to the ENGINE logic after
+    the ENGINE is initialized. If the command has a parameter, this is passed
+    passed in from _parameter_2_.  Some commands do not have a _parameter_2_ which
+    usually is enforced by the ENGINE.
+
+*enable-methods* ::
+    
+    _parameter_1_ is the numeric value of the or'd set of required ENGINE_METHOD_*
+    or ENGINE_METHOD_ALL. _parameter_1_ can be an ascii representation of a number
+    or formated as 0xXXXX. _parameter_2_ is ignored.
+
+EXAMPLE TLS ENGINE CONFIGURATION FILE
+-------------------------------------
+
+[source, c]
+----
+# Define the engine name
+engine:pkcs11
+
+# Define which methods are to be enabled
+enable-methods:0xffff
+
+# Define any post initialization commands
+post-cmd:PIN:1234
+
+----
+
+SEE ALSO
+--------
+
+*coap-client*(5), *coap-server*(5) and *coap_tls_engine_configure*(3)
+
+FURTHER INFORMATION
+-------------------
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
+
+BUGS
+-----
+Please raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues to report any bugs.
+
+Please raise a Pull Request at https://github.com/obgm/libcoap/pulls
+for any fixes.
+
+AUTHORS
+-------
+The libcoap project <libcoap-developers@lists.sourceforge.net>

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -612,6 +612,7 @@ typedef struct coap_dtls_key_t {
     coap_pki_key_pem_buf_t pem_buf; /* for PEM memory keys */
     coap_pki_key_asn1_t asn1;       /* for ASN.1 (DER) memory keys */
     coap_pki_key_pkcs11_t pkcs11;   /* for PKCS11 keys */
+    coap_pki_key_define_t define;   /* definable type keys */
   } key;
 } coap_dtls_key_t;
 
@@ -687,12 +688,13 @@ typedef enum coap_pki_key_t {
   COAP_PKI_KEY_ASN1,    /* The PKI key type is ASN.1 (DER) buffer */
   COAP_PKI_KEY_PEM_BUF, /* The PKI key type is PEM buffer */
   COAP_PKI_KEY_PKCS11,  /* The PKI key type is PKCS11 (DER) */
+  COAP_PKI_KEY_DEFINE,  /* The individual PKI key types are Definable */
 } coap_pki_key_t;
 ----
 
 *key_type* defines the format that the certificates / keys are provided in.
-This can be COAP_PKI_KEY_PEM, COAP_PKI_KEY_PEM_BUF, COAP_PKI_KEY_ASN1 or
-COAP_PKI_KEY_PKCS11.
+This can be COAP_PKI_KEY_PEM, COAP_PKI_KEY_PEM_BUF, COAP_PKI_KEY_ASN1
+COAP_PKI_KEY_PKCS11 or COAP_PKI_KEY_DEFINE.
 
 *SECTION: PKI: coap_dtls_pki_t: PEM Key Definitions*
 [source, c]
@@ -712,7 +714,8 @@ requesting the client's certificate. This certificate is also added into
 the valid root CAs list if not already present.
 
 *key.pem.public_cert* points to the public certificate location on disk which
-will be in PEM format.
+will be in PEM format. This can be the entire certificate chain including the
+CAs.
 
 *key.pem.private_key* points to the private key location on disk which
 will be in PEM format.  This file cannot be password protected.
@@ -820,7 +823,7 @@ typedef struct coap_pki_key_pkcs11_t {
   const char *ca;            /* pkcs11: URI for Common CA Certificate */
   const char *public_cert;   /* pkcs11: URI for Public Cert */
   const char *private_key;   /* pkcs11: URI for Private Key */
-  const char *pin;           /* pin to access PKCS11.  If NULL, then
+  const char *user_pin;      /* User pin to access PKCS11.  If NULL, then
                                 pin-value= parameter must be set in
                                 pkcs11: URI as a query. */
 } coap_pki_key_pkcs11_t;
@@ -844,6 +847,103 @@ If NULL, the pin can be defined on the other pkcs11: URI entries by using
 pin-value=XXX as a query - e.g.
 'pkcs11:pkcs11:token=My%20Token;id=%aa%bb%cc%dd?pin-value=XXX' where XXX is
 the user pin.
+
+*SECTION: PKI/RPK: coap_dtls_pki_t: Individual Cert/Key type Definitions*
+[source, c]
+----
+typedef struct coap_pki_key_define_t {
+  coap_const_char_ptr_t ca;          /* define: Common CA Certificate */
+  coap_const_char_ptr_t public_cert; /* define: Public Cert */
+  coap_const_char_ptr_t private_key; /* define: Private Key */
+  size_t ca_len;             /* define CA Cert length (if needed)*/
+  size_t public_cert_len;    /* define Public Cert length (if needed)*/
+  size_t private_key_len;    /* define Private Key length (if needed)*/
+  coap_pki_define_t ca_def;  /* define: Common CA type definition*/
+  coap_pki_define_t public_cert_def;  /* define: Public Cert type definition*/
+  coap_pki_define_t private_key_def;  /* define: Private Key type definition*/
+  coap_asn1_privatekey_type_t private_key_type; /* define: ASN1 Private Key
+                                                   Type (if needed) */
+  const char *user_pin;      /* define: User pin to access type PKCS11.
+                                If PKCS11 and NULL, then pin-value= parameter
+                                must be set in pkcs11: URI as a query. */
+} coap_pki_key_define_t;
+
+typedef union {
+  const char *s_byte;    /* signed char ptr */
+  const uint8_t *u_byte; /* unsigned char ptr */
+} coap_const_char_ptr_t;
+
+typedef enum coap_pki_define_t {
+  COAP_PKI_KEY_DEF_PEM = 0, /* The PKI key type is PEM file.
+                               Length ignored, NULL terminated. */
+  COAP_PKI_KEY_DEF_PEM_BUF, /* The PKI key type is PEM buffer.
+                               Length required. */
+  COAP_PKI_KEY_DEF_RPK_BUF, /* The PKI key type is RPK in buffer.
+                               Length required. */
+  COAP_PKI_KEY_DEF_DER,     /* The PKI key type is DER file.
+                               Length ignored, NULL terminated. */
+  COAP_PKI_KEY_DEF_ASN1,    /* The PKI key type is ASN.1 (DER) buffer.
+                               Length required.
+                               Private Key Type required. */
+  COAP_PKI_KEY_DEF_PKCS11,  /* The PKI key type is PKCS11 (pkcs11:...).
+                               Length ignored, NULL terminated.
+                               User Pin optional. */
+  COAP_PKI_KEY_DEF_ENGINE,  /* The PKI key type is to be passed to ENGINE.
+                               Length ignored, NULL terminated.
+                               Supported by OpenSSL only */
+} coap_pki_define_t;
+----
+
+*key.define.ca.[su]_char* and possibly *key.define.ca_len* points to the CA
+location as defined by *key.define.ca_def*. *key.define.ca.[su]_char* can be
+NULL if there is no CA explicitely defined.  This definition should only
+contain one CA (that has signed the public certificate) as this is passed
+from the server to the client when requesting the client's certificate. This
+certificate is also added into the valid root CAs list if not already present.
+
+*key.define.public_cert.[su]_char* and possibly *key.define.public_cert_len*
+points to the public certificate location as defined by
+*key.define.public_cert_def*.
+
+*key.define.private_key.[su]_char* and possibly *key.define.privatr_key_len*
+points to the private key location as defined by *key.define.private_key_def*.
+This information cannot be password protected, but for type PKCS11
+*key.define.user_pin* can be defined. If type RPK and
+'EC PRIVATE KEY' this can be used for both the public_cert and private_key.
+
+*key.define.ca_len* is the optional length of the CA definition if
+required by *key.define.ca_def*.
+
+*key.define.public_cert_len* is the optional length of the public
+certificate definition if required by *key.define.public_cert_def*
+
+*key.define.private_key_len* is the optional length of the private key
+definition if required by *key.define.private_key_def*.
+
+*key.define.ca_def* defines the type of the CA entry, one of
+*coap_pki_define_t*.
+
+*key.define.public_cert_def* defines the type of the Public Cert/Key entry,
+one of *coap_pki_define_t*.
+
+*key.define.private_key_def* defines the type of the Private Key entry,
+one of *coap_pki_define_t*.
+
+*key.define.private_key_type* is the encoding type of the DER encoded ASN.1
+definition of the private key.  This will be one of the COAP_ASN1_PKEY_*
+definitions.
+
+*key.define.user_pin* is the user pin used to unlock the token or NULL if
+type is PKCS11.
+If NULL, the pin can be defined on the pkcs11: URI entry by using
+pin-value=XXX as a query - e.g.
+'pkcs11:pkcs11:token=My%20Token;id=%aa%bb%cc%dd?pin-value=XXX' where XXX is
+the user pin.
+
+*NOTE:* The PEM/ASN1/RPK buffer Certs and Key should be be NULL terminated strings for
+performance reasons (to save a potential buffer copy) and the length include
+this NULL terminator. It is not a requirement to have the NULL terminator
+though and the length must then reflect the actual data size.
 
 EXAMPLES
 --------
@@ -992,6 +1092,18 @@ setup_server_context_pki(const char *public_cert_file,
   dtls_pki.pki_key.key.pem.ca_file = ca_file;
   dtls_pki.pki_key.key.pem.public_cert = public_cert_file;
   dtls_pki.pki_key.key.pem.private_key = private_key_file;
+
+  /* Alternative definition for dtls_pki.pki_key that does the
+   * same thing as above.
+   *
+   * dtls_pki.pki_key.key_type                      = COAP_PKI_KEY_DEFINE;
+   * dtls_pki.pki_key.key.define.ca.s_byte          = ca_file;
+   * dtls_pki.pki_key.key.define.public_cert.s_byte = public_cert_file;
+   * dtls_pki.pki_key.key.define.private_key.s_byte = private_key_file;
+   * dtls_pki.pki_key.key.define.ca_def             = COAP_PKI_KEY_DEF_PEM;
+   * dtls_pki.pki_key.key.define.public_cert_def    = COAP_PKI_KEY_DEF_PEM;
+   * dtls_pki.pki_key.key.define.private_key_def    = COAP_PKI_KEY_DEF_PEM;
+   */
 
   /* See coap_context(3) */
   if (coap_context_set_pki(context, &dtls_pki)) {

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -21,7 +21,9 @@ coap_tcp_is_supported,
 coap_get_tls_library_version,
 coap_string_tls_support,
 coap_string_tls_version,
-coap_show_tls_version
+coap_show_tls_version,
+coap_tls_engine_configure,
+coap_tls_engine_remove
 - Work with CoAP TLS libraries
 
 SYNOPSIS
@@ -49,6 +51,10 @@ SYNOPSIS
 *char *coap_string_tls_version(char *_buffer_, size_t _bufsize_);*
 
 *void coap_show_tls_version(coap_log_t _level_);*
+
+*int coap_tls_engine_configure(coap_str_const_t *_conf_mem_);*
+
+*int coap_tls_engine_remove(void);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -174,6 +180,18 @@ current (D)TLS library that libcoap was built against, as well as the current
 linked version of the (D)TLS library. _level_ defines the minimum logging level
 for this information to be output using coap_log().
 
+*Function: coap_tls_engine_configure()*
+
+The *coap_tls_engine_configure*() function is used to configure a TLS ENGINE
+(currently only OpenSSL).  It parses the provided configuration in _conf_mem_
+and initializes the ENGINE appropriately. The format of the parameters is
+documented in *coap-tls-engine-conf*(5).
+
+*Function: coap_tls_engine_remove()*
+
+The *coap_tls_engine_remove*() function removes a previously configured TLS
+ENGINE.  This function is called when coap_free_context() is called.
+
 RETURN VALUES
 -------------
 *coap_dtls_is_supported*(), *coap_tls_is_supported*(),
@@ -189,6 +207,97 @@ available, otherwise 0.
 
 *coap_string_tls_version*() and *coap_string_tls_support*() return
 a pointer to the provided buffer.
+
+*coap_tls_engine_configure*() returns 1 if the TLS ENGINE was successfully configured, otherwise 0.
+
+*coap_tls_engine_remove*() returns 1 if the TLS ENGINE was successfully removed, otherwise 0.
+
+EXAMPLES
+--------
+*CoAP Server DTLS PKI Setup with OpenSSL Engine *
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#define ENGINE_CONFIG \
+  "engine:pkcs11\n" \
+  "enable-methods:0xffff\n" \
+  "post-cmd:PIN:1234\n"
+
+/*
+ * Set up PKI encryption information
+ */
+static coap_context_t *
+setup_server_context_pki(const char *public_cert_file,
+                         const char *private_key,
+                         const char *ca_file) {
+  coap_endpoint_t *endpoint;
+  coap_address_t listen_addr;
+  coap_dtls_pki_t dtls_pki;
+  coap_context_t *context;
+  coap_str_const_t *engine_conf = coap_make_str_const(ENGINE_CONFIG);
+
+  /* See coap_tls_library(3) */
+  if (!coap_dtls_is_supported())
+    return NULL;
+
+  context = coap_new_context(NULL);
+  if (!context)
+    return NULL;
+  /* See coap_block(3) */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
+  /* To get full logging of any issues here, you need to
+   *
+   * coap_set_log_level(COAP_LOG_DEBUG);
+   * coap_set_dtls_log_level(COAP_LOG_DEBUG);
+   */
+  if (!coap_tls_engine_configure(engine_conf))
+    return NULL;
+
+  memset(&dtls_pki, 0, sizeof(dtls_pki));
+
+  /* see coap_encryption(3) */
+  dtls_pki.version                 = COAP_DTLS_PKI_SETUP_VERSION;
+  dtls_pki.verify_peer_cert        = 1;
+  dtls_pki.check_common_ca         = 1;
+  dtls_pki.allow_self_signed       = 1;
+  dtls_pki.allow_expired_certs     = 1;
+  dtls_pki.cert_chain_validation   = 1;
+  dtls_pki.cert_chain_verify_depth = 1;
+  dtls_pki.check_cert_revocation   = 1;
+  dtls_pki.allow_no_crl            = 1;
+  dtls_pki.allow_expired_crl       = 1;
+  dtls_pki.pki_key.key_type                      = COAP_PKI_KEY_DEFINE;
+  dtls_pki.pki_key.key.define.ca.s_byte          = ca_file;
+  dtls_pki.pki_key.key.define.public_cert.s_byte = public_cert_file;
+  dtls_pki.pki_key.key.define.private_key.s_byte = private_key;
+  dtls_pki.pki_key.key.define.public_cert_def    = COAP_PKI_KEY_DEF_PEM;
+  dtls_pki.pki_key.key.define.private_key_def    = COAP_PKI_KEY_DEF_ENGINE;
+  dtls_pki.pki_key.key.define.ca_def             = COAP_PKI_KEY_DEF_PEM;
+
+  if (coap_context_set_pki(context, &dtls_pki)) {
+    coap_free_context(context);
+    return NULL;
+  }
+
+  /* See coap_address(3) */
+  coap_address_init(&listen_addr);
+  listen_addr.addr.sa.sa_family = AF_INET;
+  listen_addr.addr.sin.sin_port = htons(5684);
+
+  endpoint = coap_new_endpoint(context, &listen_addr, COAP_PROTO_DTLS);
+  if (!endpoint) {
+    coap_free_context(context);
+    return NULL;
+  }
+
+  /* Initialize resources - See coap_resource(3) init_resources() example */
+
+  return context;
+}
+----
 
 SEE ALSO
 --------

--- a/src/coap_dtls.c
+++ b/src/coap_dtls.c
@@ -17,6 +17,204 @@
 
 #include "coap3/coap_internal.h"
 
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#endif
+
+void
+coap_dtls_map_key_type_to_define(const coap_dtls_pki_t *setup_data, coap_dtls_key_t *key) {
+  *key = setup_data->pki_key;
+
+  switch (key->key_type) {
+  case COAP_PKI_KEY_PEM:
+    key->key_type = COAP_PKI_KEY_DEFINE;
+    key->key.define.ca.s_byte = setup_data->pki_key.key.pem.ca_file;
+    key->key.define.public_cert.s_byte = setup_data->pki_key.key.pem.public_cert;
+    key->key.define.private_key.s_byte = setup_data->pki_key.key.pem.private_key;
+
+    key->key.define.public_cert_def = COAP_PKI_KEY_DEF_PEM;
+    key->key.define.private_key_def = COAP_PKI_KEY_DEF_PEM;
+    key->key.define.ca_def = COAP_PKI_KEY_DEF_PEM;
+    break;
+  case COAP_PKI_KEY_ASN1:
+    key->key_type = COAP_PKI_KEY_DEFINE;
+    key->key.define.ca.u_byte = setup_data->pki_key.key.asn1.ca_cert;
+    key->key.define.public_cert.u_byte = setup_data->pki_key.key.asn1.public_cert;
+    key->key.define.private_key.u_byte = setup_data->pki_key.key.asn1.private_key;
+
+    key->key.define.ca_len = setup_data->pki_key.key.asn1.ca_cert_len;
+    key->key.define.public_cert_len = setup_data->pki_key.key.asn1.public_cert_len;
+    key->key.define.private_key_len = setup_data->pki_key.key.asn1.private_key_len;
+
+    key->key.define.private_key_type = setup_data->pki_key.key.asn1.private_key_type;
+
+    key->key.define.public_cert_def = COAP_PKI_KEY_DEF_ASN1;
+    key->key.define.private_key_def = COAP_PKI_KEY_DEF_ASN1;
+    key->key.define.ca_def = COAP_PKI_KEY_DEF_ASN1;
+    break;
+  case COAP_PKI_KEY_PEM_BUF:
+    key->key_type = COAP_PKI_KEY_DEFINE;
+    key->key.define.ca.u_byte = setup_data->pki_key.key.pem_buf.ca_cert;
+    key->key.define.public_cert.u_byte = setup_data->pki_key.key.pem_buf.public_cert;
+    key->key.define.private_key.u_byte = setup_data->pki_key.key.pem_buf.private_key;
+
+    key->key.define.ca_len = setup_data->pki_key.key.pem_buf.ca_cert_len;
+    key->key.define.public_cert_len = setup_data->pki_key.key.pem_buf.public_cert_len;
+    key->key.define.private_key_len = setup_data->pki_key.key.pem_buf.private_key_len;
+
+    if (setup_data->is_rpk_not_cert) {
+      key->key.define.public_cert_def = COAP_PKI_KEY_DEF_RPK_BUF;
+    } else {
+      key->key.define.public_cert_def = COAP_PKI_KEY_DEF_PEM_BUF;
+    }
+    if (setup_data->is_rpk_not_cert) {
+      key->key.define.private_key_def = COAP_PKI_KEY_DEF_RPK_BUF;
+    } else {
+      key->key.define.private_key_def = COAP_PKI_KEY_DEF_PEM_BUF;
+    }
+    if (setup_data->is_rpk_not_cert) {
+      key->key.define.ca_def = COAP_PKI_KEY_DEF_RPK_BUF;
+    } else {
+      key->key.define.ca_def = COAP_PKI_KEY_DEF_PEM_BUF;
+    }
+    break;
+  case COAP_PKI_KEY_PKCS11:
+    key->key_type = COAP_PKI_KEY_DEFINE;
+    key->key.define.ca.s_byte = setup_data->pki_key.key.pkcs11.ca;
+    key->key.define.public_cert.s_byte = setup_data->pki_key.key.pkcs11.public_cert;
+    key->key.define.private_key.s_byte = setup_data->pki_key.key.pkcs11.private_key;
+
+    key->key.define.user_pin = setup_data->pki_key.key.pkcs11.user_pin;
+
+    if (strncasecmp(key->key.pkcs11.ca, "pkcs11:", 7) == 0) {
+      key->key.define.ca_def = COAP_PKI_KEY_DEF_PKCS11;
+    } else {
+      key->key.define.ca_def = COAP_PKI_KEY_DEF_DER;
+    }
+    if (strncasecmp(key->key.pkcs11.public_cert, "pkcs11:", 7) == 0) {
+      key->key.define.public_cert_def = COAP_PKI_KEY_DEF_PKCS11;
+    } else {
+      key->key.define.public_cert_def = COAP_PKI_KEY_DEF_DER;
+    }
+    if (strncasecmp(key->key.pkcs11.private_key, "pkcs11:", 7) == 0) {
+      key->key.define.private_key_def = COAP_PKI_KEY_DEF_PKCS11;
+    } else {
+      key->key.define.private_key_def = COAP_PKI_KEY_DEF_DER;
+    }
+    break;
+  case COAP_PKI_KEY_DEFINE:
+    /* Already configured */
+    break;
+  default:
+    break;
+  }
+}
+
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_ERR)
+static const char *
+coap_dtls_get_define_type(coap_pki_define_t def, coap_const_char_ptr_t name) {
+  switch (def) {
+  case COAP_PKI_KEY_DEF_PEM:
+    return name.s_byte;
+  case COAP_PKI_KEY_DEF_PEM_BUF:
+    return "PEM_BUF";
+  case COAP_PKI_KEY_DEF_RPK_BUF:
+    return "RPK_BUF";
+  case COAP_PKI_KEY_DEF_DER:
+    return name.s_byte;
+  case COAP_PKI_KEY_DEF_ASN1:
+    return "ASN1";
+  case COAP_PKI_KEY_DEF_PKCS11:
+    return name.s_byte;
+  case COAP_PKI_KEY_DEF_ENGINE:
+    return name.s_byte;
+  default:
+    return "???";
+  }
+}
+#endif /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_ERR */
+
+int
+coap_dtls_define_issue(coap_define_issue_key_t type, coap_define_issue_fail_t fail,
+                       coap_dtls_key_t *key, const coap_dtls_role_t role) {
+#if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_ERR)
+  coap_pki_key_define_t define = key->key.define;
+  switch (type) {
+  case COAP_DEFINE_KEY_CA:
+    switch (fail) {
+    case COAP_DEFINE_FAIL_BAD:
+      coap_log_warn("*** setup_pki: (D)TLS: %s: %s CA configure failure\n",
+                    coap_dtls_get_define_type(define.ca_def, define.ca),
+                    role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
+      break;
+    case COAP_DEFINE_FAIL_NOT_SUPPORTED:
+      coap_log_err("*** setup_pki: (D)TLS: %s: %s CA type not supported\n",
+                   coap_dtls_get_define_type(define.ca_def, define.ca),
+                   role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
+      break;
+    case COAP_DEFINE_FAIL_NONE:
+      coap_log_err("*** setup_pki: (D)TLS: %s: %s CA not defined\n",
+                   coap_dtls_get_define_type(define.ca_def, define.ca),
+                   role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
+      break;
+    default:
+      break;
+    }
+    break;
+  case COAP_DEFINE_KEY_PUBLIC:
+    switch (fail) {
+    case COAP_DEFINE_FAIL_BAD:
+      coap_log_warn("*** setup_pki: (D)TLS: %s: %s Certificate configure failure\n",
+                    coap_dtls_get_define_type(define.public_cert_def, define.public_cert),
+                    role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
+      break;
+    case COAP_DEFINE_FAIL_NOT_SUPPORTED:
+      coap_log_err("*** setup_pki: (D)TLS: %s: %s Certificate type not supported\n",
+                   coap_dtls_get_define_type(define.public_cert_def, define.public_cert),
+                   role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
+      break;
+    case COAP_DEFINE_FAIL_NONE:
+      coap_log_err("*** setup_pki: (D)TLS: %s: %s Certificate not defined\n",
+                   coap_dtls_get_define_type(define.public_cert_def, define.public_cert),
+                   role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
+      break;
+    default:
+      break;
+    }
+    break;
+  case COAP_DEFINE_KEY_PRIVATE:
+    switch (fail) {
+    case COAP_DEFINE_FAIL_BAD:
+      coap_log_warn("*** setup_pki: (D)TLS: %s: %s Private Key configure failure\n",
+                    coap_dtls_get_define_type(define.private_key_def, define.private_key),
+                    role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
+      break;
+    case COAP_DEFINE_FAIL_NOT_SUPPORTED:
+      coap_log_err("*** setup_pki: (D)TLS: %s: %s Private Key type not supported\n",
+                   coap_dtls_get_define_type(define.private_key_def, define.private_key),
+                   role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
+      break;
+    case COAP_DEFINE_FAIL_NONE:
+      coap_log_err("*** setup_pki: (D)TLS: %s: %s Private Key not defined\n",
+                   coap_dtls_get_define_type(define.private_key_def, define.private_key),
+                   role == COAP_DTLS_ROLE_SERVER ? "Server" : "Client");
+      break;
+    default:
+      break;
+    }
+  default:
+    break;
+  }
+#else /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_ERR */
+  (void)type;
+  (void)fail;
+  (void)key;
+  (void)role;
+#endif /* COAP_MAX_LOGGING_LEVEL < _COAP_LOG_ERR */
+  return 0;
+}
+
 void
 coap_dtls_establish(coap_session_t *session) {
   session->state = COAP_SESSION_STATE_HANDSHAKE;

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -1323,6 +1323,9 @@ setup_pki_credentials(gnutls_certificate_credentials_t *pki_credentials,
     }
     break;
 
+  case COAP_PKI_KEY_DEFINE:
+    coap_log_err("*** setup_pki: (D)TLS: PKI type DEFINE not (yet) supported\n");
+    break;
   default:
     coap_log_err("***setup_pki: (D)TLS: Unknown key type %d\n",
                  setup_data->pki_key.key_type);

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -752,6 +752,9 @@ setup_pki_credentials(mbedtls_x509_crt *cacert,
     coap_log_err("***setup_pki: (D)TLS: PKCS11 not currently supported\n");
     return -1;
 
+  case COAP_PKI_KEY_DEFINE:
+    coap_log_err("*** setup_pki: (D)TLS: PKI type DEFINE not (yet) supported\n");
+    break;
   default:
     coap_log_err("***setup_pki: (D)TLS: Unknown key type %d\n",
                  setup_data->pki_key.key_type);

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -17,6 +17,19 @@
 
 #include "coap3/coap_internal.h"
 
+#if !defined(COAP_WITH_LIBOPENSSL)
+int
+coap_tls_engine_configure(coap_str_const_t *conf_mem) {
+  (void)conf_mem;
+  return 0;
+}
+
+int
+coap_tls_engine_remove(void) {
+  return 0;
+}
+#endif /* ! COAP_WITH_LIBOPENSSL */
+
 #if !defined(COAP_WITH_LIBTINYDTLS) && !defined(COAP_WITH_LIBOPENSSL) && !defined(COAP_WITH_LIBWOLFSSL) && !defined(COAP_WITH_LIBGNUTLS) && !defined(COAP_WITH_LIBMBEDTLS)
 
 int

--- a/src/coap_wolfssl.c
+++ b/src/coap_wolfssl.c
@@ -1390,6 +1390,9 @@ setup_pki_ssl(WOLFSSL *ssl,
     /* TODO: check if this can be implemented*/
     coap_log_err("PKCS11 Support not available in wolfSSL\n");
     return 0;
+  case COAP_PKI_KEY_DEFINE:
+    coap_log_err("*** setup_pki: (D)TLS: PKI type DEFINE not (yet) supported\n");
+    break;
   default:
     coap_log_err("*** setup_pki_ssl: (D)TLS: Unknown key type %d\n",
                  setup_data->pki_key.key_type);


### PR DESCRIPTION
Two new functions added

coap_tls_engine_configure()
coap_tls_engine_remove()