### PR TITLE
locking: Simplify maintenance / debugging /documentation

### DIFF
--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -672,15 +672,6 @@ int coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
  */
 int coap_io_pending(coap_context_t *context);
 
-/**@}*/
-
-/**
- * @ingroup internal_api
- * @defgroup app_io_internal Application I/O Handling
- * Internal API for Application Input / Output checking
- * @{
- */
-
 /**
 * Iterates through all the coap_socket_t structures embedded in endpoints or
 * sessions associated with the @p ctx to determine which are wanting any
@@ -870,8 +861,7 @@ coap_write(coap_context_t *ctx,
            coap_socket_t *sockets[],
            unsigned int max_sockets,
            unsigned int *num_sockets,
-           coap_tick_t now
-          ) {
+           coap_tick_t now) {
   return coap_io_prepare_io(ctx, sockets, max_sockets, num_sockets, now);
 }
 
@@ -886,8 +876,7 @@ coap_write(coap_context_t *ctx,
  * @param now Current time
  */
 COAP_STATIC_INLINE COAP_DEPRECATED void
-coap_read(coap_context_t *ctx, coap_tick_t now
-         ) {
+coap_read(coap_context_t *ctx, coap_tick_t now) {
   coap_io_do_io(ctx, now);
 }
 

--- a/include/coap3/coap_threadsafe_internal.h
+++ b/include/coap3/coap_threadsafe_internal.h
@@ -43,18 +43,8 @@
 #define coap_find_async(s,t)                            coap_find_async_locked(s,t)
 #define coap_delete_oscore_recipient(s,r)               coap_delete_oscore_recipient_locked(s,r)
 #define coap_delete_resource(c,r)                       coap_delete_resource_locked(c,r)
-#define coap_free_context(c)                            coap_free_context_locked(c)
 #define coap_free_endpoint(e)                           coap_free_endpoint_locked(e)
 #define coap_get_resource_from_uri_path(c,u)            coap_get_resource_from_uri_path_locked(c,u)
-#define coap_io_do_epoll(c,e,n)                         coap_io_do_epoll_locked(c,e,n)
-#define coap_io_do_io(c,n)                              coap_io_do_io_locked(c,n)
-#define coap_io_pending(c)                              coap_io_pending_locked(c)
-#define coap_io_prepare_epoll(c,n)                      coap_io_prepare_epoll_locked(c,n)
-#define coap_io_prepare_io(c,s,m,n,t)                   coap_io_prepare_io_locked(c,s,m,n,t)
-#define coap_io_process(s,t)                            coap_io_process_locked(s,t)
-#ifdef HAVE_SYS_SELECT_H
-#define coap_io_process_with_fds(s,t,n,r,w,e)           coap_io_process_with_fds_locked(s,t,n,r,w,e)
-#endif /* HAVE_SYS_SELECT_H */
 #define coap_join_mcast_group_intf(c,g,i)               coap_join_mcast_group_intf_locked(c,g,i)
 #define coap_new_cache_entry(s,p,r,b,i)                 coap_new_cache_entry_locked(s,p,r,b,i)
 #define coap_new_client_session(c,l,s,p)                coap_new_client_session_locked(c,l,s,p)
@@ -142,20 +132,9 @@ int                  coap_delete_oscore_recipient_locked(coap_context_t *context
                                                          coap_bin_const_t *recipient_id);
 int                  coap_delete_resource_locked(coap_context_t *context, coap_resource_t *resource);
 coap_async_t        *coap_find_async_locked(coap_session_t *session, coap_bin_const_t token);
-void                 coap_free_context_locked(coap_context_t *context);
 void                 coap_free_endpoint_locked(coap_endpoint_t *ep);
 coap_resource_t     *coap_get_resource_from_uri_path_locked(coap_context_t *context,
                                                             coap_str_const_t *uri_path);
-void                 coap_io_do_epoll_locked(coap_context_t *ctx, struct epoll_event *events,
-                                             size_t nevents);
-void                 coap_io_do_io_locked(coap_context_t *ctx, coap_tick_t now);
-int                  coap_io_pending_locked(coap_context_t *context);
-unsigned int         coap_io_prepare_epoll_locked(coap_context_t *ctx, coap_tick_t now);
-unsigned int         coap_io_prepare_io_locked(coap_context_t *ctx,
-                                               coap_socket_t *sockets[],
-                                               unsigned int max_sockets,
-                                               unsigned int *num_sockets,
-                                               coap_tick_t now);
 int                  coap_join_mcast_group_intf_locked(coap_context_t *ctx, const char *group_name,
                                                        const char *ifname);
 coap_subscription_t *coap_persist_observe_add_locked(coap_context_t *context,
@@ -170,12 +149,6 @@ int                  coap_persist_startup_locked(coap_context_t *context,
                                                  const char *obs_cnt_save_file,
                                                  uint32_t save_freq);
 void                 coap_persist_stop_locked(coap_context_t *context);
-int                  coap_io_process_locked(coap_context_t *ctx, uint32_t timeout_ms);
-#ifdef HAVE_SYS_SELECT_H
-int                  coap_io_process_with_fds_locked(coap_context_t *ctx, uint32_t timeout_ms,
-                                                     int nfds, fd_set *readfds, fd_set *writefds,
-                                                     fd_set *exceptfds);
-#endif /* HAVE_SYS_SELECT_H */
 coap_async_t        *coap_register_async_locked(coap_session_t *session, const coap_pdu_t *request,
                                                 coap_tick_t delay);
 size_t               coap_session_max_pdu_size_locked(const coap_session_t *session);

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -57,7 +57,17 @@ coap_io_process_timeout(void *arg) {
 }
 
 int
-coap_io_process(coap_context_t *context, uint32_t timeout_ms) {
+coap_io_process(coap_context_t *ctx, uint32_t timeout_ms) {
+  int ret;
+
+  coap_lock_lock(ctx, return 0);
+  ret = coap_io_process_locked(ctx, timeout_ms);
+  coap_lock_unlock(ctx);
+  return ret;
+}
+
+int
+coap_io_process_locked(coap_context_t *context, uint32_t timeout_ms) {
   coap_tick_t before;
   coap_tick_t now;
   unsigned int num_sockets;
@@ -65,7 +75,7 @@ coap_io_process(coap_context_t *context, uint32_t timeout_ms) {
 
   coap_lock_check_locked(context);
   coap_ticks(&before);
-  timeout = coap_io_prepare_io(context, NULL, 0, &num_sockets, before);
+  timeout = coap_io_prepare_io_locked(context, NULL, 0, &num_sockets, before);
   if (timeout == 0 || (timeout_ms != COAP_IO_WAIT && timeout_ms < timeout))
     timeout = timeout_ms;
 

--- a/src/coap_io_riot.c
+++ b/src/coap_io_riot.c
@@ -30,6 +30,16 @@
 
 int
 coap_io_process(coap_context_t *ctx, uint32_t timeout_ms) {
+  int ret;
+
+  coap_lock_lock(ctx, return 0);
+  ret = coap_io_process_locked(ctx, timeout_ms);
+  coap_lock_unlock(ctx);
+  return ret;
+}
+
+int
+coap_io_process_locked(coap_context_t *ctx, uint32_t timeout_ms) {
   coap_tick_t before, now;
   uint32_t timeout;
   coap_socket_t *sockets[1];
@@ -42,7 +52,7 @@ coap_io_process(coap_context_t *ctx, uint32_t timeout_ms) {
 
   coap_ticks(&before);
   /* Use the common logic */
-  timeout = coap_io_prepare_io(ctx, sockets, max_sockets, &num_sockets, before);
+  timeout = coap_io_prepare_io_locked(ctx, sockets, max_sockets, &num_sockets, before);
 
   if (timeout_ms == COAP_IO_NO_WAIT) {
     timeout = 0;
@@ -73,7 +83,7 @@ coap_io_process(coap_context_t *ctx, uint32_t timeout_ms) {
   }
 
   coap_ticks(&now);
-  coap_io_do_io(ctx, now);
+  coap_io_do_io_locked(ctx, now);
 
 #if COAP_SERVER_SUPPORT
   coap_expire_cache_entries(ctx);

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -202,6 +202,28 @@ coap_insert_node(coap_queue_t **queue, coap_queue_t *node) {
 
 int
 coap_delete_node(coap_queue_t *node) {
+  int ret;
+#if COAP_THREAD_SAFE
+  coap_context_t *context;
+#endif /* COAP_THREAD_SAFE */
+
+  if (!node)
+    return 0;
+  if (!node->session)
+    return coap_delete_node_locked(node);
+
+#if COAP_THREAD_SAFE
+  /* Keep copy as node will be going away */
+  context = node->session->context;
+#endif /* COAP_THREAD_SAFE */
+  coap_lock_lock(context, return 0);
+  ret = coap_delete_node_locked(node);
+  coap_lock_unlock(context);
+  return ret;
+}
+
+int
+coap_delete_node_locked(coap_queue_t *node) {
   if (!node)
     return 0;
 
@@ -226,7 +248,7 @@ coap_delete_all(coap_queue_t *queue) {
     return;
 
   coap_delete_all(queue->next);
-  coap_delete_node(queue);
+  coap_delete_node_locked(queue);
 }
 
 coap_queue_t *
@@ -546,7 +568,7 @@ coap_new_context(const coap_address_t *listen_addr) {
     c->dtls_context = coap_dtls_new_context(c);
     if (!c->dtls_context) {
       coap_log_emerg("coap_init: no DTLS context available\n");
-      coap_free_context(c);
+      coap_free_context_locked(c);
       return NULL;
     }
   }
@@ -590,6 +612,19 @@ coap_get_app_data(const coap_context_t *ctx) {
 
 void
 coap_free_context(coap_context_t *context) {
+  if (!context)
+    return;
+  /*
+   * Note there is an immediate unlock to release any other 'context' waiters
+   * So that their coap_lock_lock() will fail as 'context' is realy no more.
+   */
+  coap_lock_being_freed(context, return);
+  coap_free_context_locked(context);
+  /* No need to unlock as context is no longer there */
+}
+
+void
+coap_free_context_locked(coap_context_t *context) {
   if (!context)
     return;
 
@@ -1031,7 +1066,7 @@ coap_client_delay_first(coap_session_t *session) {
      */
     coap_session_reference(session);
     while (session->doing_first != 0) {
-      int result = coap_io_process(session->context, 1000);
+      int result = coap_io_process_locked(session->context, 1000);
 
       if (result < 0) {
         session->doing_first = 0;
@@ -1040,7 +1075,7 @@ coap_client_delay_first(coap_session_t *session) {
         return 0;
       }
 
-      /* coap_io_process() may have updated session state */
+      /* coap_io_process_locked() may have updated session state */
       if (session->state == COAP_SESSION_STATE_CSM &&
           current_state != COAP_SESSION_STATE_CSM) {
         /* Update timeout and restart the clock for CSM timeout */
@@ -1730,7 +1765,7 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
 
     if (node->is_mcast) {
       coap_session_connected(node->session);
-      coap_delete_node(node);
+      coap_delete_node_locked(node);
       return COAP_INVALID_MID;
     }
     if (bytes_written == COAP_PDU_DELAYED) {
@@ -1765,7 +1800,8 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
        * coap_session_connected() is called.
        * However, there is the possibility coap_wait_ack() may be called for
        * this node (queue) and re-added to context->sendqueue.
-       * coap_delete_node(node) called shortly will handle this and remove it.
+       * coap_delete_node_locked(node) called shortly will handle this and
+       * remove it.
        */
       coap_session_connected(node->session);
     }
@@ -1778,7 +1814,7 @@ coap_retransmit(coap_context_t *context, coap_queue_t *node) {
                        context->nack_handler(node->session, node->pdu,
                                              COAP_NACK_TOO_MANY_RETRIES, node->id));
   }
-  coap_delete_node(node);
+  coap_delete_node_locked(node);
   return COAP_INVALID_MID;
 }
 
@@ -1847,7 +1883,7 @@ coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now
     }
     session->delayqueue = q->next;
     session->partial_write = 0;
-    coap_delete_node(q);
+    coap_delete_node_locked(q);
   }
 }
 
@@ -2114,10 +2150,17 @@ coap_accept_endpoint(coap_context_t *ctx, coap_endpoint_t *endpoint,
 
 void
 coap_io_do_io(coap_context_t *ctx, coap_tick_t now) {
+  coap_lock_lock(ctx, return);
+  coap_io_do_io_locked(ctx, now);
+  coap_lock_unlock(ctx);
+}
+
+void
+coap_io_do_io_locked(coap_context_t *ctx, coap_tick_t now) {
 #ifdef COAP_EPOLL_SUPPORT
   (void)ctx;
   (void)now;
-  coap_log_emerg("coap_io_do_io() requires libcoap not compiled for using epoll\n");
+  coap_log_emerg("coap_io_do_io_locked() requires libcoap not compiled for using epoll\n");
 #else /* ! COAP_EPOLL_SUPPORT */
   coap_session_t *s, *rtmp;
 
@@ -2166,17 +2209,24 @@ coap_io_do_io(coap_context_t *ctx, coap_tick_t now) {
 #endif /* ! COAP_EPOLL_SUPPORT */
 }
 
+void
+coap_io_do_epoll(coap_context_t *ctx, struct epoll_event *events, size_t nevents) {
+  coap_lock_lock(ctx, return);
+  coap_io_do_epoll_locked(ctx, events, nevents);
+  coap_lock_unlock(ctx);
+}
+
 /*
- * While this code in part replicates coap_io_do_io(), doing the functions
+ * While this code in part replicates coap_io_do_io_locked(), doing the functions
  * directly saves having to iterate through the endpoints / sessions.
  */
 void
-coap_io_do_epoll(coap_context_t *ctx, struct epoll_event *events, size_t nevents) {
+coap_io_do_epoll_locked(coap_context_t *ctx, struct epoll_event *events, size_t nevents) {
 #ifndef COAP_EPOLL_SUPPORT
   (void)ctx;
   (void)events;
   (void)nevents;
-  coap_log_emerg("coap_io_do_epoll() requires libcoap compiled for using epoll\n");
+  coap_log_emerg("coap_io_do_epoll_locked() requires libcoap compiled for using epoll\n");
 #else /* COAP_EPOLL_SUPPORT */
   coap_tick_t now;
   size_t j;
@@ -2271,7 +2321,7 @@ coap_io_do_epoll(coap_context_t *ctx, struct epoll_event *events, size_t nevents
   }
   /* And update eptimerfd as to when to next trigger */
   coap_ticks(&now);
-  coap_io_prepare_epoll(ctx, now);
+  coap_io_prepare_epoll_locked(ctx, now);
 #endif /* COAP_EPOLL_SUPPORT */
 }
 
@@ -2380,7 +2430,7 @@ coap_cancel_session_messages(coap_context_t *context, coap_session_t *session,
       coap_lock_callback(context,
                          context->nack_handler(session, q->pdu, reason, q->id));
     }
-    coap_delete_node(q);
+    coap_delete_node_locked(q);
   }
 
   if (!context->sendqueue)
@@ -2399,7 +2449,7 @@ coap_cancel_session_messages(coap_context_t *context, coap_session_t *session,
         coap_lock_callback(context,
                            context->nack_handler(session, q->pdu, reason, q->id));
       }
-      coap_delete_node(q);
+      coap_delete_node_locked(q);
       q = p->next;
     } else {
       p = q;
@@ -2433,7 +2483,7 @@ coap_cancel_all_messages(coap_context_t *context, coap_session_t *session,
           /* Flush out any entries on session->delayqueue */
           coap_session_connected(session);
       }
-      coap_delete_node(q);
+      coap_delete_node_locked(q);
     } else {
       p = &(q->next);
     }
@@ -3362,7 +3412,7 @@ skip_handler:
         goto drop_it_no_debug;
       }
       if (!coap_pdu_encode_header(response, session->proto)) {
-        coap_delete_node(node);
+        coap_delete_node_locked(node);
         goto drop_it_no_debug;
       }
 
@@ -3744,7 +3794,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
             session->recipient_ctx->initial_state == 0) {
           coap_log_warn("OSCORE: PDU could not be decrypted\n");
         }
-        coap_delete_node(sent);
+        coap_delete_node_locked(sent);
         return;
       } else {
         session->oscore_encryption = 1;
@@ -4007,7 +4057,7 @@ cleanup:
       coap_handle_event(context, COAP_EVENT_BAD_PACKET, session);
     }
   }
-  coap_delete_node(sent);
+  coap_delete_node_locked(sent);
 #if COAP_OSCORE_SUPPORT
   coap_delete_pdu(dec_pdu);
 #endif /* COAP_OSCORE_SUPPORT */

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -481,7 +481,7 @@ coap_session_mfree(coap_session_t *session) {
 
         while (queue) {
           if (queue->session == session) {
-            coap_delete_node(queue);
+            coap_delete_node_locked(queue);
             break;
           }
           queue = queue->next;
@@ -522,7 +522,7 @@ coap_session_mfree(coap_session_t *session) {
                                                         COAP_NACK_TLS_FAILED : COAP_NACK_NOT_DELIVERABLE,
                                                         q->id));
     }
-    coap_delete_node(q);
+    coap_delete_node_locked(q);
   }
   LL_FOREACH_SAFE(session->lg_xmit, lq, ltmp) {
     LL_DELETE(session->lg_xmit, lq);
@@ -806,7 +806,7 @@ coap_session_connected(coap_session_t *session) {
     }
     if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
       if (q)
-        coap_delete_node(q);
+        coap_delete_node_locked(q);
       if (bytes_written < 0)
         break;
     } else if (q) {
@@ -817,7 +817,7 @@ coap_session_connected(coap_session_t *session) {
           session->partial_write = (size_t)bytes_written;
         break;
       } else {
-        coap_delete_node(q);
+        coap_delete_node_locked(q);
       }
     }
   }
@@ -897,7 +897,7 @@ coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reason) {
                              session->context->nack_handler(session, q->pdu, reason, q->id));
           sent_nack = 1;
         }
-        coap_delete_node(q);
+        coap_delete_node_locked(q);
       }
     }
 #if COAP_CLIENT_SUPPORT
@@ -946,7 +946,7 @@ coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reason) {
     q->next = NULL;
     coap_log_debug("** %s: mid=0x%04x: not transmitted after disconnect\n",
                    coap_session_str(session), q->id);
-    coap_delete_node(q);
+    coap_delete_node_locked(q);
   }
 
 #if COAP_CLIENT_SUPPORT

--- a/tests/test_sendqueue.c
+++ b/tests/test_sendqueue.c
@@ -320,15 +320,12 @@ t_sendqueue_tests_create(void) {
 static int
 t_sendqueue_tests_remove(void) {
   size_t n;
-  /* As coap_delete_node() is not in the Public API, need to lock */
-  coap_lock_lock(ctx, return 1);
   for (n = 0; n < sizeof(node)/sizeof(coap_queue_t *); n++) {
     if (node[n]) {
       coap_delete_node(node[n]);
       node[n] = NULL;
     }
   }
-  coap_lock_unlock(ctx);
   coap_free_context(ctx);
   ctx = NULL;
   return 0;


### PR DESCRIPTION
Update libcoap functions that need to be called locked with a name suffix of _locked.

Move matching functions out of coap_threadsafe.c to be coded just ahead of the newly renamed _locked function.

Properly define the _locked function in the appropriate _internal.h file for documentation, removing the #defines from coap_threadsafe_internal.h.

Work in progress for all the functions.

Remove coap_lock_* requirements for testdriver (coap_delete_node()).

Addresses issue reported in #1384.