### PR TITLE
coap_net: additionally provide coap_context_set/get_app_data 

### DIFF
--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -397,6 +397,8 @@ uint16_t coap_new_message_id(coap_session_t *session);
 void coap_free_context(coap_context_t *context);
 
 /**
+ * @deprecated Use coap_context_set_app_data() instead.
+ *
  * Stores @p data with the given CoAP context. This function
  * overwrites any value that has previously been stored with @p
  * context.
@@ -408,6 +410,8 @@ void coap_free_context(coap_context_t *context);
 void coap_set_app_data(coap_context_t *context, void *data);
 
 /**
+ * @deprecated Use coap_context_get_app_data() instead.
+ *
  * Returns any application-specific data that has been stored with @p
  * context using the function coap_set_app_data(). This function will
  * return @c NULL if no data has been stored.
@@ -582,6 +586,26 @@ int coap_mcast_set_hops(coap_session_t *session, size_t hops);
  * @param context The current context.
  */
 void coap_mcast_per_resource(coap_context_t *context);
+
+/**
+ * Stores @p data with the given context. This function overwrites any value
+ * that has previously been stored with @p context.
+ *
+ * @param context The CoAP context.
+ * @param data The pointer to the data to store.
+ */
+void coap_context_set_app_data(coap_context_t *context, void *data);
+
+/**
+ * Returns any application-specific data that has been stored with @p
+ * context using the function coap_context_set_app_data(). This function will
+ * return @c NULL if no data has been stored.
+ *
+ * @param context The CoAP context.
+ *
+ * @return Pointer to the stored data or @c NULL.
+ */
+void *coap_context_get_app_data(const coap_context_t *context);
 
 /**@}*/
 

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -41,6 +41,7 @@ global:
   coap_clear_event_handler;
   coap_clock_init;
   coap_clone_uri;
+  coap_context_get_app_data;
   coap_context_get_coap_fd;
   coap_context_get_csm_max_message_size;
   coap_context_get_csm_timeout;
@@ -49,6 +50,7 @@ global:
   coap_context_get_max_idle_sessions;
   coap_context_get_session_timeout;
   coap_context_oscore_server;
+  coap_context_set_app_data;
   coap_context_set_block_mode;
   coap_context_set_csm_max_message_size;
   coap_context_set_csm_timeout;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -39,6 +39,7 @@ coap_cleanup
 coap_clear_event_handler
 coap_clock_init
 coap_clone_uri
+coap_context_get_app_data
 coap_context_get_coap_fd
 coap_context_get_csm_max_message_size
 coap_context_get_csm_timeout
@@ -47,6 +48,7 @@ coap_context_get_max_handshake_sessions
 coap_context_get_max_idle_sessions
 coap_context_get_session_timeout
 coap_context_oscore_server
+coap_context_set_app_data
 coap_context_set_block_mode
 coap_context_set_csm_max_message_size
 coap_context_set_csm_timeout

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -119,6 +119,10 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_set_csm_timeout_ms.3
 	@echo ".so man3/coap_context.3" > coap_context_get_csm_timeout_ms.3
 	@echo ".so man3/coap_context.3" > coap_context_set_max_token_size.3
+	@echo ".so man3/coap_context.3" > coap_context_set_app_data.3
+	@echo ".so man3/coap_context.3" > coap_context_get_app_data.3
+	@echo ".so man3/coap_deprecated.3" > coap_set_app_data.3
+	@echo ".so man3/coap_deprecated.3" > coap_get_app_data.3
 	@echo ".so man3/coap_deprecated.3" > coap_option_setb.3
 	@echo ".so man3/coap_deprecated.3" > coap_read.3
 	@echo ".so man3/coap_deprecated.3" > coap_register_handler.3

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -21,7 +21,9 @@ coap_context_set_session_timeout,
 coap_context_get_session_timeout,
 coap_context_set_csm_timeout_ms,
 coap_context_get_csm_timeout_ms,
-coap_context_set_max_token_size
+coap_context_set_max_token_size,
+coap_context_set_app_data,
+coap_context_get_app_data
 - Work with CoAP contexts
 
 SYNOPSIS
@@ -57,6 +59,10 @@ unsigned int _csm_timeout_ms_);*
 
 *void coap_context_set_max_token_size(coap_context_t *_context_,
 size_t _max_token_size_);*
+
+*void coap_context_set_app_data(coap_context_t *_context_, void *_app_data_);*
+
+*void *coap_context_get_app_data(const coap_context_t *_context_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -167,6 +173,16 @@ bytes, else 8 to disable https://rfc-editor.org/rfc/rfc8974[RFC8974]
 supports the requested extended token size as per
 "https://rfc-editor.org/rfc/rfc8974.html#section-2.2.2[RFC8794 Section 2.2.2]"
 
+*Function: coap_context_set_app_data()*
+
+The *coap_context_set_app_data*() function is used to define a _app_data_
+pointer for the _context_ which can then be retrieved at a later date.
+
+*Function: coap_context_get_app_data()*
+
+The *coap_context_get_app_data*() function is used to retrieve the app_data
+pointer previously defined by *coap_context_set_app_data*().
+
 RETURN VALUES
 -------------
 *coap_new_context*() returns a newly created context or
@@ -183,6 +199,8 @@ out an idle server session.
 
 *coap_context_get_csm_timeout_ms*() returns the milliseconds to wait for a
 (TCP) CSM negotiation response from the peer.
+
+*coap_context_get_app_data*() returns a previously defined pointer.
 
 SEE ALSO
 --------

--- a/man/coap_deprecated.txt.in
+++ b/man/coap_deprecated.txt.in
@@ -25,7 +25,9 @@ coap_register_handler,
 coap_resource_set_dirty,
 coap_run_once,
 coap_set_event_handler,
-coap_write
+coap_write,
+coap_get_app_data,
+coap_set_app_data
 - Work with CoAP deprecated functions
 
 SYNOPSIS
@@ -70,6 +72,10 @@ coap_event_handler_t _handler_);*
 
 *unsigned int coap_write(coap_context_t *_context_, coap_socket_t *_sockets_[],
 unsigned int _max_sockets_, unsigned int *_num_sockets_, coap_tick_t _now_);*
+
+*void coap_set_app_data(coap_context_t *_context_, void *_app_data_);*
+
+*void *coap_get_app_data(const coap_context_t *_context_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -164,6 +170,16 @@ The *coap_set_event_handler*() function is replaced by
 The *coap_write*() function is replaced by
 *coap_io_prepare_io*(3).
 
+*Function: coap_set_app_data()*
+
+The *coap_set_app_data*() function is replaced by
+*coap_context_set_app_data*(3).
+
+*Function: coap_get_app_data()*
+
+The *coap_get_app_data*() function is replaced by
+*coap_context_get_app_data*(3).
+
 RETURN VALUES
 -------------
 *coap_context_get_csm_timeout*() returns the seconds to wait for a (TCP) CSM
@@ -191,10 +207,13 @@ if there was an error.
 *coap_write*() returns the number of milli-seconds that need to be waited
 before the function should next be called.
 
+*coap_get_app_data*() returns a previously defined pointer.
+
 SEE ALSO
 --------
-*coap_endpoint_client*(3), *coap_endpoint_server*(3), *coap_handler*(3),
-*coap_io*(3), *coap_observe*(3), *coap_pdu_access*(3) and *coap_pdu_setup*(3).
+*coap_context*(3), *coap_endpoint_client*(3), *coap_endpoint_server*(3),
+*coap_handler*(3), *coap_io*(3), *coap_observe*(3), *coap_pdu_access*(3) and
+*coap_pdu_setup*(3).
 
 FURTHER INFORMATION
 -------------------

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -483,6 +483,18 @@ coap_context_get_coap_fd(const coap_context_t *context) {
 #endif /* ! COAP_EPOLL_SUPPORT */
 }
 
+void
+coap_context_set_app_data(coap_context_t *context, void *app_data) {
+  assert(context);
+  context->app = app_data;
+}
+
+void *
+coap_context_get_app_data(const coap_context_t *context) {
+  assert(context);
+  return context->app;
+}
+
 coap_context_t *
 coap_new_context(const coap_address_t *listen_addr) {
   coap_context_t *c;


### PR DESCRIPTION
I somehow missed the documented coap_set/get_app_data functions but found them while adding new coap_context_set/get_app_data functions myself. I think the prefix of the latter would better fit the scheme - like coap_session_set_data and coap_resource_set_userdata. I am fine with using the existing functions now but I thought I send the PR anyways as I already finished it and in case you see a benefit here. If you think this change is not worth the effort, I don't mind if you just close the PR. Thanks!