### PR TITLE
locking: Simplify maintenance / debugging /documentation

### DIFF
--- a/include/coap3/coap_libcoap_build.h
+++ b/include/coap3/coap_libcoap_build.h
@@ -29,6 +29,19 @@
 
 #include "coap_config.h"
 
+/*
+ * This is here to to catch any code within libcoap that is not
+ * calling the _lkd version of the Public API function when
+ * compiling. This is to try and catch all the locking dead-locks.
+ */
+#if !defined(COAP_API)
+#  ifdef __GNUC__
+#    define COAP_API __attribute__((deprecated))
+#  else /* __GNUC__ */
+#    define COAP_API
+#  endif /* __GNUC__ */
+#endif
+
 #include "coap_internal.h"
 
 #endif /* COAP_LIBCOAP_BUILD_H_ */

--- a/include/coap3/coap_mutex_internal.h
+++ b/include/coap3/coap_mutex_internal.h
@@ -172,6 +172,19 @@ extern coap_mutex_t m_persist_add;
  *
  * So the initial support for thread safe is done at the context level.
  *
+ * New model, simplifying debugging and better documentation.
+ *
+ * Any public API call needs to potentially lock context, as there may be
+ * multiple contexts. If a public API needs thread safe protection, the
+ * coap_X() function locks the context lock, calls the coap_X_lkd() function
+ * that does all the work and on return unlocks the context before returning
+ * to the caller of coap_X().
+ *
+ * Any internal libcoap calls that are to the public API coap_X() must call
+ * coap_X_lkd() if the calling code is already locked.
+ *
+ * Old, equivalent model
+ *
  * Any public API call needs to potentially lock context, as there may be
  * multiple contexts. If a public API needs thread safe protection, a
  * locking wrapper for coap_X() is added to src/coap_threadsafe.c which then

--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -394,7 +394,7 @@ uint16_t coap_new_message_id(coap_session_t *session);
  *
  * @param context The current coap_context_t object to free off.
  */
-void coap_free_context(coap_context_t *context);
+COAP_API void coap_free_context(coap_context_t *context);
 
 /**
  * @deprecated Use coap_context_set_app_data() instead.
@@ -647,7 +647,7 @@ void *coap_context_get_app_data(const coap_context_t *context);
  * @return Number of milliseconds spent in function or @c -1 if there was
  *         an error
  */
-int coap_io_process(coap_context_t *ctx, uint32_t timeout_ms);
+COAP_API int coap_io_process(coap_context_t *ctx, uint32_t timeout_ms);
 
 #if !defined(RIOT_VERSION) && !defined(WITH_CONTIKI)
 /**
@@ -677,9 +677,9 @@ int coap_io_process(coap_context_t *ctx, uint32_t timeout_ms);
  *         if there was an error.  If defined, readfds, writefds, exceptfds
  *         are updated as returned by the internal select() call.
  */
-int coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
-                             int nfds, fd_set *readfds, fd_set *writefds,
-                             fd_set *exceptfds);
+COAP_API int coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
+                                      int nfds, fd_set *readfds, fd_set *writefds,
+                                      fd_set *exceptfds);
 #endif /* ! RIOT_VERSION && ! WITH_CONTIKI */
 
 /**
@@ -694,7 +694,7 @@ int coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
  *
  * @return @c 1 I/O still pending, @c 0 no I/O pending.
  */
-int coap_io_pending(coap_context_t *context);
+COAP_API int coap_io_pending(coap_context_t *context);
 
 /**
 * Iterates through all the coap_socket_t structures embedded in endpoints or
@@ -729,12 +729,12 @@ int coap_io_pending(coap_context_t *context);
 *                 select() to wait for network events or 0 if wait should be
 *                 forever.
 */
-unsigned int coap_io_prepare_io(coap_context_t *ctx,
-                                coap_socket_t *sockets[],
-                                unsigned int max_sockets,
-                                unsigned int *num_sockets,
-                                coap_tick_t now
-                               );
+COAP_API unsigned int coap_io_prepare_io(coap_context_t *ctx,
+                                         coap_socket_t *sockets[],
+                                         unsigned int max_sockets,
+                                         unsigned int *num_sockets,
+                                         coap_tick_t now
+                                        );
 
 /**
  * Processes any outstanding read, write, accept or connect I/O as indicated
@@ -749,7 +749,7 @@ unsigned int coap_io_prepare_io(coap_context_t *ctx,
  * @param ctx The CoAP context
  * @param now Current time
  */
-void coap_io_do_io(coap_context_t *ctx, coap_tick_t now);
+COAP_API void coap_io_do_io(coap_context_t *ctx, coap_tick_t now);
 
 /**
  * Any now timed out delayed packet is transmitted, along with any packets
@@ -770,7 +770,7 @@ void coap_io_do_io(coap_context_t *ctx, coap_tick_t now);
  *                 epoll_wait() to wait for network events or 0 if wait should be
  *                 forever.
  */
-unsigned int coap_io_prepare_epoll(coap_context_t *ctx, coap_tick_t now);
+COAP_API unsigned int coap_io_prepare_epoll(coap_context_t *ctx, coap_tick_t now);
 
 struct epoll_event;
 
@@ -787,8 +787,8 @@ struct epoll_event;
  * @param nevents The number of events.
  *
  */
-void coap_io_do_epoll(coap_context_t *ctx, struct epoll_event *events,
-                      size_t nevents);
+COAP_API void coap_io_do_epoll(coap_context_t *ctx, struct epoll_event *events,
+                               size_t nevents);
 
 /**@}*/
 
@@ -857,10 +857,7 @@ void coap_lwip_set_input_wait_handler(coap_context_t *context,
  * @return Number of milliseconds spent in function or @c -1 if there was
  *         an error
  */
-COAP_STATIC_INLINE COAP_DEPRECATED int
-coap_run_once(coap_context_t *ctx, uint32_t timeout_ms) {
-  return coap_io_process(ctx, timeout_ms);
-}
+#define coap_run_once(ctx, timeout_ms) coap_io_process(ctx, timeout_ms)
 
 /**
 * @deprecated Use coap_io_prepare_io() instead.
@@ -880,14 +877,8 @@ coap_run_once(coap_context_t *ctx, uint32_t timeout_ms) {
 *                 select() to wait for network events or 0 if wait should be
 *                 forever.
 */
-COAP_STATIC_INLINE COAP_DEPRECATED unsigned int
-coap_write(coap_context_t *ctx,
-           coap_socket_t *sockets[],
-           unsigned int max_sockets,
-           unsigned int *num_sockets,
-           coap_tick_t now) {
-  return coap_io_prepare_io(ctx, sockets, max_sockets, num_sockets, now);
-}
+#define coap_write(ctx, sockets, max_sockets, num_sockets, now) \
+  coap_io_prepare_io(ctx, sockets, max_sockets, num_sockets, now)
 
 /**
  * @deprecated Use coap_io_do_io() instead.
@@ -899,10 +890,7 @@ coap_write(coap_context_t *ctx,
  * @param ctx The CoAP context
  * @param now Current time
  */
-COAP_STATIC_INLINE COAP_DEPRECATED void
-coap_read(coap_context_t *ctx, coap_tick_t now) {
-  coap_io_do_io(ctx, now);
-}
+#define coap_read(ctx, now) coap_io_do_io(ctx, now)
 
 /* Old definitions which may be hanging around in old code - be helpful! */
 #define COAP_RUN_NONBLOCK COAP_RUN_NONBLOCK_deprecated_use_COAP_IO_NO_WAIT

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -230,7 +230,7 @@ int coap_delete_node(coap_queue_t *node);
  *
  * @return @c 1 node deleted from queue, @c 0 failure.
  */
-int coap_delete_node_locked(coap_queue_t *node);
+int coap_delete_node_lkd(coap_queue_t *node);
 
 /**
  * Removes all items from given @p queue and frees the allocated storage.
@@ -447,7 +447,7 @@ coap_mid_t coap_send_internal(coap_session_t *session, coap_pdu_t *pdu);
 int coap_client_delay_first(coap_session_t *session);
 
 /**
- * CoAP stack context must be released with coap_free_context_locked(). This
+ * CoAP stack context must be released with coap_free_context_lkd(). This
  * function  clears all entries from the receive queue and send queue and deletes the
  * resources that have been registered with @p context, and frees the attached
  * endpoints.
@@ -456,7 +456,7 @@ int coap_client_delay_first(coap_session_t *session);
  *
  * @param context The current coap_context_t object to free off.
  */
-void coap_free_context_locked(coap_context_t *context);
+void coap_free_context_lkd(coap_context_t *context);
 
 /** @} */
 
@@ -472,21 +472,21 @@ void coap_free_context_locked(coap_context_t *context);
  * in the coap_socket_t structures (COAP_SOCKET_CAN_xxx set) embedded in
  * endpoints or sessions associated with @p ctx.
  *
- * Note: If epoll support is compiled into libcoap, coap_io_do_epoll_locked() must
- * be used instead of coap_io_do_io_locked().
+ * Note: If epoll support is compiled into libcoap, coap_io_do_epoll_lkd() must
+ * be used instead of coap_io_do_io_lkd().
  *
  * Note: This function must be called in the locked state.
  *
  * @param ctx The CoAP context
  * @param now Current time
  */
-void coap_io_do_io_locked(coap_context_t *ctx, coap_tick_t now);
+void coap_io_do_io_lkd(coap_context_t *ctx, coap_tick_t now);
 
 /**
  * Process all the epoll events
  *
- * Note: If epoll support is compiled into libcoap, coap_io_do_epoll_locked() must
- * be used instead of coap_io_do_io_locked().
+ * Note: If epoll support is compiled into libcoap, coap_io_do_epoll_lkd() must
+ * be used instead of coap_io_do_io_lkd().
  *
  * Note: This function must be called in the locked state.
  *
@@ -495,8 +495,8 @@ void coap_io_do_io_locked(coap_context_t *ctx, coap_tick_t now);
  * @param nevents The number of events.
  *
  */
-void coap_io_do_epoll_locked(coap_context_t *ctx, struct epoll_event *events,
-                             size_t nevents);
+void coap_io_do_epoll_lkd(coap_context_t *ctx, struct epoll_event *events,
+                          size_t nevents);
 
 /**
  * Check to see if there is any i/o pending for the @p context.
@@ -512,7 +512,7 @@ void coap_io_do_epoll_locked(coap_context_t *ctx, struct epoll_event *events,
  *
  * @return @c 1 I/O still pending, @c 0 no I/O pending.
  */
-int coap_io_pending_locked(coap_context_t *context);
+int coap_io_pending_lkd(coap_context_t *context);
 
 /**
  * Any now timed out delayed packet is transmitted, along with any packets
@@ -521,8 +521,8 @@ int coap_io_pending_locked(coap_context_t *context);
  * In addition, it returns when the next expected I/O is expected to take place
  * (e.g. a packet retransmit).
  *
- * Note: If epoll support is compiled into libcoap, coap_io_prepare_epoll_locked()
- * must  be used instead of coap_io_prepare_io_locked().
+ * Note: If epoll support is compiled into libcoap, coap_io_prepare_epoll_lkd()
+ * must  be used instead of coap_io_prepare_io_lkd().
  *
  * Note: This function must be called in the locked state.
  *
@@ -533,7 +533,7 @@ int coap_io_pending_locked(coap_context_t *context);
  *                 epoll_wait() to wait for network events or 0 if wait should be
  *                 forever.
  */
-unsigned int coap_io_prepare_epoll_locked(coap_context_t *ctx, coap_tick_t now);
+unsigned int coap_io_prepare_epoll_lkd(coap_context_t *ctx, coap_tick_t now);
 
 /**
  * Iterates through all the coap_socket_t structures embedded in endpoints or
@@ -547,13 +547,13 @@ unsigned int coap_io_prepare_epoll_locked(coap_context_t *ctx, coap_tick_t now);
  * In addition, it returns when the next expected I/O is expected to take place
  * (e.g. a packet retransmit).
  *
- * Prior to calling coap_io_do_io_locked(), the @p sockets must be tested to see
+ * Prior to calling coap_io_do_io_lkd(), the @p sockets must be tested to see
  * if any of the COAP_SOCKET_WANT_xxx have the appropriate information and if
  * so, COAP_SOCKET_CAN_xxx is set. This typically will be done after using a
  * select() call.
  *
- * Note: If epoll support is compiled into libcoap, coap_io_prepare_epoll_locked()
- * must be used instead of coap_io_prepare_io_locked().
+ * Note: If epoll support is compiled into libcoap, coap_io_prepare_epoll_lkd()
+ * must be used instead of coap_io_prepare_io_lkd().
  *
  * Note: This function must be called in the locked state.
  *
@@ -568,12 +568,12 @@ unsigned int coap_io_prepare_epoll_locked(coap_context_t *ctx, coap_tick_t now);
  *                 select() to wait for network events or 0 if wait should be
  *                 forever.
  */
-unsigned int coap_io_prepare_io_locked(coap_context_t *ctx,
-                                       coap_socket_t *sockets[],
-                                       unsigned int max_sockets,
-                                       unsigned int *num_sockets,
-                                       coap_tick_t now
-                                      );
+unsigned int coap_io_prepare_io_lkd(coap_context_t *ctx,
+                                    coap_socket_t *sockets[],
+                                    unsigned int max_sockets,
+                                    unsigned int *num_sockets,
+                                    coap_tick_t now
+                                   );
 
 /**
  * The main I/O processing function.  All pending network I/O is completed,
@@ -605,7 +605,7 @@ unsigned int coap_io_prepare_io_locked(coap_context_t *ctx,
  * @return Number of milliseconds spent in function or @c -1 if there was
  *         an error
  */
-int coap_io_process_locked(coap_context_t *ctx, uint32_t timeout_ms);
+int coap_io_process_lkd(coap_context_t *ctx, uint32_t timeout_ms);
 
 #if !defined(RIOT_VERSION) && !defined(WITH_CONTIKI)
 /**
@@ -637,9 +637,9 @@ int coap_io_process_locked(coap_context_t *ctx, uint32_t timeout_ms);
  *         if there was an error.  If defined, readfds, writefds, exceptfds
  *         are updated as returned by the internal select() call.
  */
-int coap_io_process_with_fds_locked(coap_context_t *ctx, uint32_t timeout_ms,
-                                    int nfds, fd_set *readfds, fd_set *writefds,
-                                    fd_set *exceptfds);
+int coap_io_process_with_fds_lkd(coap_context_t *ctx, uint32_t timeout_ms,
+                                 int nfds, fd_set *readfds, fd_set *writefds,
+                                 fd_set *exceptfds);
 #endif /* ! RIOT_VERSION && ! WITH_CONTIKI */
 
 /**@}*/

--- a/include/coap3/coap_oscore_internal.h
+++ b/include/coap3/coap_oscore_internal.h
@@ -80,10 +80,10 @@ typedef enum oscore_partial_iv_t {
  *
  * @return The OSCORE encrypted version of @p pdu, or @c NULL on error.
  */
-coap_pdu_t *coap_oscore_new_pdu_encrypted(coap_session_t *session,
-                                          coap_pdu_t *pdu,
-                                          coap_bin_const_t *kid_context,
-                                          oscore_partial_iv_t send_partial_iv);
+COAP_API coap_pdu_t *coap_oscore_new_pdu_encrypted(coap_session_t *session,
+                                                   coap_pdu_t *pdu,
+                                                   coap_bin_const_t *kid_context,
+                                                   oscore_partial_iv_t send_partial_iv);
 
 /**
  * Encrypts the specified @p pdu when OSCORE encryption is required
@@ -102,10 +102,10 @@ coap_pdu_t *coap_oscore_new_pdu_encrypted(coap_session_t *session,
  *
  * @return The OSCORE encrypted version of @p pdu, or @c NULL on error.
  */
-coap_pdu_t *coap_oscore_new_pdu_encrypted_locked(coap_session_t *session,
-                                                 coap_pdu_t *pdu,
-                                                 coap_bin_const_t *kid_context,
-                                                 oscore_partial_iv_t send_partial_iv);
+coap_pdu_t *coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
+                                              coap_pdu_t *pdu,
+                                              coap_bin_const_t *kid_context,
+                                              oscore_partial_iv_t send_partial_iv);
 
 /**
  * Decrypts the OSCORE-encrypted parts of @p pdu when OSCORE is used.

--- a/include/coap3/libcoap.h
+++ b/include/coap3/libcoap.h
@@ -54,6 +54,7 @@ typedef USHORT in_port_t;
 #    endif
 #  endif
 #endif
+
 #ifndef COAP_DEPRECATED
 #  if defined(_MSC_VER)
 #    define COAP_DEPRECATED __declspec(deprecated)
@@ -61,6 +62,7 @@ typedef USHORT in_port_t;
 #    define COAP_DEPRECATED __attribute__ ((deprecated))
 #  endif
 #endif
+
 #ifndef COAP_UNUSED
 #  ifdef __GNUC__
 #    define COAP_UNUSED __attribute__((unused))
@@ -68,6 +70,10 @@ typedef USHORT in_port_t;
 #    define COAP_UNUSED
 #  endif /* __GNUC__ */
 #endif /* COAP_UNUSED */
+
+#ifndef COAP_API
+#define COAP_API
+#endif
 
 void coap_startup(void);
 

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -60,9 +60,6 @@ const char *inline_list[] = {
   "coap_option_clrb(",
   "coap_option_getb(",
   "coap_option_setb(",
-  "coap_read(",
-  "coap_run_once(",
-  "coap_write(",
 };
 
 const char *define_list[] = {

--- a/src/coap_io_contiki.c
+++ b/src/coap_io_contiki.c
@@ -61,7 +61,7 @@ prepare_io(coap_context_t *ctx) {
   unsigned next_io;
 
   coap_ticks(&now);
-  next_io = coap_io_prepare_io_locked(ctx, sockets, max_sockets, &num_sockets, now);
+  next_io = coap_io_prepare_io_lkd(ctx, sockets, max_sockets, &num_sockets, now);
   if (next_io) {
     coap_update_io_timer(ctx, next_io);
   }
@@ -84,7 +84,7 @@ PROCESS_THREAD(libcoap_io_process, ev, data) {
 
         coap_socket->flags |= COAP_SOCKET_CAN_READ;
         coap_ticks(&now);
-        coap_io_do_io_locked(coap_socket->context, now);
+        coap_io_do_io_lkd(coap_socket->context, now);
       }
     }
     if (ev == PROCESS_EVENT_POLL) {
@@ -236,19 +236,19 @@ coap_socket_recv(coap_socket_t *sock, coap_packet_t *packet) {
 }
 
 int
-coap_io_process_locked(coap_context_t *ctx, uint32_t timeout_ms) {
+coap_io_process_lkd(coap_context_t *ctx, uint32_t timeout_ms) {
   coap_tick_t before, now;
 
   coap_lock_check_locked(ctx);
   if (timeout_ms != COAP_IO_NO_WAIT) {
-    coap_log_err("coap_io_process_locked() must be called with COAP_IO_NO_WAIT\n");
+    coap_log_err("coap_io_process_lkd() must be called with COAP_IO_NO_WAIT\n");
     return -1;
   }
 
   coap_ticks(&before);
   PROCESS_CONTEXT_BEGIN(&libcoap_io_process);
   prepare_io(ctx);
-  coap_io_do_io_locked(ctx, before);
+  coap_io_do_io_lkd(ctx, before);
   PROCESS_CONTEXT_END(&libcoap_io_process);
   coap_ticks(&now);
   return (int)(((now - before) * 1000) / COAP_TICKS_PER_SECOND);

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -61,13 +61,13 @@ coap_io_process(coap_context_t *ctx, uint32_t timeout_ms) {
   int ret;
 
   coap_lock_lock(ctx, return 0);
-  ret = coap_io_process_locked(ctx, timeout_ms);
+  ret = coap_io_process_lkd(ctx, timeout_ms);
   coap_lock_unlock(ctx);
   return ret;
 }
 
 int
-coap_io_process_locked(coap_context_t *context, uint32_t timeout_ms) {
+coap_io_process_lkd(coap_context_t *context, uint32_t timeout_ms) {
   coap_tick_t before;
   coap_tick_t now;
   unsigned int num_sockets;
@@ -75,7 +75,7 @@ coap_io_process_locked(coap_context_t *context, uint32_t timeout_ms) {
 
   coap_lock_check_locked(context);
   coap_ticks(&before);
-  timeout = coap_io_prepare_io_locked(context, NULL, 0, &num_sockets, before);
+  timeout = coap_io_prepare_io_lkd(context, NULL, 0, &num_sockets, before);
   if (timeout == 0 || (timeout_ms != COAP_IO_WAIT && timeout_ms < timeout))
     timeout = timeout_ms;
 

--- a/src/coap_io_riot.c
+++ b/src/coap_io_riot.c
@@ -33,13 +33,13 @@ coap_io_process(coap_context_t *ctx, uint32_t timeout_ms) {
   int ret;
 
   coap_lock_lock(ctx, return 0);
-  ret = coap_io_process_locked(ctx, timeout_ms);
+  ret = coap_io_process_lkd(ctx, timeout_ms);
   coap_lock_unlock(ctx);
   return ret;
 }
 
 int
-coap_io_process_locked(coap_context_t *ctx, uint32_t timeout_ms) {
+coap_io_process_lkd(coap_context_t *ctx, uint32_t timeout_ms) {
   coap_tick_t before, now;
   uint32_t timeout;
   coap_socket_t *sockets[1];
@@ -52,7 +52,7 @@ coap_io_process_locked(coap_context_t *ctx, uint32_t timeout_ms) {
 
   coap_ticks(&before);
   /* Use the common logic */
-  timeout = coap_io_prepare_io_locked(ctx, sockets, max_sockets, &num_sockets, before);
+  timeout = coap_io_prepare_io_lkd(ctx, sockets, max_sockets, &num_sockets, before);
 
   if (timeout_ms == COAP_IO_NO_WAIT) {
     timeout = 0;
@@ -83,7 +83,7 @@ coap_io_process_locked(coap_context_t *ctx, uint32_t timeout_ms) {
   }
 
   coap_ticks(&now);
-  coap_io_do_io_locked(ctx, now);
+  coap_io_do_io_lkd(ctx, now);
 
 #if COAP_SERVER_SUPPORT
   coap_expire_cache_entries(ctx);

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -268,7 +268,7 @@ dump_cose(cose_encrypt0_t *cose, const char *message) {
 #endif /* COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_OSCORE */
 }
 
-coap_pdu_t *
+COAP_API coap_pdu_t *
 coap_oscore_new_pdu_encrypted(coap_session_t *session,
                               coap_pdu_t *pdu,
                               coap_bin_const_t *kid_context,
@@ -276,7 +276,7 @@ coap_oscore_new_pdu_encrypted(coap_session_t *session,
   coap_pdu_t *ret_pdu;
 
   coap_lock_lock(session->context, return NULL);
-  ret_pdu = coap_oscore_new_pdu_encrypted_locked(session, pdu, kid_context, send_partial_iv);
+  ret_pdu = coap_oscore_new_pdu_encrypted_lkd(session, pdu, kid_context, send_partial_iv);
   coap_lock_unlock(session->context);
 
   return ret_pdu;
@@ -287,10 +287,10 @@ coap_oscore_new_pdu_encrypted(coap_session_t *session,
  * and then encrypt / integrity check the OSCORE data
  */
 coap_pdu_t *
-coap_oscore_new_pdu_encrypted_locked(coap_session_t *session,
-                                     coap_pdu_t *pdu,
-                                     coap_bin_const_t *kid_context,
-                                     oscore_partial_iv_t send_partial_iv) {
+coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
+                                  coap_pdu_t *pdu,
+                                  coap_bin_const_t *kid_context,
+                                  oscore_partial_iv_t send_partial_iv) {
   uint8_t coap_request = COAP_PDU_IS_REQUEST(pdu) || COAP_PDU_IS_PING(pdu);
   coap_pdu_code_t code =
       coap_request ? COAP_REQUEST_CODE_POST : COAP_RESPONSE_CODE(204);
@@ -569,7 +569,7 @@ coap_oscore_new_pdu_encrypted_locked(coap_session_t *session,
       /*
        * Should have already been caught by doing
        * coap_rebuild_pdu_for_proxy() before calling
-       * coap_oscore_new_pdu_encrypted_locked()
+       * coap_oscore_new_pdu_encrypted_lkd()
        */
       assert(0);
       break;
@@ -767,8 +767,8 @@ build_and_send_error_pdu(coap_session_t *session,
     coap_pdu_t *osc_pdu;
 
     osc_pdu =
-        coap_oscore_new_pdu_encrypted_locked(session, err_pdu, kid_context,
-                                             echo_data ? 1 : 0);
+        coap_oscore_new_pdu_encrypted_lkd(session, err_pdu, kid_context,
+                                          echo_data ? 1 : 0);
     if (!osc_pdu)
       goto fail_resp;
     session->oscore_encryption = 0;

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -481,7 +481,7 @@ coap_session_mfree(coap_session_t *session) {
 
         while (queue) {
           if (queue->session == session) {
-            coap_delete_node_locked(queue);
+            coap_delete_node_lkd(queue);
             break;
           }
           queue = queue->next;
@@ -522,7 +522,7 @@ coap_session_mfree(coap_session_t *session) {
                                                         COAP_NACK_TLS_FAILED : COAP_NACK_NOT_DELIVERABLE,
                                                         q->id));
     }
-    coap_delete_node_locked(q);
+    coap_delete_node_lkd(q);
   }
   LL_FOREACH_SAFE(session->lg_xmit, lq, ltmp) {
     LL_DELETE(session->lg_xmit, lq);
@@ -807,7 +807,7 @@ coap_session_connected(coap_session_t *session) {
     }
     if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
       if (q)
-        coap_delete_node_locked(q);
+        coap_delete_node_lkd(q);
       if (bytes_written < 0)
         break;
     } else if (q) {
@@ -818,7 +818,7 @@ coap_session_connected(coap_session_t *session) {
           session->partial_write = (size_t)bytes_written;
         break;
       } else {
-        coap_delete_node_locked(q);
+        coap_delete_node_lkd(q);
       }
     }
   }
@@ -898,7 +898,7 @@ coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reason) {
                              session->context->nack_handler(session, q->pdu, reason, q->id));
           sent_nack = 1;
         }
-        coap_delete_node_locked(q);
+        coap_delete_node_lkd(q);
       }
     }
 #if COAP_CLIENT_SUPPORT
@@ -947,7 +947,7 @@ coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reason) {
     q->next = NULL;
     coap_log_debug("** %s: mid=0x%04x: not transmitted after disconnect\n",
                    coap_session_str(session), q->id);
-    coap_delete_node_locked(q);
+    coap_delete_node_lkd(q);
   }
 
 #if COAP_CLIENT_SUPPORT


### PR DESCRIPTION
Update the Public API equivalent of the libcoap functions that need to be called when locked with a name suffix of _lkd.

Move matching Public API functions out of coap_threadsafe.c to be coded just ahead of the newly renamed _lkd function.

Properly define the _lkd function in the appropriate _internal.h file for documentation, removing the #defines from coap_threadsafe_internal.h.

Tag all the Public API functions that have a _lkd function with COAP_API. COAP_API can then be defined as to what should be done for that function.

Check libcoap library does not call the original Public API function when it should be calling the _lkd function by marking the Public API not _lkd functions as deprecated during the libcoap library build. [Done by the new COAP_API being defined as __attribute__((deprecated)).]

Work in progress for all the functions that need to be multi-thread safe.