### PR TITLE
Nits: Tidy up code

### DIFF
--- a/examples/riot/pkg_libcoap/Makefile
+++ b/examples/riot/pkg_libcoap/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=libcoap
 PKG_URL=https://github.com/obgm/libcoap
-PKG_VERSION=e599e25d6e2b0d0e7b29dc2710f2f15e0b7e5e51
+PKG_VERSION=e521eab58bbd15de7b9878551e979ce5c442d9b8
 PKG_LICENSE=BSD-2-Clause
 
 LIBCOAP_BUILD_DIR=$(BINDIR)/pkg/$(PKG_NAME)

--- a/include/coap3/coap_resource.h
+++ b/include/coap3/coap_resource.h
@@ -492,18 +492,6 @@ coap_print_status_t coap_print_link(const coap_resource_t *resource,
 /** @} */
 
 /**
- * Returns the resource identified by the unique string @p uri_path. If no
- * resource was found, this function returns @c NULL.
- *
- * @param context  The context to look for this resource.
- * @param uri_path  The unique string uri of the resource.
- *
- * @return         A pointer to the resource or @c NULL if not found.
- */
-coap_resource_t *coap_get_resource_from_uri_path(coap_context_t *context,
-                                                 coap_str_const_t *uri_path);
-
-/**
  * @deprecated use coap_resource_notify_observers() instead.
  */
 COAP_DEPRECATED int coap_resource_set_dirty(coap_resource_t *r,

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -191,6 +191,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_resource.3" > coap_resource_get_userdata.3
 	@echo ".so man3/coap_resource.3" > coap_resource_release_userdata_handler.3
 	@echo ".so man3/coap_resource.3" > coap_resource_get_uri_path.3
+	@echo ".so man3/coap_resource.3" > coap_get_resource_from_uri_path.3
 	@echo ".so man3/coap_session.3" > coap_session_get_addr_remote.3
 	@echo ".so man3/coap_session.3" > coap_session_get_context.3
 	@echo ".so man3/coap_session.3" > coap_session_get_ifindex.3

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -22,7 +22,8 @@ coap_resource_set_mode,
 coap_resource_set_userdata,
 coap_resource_get_userdata,
 coap_resource_release_userdata_handler,
-coap_resource_get_uri_path
+coap_resource_get_uri_path,
+coap_get_resource_from_uri_path
 - Work with CoAP resources
 
 SYNOPSIS
@@ -61,6 +62,9 @@ coap_resource_t *_resource_);*
 coap_resource_release_userdata_handler_t _callback_);*
 
 *coap_str_const_t *coap_resource_get_uri_path(coap_resource_t *_resource_);*
+
+*coap_resource_t *coap_get_resource_from_uri_path(coap_context_t *_context_,
+coap_str_const_t *_uri_path_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -283,6 +287,12 @@ needs to be freed off.
 The *coap_resource_get_uri_path*() function is used to obtain the UriPath of
 the _resource_ definion.
 
+*Function: coap_get_resource_from_uri_path()*
+
+The *coap_get_resource_from_uri_path*() function is used to return the resource
+identified by the unique string _uri_path_ associated with _context_.
+
+
 RETURN VALUES
 -------------
 *coap_resource_init*(), *coap_resource_unknown_init*(),
@@ -298,6 +308,9 @@ by the *coap_resource_set_userdata*() function or NULL.
 
 *coap_resource_get_uri_path*() returns the uri_path or NULL if
 there was a failure.
+
+*coap_get_resource_from_uri_path*() returns the resource or NULL
+if not found.
 
 EXAMPLES
 --------

--- a/src/oscore/oscore_cbor.c
+++ b/src/oscore/oscore_cbor.c
@@ -238,11 +238,9 @@ oscore_cbor_get_next_element(const uint8_t **buffer, size_t *buf_len) {
 
 size_t
 oscore_cbor_get_element_size(const uint8_t **buffer, size_t *buf_len) {
-  uint8_t control = get_byte(buffer, buf_len) & 0x1f;
+  uint8_t control = get_byte_inc(buffer, buf_len) & 0x1f;
   size_t size;
 
-  /* Move to data payload, or extended count */
-  get_byte_inc(buffer, buf_len);
   if (control < 0x18) {
     size = (uint64_t)control;
   } else {


### PR DESCRIPTION
Add documentation for coap_get_resource_from_uri_path().

Remove duplicate coap_get_resource_from_uri_path() definition.

Better fix for scan-build issue.

Update RIOT libcoap base version.

Addresses #1383.