### PR TITLE
locking: Simplify maintenance / debugging /documentation

### DIFF
--- a/include/coap3/coap_async.h
+++ b/include/coap3/coap_async.h
@@ -53,9 +53,9 @@ int coap_async_is_supported(void);
  * @return         A pointer to the registered coap_async_t object or @c
  *                 NULL in case of an error.
  */
-coap_async_t *coap_register_async(coap_session_t *session,
-                                  const coap_pdu_t *request,
-                                  coap_tick_t delay);
+COAP_API coap_async_t *coap_register_async(coap_session_t *session,
+                                           const coap_pdu_t *request,
+                                           coap_tick_t delay);
 
 /**
  * Update the delay timeout, so changing when the registered @p async triggers.
@@ -67,7 +67,7 @@ coap_async_t *coap_register_async(coap_session_t *session,
  * @param delay    The amount of time to delay before sending response, 0 means
  *                 wait forever.
  */
-void coap_async_set_delay(coap_async_t *async, coap_tick_t delay);
+COAP_API void coap_async_set_delay(coap_async_t *async, coap_tick_t delay);
 
 /**
  * Trigger the registered @p async.
@@ -77,7 +77,7 @@ void coap_async_set_delay(coap_async_t *async, coap_tick_t delay);
  *
  * @param async The async object to trigger.
  */
-void coap_async_trigger(coap_async_t *async);
+COAP_API void coap_async_trigger(coap_async_t *async);
 
 /**
  * Releases the memory that was allocated by coap_register_async() for the
@@ -99,7 +99,7 @@ void coap_free_async(coap_session_t *session, coap_async_t *async);
  * @return        A pointer to the object identified by @p token or @c NULL if
  *                not found.
  */
-coap_async_t *coap_find_async(coap_session_t *session, coap_bin_const_t token);
+COAP_API coap_async_t *coap_find_async(coap_session_t *session, coap_bin_const_t token);
 
 /**
  * Set the application data pointer held in @p async. This overwrites any

--- a/include/coap3/coap_async_internal.h
+++ b/include/coap3/coap_async_internal.h
@@ -42,6 +42,30 @@ struct coap_async_t {
 };
 
 /**
+ * Allocates a new coap_async_t object and fills its fields according to
+ * the given @p request. This function returns a pointer to the registered
+ * coap_async_t object or @c NULL on error. Note that this function will
+ * return @c NULL in case that an object with the same identifier is already
+ * registered.
+ *
+ * When the delay expires, a copy of the @p request will get sent to the
+ * appropriate request handler.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param session  The session that is used for asynchronous transmissions.
+ * @param request  The request that is handled asynchronously.
+ * @param delay    The amount of time to delay before sending response, 0 means
+ *                 wait forever.
+ *
+ * @return         A pointer to the registered coap_async_t object or @c
+ *                 NULL in case of an error.
+ */
+coap_async_t *coap_register_async_lkd(coap_session_t *session,
+                                      const coap_pdu_t *request,
+                                      coap_tick_t delay);
+
+/**
  * Checks if there are any pending Async requests - if so, send them off.
  * Otherewise return the time remaining for the next Async to be triggered
  * or 0 if nothing to do.
@@ -53,6 +77,58 @@ struct coap_async_t {
  *         nothing to do.
  */
 coap_tick_t coap_check_async(coap_context_t *context, coap_tick_t now);
+
+/**
+ * Retrieves the object identified by @p token from the list of asynchronous
+ * transactions that are registered with @p context. This function returns a
+ * pointer to that object or @c NULL if not found.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param session The session that is used for asynchronous transmissions.
+ * @param token   The PDU's token of the object to retrieve.
+ *
+ * @return        A pointer to the object identified by @p token or @c NULL if
+ *                not found.
+ */
+coap_async_t *coap_find_async_lkd(coap_session_t *session, coap_bin_const_t token);
+
+/**
+ * Trigger the registered @p async.
+ *
+ * A copy of the original request will get sent to the appropriate request
+ * handler.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param async The async object to trigger.
+ */
+void coap_async_trigger_lkd(coap_async_t *async);
+
+/**
+ * Update the delay timeout, so changing when the registered @p async triggers.
+ *
+ * When the new delay expires, a copy of the original request will get sent to
+ * the appropriate request handler.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param async The object to update.
+ * @param delay    The amount of time to delay before sending response, 0 means
+ *                 wait forever.
+ */
+void coap_async_set_delay_lkd(coap_async_t *async, coap_tick_t delay);
+
+/**
+ * Releases the memory that was allocated by coap_register_async() for the
+ * object @p async.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param session  The session to use.
+ * @param async The object to delete.
+ */
+void coap_free_async_lkd(coap_session_t *session, coap_async_t *async);
 
 /**
  * Removes and frees off all of the async entries for the given context.

--- a/include/coap3/coap_block.h
+++ b/include/coap3/coap_block.h
@@ -335,12 +335,12 @@ typedef void (*coap_release_large_data_t)(coap_session_t *session,
  *
  * @return @c 1 if addition is successful, else @c 0.
  */
-int coap_add_data_large_request(coap_session_t *session,
-                                coap_pdu_t *pdu,
-                                size_t length,
-                                const uint8_t *data,
-                                coap_release_large_data_t release_func,
-                                void *app_ptr);
+COAP_API int coap_add_data_large_request(coap_session_t *session,
+                                         coap_pdu_t *pdu,
+                                         size_t length,
+                                         const uint8_t *data,
+                                         coap_release_large_data_t release_func,
+                                         void *app_ptr);
 
 /**
  * Associates given data with the @p response pdu that is passed as fourth
@@ -392,18 +392,18 @@ int coap_add_data_large_request(coap_session_t *session,
  *
  * @return @c 1 if addition is successful, else @c 0.
  */
-int coap_add_data_large_response(coap_resource_t *resource,
-                                 coap_session_t *session,
-                                 const coap_pdu_t *request,
-                                 coap_pdu_t *response,
-                                 const coap_string_t *query,
-                                 uint16_t media_type,
-                                 int maxage,
-                                 uint64_t etag,
-                                 size_t length,
-                                 const uint8_t *data,
-                                 coap_release_large_data_t release_func,
-                                 void *app_ptr);
+COAP_API int coap_add_data_large_response(coap_resource_t *resource,
+                                          coap_session_t *session,
+                                          const coap_pdu_t *request,
+                                          coap_pdu_t *response,
+                                          const coap_string_t *query,
+                                          uint16_t media_type,
+                                          int maxage,
+                                          uint64_t etag,
+                                          size_t length,
+                                          const uint8_t *data,
+                                          coap_release_large_data_t release_func,
+                                          void *app_ptr);
 
 /**
  * Set the context level CoAP block handling bits for handling RFC7959.

--- a/include/coap3/coap_cache.h
+++ b/include/coap3/coap_cache.h
@@ -123,8 +123,8 @@ void coap_delete_cache_key(coap_cache_key_t *cache_key);
  *
  * @return          @return @c 1 if successful, else @c 0.
  */
-int coap_cache_ignore_options(coap_context_t *context,
-                              const uint16_t *options, size_t count);
+COAP_API int coap_cache_ignore_options(coap_context_t *context,
+                                       const uint16_t *options, size_t count);
 
 /**
  * Create a new cache-entry hash keyed by cache-key derived from the PDU.
@@ -149,11 +149,11 @@ int coap_cache_ignore_options(coap_context_t *context,
  *
  * @return          The returned cache-key or @c NULL if failure.
  */
-coap_cache_entry_t *coap_new_cache_entry(coap_session_t *session,
-                                         const coap_pdu_t *pdu,
-                                         coap_cache_record_pdu_t record_pdu,
-                                         coap_cache_session_based_t session_based,
-                                         unsigned int idle_time);
+COAP_API coap_cache_entry_t *coap_new_cache_entry(coap_session_t *session,
+                                                  const coap_pdu_t *pdu,
+                                                  coap_cache_record_pdu_t record_pdu,
+                                                  coap_cache_session_based_t session_based,
+                                                  unsigned int idle_time);
 
 /**
  * Remove a cache-entry from the hash list and free off all the appropriate
@@ -175,8 +175,8 @@ void coap_delete_cache_entry(coap_context_t *context,
  *
  * @return The cache-entry for @p cache_key or @c NULL if not found.
  */
-coap_cache_entry_t *coap_cache_get_by_key(coap_context_t *context,
-                                          const coap_cache_key_t *cache_key);
+COAP_API coap_cache_entry_t *coap_cache_get_by_key(coap_context_t *context,
+                                                   const coap_cache_key_t *cache_key);
 
 /**
  * Searches for a cache-entry corresponding to @p pdu. This
@@ -190,9 +190,9 @@ coap_cache_entry_t *coap_cache_get_by_key(coap_context_t *context,
  *
  * @return The cache-entry for @p request or @c NULL if not found.
  */
-coap_cache_entry_t *coap_cache_get_by_pdu(coap_session_t *session,
-                                          const coap_pdu_t *pdu,
-                                          coap_cache_session_based_t session_based);
+COAP_API coap_cache_entry_t *coap_cache_get_by_pdu(coap_session_t *session,
+                                                   const coap_pdu_t *pdu,
+                                                   coap_cache_session_based_t session_based);
 
 /**
  * Returns the PDU information stored in the @p coap_cache entry.

--- a/include/coap3/coap_cache_internal.h
+++ b/include/coap3/coap_cache_internal.h
@@ -58,6 +58,87 @@ struct coap_cache_entry_t {
  */
 void coap_expire_cache_entries(coap_context_t *context);
 
+/**
+ * Searches for a cache-entry identified by @p cache_key. This
+ * function returns the corresponding cache-entry or @c NULL
+ * if not found.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param context    The context to use.
+ * @param cache_key  The cache-key to get the hashed coap-entry.
+ *
+ * @return The cache-entry for @p cache_key or @c NULL if not found.
+ */
+coap_cache_entry_t *coap_cache_get_by_key_lkd(coap_context_t *context,
+                                              const coap_cache_key_t *cache_key);
+
+/**
+ * Searches for a cache-entry corresponding to @p pdu. This
+ * function returns the corresponding cache-entry or @c NULL if not
+ * found.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param session    The session to use.
+ * @param pdu        The CoAP request to search for.
+ * @param session_based COAP_CACHE_IS_SESSION_BASED if session based
+ *                     cache-key to be used, else COAP_CACHE_NOT_SESSION_BASED.
+ *
+ * @return The cache-entry for @p request or @c NULL if not found.
+ */
+coap_cache_entry_t *coap_cache_get_by_pdu_lkd(coap_session_t *session,
+                                              const coap_pdu_t *pdu,
+                                              coap_cache_session_based_t session_based);
+
+/**
+ * Define the CoAP options that are not to be included when calculating
+ * the cache-key. Options that are defined as Non-Cache and the Observe
+ * option are always ignored.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param context   The context to save the ignored options information in.
+ * @param options   The array of options to ignore.
+ * @param count     The number of options to ignore.  Use 0 to reset the
+ *                  options matching.
+ *
+ * @return          @return @c 1 if successful, else @c 0.
+ */
+int coap_cache_ignore_options_lkd(coap_context_t *context,
+                                  const uint16_t *options, size_t count);
+
+/**
+ * Create a new cache-entry hash keyed by cache-key derived from the PDU.
+ *
+ * If @p session_based is set, then this cache-entry will get deleted when
+ * the session is freed off.
+ * If @p record_pdu is set, then the copied PDU will get freed off when
+ * this cache-entry is deleted.
+ *
+ * The cache-entry is maintained on a context hash list.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param session   The session to use to derive the context from.
+ * @param pdu       The pdu to use to generate the cache-key.
+ * @param record_pdu COAP_CACHE_RECORD_PDU if to take a copy of the PDU for
+ *                   later use, else COAP_CACHE_NOT_RECORD_PDU.
+ * @param session_based COAP_CACHE_IS_SESSION_BASED if to associate this
+ *                      cache-entry with the the session (which is embedded
+ *                      in the cache-entry), else COAP_CACHE_NOT_SESSION_BASED.
+ * @param idle_time Idle time in seconds before cache-entry is expired.
+ *                  If set to 0, it does not expire (but will get
+ *                  deleted if the session is deleted and it is session_based).
+ *
+ * @return          The returned cache-key or @c NULL if failure.
+ */
+coap_cache_entry_t *coap_new_cache_entry_lkd(coap_session_t *session,
+                                             const coap_pdu_t *pdu,
+                                             coap_cache_record_pdu_t record_pdu,
+                                             coap_cache_session_based_t session_based,
+                                             unsigned int idle_time);
+
 typedef void coap_digest_ctx_t;
 
 /**

--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -528,9 +528,9 @@ coap_mid_t coap_send(coap_session_t *session, coap_pdu_t *pdu);
  * @return The result from the associated event handler or 0 if none was
  * registered.
  */
-int coap_handle_event(coap_context_t *context,
-                      coap_event_t event,
-                      coap_session_t *session);
+COAP_API int coap_handle_event(coap_context_t *context,
+                               coap_event_t event,
+                               coap_session_t *session);
 /**
  * Returns 1 if there are no messages to send or to dispatch in the context's
  * queues.
@@ -541,7 +541,7 @@ int coap_handle_event(coap_context_t *context,
  *         queued for transmission.  Note that @c 0 does not mean there has
  *         been a response to a transmitted request.
  */
-int coap_can_exit(coap_context_t *context);
+COAP_API int coap_can_exit(coap_context_t *context);
 
 /**
  * Returns the current value of an internal tick counter. The counter counts \c

--- a/include/coap3/coap_resource.h
+++ b/include/coap3/coap_resource.h
@@ -288,8 +288,8 @@ coap_resource_t *coap_resource_proxy_uri_init2(coap_method_handler_t handler,
  *
  * @return         A pointer to the resource or @c NULL if not found.
  */
-coap_resource_t *coap_get_resource_from_uri_path(coap_context_t *context,
-                                                 coap_str_const_t *uri_path);
+COAP_API coap_resource_t *coap_get_resource_from_uri_path(coap_context_t *context,
+                                                          coap_str_const_t *uri_path);
 
 /**
  * Get the uri_path from a @p resource.
@@ -354,7 +354,7 @@ void coap_resource_release_userdata_handler(coap_context_t *context,
  * @param context  The context to use.
  * @param resource The resource to store.
  */
-void coap_add_resource(coap_context_t *context, coap_resource_t *resource);
+COAP_API void coap_add_resource(coap_context_t *context, coap_resource_t *resource);
 
 /**
  * Deletes a resource identified by @p resource. The storage allocated for that
@@ -367,7 +367,7 @@ void coap_add_resource(coap_context_t *context, coap_resource_t *resource);
  * @return         @c 1 if the resource was found (and destroyed),
  *                 @c 0 otherwise.
  */
-int coap_delete_resource(coap_context_t *context, coap_resource_t *resource);
+COAP_API int coap_delete_resource(coap_context_t *context, coap_resource_t *resource);
 
 /**
  * Registers the specified @p handler as message handler for the request type
@@ -499,7 +499,7 @@ coap_print_status_t coap_print_link(const coap_resource_t *resource,
 /**
  * @deprecated use coap_resource_notify_observers() instead.
  */
-COAP_DEPRECATED int coap_resource_set_dirty(coap_resource_t *r,
-                                            const coap_string_t *query);
+COAP_DEPRECATED COAP_API int coap_resource_set_dirty(coap_resource_t *r,
+                                                     const coap_string_t *query);
 
 #endif /* COAP_RESOURCE_H_ */

--- a/include/coap3/coap_resource_internal.h
+++ b/include/coap3/coap_resource_internal.h
@@ -112,6 +112,33 @@ struct coap_resource_t {
 };
 
 /**
+ * Registers the given @p resource for @p context. The resource must have been
+ * created by coap_resource_init() or coap_resource_unknown_init(), the
+ * storage allocated for the resource will be released by coap_delete_resource_lkd().
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param context  The context to use.
+ * @param resource The resource to store.
+ */
+void coap_add_resource_lkd(coap_context_t *context, coap_resource_t *resource);
+
+/**
+ * Deletes a resource identified by @p resource. The storage allocated for that
+ * resource is freed, and removed from the context.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param context  This parameter is ignored, but kept for backward
+ *                 compatibility.
+ * @param resource The resource to delete.
+ *
+ * @return         @c 1 if the resource was found (and destroyed),
+ *                 @c 0 otherwise.
+ */
+int coap_delete_resource_lkd(coap_context_t *context, coap_resource_t *resource);
+
+/**
  * Deletes all resources from given @p context and frees their storage.
  *
  * @param context The CoAP context with the resources to be deleted.
@@ -131,6 +158,20 @@ void coap_delete_all_resources(coap_context_t *context);
 #define RESOURCES_FIND(r, k, res) {                     \
     HASH_FIND(hh, (r), (k)->s, (k)->length, (res)); \
   }
+
+/**
+ * Returns the resource identified by the unique string @p uri_path. If no
+ * resource was found, this function returns @c NULL.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param context  The context to look for this resource.
+ * @param uri_path  The unique string uri of the resource.
+ *
+ * @return         A pointer to the resource or @c NULL if not found.
+ */
+coap_resource_t *coap_get_resource_from_uri_path_lkd(coap_context_t *context,
+                                                     coap_str_const_t *uri_path);
 
 /**
  * Deletes an attribute.

--- a/include/coap3/coap_subscribe.h
+++ b/include/coap3/coap_subscribe.h
@@ -60,8 +60,8 @@ void coap_resource_set_get_observable(coap_resource_t *resource, int mode);
  *
  * @return         @c 1 if the Observe has been triggered, @c 0 otherwise.
  */
-int coap_resource_notify_observers(coap_resource_t *resource,
-                                   const coap_string_t *query);
+COAP_API int coap_resource_notify_observers(coap_resource_t *resource,
+                                            const coap_string_t *query);
 
 /**
  * Checks all known resources to see if they are dirty and then notifies
@@ -69,7 +69,7 @@ int coap_resource_notify_observers(coap_resource_t *resource,
  *
  * @param context The context to check for dirty resources.
  */
-void coap_check_notify(coap_context_t *context);
+COAP_API void coap_check_notify(coap_context_t *context);
 
 /**
  * Callback handler definition called when a new observe has been set up,
@@ -279,8 +279,8 @@ void coap_persist_set_observe_num(coap_resource_t *resource,
  * @return @c 1 if observe cancel transmission initiation is successful,
  *         else @c 0.
  */
-int coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
-                        coap_pdu_type_t message_type);
+COAP_API int coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
+                                 coap_pdu_type_t message_type);
 
 /** @} */
 

--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -148,13 +148,59 @@ int coap_delete_observer(coap_resource_t *resource,
 void coap_delete_observers(coap_context_t *context, coap_session_t *session);
 
 /**
+ * Initiate the sending of an Observe packet for all observers of @p resource,
+ * optionally matching @p query if not NULL
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param resource The CoAP resource to use.
+ * @param query    The Query to match against or NULL
+ *
+ * @return         @c 1 if the Observe has been triggered, @c 0 otherwise.
+ */
+int coap_resource_notify_observers_lkd(coap_resource_t *resource,
+                                       const coap_string_t *query);
+
+/**
+ * Checks all known resources to see if they are dirty and then notifies
+ * subscribed observers.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param context The context to check for dirty resources.
+ */
+void coap_check_notify_lkd(coap_context_t *context);
+
+/**
  * Close down persist tracking, releasing any memory used.
  *
  * @param context The current CoAP context.
  */
 void coap_persist_cleanup(coap_context_t *context);
 
-/** @} */
-
 #endif /* COAP_SERVER_SUPPORT */
+
+#if COAP_CLIENT_SUPPORT
+
+/**
+ * Cancel an observe that is being tracked by the client large receive logic.
+ * (coap_context_set_block_mode() has to be called)
+ * This will trigger the sending of an observe cancel pdu to the server.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param session  The session that is being used for the observe.
+ * @param token    The original token used to initiate the observation.
+ * @param message_type The COAP_MESSAGE_ type (NON or CON) to send the observe
+ *                 cancel pdu as.
+ *
+ * @return @c 1 if observe cancel transmission initiation is successful,
+ *         else @c 0.
+ */
+int coap_cancel_observe_lkd(coap_session_t *session, coap_binary_t *token,
+                            coap_pdu_type_t message_type);
+
+#endif /* COAP_CLIENT_SUPPORT */
+
+/** @} */
 #endif /* COAP_SUBSCRIBE_INTERNAL_H_ */

--- a/include/coap3/coap_threadsafe_internal.h
+++ b/include/coap3/coap_threadsafe_internal.h
@@ -22,17 +22,6 @@
 /* *INDENT-OFF* */
 #ifndef COAP_THREAD_IGNORE_LOCKED_MAPPING
 
-#define coap_add_data_large_request(a,b,c,d,e,f)        coap_add_data_large_request_locked(a,b,c,d,e,f)
-#define coap_add_data_large_response(a,b,c,d,e,f,g,h,i,j,k,l) coap_add_data_large_response_locked(a,b,c,d,e,f,g,h,i,j,k,l)
-#define coap_add_resource(c,r)                          coap_add_resource_locked(c,r)
-#define coap_async_trigger(a)                           coap_async_trigger_locked(a)
-#define coap_async_set_delay(a,d)                       coap_async_set_delay_locked(a,d)
-#define coap_cache_get_by_key(s,c)                      coap_cache_get_by_key_locked(s,c)
-#define coap_cache_get_by_pdu(s,r,b)                    coap_cache_get_by_pdu_locked(s,r,b)
-#define coap_cache_ignore_options(c,o,n)                coap_cache_ignore_options_locked(c,o,n)
-#define coap_can_exit(c)                                coap_can_exit_locked(c)
-#define coap_cancel_observe(s,t,v)                      coap_cancel_observe_locked(s,t,v)
-#define coap_check_notify(s)                            coap_check_notify_locked(s)
 #define coap_context_oscore_server(c,o)                 coap_context_oscore_server_locked(c,o)
 #define coap_context_set_block_mode(c,b)                coap_context_set_block_mode_locked(c,b)
 #define coap_context_set_max_block_size(c,m)            coap_context_set_max_block_size_locked(c,m)
@@ -40,13 +29,9 @@
 #define coap_context_set_pki_root_cas(c,f,d)            coap_context_set_pki_root_cas_locked(c,f,d)
 #define coap_context_set_psk(c,h,k,l)                   coap_context_set_psk_locked(c,h,k,l)
 #define coap_context_set_psk2(c,s)                      coap_context_set_psk2_locked(c,s)
-#define coap_find_async(s,t)                            coap_find_async_locked(s,t)
 #define coap_delete_oscore_recipient(s,r)               coap_delete_oscore_recipient_locked(s,r)
-#define coap_delete_resource(c,r)                       coap_delete_resource_locked(c,r)
 #define coap_free_endpoint(e)                           coap_free_endpoint_locked(e)
-#define coap_get_resource_from_uri_path(c,u)            coap_get_resource_from_uri_path_locked(c,u)
 #define coap_join_mcast_group_intf(c,g,i)               coap_join_mcast_group_intf_locked(c,g,i)
-#define coap_new_cache_entry(s,p,r,b,i)                 coap_new_cache_entry_locked(s,p,r,b,i)
 #define coap_new_client_session(c,l,s,p)                coap_new_client_session_locked(c,l,s,p)
 #define coap_new_client_session_oscore(c,l,s,p,o)       coap_new_client_session_oscore_locked(c,l,s,p,o)
 #define coap_new_client_session_oscore_pki(c,l,s,p,d,o) coap_new_client_session_oscore_pki_locked(c,l,s,p,d,o)
@@ -62,10 +47,7 @@
 #define coap_persist_startup(c,d,o,m,s)                 coap_persist_startup_locked(c,d,o,m,s)
 #define coap_persist_stop(c)                            coap_persist_stop_locked(c)
 #define coap_pdu_duplicate(o,s,l,t,d)                   coap_pdu_duplicate_locked(o,s,l,t,d)
-#define coap_register_async(s,r,d)                      coap_register_async_locked(s,r,d)
 #define coap_register_option(c,t)                       coap_register_option_locked(c,t)
-#define coap_resource_notify_observers(r,q)             coap_resource_notify_observers_locked(r,q)
-#define coap_resource_set_dirty(r,q)                    coap_resource_set_dirty_locked(r,q)
 #define coap_send(s,p)                                  coap_send_locked(s,p)
 #define coap_send_ack(s,r)                              coap_send_ack_locked(s,r)
 #define coap_send_error(s,r,c,o)                        coap_send_error_locked(s,r,c,o)
@@ -81,39 +63,6 @@
 
 /* Locked equivalend functions */
 
-int                  coap_add_data_large_request_locked(coap_session_t *session,
-                                                        coap_pdu_t *pdu,
-                                                        size_t length,
-                                                        const uint8_t *data,
-                                                        coap_release_large_data_t release_func,
-                                                        void *app_ptr);
-int                  coap_add_data_large_response_locked(coap_resource_t *resource,
-                                                         coap_session_t *session,
-                                                         const coap_pdu_t *request,
-                                                         coap_pdu_t *response,
-                                                         const coap_string_t *query,
-                                                         uint16_t media_type,
-                                                         int maxage,
-                                                         uint64_t etag,
-                                                         size_t length,
-                                                         const uint8_t *data,
-                                                         coap_release_large_data_t release_func,
-                                                         void *app_ptr);
-void                 coap_add_resource_locked(coap_context_t *context, coap_resource_t *resource);
-void                 coap_async_trigger_locked(coap_async_t *async);
-void                 coap_async_set_delay_locked(coap_async_t *async, coap_tick_t delay);
-coap_cache_entry_t  *coap_cache_get_by_key_locked(coap_context_t *context,
-                                                  const coap_cache_key_t *cache_key);
-coap_cache_entry_t  *coap_cache_get_by_pdu_locked(coap_session_t *session,
-                                                  const coap_pdu_t *request,
-                                                  coap_cache_session_based_t session_based);
-int                  coap_cache_ignore_options_locked(coap_context_t *ctx,
-                                                      const uint16_t *options,
-                                                      size_t count);
-int                  coap_can_exit_locked(coap_context_t *context);
-int                  coap_cancel_observe_locked(coap_session_t *session, coap_binary_t *token,
-                                                coap_pdu_type_t type);
-void                 coap_check_notify_locked(coap_context_t *context);
 int                  coap_context_oscore_server_locked(coap_context_t *context,
                                                        coap_oscore_conf_t *oscore_conf);
 void                 coap_context_set_block_mode_locked(coap_context_t *context,
@@ -130,11 +79,7 @@ int                  coap_context_set_psk2_locked(coap_context_t *ctx,
                                                   coap_dtls_spsk_t *setup_data);
 int                  coap_delete_oscore_recipient_locked(coap_context_t *context,
                                                          coap_bin_const_t *recipient_id);
-int                  coap_delete_resource_locked(coap_context_t *context, coap_resource_t *resource);
-coap_async_t        *coap_find_async_locked(coap_session_t *session, coap_bin_const_t token);
 void                 coap_free_endpoint_locked(coap_endpoint_t *ep);
-coap_resource_t     *coap_get_resource_from_uri_path_locked(coap_context_t *context,
-                                                            coap_str_const_t *uri_path);
 int                  coap_join_mcast_group_intf_locked(coap_context_t *ctx, const char *group_name,
                                                        const char *ifname);
 coap_subscription_t *coap_persist_observe_add_locked(coap_context_t *context,
@@ -149,13 +94,7 @@ int                  coap_persist_startup_locked(coap_context_t *context,
                                                  const char *obs_cnt_save_file,
                                                  uint32_t save_freq);
 void                 coap_persist_stop_locked(coap_context_t *context);
-coap_async_t        *coap_register_async_locked(coap_session_t *session, const coap_pdu_t *request,
-                                                coap_tick_t delay);
 size_t               coap_session_max_pdu_size_locked(const coap_session_t *session);
-coap_cache_entry_t  *coap_new_cache_entry_locked(coap_session_t *session, const coap_pdu_t *pdu,
-                                                 coap_cache_record_pdu_t record_pdu,
-                                                 coap_cache_session_based_t session_based,
-                                                 unsigned int idle_timeout);
 coap_session_t      *coap_new_client_session_locked(coap_context_t *ctx,
                                                     const coap_address_t *local_if,
                                                     const coap_address_t *server,
@@ -206,8 +145,6 @@ coap_pdu_t          *coap_pdu_duplicate_locked(const coap_pdu_t *old_pdu,
                                                const uint8_t *token,
                                                coap_opt_filter_t *drop_options);
 void                 coap_register_option_locked(coap_context_t *ctx, uint16_t type);
-int                  coap_resource_notify_observers_locked(coap_resource_t *r,
-                                                           const coap_string_t *query);
 int                  coap_resource_set_dirty_locked(coap_resource_t *r,
                                                     const coap_string_t *query);
 coap_mid_t          coap_send_locked(coap_session_t *session, coap_pdu_t *pdu);

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -2271,7 +2271,7 @@ coap_dtls_free_session(coap_session_t *c_session) {
                               COAP_PROTO_NOT_RELIABLE(c_session->proto) ?
                               COAP_FREE_BYE_AS_UDP : COAP_FREE_BYE_AS_TCP);
     c_session->tls = NULL;
-    coap_handle_event(c_session->context, COAP_EVENT_DTLS_CLOSED, c_session);
+    coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CLOSED, c_session);
   }
 }
 
@@ -2338,7 +2338,7 @@ coap_dtls_send(coap_session_t *c_session,
   }
 
   if (c_session->dtls_event >= 0) {
-    coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+    coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
@@ -2440,8 +2440,8 @@ coap_dtls_receive(coap_session_t *c_session, const uint8_t *data,
   c_session->dtls_event = -1;
   if (g_env->established) {
     if (c_session->state == COAP_SESSION_STATE_HANDSHAKE) {
-      coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
-                        c_session);
+      coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CONNECTED,
+                            c_session);
       gnutls_transport_set_ptr(g_env->g_session, c_session);
       c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
     }
@@ -2490,7 +2490,7 @@ coap_dtls_receive(coap_session_t *c_session, const uint8_t *data,
   if (c_session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
@@ -2696,7 +2696,7 @@ coap_tls_new_client_session(coap_session_t *c_session) {
   c_session->tls = g_env;
   ret = do_gnutls_handshake(c_session, g_env);
   if (ret == 1) {
-    coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
+    coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
     c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
   }
   return g_env;
@@ -2742,7 +2742,7 @@ coap_tls_new_server_session(coap_session_t *c_session) {
   c_session->tls = g_env;
   ret = do_gnutls_handshake(c_session, g_env);
   if (ret == 1) {
-    coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
+    coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
     c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
   }
   return g_env;
@@ -2805,8 +2805,8 @@ coap_tls_write(coap_session_t *c_session, const uint8_t *data,
   } else {
     ret = do_gnutls_handshake(c_session, g_env);
     if (ret == 1) {
-      coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
-                        c_session);
+      coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CONNECTED,
+                            c_session);
       c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
       ret = 0;
     } else {
@@ -2817,7 +2817,7 @@ coap_tls_write(coap_session_t *c_session, const uint8_t *data,
   if (c_session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
@@ -2855,8 +2855,8 @@ coap_tls_read(coap_session_t *c_session, uint8_t *data, size_t data_len) {
   if (!g_env->established && !g_env->sent_alert) {
     ret = do_gnutls_handshake(c_session, g_env);
     if (ret == 1) {
-      coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
-                        c_session);
+      coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CONNECTED,
+                            c_session);
       c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
       ret = 0;
     }
@@ -2898,7 +2898,7 @@ coap_tls_read(coap_session_t *c_session, uint8_t *data, size_t data_len) {
   if (c_session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -513,7 +513,7 @@ coap_update_io_timer(coap_context_t *context, coap_tick_t delay) {
       ret = timerfd_settime(context->eptimerfd, 0, &new_value, NULL);
       if (ret == -1) {
         coap_log_err("%s: timerfd_settime failed: %s (%d)\n",
-                     "coap_resource_notify_observers",
+                     "coap_update_io_timer",
                      coap_socket_strerror(), errno);
       }
 #ifdef COAP_DEBUG_WAKEUP_TIMES
@@ -1194,7 +1194,7 @@ coap_io_prepare_epoll_lkd(coap_context_t *ctx, coap_tick_t now) {
 #ifndef COAP_EPOLL_SUPPORT
   (void)ctx;
   (void)now;
-  coap_log_emerg("coap_io_prepare_epoll_lkd() requires libcoap compiled for using epoll\n");
+  coap_log_emerg("coap_io_prepare_epoll() requires libcoap compiled for using epoll\n");
   return 0;
 #else /* COAP_EPOLL_SUPPORT */
   coap_socket_t *sockets[1];
@@ -1228,7 +1228,7 @@ coap_io_prepare_epoll_lkd(coap_context_t *ctx, coap_tick_t now) {
     ret = timerfd_settime(ctx->eptimerfd, 0, &new_value, NULL);
     if (ret == -1) {
       coap_log_err("%s: timerfd_settime failed: %s (%d)\n",
-                   "coap_io_prepare_epoll_lkd",
+                   "coap_io_prepare_epoll",
                    coap_socket_strerror(), errno);
     }
   }
@@ -1281,7 +1281,7 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
 
 #if COAP_SERVER_SUPPORT
   /* Check to see if we need to send off any Observe requests */
-  coap_check_notify(ctx);
+  coap_check_notify_lkd(ctx);
 
 #if COAP_ASYNC_SUPPORT
   /* Check to see if we need to send off any Async requests */
@@ -1340,7 +1340,7 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
           s->delayqueue == NULL &&
           (s->last_rx_tx + session_timeout <= now ||
            s->state == COAP_SESSION_STATE_NONE)) {
-        coap_handle_event(ctx, COAP_EVENT_SERVER_SESSION_DEL, s);
+        coap_handle_event_lkd(ctx, COAP_EVENT_SERVER_SESSION_DEL, s);
         coap_session_free(s);
       } else {
         if (s->type == COAP_SESSION_TYPE_SERVER && s->ref == 0 &&
@@ -1419,7 +1419,7 @@ release_1:
           /* Some issue - not safe to continue processing */
           continue;
         if (s->last_ping > 0 && s->last_pong < s->last_ping) {
-          coap_handle_event(s->context, COAP_EVENT_KEEPALIVE_FAILURE, s);
+          coap_handle_event_lkd(s->context, COAP_EVENT_KEEPALIVE_FAILURE, s);
         }
         s->last_rx_tx = now;
         s->last_ping = now;

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -443,7 +443,7 @@ do_tcp_err(void *arg, err_t err) {
 
   (void)err;
 
-  coap_handle_event(session->context, COAP_EVENT_TCP_FAILED, session);
+  coap_handle_event_lkd(session->context, COAP_EVENT_TCP_FAILED, session);
   /*
    * as per tcp_err() documentation, the corresponding pcb is already freed
    * when this callback is called.  So, stop a double free when

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -1974,7 +1974,7 @@ coap_dtls_free_session(coap_session_t *c_session) {
   if (c_session && c_session->context && c_session->tls) {
     coap_dtls_free_mbedtls_env(c_session->tls);
     c_session->tls = NULL;
-    coap_handle_event(c_session->context, COAP_EVENT_DTLS_CLOSED, c_session);
+    coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CLOSED, c_session);
   }
   return;
 }
@@ -2041,7 +2041,7 @@ coap_dtls_send(coap_session_t *c_session,
   if (c_session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
@@ -2165,8 +2165,8 @@ coap_dtls_receive(coap_session_t *c_session,
 #endif /* COAP_CONSTRAINED_STACK */
 
     if (c_session->state == COAP_SESSION_STATE_HANDSHAKE) {
-      coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
-                        c_session);
+      coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CONNECTED,
+                            c_session);
       c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
     }
 
@@ -2216,7 +2216,7 @@ coap_dtls_receive(coap_session_t *c_session,
   if (c_session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
@@ -2349,7 +2349,7 @@ coap_tls_new_client_session(coap_session_t *c_session) {
   c_session->tls = m_env;
   ret = do_mbedtls_handshake(c_session, m_env);
   if (ret == 1) {
-    coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
+    coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
     c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
   }
   return m_env;
@@ -2380,7 +2380,7 @@ coap_tls_new_server_session(coap_session_t *c_session) {
   c_session->tls = m_env;
   ret = do_mbedtls_handshake(c_session, m_env);
   if (ret == 1) {
-    coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
+    coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CONNECTED, c_session);
     c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
   }
   return m_env;
@@ -2448,8 +2448,8 @@ coap_tls_write(coap_session_t *c_session, const uint8_t *data,
   } else {
     ret = do_mbedtls_handshake(c_session, m_env);
     if (ret == 1) {
-      coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
-                        c_session);
+      coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CONNECTED,
+                            c_session);
       c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
     } else {
       ret = -1;
@@ -2459,7 +2459,7 @@ coap_tls_write(coap_session_t *c_session, const uint8_t *data,
   if (c_session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);
@@ -2498,8 +2498,8 @@ coap_tls_read(coap_session_t *c_session, uint8_t *data, size_t data_len) {
   if (!m_env->established && !m_env->sent_alert) {
     ret = do_mbedtls_handshake(c_session, m_env);
     if (ret == 1) {
-      coap_handle_event(c_session->context, COAP_EVENT_DTLS_CONNECTED,
-                        c_session);
+      coap_handle_event_lkd(c_session->context, COAP_EVENT_DTLS_CONNECTED,
+                            c_session);
       c_session->sock.lfunc[COAP_LAYER_TLS].l_establish(c_session);
     }
   }
@@ -2537,7 +2537,7 @@ coap_tls_read(coap_session_t *c_session, uint8_t *data, size_t data_len) {
   if (c_session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(c_session->context, c_session->dtls_event, c_session);
+      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(c_session, COAP_NACK_TLS_FAILED);

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -3466,7 +3466,7 @@ coap_dtls_free_session(coap_session_t *session) {
     SSL_free(ssl);
     session->tls = NULL;
     if (session->context)
-      coap_handle_event(session->context, COAP_EVENT_DTLS_CLOSED, session);
+      coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CLOSED, session);
   }
 }
 
@@ -3498,7 +3498,7 @@ coap_dtls_send(coap_session_t *session,
   if (session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(session->context, session->dtls_event, session);
+      coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
@@ -3626,7 +3626,7 @@ coap_dtls_receive(coap_session_t *session, const uint8_t *data, size_t data_len)
       if (in_init && SSL_is_init_finished(ssl)) {
         coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                       coap_session_str(session), SSL_get_cipher_name(ssl));
-        coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+        coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
         session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
       }
       r = 0;
@@ -3640,7 +3640,7 @@ coap_dtls_receive(coap_session_t *session, const uint8_t *data, size_t data_len)
     if (session->dtls_event >= 0) {
       /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
       if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-        coap_handle_event(session->context, session->dtls_event, session);
+        coap_handle_event_lkd(session->context, session->dtls_event, session);
       if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
           session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
         coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
@@ -3768,7 +3768,7 @@ coap_tls_new_client_session(coap_session_t *session) {
 
   session->tls = ssl;
   if (SSL_is_init_finished(ssl)) {
-    coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+    coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
     session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
@@ -3838,7 +3838,7 @@ coap_tls_new_server_session(coap_session_t *session) {
 
   session->tls = ssl;
   if (SSL_is_init_finished(ssl)) {
-    coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+    coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
     session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
@@ -3871,7 +3871,7 @@ coap_tls_free_session(coap_session_t *session) {
     SSL_free(ssl);
     session->tls = NULL;
     if (session->context)
-      coap_handle_event(session->context, COAP_EVENT_DTLS_CLOSED, session);
+      coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CLOSED, session);
   }
 }
 
@@ -3898,7 +3898,7 @@ coap_tls_write(coap_session_t *session, const uint8_t *data, size_t data_len) {
       if (in_init && SSL_is_init_finished(ssl)) {
         coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                       coap_session_str(session), SSL_get_cipher_name(ssl));
-        coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+        coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
         session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
       }
       if (err == SSL_ERROR_WANT_READ)
@@ -3926,14 +3926,14 @@ coap_tls_write(coap_session_t *session, const uint8_t *data, size_t data_len) {
   } else if (in_init && SSL_is_init_finished(ssl)) {
     coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                   coap_session_str(session), SSL_get_cipher_name(ssl));
-    coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+    coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
     session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
   if (session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(session->context, session->dtls_event, session);
+      coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
@@ -3976,7 +3976,7 @@ coap_tls_read(coap_session_t *session, uint8_t *data, size_t data_len) {
       if (in_init && SSL_is_init_finished(ssl)) {
         coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                       coap_session_str(session), SSL_get_cipher_name(ssl));
-        coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+        coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
         session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
       }
       if (err == SSL_ERROR_WANT_READ)
@@ -4002,14 +4002,14 @@ coap_tls_read(coap_session_t *session, uint8_t *data, size_t data_len) {
   } else if (in_init && SSL_is_init_finished(ssl)) {
     coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                   coap_session_str(session), SSL_get_cipher_name(ssl));
-    coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+    coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
     session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
   if (session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(session->context, session->dtls_event, session);
+      coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(session, COAP_NACK_TLS_FAILED);

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -828,18 +828,18 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
   if (session->context->p_osc_ctx == NULL) {
     coap_log_warn("OSCORE: Not enabled\n");
     if (!coap_request)
-      coap_handle_event(session->context,
-                        COAP_EVENT_OSCORE_NOT_ENABLED,
-                        session);
+      coap_handle_event_lkd(session->context,
+                            COAP_EVENT_OSCORE_NOT_ENABLED,
+                            session);
     return NULL;
   }
 
   if (pdu->data == NULL) {
     coap_log_warn("OSCORE: No protected payload\n");
     if (!coap_request)
-      coap_handle_event(session->context,
-                        COAP_EVENT_OSCORE_NO_PROTECTED_PAYLOAD,
-                        session);
+      coap_handle_event_lkd(session->context,
+                            COAP_EVENT_OSCORE_NO_PROTECTED_PAYLOAD,
+                            session);
     return NULL;
   }
 
@@ -853,9 +853,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
       coap_pdu_init(pdu->type, 0, pdu->mid, pdu->used_size);
   if (decrypt_pdu == NULL) {
     if (!coap_request)
-      coap_handle_event(session->context,
-                        COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                        session);
+      coap_handle_event_lkd(session->context,
+                            COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                            session);
     goto error;
   }
 
@@ -898,9 +898,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
                                     coap_opt_length(opt),
                                     coap_opt_value(opt))) {
         if (!coap_request)
-          coap_handle_event(session->context,
-                            COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                            session);
+          coap_handle_event_lkd(session->context,
+                                COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                                session);
         goto error;
       }
       break;
@@ -1035,9 +1035,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
      */
     if (oscore_decode_option_value(osc_value, osc_size, cose) == 0) {
       coap_log_warn("OSCORE: OSCORE Option cannot be decoded.\n");
-      coap_handle_event(session->context,
-                        COAP_EVENT_OSCORE_DECODE_ERROR,
-                        session);
+      coap_handle_event_lkd(session->context,
+                            COAP_EVENT_OSCORE_DECODE_ERROR,
+                            session);
       goto error;
     }
     association = oscore_find_association(session, &pdu_token);
@@ -1066,9 +1066,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
                                               osc_ctx->id_context->length);
 
           if (kc == NULL) {
-            coap_handle_event(session->context,
-                              COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                              session);
+            coap_handle_event_lkd(session->context,
+                                  COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                                  session);
             goto error;
           }
 
@@ -1088,9 +1088,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
 #endif /* COAP_CLIENT_SUPPORT */
     } else {
       coap_log_crit("OSCORE: Security Context association not found\n");
-      coap_handle_event(session->context,
-                        COAP_EVENT_OSCORE_NO_SECURITY,
-                        session);
+      coap_handle_event_lkd(session->context,
+                            COAP_EVENT_OSCORE_NO_SECURITY,
+                            session);
       goto error;
     }
   }
@@ -1299,9 +1299,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
   if (encrypt_len <= 0) {
     coap_log_warn("OSCORE: No protected payload\n");
     if (!coap_request)
-      coap_handle_event(session->context,
-                        COAP_EVENT_OSCORE_NO_PROTECTED_PAYLOAD,
-                        session);
+      coap_handle_event_lkd(session->context,
+                            COAP_EVENT_OSCORE_NO_PROTECTED_PAYLOAD,
+                            session);
     goto error;
   }
   cose_encrypt0_set_key(cose, rcp_ctx->recipient_key);
@@ -1312,18 +1312,18 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
   plain_pdu = coap_pdu_init(0, 0, 0, encrypt_len /* - tag_len */);
   if (plain_pdu == NULL) {
     if (!coap_request)
-      coap_handle_event(session->context,
-                        COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                        session);
+      coap_handle_event_lkd(session->context,
+                            COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                            session);
     goto error;
   }
 
   /* need the tag_len on the end for TinyDTLS to do its work - yuk */
   if (!coap_pdu_resize(plain_pdu, encrypt_len /* - tag_len */)) {
     if (!coap_request)
-      coap_handle_event(session->context,
-                        COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                        session);
+      coap_handle_event_lkd(session->context,
+                            COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                            session);
     goto error;
   }
 
@@ -1350,9 +1350,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
       oscore_roll_back_seq(rcp_ctx);
       goto error_no_ack;
     } else {
-      coap_handle_event(session->context,
-                        COAP_EVENT_OSCORE_DECRYPTION_FAILURE,
-                        session);
+      coap_handle_event_lkd(session->context,
+                            COAP_EVENT_OSCORE_DECRYPTION_FAILURE,
+                            session);
     }
     goto error;
   }
@@ -1368,9 +1368,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
 
     if (kc == NULL) {
       if (!coap_request)
-        coap_handle_event(session->context,
-                          COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                          session);
+        coap_handle_event_lkd(session->context,
+                              COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                              session);
       goto error;
     }
 
@@ -1422,9 +1422,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
 
     if (kc == NULL) {
       if (!coap_request)
-        coap_handle_event(session->context,
-                          COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                          session);
+        coap_handle_event_lkd(session->context,
+                              COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                              session);
       goto error;
     }
     memcpy(kc->s, cose->kid_context.s, cose->kid_context.length);
@@ -1519,9 +1519,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
                 opt_iter.number,
                 len,
                 cose->partial_iv.s ? &cose->partial_iv.s[bias] : NULL)) {
-          coap_handle_event(session->context,
-                            COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                            session);
+          coap_handle_event_lkd(session->context,
+                                COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                                session);
           goto error;
         }
         break;
@@ -1538,9 +1538,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
                               coap_opt_length(opt),
                               coap_opt_value(opt))) {
         if (!coap_request)
-          coap_handle_event(session->context,
-                            COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                            session);
+          coap_handle_event_lkd(session->context,
+                                COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                                session);
         goto error;
       }
       break;
@@ -1555,9 +1555,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
                        (plain_pdu->data - plain_pdu->token),
                        plain_pdu->data)) {
       if (!coap_request)
-        coap_handle_event(session->context,
-                          COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                          session);
+        coap_handle_event_lkd(session->context,
+                              COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                              session);
       goto error;
     }
   }
@@ -1567,9 +1567,9 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
   /* Make sure headers are correctly set up */
   if (!coap_pdu_encode_header(decrypt_pdu, session->proto)) {
     if (!coap_request)
-      coap_handle_event(session->context,
-                        COAP_EVENT_OSCORE_INTERNAL_ERROR,
-                        session);
+      coap_handle_event_lkd(session->context,
+                            COAP_EVENT_OSCORE_INTERNAL_ERROR,
+                            session);
     goto error;
   }
 

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -139,8 +139,8 @@ coap_persist_observe_add(coap_context_t *context,
   if (!uri_path)
     goto malformed;
 
-  r = coap_get_resource_from_uri_path(session->context,
-                                      (coap_str_const_t *)uri_path);
+  r = coap_get_resource_from_uri_path_lkd(session->context,
+                                          (coap_str_const_t *)uri_path);
   if (r == NULL) {
     coap_log_warn("coap_persist_observe_add: resource '%s' not defined\n",
                   uri_path->s);
@@ -677,7 +677,7 @@ coap_op_obs_cnt_load_disk(coap_context_t *context) {
                   context->observe_save_freq - 1;
     resource_key.s = (uint8_t *)buf;
     resource_key.length = strlen(buf);
-    r = coap_get_resource_from_uri_path(context, &resource_key);
+    r = coap_get_resource_from_uri_path_lkd(context, &resource_key);
     if (r) {
       coap_log_debug("persist: Initial observe number being updated\n");
       coap_persist_set_observe_num(r, observe_num);
@@ -915,7 +915,7 @@ coap_op_dyn_resource_load_disk(coap_context_t *ctx) {
   while (1) {
     if (!coap_op_dyn_resource_read(fp_orig, &e_proto, &name, &raw_packet))
       break;
-    r = coap_get_resource_from_uri_path(ctx, (coap_str_const_t *)name);
+    r = coap_get_resource_from_uri_path_lkd(ctx, (coap_str_const_t *)name);
     if (!r) {
       /* Create the new resource using the application logic */
 

--- a/src/coap_threadsafe.c
+++ b/src/coap_threadsafe.c
@@ -34,34 +34,6 @@
 
 /* Client only wrapper functions */
 
-int
-coap_add_data_large_request(coap_session_t *session,
-                            coap_pdu_t *pdu,
-                            size_t length,
-                            const uint8_t *data,
-                            coap_release_large_data_t release_func,
-                            void *app_ptr
-                           ) {
-  int ret;
-
-  coap_lock_lock(session->context, return 0);
-  ret = coap_add_data_large_request_locked(session, pdu, length, data,
-                                           release_func, app_ptr);
-  coap_lock_unlock(session->context);
-  return ret;
-}
-
-int
-coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
-                    coap_pdu_type_t type) {
-  int ret;
-
-  coap_lock_lock(session->context, return 0);
-  ret = coap_cancel_observe_locked(session, token, type);
-  coap_lock_unlock(session->context);
-  return ret;
-}
-
 coap_session_t *
 coap_new_client_session(coap_context_t *ctx,
                         const coap_address_t *local_if,
@@ -170,92 +142,6 @@ coap_new_client_session_psk2(coap_context_t *ctx,
 /* Server only wrapper functions */
 
 int
-coap_add_data_large_response(coap_resource_t *resource,
-                             coap_session_t *session,
-                             const coap_pdu_t *request,
-                             coap_pdu_t *response,
-                             const coap_string_t *query,
-                             uint16_t media_type,
-                             int maxage,
-                             uint64_t etag,
-                             size_t length,
-                             const uint8_t *data,
-                             coap_release_large_data_t release_func,
-                             void *app_ptr
-                            ) {
-  int ret;
-
-  coap_lock_lock(session->context, return 0);
-  ret = coap_add_data_large_response_locked(resource, session, request,
-                                            response, query, media_type, maxage, etag,
-                                            length, data, release_func, app_ptr);
-  coap_lock_unlock(session->context);
-  return ret;
-}
-
-void
-coap_add_resource(coap_context_t *context, coap_resource_t *resource) {
-  coap_lock_lock(context, return);
-  coap_add_resource_locked(context, resource);
-  coap_lock_unlock(context);
-}
-
-void
-coap_async_trigger(coap_async_t *async) {
-  coap_lock_lock(async->session->context, return);
-  coap_async_trigger_locked(async);
-  coap_lock_unlock(async->session->context);
-}
-
-void
-coap_async_set_delay(coap_async_t *async, coap_tick_t delay) {
-  coap_lock_lock(async->session->context, return);
-  coap_async_set_delay_locked(async, delay);
-  coap_lock_unlock(async->session->context);
-}
-
-coap_cache_entry_t *
-coap_cache_get_by_key(coap_context_t *ctx, const coap_cache_key_t *cache_key) {
-  coap_cache_entry_t *cache;
-
-  coap_lock_lock(ctx, return NULL);
-  cache = coap_cache_get_by_key_locked(ctx, cache_key);
-  coap_lock_unlock(ctx);
-  return cache;
-}
-
-coap_cache_entry_t *
-coap_cache_get_by_pdu(coap_session_t *session,
-                      const coap_pdu_t *request,
-                      coap_cache_session_based_t session_based) {
-  coap_cache_entry_t *entry;
-
-  coap_lock_lock(session->context, return NULL);
-  entry = coap_cache_get_by_pdu_locked(session, request, session_based);
-  coap_lock_unlock(session->context);
-  return entry;
-}
-
-int
-coap_cache_ignore_options(coap_context_t *ctx,
-                          const uint16_t *options,
-                          size_t count) {
-  int ret;
-
-  coap_lock_lock(ctx, return 0);
-  ret = coap_cache_ignore_options_locked(ctx, options, count);
-  coap_lock_unlock(ctx);
-  return ret;
-}
-
-void
-coap_check_notify(coap_context_t *context) {
-  coap_lock_lock(context, return);
-  coap_check_notify_locked(context);
-  coap_lock_unlock(context);
-}
-
-int
 coap_context_oscore_server(coap_context_t *context,
                            coap_oscore_conf_t *oscore_conf) {
   int ret;
@@ -300,34 +186,6 @@ coap_context_set_psk2(coap_context_t *ctx, coap_dtls_spsk_t *setup_data) {
   return ret;
 }
 
-int
-coap_delete_resource(coap_context_t *context, coap_resource_t *resource) {
-  int ret;
-
-  if (!resource)
-    return 0;
-
-  context = resource->context;
-  if (context) {
-    coap_lock_lock(context, return 0);
-    ret = coap_delete_resource_locked(context, resource);
-    coap_lock_unlock(context);
-  } else {
-    ret = coap_delete_resource_locked(context, resource);
-  }
-  return ret;
-}
-
-coap_async_t *
-coap_find_async(coap_session_t *session, coap_bin_const_t token) {
-  coap_async_t *tmp;
-
-  coap_lock_lock(session->context, return NULL);
-  tmp = coap_find_async_locked(session, token);
-  coap_lock_unlock(session->context);
-  return tmp;
-}
-
 void
 coap_free_endpoint(coap_endpoint_t *ep) {
   if (ep) {
@@ -340,17 +198,6 @@ coap_free_endpoint(coap_endpoint_t *ep) {
   }
 }
 
-coap_resource_t *
-coap_get_resource_from_uri_path(coap_context_t *context, coap_str_const_t *uri_path) {
-  coap_resource_t *result;
-
-  coap_lock_lock(context, return NULL);
-  result = coap_get_resource_from_uri_path_locked(context, uri_path);
-  coap_lock_unlock(context);
-
-  return result;
-}
-
 int
 coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
                            const char *ifname) {
@@ -360,20 +207,6 @@ coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
   ret = coap_join_mcast_group_intf_locked(ctx, group_name, ifname);
   coap_lock_unlock(ctx);
   return ret;
-}
-
-coap_cache_entry_t *
-coap_new_cache_entry(coap_session_t *session, const coap_pdu_t *pdu,
-                     coap_cache_record_pdu_t record_pdu,
-                     coap_cache_session_based_t session_based,
-                     unsigned int idle_timeout) {
-  coap_cache_entry_t *cache;
-
-  coap_lock_lock(session->context, return NULL);
-  cache = coap_new_cache_entry_locked(session, pdu, record_pdu, session_based,
-                                      idle_timeout);
-  coap_lock_unlock(session->context);
-  return cache;
 }
 
 coap_endpoint_t *
@@ -433,41 +266,9 @@ coap_persist_stop(coap_context_t *context) {
   coap_lock_unlock(context);
 }
 
-coap_async_t *
-coap_register_async(coap_session_t *session,
-                    const coap_pdu_t *request, coap_tick_t delay) {
-  coap_async_t *async;
-
-  coap_lock_lock(session->context, return NULL);
-  async = coap_register_async_locked(session, request, delay);
-  coap_lock_unlock(session->context);
-  return async;
-}
-
-int
-coap_resource_notify_observers(coap_resource_t *r,
-                               const coap_string_t *query) {
-  int ret;
-
-  coap_lock_lock(r->context, return 0);
-  ret = coap_resource_notify_observers_locked(r, query);
-  coap_lock_unlock(r->context);
-  return ret;
-}
-
 #endif /* COAP_SERVER_SUPPORT */
 
 /* Both Client and Server wrapper functions */
-
-int
-coap_can_exit(coap_context_t *context) {
-  int ret;
-
-  coap_lock_lock(context, return 0);
-  ret = coap_can_exit_locked(context);
-  coap_lock_unlock(context);
-  return ret;
-}
 
 void
 coap_context_set_block_mode(coap_context_t *context,

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -759,7 +759,7 @@ coap_dtls_free_session(coap_session_t *coap_session) {
     coap_log_debug("***removed session %p\n", coap_session->tls);
     coap_free_type(COAP_DTLS_SESSION, coap_session->tls);
     coap_session->tls = NULL;
-    coap_handle_event(coap_session->context, COAP_EVENT_DTLS_CLOSED, coap_session);
+    coap_handle_event_lkd(coap_session->context, COAP_EVENT_DTLS_CLOSED, coap_session);
   }
 }
 
@@ -788,7 +788,7 @@ coap_dtls_send(coap_session_t *session,
   if (coap_event_dtls >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (coap_event_dtls != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(session->context, coap_event_dtls, session);
+      coap_handle_event_lkd(session->context, coap_event_dtls, session);
     if (coap_event_dtls == COAP_EVENT_DTLS_CONNECTED)
       coap_session_connected(session);
     else if (coap_event_dtls == COAP_EVENT_DTLS_CLOSED || coap_event_dtls == COAP_EVENT_DTLS_ERROR)
@@ -857,7 +857,7 @@ coap_dtls_receive(coap_session_t *session,
   if (coap_event_dtls >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (coap_event_dtls != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(session->context, coap_event_dtls, session);
+      coap_handle_event_lkd(session->context, coap_event_dtls, session);
     if (coap_event_dtls == COAP_EVENT_DTLS_CONNECTED)
       coap_session_connected(session);
     else if (coap_event_dtls == COAP_EVENT_DTLS_CLOSED || coap_event_dtls == COAP_EVENT_DTLS_ERROR) {

--- a/src/coap_wolfssl.c
+++ b/src/coap_wolfssl.c
@@ -2088,7 +2088,7 @@ coap_dtls_free_session(coap_session_t *session) {
     w_env->ssl = NULL;
     wolfSSL_free(ssl);
     if (session->context)
-      coap_handle_event(session->context, COAP_EVENT_DTLS_CLOSED, session);
+      coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CLOSED, session);
   }
   coap_dtls_free_wolfssl_env(w_env);
 }
@@ -2124,7 +2124,7 @@ coap_dtls_send(coap_session_t *session,
   if (session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(session->context, session->dtls_event, session);
+      coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
@@ -2252,7 +2252,7 @@ coap_dtls_receive(coap_session_t *session, const uint8_t *data, size_t data_len)
       if (in_init && wolfSSL_is_init_finished(ssl)) {
         coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                       coap_session_str(session), wolfSSL_get_cipher((ssl)));
-        coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+        coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
         session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
       }
       r = 0;
@@ -2287,7 +2287,7 @@ coap_dtls_receive(coap_session_t *session, const uint8_t *data, size_t data_len)
     if (session->dtls_event >= 0) {
       /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
       if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-        coap_handle_event(session->context, session->dtls_event, session);
+        coap_handle_event_lkd(session->context, session->dtls_event, session);
       if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
           session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
         coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
@@ -2439,7 +2439,7 @@ coap_tls_new_client_session(coap_session_t *session) {
   coap_ticks(&now);
   w_env->last_timeout = now;
   if (wolfSSL_is_init_finished(ssl)) {
-    coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+    coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
     session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
@@ -2540,7 +2540,7 @@ coap_tls_new_server_session(coap_session_t *session) {
 
   session->tls = w_env;
   if (wolfSSL_is_init_finished(ssl)) {
-    coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+    coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
     session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
@@ -2568,7 +2568,7 @@ coap_tls_free_session(coap_session_t *session) {
     wolfSSL_free(ssl);
     w_env->ssl = NULL;
     if (session->context)
-      coap_handle_event(session->context, COAP_EVENT_DTLS_CLOSED, session);
+      coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CLOSED, session);
   }
   coap_dtls_free_wolfssl_env(w_env);
 }
@@ -2597,7 +2597,7 @@ coap_tls_write(coap_session_t *session, const uint8_t *data, size_t data_len) {
       if (in_init && wolfSSL_is_init_finished(ssl)) {
         coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                       coap_session_str(session), wolfSSL_get_cipher((ssl)));
-        coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+        coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
         session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
       }
       if (err == WOLFSSL_ERROR_WANT_READ)
@@ -2625,14 +2625,14 @@ coap_tls_write(coap_session_t *session, const uint8_t *data, size_t data_len) {
   } else if (in_init && wolfSSL_is_init_finished(ssl)) {
     coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                   coap_session_str(session), wolfSSL_get_cipher((ssl)));
-    coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+    coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
     session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
   if (session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(session->context, session->dtls_event, session);
+      coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(session, COAP_NACK_TLS_FAILED);
@@ -2676,7 +2676,7 @@ coap_tls_read(coap_session_t *session, uint8_t *data, size_t data_len) {
       if (in_init && wolfSSL_is_init_finished(ssl)) {
         coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                       coap_session_str(session), wolfSSL_get_cipher((ssl)));
-        coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+        coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
         session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
       }
       if (err == WOLFSSL_ERROR_WANT_READ)
@@ -2715,14 +2715,14 @@ coap_tls_read(coap_session_t *session, uint8_t *data, size_t data_len) {
   } else if (in_init && wolfSSL_is_init_finished(ssl)) {
     coap_dtls_log(COAP_LOG_INFO, "*  %s: Using cipher: %s\n",
                   coap_session_str(session), wolfSSL_get_cipher((ssl)));
-    coap_handle_event(session->context, COAP_EVENT_DTLS_CONNECTED, session);
+    coap_handle_event_lkd(session->context, COAP_EVENT_DTLS_CONNECTED, session);
     session->sock.lfunc[COAP_LAYER_TLS].l_establish(session);
   }
 
   if (session->dtls_event >= 0) {
     /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected() */
     if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event(session->context, session->dtls_event, session);
+      coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected(session, COAP_NACK_TLS_FAILED);

--- a/src/coap_ws.c
+++ b/src/coap_ws.c
@@ -613,12 +613,12 @@ coap_ws_read(coap_session_t *session, uint8_t *data, size_t datalen) {
       session->sock.lfunc[COAP_LAYER_WS].l_write(session, (uint8_t *)buf,
                                                  strlen(buf));
 
-      coap_handle_event(session->context, COAP_EVENT_WS_CONNECTED, session);
+      coap_handle_event_lkd(session->context, COAP_EVENT_WS_CONNECTED, session);
       coap_log_debug("WS: established\n");
     } else {
       /* TODO Process the GET response - error on failure */
 
-      coap_handle_event(session->context, COAP_EVENT_WS_CONNECTED, session);
+      coap_handle_event_lkd(session->context, COAP_EVENT_WS_CONNECTED, session);
     }
     session->sock.lfunc[COAP_LAYER_WS].l_establish(session);
     if (session->ws->hdr_ofs == 0)
@@ -695,7 +695,7 @@ coap_ws_read(coap_session_t *session, uint8_t *data, size_t datalen) {
     if ((size_t)bytes_size > datalen) {
       coap_log_err("coap_ws_read: packet size bigger than provided data space"
                    " (%zu > %zu)\n", bytes_size, datalen);
-      coap_handle_event(session->context, COAP_EVENT_WS_PACKET_SIZE, session);
+      coap_handle_event_lkd(session->context, COAP_EVENT_WS_PACKET_SIZE, session);
       session->ws->close_reason = 1009;
       coap_ws_close(session);
       return 0;
@@ -910,7 +910,7 @@ coap_ws_close(coap_session_t *session) {
       count --;
     }
 #endif /* ! WITH_LWIP && ! WITH_CONTIKI */
-    coap_handle_event(session->context, COAP_EVENT_WS_CLOSED, session);
+    coap_handle_event_lkd(session->context, COAP_EVENT_WS_CLOSED, session);
   }
   session->sock.lfunc[COAP_LAYER_WS].l_close(session);
 }


### PR DESCRIPTION
Update the Public API equivalent of the libcoap functions that need to be called when locked with a name suffix of _lkd.

Move matching Public API functions out of coap_threadsafe.c to be coded just ahead of the newly renamed _lkd function.

Properly define the _lkd function in the appropriate _internal.h file for documentation, removing the #defines from coap_threadsafe_internal.h.

Tag all the Public API functions that have a _lkd function with COAP_API. COAP_API can then be defined as to what should be done for that function.

Check libcoap library does not call the original Public API function when it should be calling the _lkd function by marking the Public API not _lkd functions as deprecated during the libcoap library build. [Done by the new COAP_API being defined as __attribute__((deprecated)).]

Work in progress for all the functions that need to be multi-thread safe.