### PR TITLE
oscore_cbor.c: Fix bad scan-build fix

### DIFF
--- a/src/oscore/oscore_cbor.c
+++ b/src/oscore/oscore_cbor.c
@@ -241,6 +241,8 @@ oscore_cbor_get_element_size(const uint8_t **buffer, size_t *buf_len) {
   uint8_t control = get_byte(buffer, buf_len) & 0x1f;
   size_t size;
 
+  /* Move to data payload, or extended count */
+  get_byte_inc(buffer, buf_len);
   if (control < 0x18) {
     size = (uint64_t)control;
   } else {


### PR DESCRIPTION
Restore missing buffer increment.