### PR TITLE
Fixed missing event for server session removal

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1846,6 +1846,7 @@ coap_free_endpoint(coap_endpoint_t *ep) {
     SESSIONS_ITER_SAFE(ep->sessions, session, rtmp) {
       assert(session->ref == 0);
       if (session->ref == 0) {
+        coap_handle_event(ep->context, COAP_EVENT_SERVER_SESSION_DEL, session);
         coap_session_free(session);
       }
     }


### PR DESCRIPTION
There was one place in the code, where server session was closing, but no event about that was generated. When any dynamically allocated app_data was attached to that session, it couldn't be freed properly, causing memory leaks. This PR fixes that.