### PR TITLE
Contiki-NG: Fix compilation error "unknown type name 'fd_set'"

### DIFF
--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -625,7 +625,7 @@ void coap_mcast_per_resource(coap_context_t *context);
  */
 int coap_io_process(coap_context_t *ctx, uint32_t timeout_ms);
 
-#if !defined(RIOT_VERSION)
+#if !defined(RIOT_VERSION) && !defined(WITH_CONTIKI)
 /**
  * The main message processing loop with additional fds for internal select.
  *
@@ -656,7 +656,7 @@ int coap_io_process(coap_context_t *ctx, uint32_t timeout_ms);
 int coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
                              int nfds, fd_set *readfds, fd_set *writefds,
                              fd_set *exceptfds);
-#endif /* ! RIOT_VERSION */
+#endif /* ! RIOT_VERSION && ! WITH_CONTIKI */
 
 /**
  * Check to see if there is any i/o pending for the @p context.

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -178,13 +178,13 @@ struct coap_context_t {
   int eptimerfd;                   /**< Internal FD for timeout */
   coap_tick_t next_timeout;        /**< When the next timeout is to occur */
 #else /* ! COAP_EPOLL_SUPPORT */
-#if !defined(RIOT_VERSION)
+#if !defined(RIOT_VERSION) && !defined(WITH_CONTIKI)
   fd_set readfds, writefds, exceptfds; /**< Used for select call
                                             in coap_io_process_with_fds() */
   coap_socket_t *sockets[64];      /**< Track different socket information
                                         in coap_io_process_with_fds */
   unsigned int num_sockets;        /**< Number of sockets being tracked */
-#endif /* ! RIOT_VERSION */
+#endif /* ! RIOT_VERSION && ! WITH_CONTIKI */
 #endif /* ! COAP_EPOLL_SUPPORT */
 #if COAP_SERVER_SUPPORT
   uint8_t observe_pending;         /**< Observe response pending */


### PR DESCRIPTION
This resolves a compilation error I encountered with OpenMote targets.