### PR TITLE
locking: Unlock context when calling request/response handlers

### DIFF
--- a/include/coap3/coap_mutex_internal.h
+++ b/include/coap3/coap_mutex_internal.h
@@ -255,6 +255,20 @@ int coap_lock_lock_func(coap_lock_t *lock, const char *file, int line);
     (s)->lock.in_callback--; \
   } while (0)
 
+#define coap_lock_callback_release(s,func,fail) do { \
+    coap_lock_check_locked(s); \
+    coap_lock_unlock(s); \
+    func; \
+    coap_lock_lock(s,fail); \
+  } while (0)
+
+#define coap_lock_callback_ret_release(r,s,func,fail) do { \
+    coap_lock_check_locked(s); \
+    coap_lock_unlock(s); \
+    r = func; \
+    coap_lock_lock(s,fail); \
+  } while (0)
+
 # else /* ! COAP_THREAD_RECURSIVE_CHECK */
 
 /*
@@ -296,6 +310,20 @@ int coap_lock_lock_func(coap_lock_t *lock);
     (s)->lock.in_callback++; \
     r = func; \
     (s)->lock.in_callback--; \
+  } while (0)
+
+#define coap_lock_callback_release(s,func,fail) do { \
+    coap_lock_check_locked(s); \
+    coap_lock_unlock(s); \
+    func; \
+    coap_lock_lock(s,fail); \
+  } while (0)
+
+#define coap_lock_callback_ret_release(r,s,func,fail) do { \
+    coap_lock_check_locked(s); \
+    coap_lock_unlock(s); \
+    r = func; \
+    coap_lock_lock(s,fail); \
   } while (0)
 
 # endif /* ! COAP_THREAD_RECURSIVE_CHECK */
@@ -342,6 +370,8 @@ typedef coap_mutex_t coap_lock_t;
 #define coap_lock_check_locked(s) {}
 #define coap_lock_callback(s,func) func
 #define coap_lock_callback_ret(r,s,func) ret = func
+#define coap_lock_callback_release(s,func,fail) func
+#define coap_lock_callback_ret_release(r,s,func,fail) ret = func
 #define coap_lock_invert(s,func,f) func
 
 #endif /* ! COAP_THREAD_SAFE */

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -127,6 +127,8 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_deprecated.3" > coap_set_event_handler.3
 	@echo ".so man3/coap_deprecated.3" > coap_write.3
 	@echo ".so man3/coap_io.3" > coap_can_exit.3
+	@echo ".so man3/coap_locking.3" > coap_lock_callback_ret_release.3
+	@echo ".so man3/coap_locking.3" > coap_lock_invert.3
 	@echo ".so man3/coap_logging.3" > coap_log_info.3
 	@echo ".so man3/coap_logging.3" > coap_log_debug.3
 	@echo ".so man3/coap_logging.3" > coap_log_oscore.3

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -97,6 +97,14 @@ attached Sessions and Endpoints.
 as other libraries may also call atexit() and clear down some CoAP
 required functionality.
 
+*WARNING:* It is unsafe to call *coap_free_context*() in any libcoap callback
+handlers as set up in *coap_handler*(3).
+
+*WARNING:* In a multi-thread, libcoap thread-safe environment, if other threads
+are using _context_, it is not recommended to call *coap_free_context*() as
+various libcoap APIs will unexpectedly fail. It is best to clear down those other
+threads first before calling *coap_free_context*().
+
 *Function: coap_context_set_max_idle_sessions()*
 
 The *coap_context_set_max_idle_sessions*() function sets the maximum number of

--- a/man/coap_locking.txt.in
+++ b/man/coap_locking.txt.in
@@ -17,7 +17,9 @@ coap_lock_unlock,
 coap_lock_being_freed,
 coap_lock_check_locked,
 coap_lock_callback,
+coap_lock_callback_release,
 coap_lock_callback_ret,
+coap_lock_callback_ret_release,
 coap_lock_invert
 - Work with CoAP thread safe locking
 
@@ -42,6 +44,12 @@ coap_func_t _callback_function_);*
 *void coap_lock_callback_ret(void *_return_value_, coap_context_t *_context_,
 coap_func_t _callback_function_, coap_code_t _failed_statement_);*
 
+*void coap_lock_callback_release(coap_context_t *_context_,
+coap_func_t _callback_function__, coap_code_t _failed_statement_);*
+
+*void coap_lock_callback_ret_release(void *_return_value_, coap_context_t *_context_,
+coap_func_t _callback_function_, coap_code_t _failed_statement_);*
+
 *void coap_lock_invert(coap_context_t *_context_, coap_func_t _locking_function_,
 coap_code_t _failed_statement_);*
 
@@ -62,7 +70,8 @@ what levels of locking has been configured. Locking uses *coap_mutex_*()
 functions.
 
 So, _failed_statement_ is the C code to execute if the
-locking fails for any reason.
+locking fails for any reason. This should only happen when an another
+thread has called *coap_free_context*(3).
 
 Likewise, _callback_function_ is the callback handler function with all of
 its parameters.
@@ -148,6 +157,22 @@ callback handler to be called, along with all of the appropriate parameters.
 The *coap_lock_callback_ret*() function is similar to *coap_lock_callback*(),
 but in addition, it updates the return value from the callback handler function
 in _return_value_.
+
+*Function: coap_lock_callback_release()*
+
+The *coap_lock_callback_release*() function is used whenever a callback handler is
+getting called, instead of calling the function directly. The lock information
+in _context_ is released so that if a public API is called from within the handler,
+it can do its own lock. The intent here is to reduce lock contention.  On return
+from the callback, the lock in _context_ is re-locked, but if there is a failure in
+re-locking, _failed_statement_ is executed. _callback_function_ is the
+callback handler to be called, along with all of the appropriate parameters.
+
+*Function: coap_lock_callback_ret_release()*
+
+The *coap_lock_callback_ret_release*() function is similar to
+*coap_lock_callback_release*(), but in addition, it updates the return value from the
+callback handler function in _return_value_.
 
 *Function: coap_lock_invert()*
 

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -85,7 +85,9 @@ const char *define_list[] = {
   "coap_lock_being_freed(",
   "coap_lock_check_locked(",
   "coap_lock_callback(",
+  "coap_lock_callback_release(",
   "coap_lock_callback_ret(",
+  "coap_lock_callback_ret_release(",
   "coap_lock_invert(",
 };
 

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -3947,9 +3947,11 @@ give_to_app:
                                   p->app_token->s);
               coap_remove_option(sent, p->block_option);
             }
-            coap_lock_callback_ret(ret, session->context,
-                                   context->response_handler(session, sent, rcvd,
-                                                             rcvd->mid));
+            coap_lock_callback_ret_release(ret, session->context,
+                                           context->response_handler(session, sent, rcvd,
+                                                                     rcvd->mid),
+                                           /* context is being freed off */
+                                           assert(0));
             if (ret == COAP_RESPONSE_FAIL) {
               coap_send_rst(session, rcvd);
             } else {

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -1105,8 +1105,10 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         coap_log_debug("call custom handler for resource '%*.*s' (4)\n",
                        (int)r->uri_path->length, (int)r->uri_path->length,
                        r->uri_path->s);
-        coap_lock_callback(obs->session->context,
-                           h(r, obs->session, obs->pdu, query, response));
+        coap_lock_callback_release(obs->session->context,
+                                   h(r, obs->session, obs->pdu, query, response),
+                                   /* context is being freed off */
+                                   return);
 
         /* Check validity of response code */
         if (!coap_check_code_class(obs->session, response)) {

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -940,10 +940,12 @@ coap_op_dyn_resource_load_disk(coap_context_t *ctx) {
         goto fail;
       query = coap_get_query(request);
       /* Call the application handler to set up this dynamic resource */
-      coap_lock_callback(ctx,
-                         ctx->unknown_resource->handler[request->code-1](ctx->unknown_resource,
-                             session, request,
-                             query, response));
+      coap_lock_callback_release(ctx,
+                                 ctx->unknown_resource->handler[request->code-1](ctx->unknown_resource,
+                                     session, request,
+                                     query, response),
+                                 /* context is being freed off */
+                                 goto fail);
       coap_delete_string(query);
       query = NULL;
       coap_delete_pdu(request);


### PR DESCRIPTION
This is to reduce contention on the context lock when a request/response handler takes time to get / update information.