### PR TITLE
Contiki-NG: Fix compilation error "implicit declaration of strncasecmp"

### DIFF
--- a/include/coap3/coap_encode.h
+++ b/include/coap3/coap_encode.h
@@ -17,7 +17,7 @@
 #ifndef COAP_ENCODE_H_
 #define COAP_ENCODE_H_
 
-#if (BSD >= 199103) || defined(WITH_CONTIKI) || defined(_WIN32)
+#if (BSD >= 199103) || defined(_WIN32)
 # include <string.h>
 #else
 # include <strings.h>


### PR DESCRIPTION
My compiler complained about the implicit declaration of `strncasecmp` in `coap_dtls.c`. I did not pinpoint the commit that introduced this problem. Contiki-NG did not include `strings.h` anyway.