### PR TITLE
coap_net.c: Tidy up Observe cancellation in coap_send()

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -915,7 +915,10 @@ set_blocksize(void) {
   unsigned int opt_length;
 
   if (method != COAP_REQUEST_DELETE) {
-    if (method == COAP_REQUEST_GET || method == COAP_REQUEST_FETCH) {
+    block.m = (1ull << (block.szx + 4)) < payload.length;
+
+    if (!block.m &&
+        (method == COAP_REQUEST_GET || method == COAP_REQUEST_FETCH)) {
       if (coap_q_block_is_supported() && block_mode & COAP_BLOCK_TRY_Q_BLOCK)
         opt = COAP_OPTION_Q_BLOCK2;
       else

--- a/include/coap3/coap_block.h
+++ b/include/coap3/coap_block.h
@@ -442,22 +442,6 @@ void coap_context_set_block_mode(coap_context_t *context,
  */
 int coap_context_set_max_block_size(coap_context_t *context, size_t max_block_size);
 
-/**
- * Cancel an observe that is being tracked by the client large receive logic.
- * (coap_context_set_block_mode() has to be called)
- * This will trigger the sending of an observe cancel pdu to the server.
- *
- * @param session  The session that is being used for the observe.
- * @param token    The original token used to initiate the observation.
- * @param message_type The COAP_MESSAGE_ type (NON or CON) to send the observe
- *                 cancel pdu as.
- *
- * @return @c 1 if observe cancel transmission initiation is successful,
- *         else @c 0.
- */
-int coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
-                        coap_pdu_type_t message_type);
-
 /**@}*/
 
 #endif /* COAP_BLOCK_H_ */

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -186,6 +186,8 @@ struct coap_lg_crcv_t {
   coap_bin_const_t **obs_token; /**< Tokens used in setting up Observe
                                   (to handle large FETCH) */
   size_t obs_token_cnt; /**< number of tokens used to set up Observe */
+  uint16_t o_block_option; /**< Block CoAP option used when initiating Observe */
+  uint8_t o_blk_size;      /**< Block size used when initiating Observe */
   uint64_t state_token; /**< state token */
   coap_pdu_t pdu;        /**< skeletal PDU */
   coap_rblock_t rec_blocks; /** < list of received blocks */

--- a/include/coap3/coap_subscribe.h
+++ b/include/coap3/coap_subscribe.h
@@ -266,6 +266,22 @@ void coap_persist_stop(coap_context_t *context);
 void coap_persist_set_observe_num(coap_resource_t *resource,
                                   uint32_t observe_num);
 
+/**
+ * Cancel an observe that is being tracked by the client large receive logic.
+ * (coap_context_set_block_mode() has to be called)
+ * This will trigger the sending of an observe cancel pdu to the server.
+ *
+ * @param session  The session that is being used for the observe.
+ * @param token    The original token used to initiate the observation.
+ * @param message_type The COAP_MESSAGE_ type (NON or CON) to send the observe
+ *                 cancel pdu as.
+ *
+ * @return @c 1 if observe cancel transmission initiation is successful,
+ *         else @c 0.
+ */
+int coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
+                        coap_pdu_type_t message_type);
+
 /** @} */
 
 #endif /* COAP_SUBSCRIBE_H_ */


### PR DESCRIPTION
If Observe cancellation is detected in sending pdu in coap_send(), call coap_cancel_observe() to to the necessary work.