### PR TITLE
locking: Simplify maintenance / debugging /documentation

### DIFF
--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -89,7 +89,7 @@ int coap_dtls_context_set_spsk(coap_context_t *coap_context,
  *
  * @param coap_context The CoAP context.
  * @param setup_data A structure containing setup data originally passed into
- *                   coap_new_client_session_psk2().
+ *                   coap_new_client_session_psk2_lkd().
  *
  * @return @c 1 if successful, else @c 0.
  */

--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -384,7 +384,7 @@ unsigned int coap_context_get_max_handshake_sessions(const coap_context_t *conte
  *
  * @return        Incremented message id in network byte order.
  */
-uint16_t coap_new_message_id(coap_session_t *session);
+COAP_API uint16_t coap_new_message_id(coap_session_t *session);
 
 /**
  * CoAP stack context must be released with coap_free_context(). This function

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -339,6 +339,19 @@ void coap_cancel_session_messages(coap_context_t *context,
                                   coap_nack_reason_t reason);
 
 /**
+ * Returns a new message id and updates @p session->tx_mid accordingly. The
+ * message id is returned in network byte order to make it easier to read in
+ * tracing tools.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param session The current coap_session_t object.
+ *
+ * @return        Incremented message id in network byte order.
+ */
+uint16_t coap_new_message_id_lkd(coap_session_t *session);
+
+/**
  * Dispatches the PDUs from the receive queue in given context.
  */
 void coap_dispatch(coap_context_t *context, coap_session_t *session,

--- a/include/coap3/coap_oscore.h
+++ b/include/coap3/coap_oscore.h
@@ -79,12 +79,12 @@ coap_session_t *coap_new_client_session_oscore(coap_context_t *ctx,
  * @return A new CoAP session or NULL if failed. Call coap_session_release()
  *         to free.
  */
-coap_session_t *coap_new_client_session_oscore_psk(coap_context_t *ctx,
-                                                   const coap_address_t *local_if,
-                                                   const coap_address_t *server,
-                                                   coap_proto_t proto,
-                                                   coap_dtls_cpsk_t *psk_data,
-                                                   coap_oscore_conf_t *oscore_conf);
+COAP_API coap_session_t *coap_new_client_session_oscore_psk(coap_context_t *ctx,
+                                                            const coap_address_t *local_if,
+                                                            const coap_address_t *server,
+                                                            coap_proto_t proto,
+                                                            coap_dtls_cpsk_t *psk_data,
+                                                            coap_oscore_conf_t *oscore_conf);
 
 /**
  * Creates a new client session to the designated server with PKI credentials
@@ -105,12 +105,12 @@ coap_session_t *coap_new_client_session_oscore_psk(coap_context_t *ctx,
  * @return A new CoAP session or NULL if failed. Call coap_session_release()
  *         to free.
  */
-coap_session_t *coap_new_client_session_oscore_pki(coap_context_t *ctx,
-                                                   const coap_address_t *local_if,
-                                                   const coap_address_t *server,
-                                                   coap_proto_t proto,
-                                                   coap_dtls_pki_t *pki_data,
-                                                   coap_oscore_conf_t *oscore_conf);
+COAP_API coap_session_t *coap_new_client_session_oscore_pki(coap_context_t *ctx,
+                                                            const coap_address_t *local_if,
+                                                            const coap_address_t *server,
+                                                            coap_proto_t proto,
+                                                            coap_dtls_pki_t *pki_data,
+                                                            coap_oscore_conf_t *oscore_conf);
 
 /**
  * Set the context's default OSCORE configuration for a server.
@@ -121,8 +121,8 @@ coap_session_t *coap_new_client_session_oscore_pki(coap_context_t *ctx,
  *
  * @return @c 1 if successful, else @c 0.
  */
-int coap_context_oscore_server(coap_context_t *context,
-                               coap_oscore_conf_t *oscore_conf);
+COAP_API int coap_context_oscore_server(coap_context_t *context,
+                                        coap_oscore_conf_t *oscore_conf);
 
 /**
  * Definition of the function used to save the current Sender Sequence Number
@@ -176,8 +176,8 @@ int coap_delete_oscore_conf(coap_oscore_conf_t *oscore_conf);
  *
  * @return @c 1 Successfully added, else @c 0 there is an issue.
  */
-int coap_new_oscore_recipient(coap_context_t *context,
-                              coap_bin_const_t *recipient_id);
+COAP_API int coap_new_oscore_recipient(coap_context_t *context,
+                                       coap_bin_const_t *recipient_id);
 
 /**
  * Release all the information associated for the specific Recipient ID
@@ -190,8 +190,8 @@ int coap_new_oscore_recipient(coap_context_t *context,
  *
  * @return @c 1 Successfully removed, else @c 0 not found.
  */
-int coap_delete_oscore_recipient(coap_context_t *context,
-                                 coap_bin_const_t *recipient_id);
+COAP_API int coap_delete_oscore_recipient(coap_context_t *context,
+                                          coap_bin_const_t *recipient_id);
 
 /** @} */
 

--- a/include/coap3/coap_oscore_internal.h
+++ b/include/coap3/coap_oscore_internal.h
@@ -163,6 +163,133 @@ int coap_rebuild_pdu_for_proxy(coap_pdu_t *pdu);
  */
 int coap_oscore_initiate(coap_session_t *session,
                          coap_oscore_conf_t *oscore_conf);
+/**
+ * Set the context's default OSCORE configuration for a server.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param context     The current coap_context_t object.
+ * @param oscore_conf OSCORE configuration information. This structure is
+ *                    freed off by this call.
+ *
+ * @return @c 1 if successful, else @c 0.
+ */
+int coap_context_oscore_server_lkd(coap_context_t *context,
+                                   coap_oscore_conf_t *oscore_conf);
+
+/**
+ * Release all the information associated for the specific Recipient ID
+ * (and hence and stop any further OSCORE protection for this Recipient).
+ * Note: This is only removed from the OSCORE context as first defined by
+ * coap_new_client_session_oscore*_lkd() or coap_context_oscore_server().
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param context The CoAP  context holding the OSCORE recipient_id to.
+ * @param recipient_id The Recipient ID to remove.
+ *
+ * @return @c 1 Successfully removed, else @c 0 not found.
+ */
+int coap_delete_oscore_recipient_lkd(coap_context_t *context,
+                                     coap_bin_const_t *recipient_id);
+
+/**
+ * Creates a new client session to the designated server, protecting the data
+ * using OSCORE.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL
+ *                 to let the operating system choose a suitable local
+ *                 interface. If an address is specified, the port number
+ *                 should be zero, which means that a free port is
+ *                 automatically selected.
+ * @param server The server's address. If the port number is zero, the default
+ *               port for the protocol will be used.
+ * @param proto  CoAP Protocol.
+ * @param oscore_conf OSCORE configuration information. This structure is
+ *                    freed off by this call.
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release()
+ *         to free.
+ */
+coap_session_t *coap_new_client_session_oscore_lkd(coap_context_t *ctx,
+                                                   const coap_address_t *local_if,
+                                                   const coap_address_t *server,
+                                                   coap_proto_t proto,
+                                                   coap_oscore_conf_t *oscore_conf);
+
+/**
+ * Creates a new client session to the designated server with PKI credentials
+ * as well as protecting the data using OSCORE.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL to
+ *                 let the operating system choose a suitable local interface.
+ *                 If an address is specified, the port number should be zero,
+ *                 which means that a free port is automatically selected.
+ * @param server The server's address. If the port number is zero, the default
+ *               port for the protocol will be used.
+ * @param proto CoAP Protocol.
+ * @param pki_data PKI parameters.
+ * @param oscore_conf OSCORE configuration information. This structure is
+ *                    freed off by this call.
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release()
+ *         to free.
+ */
+coap_session_t *coap_new_client_session_oscore_pki_lkd(coap_context_t *ctx,
+                                                       const coap_address_t *local_if,
+                                                       const coap_address_t *server,
+                                                       coap_proto_t proto,
+                                                       coap_dtls_pki_t *pki_data,
+                                                       coap_oscore_conf_t *oscore_conf);
+
+/**
+ * Creates a new client session to the designated server with PSK credentials
+ * as well as protecting the data using OSCORE.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL to
+ *                 let the operating system choose a suitable local interface.
+ *                 If an address is specified, the port number should be zero,
+ *                 which means that a free port is automatically selected.
+ * @param server The server's address. If the port number is zero, the default
+ *               port for the protocol will be used.
+ * @param proto CoAP Protocol.
+ * @param psk_data PSK parameters.
+ * @param oscore_conf OSCORE configuration information. This structure is
+ *                    freed off by this call.
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release()
+ *         to free.
+ */
+coap_session_t *coap_new_client_session_oscore_psk_lkd(coap_context_t *ctx,
+                                                       const coap_address_t *local_if,
+                                                       const coap_address_t *server,
+                                                       coap_proto_t proto,
+                                                       coap_dtls_cpsk_t *psk_data,
+                                                       coap_oscore_conf_t *oscore_conf);
+
+/**
+ * Add in the specific Recipient ID into the OSCORE context (server only).
+ * Note: This is only added to the OSCORE context as first defined by
+ * coap_new_client_session_oscore*() or coap_context_oscore_server().
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param context The CoAP  context to add the OSCORE recipient_id to.
+ * @param recipient_id The Recipient ID to add.
+ *
+ * @return @c 1 Successfully added, else @c 0 there is an issue.
+ */
+int coap_new_oscore_recipient_lkd(coap_context_t *context,
+                                  coap_bin_const_t *recipient_id);
 
 /** @} */
 

--- a/include/coap3/coap_pdu.h
+++ b/include/coap3/coap_pdu.h
@@ -396,8 +396,8 @@ coap_pdu_t *coap_pdu_init(coap_pdu_type_t type, coap_pdu_code_t code,
  *
  * @return The skeletal PDU or @c NULL if failure.
  */
-coap_pdu_t *coap_new_pdu(coap_pdu_type_t type, coap_pdu_code_t code,
-                         coap_session_t *session);
+COAP_API coap_pdu_t *coap_new_pdu(coap_pdu_type_t type, coap_pdu_code_t code,
+                                  coap_session_t *session);
 
 /**
  * Dispose of an CoAP PDU and frees associated storage.

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -356,6 +356,21 @@ int coap_update_token(coap_pdu_t *pdu,
  */
 int coap_option_check_repeatable(coap_option_num_t number);
 
+/**
+ * Creates a new CoAP PDU.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param type The type of the PDU (one of COAP_MESSAGE_CON, COAP_MESSAGE_NON,
+ *             COAP_MESSAGE_ACK, COAP_MESSAGE_RST).
+ * @param code The message code of the PDU.
+ * @param session The session that will be using this PDU
+ *
+ * @return The skeletal PDU or @c NULL if failure.
+ */
+coap_pdu_t *coap_new_pdu_lkd(coap_pdu_type_t type, coap_pdu_code_t code,
+                             coap_session_t *session);
+
 /** @} */
 
 #endif /* COAP_COAP_PDU_INTERNAL_H_ */

--- a/include/coap3/coap_session.h
+++ b/include/coap3/coap_session.h
@@ -241,15 +241,19 @@ void coap_session_set_mtu(coap_session_t *session, unsigned mtu);
 size_t coap_session_max_pdu_size(const coap_session_t *session);
 
 /**
-* Creates a new client session to the designated server.
-* @param ctx The CoAP context.
-* @param local_if Address of local interface. It is recommended to use NULL to let the operating system choose a suitable local interface. If an address is specified, the port number should be zero, which means that a free port is automatically selected.
-* @param server The server's address. If the port number is zero, the default port for the protocol will be used.
-* @param proto Protocol.
-*
-* @return A new CoAP session or NULL if failed. Call coap_session_release to free.
-*/
-coap_session_t *coap_new_client_session(
+ * Creates a new client session to the designated server.
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL to let
+ *                 the operating system choose a suitable local interface. If an
+ *                 address is specified, the port number should be zero, which means
+ *                 that a free port is automatically selected.
+ * @param server The server's address. If the port number is zero, the default port
+ *               for the protocol will be used.
+ * @param proto Protocol.
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release to free.
+ */
+COAP_API coap_session_t *coap_new_client_session(
     coap_context_t *ctx,
     const coap_address_t *local_if,
     const coap_address_t *server,
@@ -257,52 +261,54 @@ coap_session_t *coap_new_client_session(
 );
 
 /**
-* Creates a new client session to the designated server with PSK credentials
+ * Creates a new client session to the designated server with PSK credentials
  *
  * @deprecated Use coap_new_client_session_psk2() instead.
  *
-* @param ctx The CoAP context.
-* @param local_if Address of local interface. It is recommended to use NULL to let the operating system choose a suitable local interface. If an address is specified, the port number should be zero, which means that a free port is automatically selected.
-* @param server The server's address. If the port number is zero, the default port for the protocol will be used.
-* @param proto Protocol.
-* @param identity PSK client identity
-* @param key PSK shared key
-* @param key_len PSK shared key length
-*
-* @return A new CoAP session or NULL if failed. Call coap_session_release to free.
-*/
-coap_session_t *coap_new_client_session_psk(
-    coap_context_t *ctx,
-    const coap_address_t *local_if,
-    const coap_address_t *server,
-    coap_proto_t proto,
-    const char *identity,
-    const uint8_t *key,
-    unsigned key_len
-);
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL to let
+ *                 the operating system choose a suitable local interface. If an
+ *                 address is specified, the port number should be zero, which means
+ *                 that a free port is automatically selected.
+ * @param server The server's address. If the port number is zero, the default port
+ *               for the protocol will be used.
+ * @param proto Protocol.
+ * @param identity PSK client identity
+ * @param key PSK shared key
+ * @param key_len PSK shared key length
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release to free.
+ */
+COAP_API coap_session_t *coap_new_client_session_psk(coap_context_t *ctx,
+                                                     const coap_address_t *local_if,
+                                                     const coap_address_t *server,
+                                                     coap_proto_t proto,
+                                                     const char *identity,
+                                                     const uint8_t *key,
+                                                     unsigned key_len
+                                                    );
 
 /**
-* Creates a new client session to the designated server with PSK credentials
-* @param ctx The CoAP context.
-* @param local_if Address of local interface. It is recommended to use NULL to
-*                 let the operating system choose a suitable local interface.
-*                 If an address is specified, the port number should be zero,
-*                 which means that a free port is automatically selected.
-* @param server The server's address. If the port number is zero, the default
-*               port for the protocol will be used.
-* @param proto CoAP Protocol.
-* @param setup_data PSK parameters.
-*
-* @return A new CoAP session or NULL if failed. Call coap_session_release()
-*         to free.
-*/
-coap_session_t *coap_new_client_session_psk2(
-    coap_context_t *ctx,
-    const coap_address_t *local_if,
-    const coap_address_t *server,
-    coap_proto_t proto,
-    coap_dtls_cpsk_t *setup_data
-);
+ * Creates a new client session to the designated server with PSK credentials
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL to
+ *                 let the operating system choose a suitable local interface.
+ *                 If an address is specified, the port number should be zero,
+ *                 which means that a free port is automatically selected.
+ * @param server The server's address. If the port number is zero, the default
+ *               port for the protocol will be used.
+ * @param proto CoAP Protocol.
+ * @param setup_data PSK parameters.
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release()
+ *         to free.
+ */
+coap_session_t *coap_new_client_session_psk2(coap_context_t *ctx,
+                                             const coap_address_t *local_if,
+                                             const coap_address_t *server,
+                                             coap_proto_t proto,
+                                             coap_dtls_cpsk_t *setup_data
+                                            );
 
 /**
  * Get the server session's current Identity Hint (PSK).
@@ -334,27 +340,26 @@ const coap_bin_const_t *coap_session_get_psk_key(
     const coap_session_t *session);
 
 /**
-* Creates a new client session to the designated server with PKI credentials
-* @param ctx The CoAP context.
-* @param local_if Address of local interface. It is recommended to use NULL to
-*                 let the operating system choose a suitable local interface.
-*                 If an address is specified, the port number should be zero,
-*                 which means that a free port is automatically selected.
-* @param server The server's address. If the port number is zero, the default
-*               port for the protocol will be used.
-* @param proto CoAP Protocol.
-* @param setup_data PKI parameters.
-*
-* @return A new CoAP session or NULL if failed. Call coap_session_release()
-*         to free.
-*/
-coap_session_t *coap_new_client_session_pki(
-    coap_context_t *ctx,
-    const coap_address_t *local_if,
-    const coap_address_t *server,
-    coap_proto_t proto,
-    coap_dtls_pki_t *setup_data
-);
+ * Creates a new client session to the designated server with PKI credentials
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL to
+ *                 let the operating system choose a suitable local interface.
+ *                 If an address is specified, the port number should be zero,
+ *                 which means that a free port is automatically selected.
+ * @param server The server's address. If the port number is zero, the default
+ *               port for the protocol will be used.
+ * @param proto CoAP Protocol.
+ * @param setup_data PKI parameters.
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release()
+ *         to free.
+ */
+COAP_API coap_session_t *coap_new_client_session_pki(coap_context_t *ctx,
+                                                     const coap_address_t *local_if,
+                                                     const coap_address_t *server,
+                                                     coap_proto_t proto,
+                                                     coap_dtls_pki_t *setup_data
+                                                    );
 
 /**
  * Initializes the token value to use as a starting point.
@@ -399,8 +404,9 @@ const char *coap_session_str(const coap_session_t *session);
  *
  * @return The new endpoint or @c NULL on failure.
  */
-coap_endpoint_t *coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr,
-                                   coap_proto_t proto);
+COAP_API coap_endpoint_t *coap_new_endpoint(coap_context_t *context,
+                                            const coap_address_t *listen_addr,
+                                            coap_proto_t proto);
 
 /**
  * Set the endpoint's default MTU. This is the maximum message size that can be

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -362,6 +362,22 @@ ssize_t coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
  */
 coap_session_t *coap_endpoint_get_session(coap_endpoint_t *endpoint,
                                           const coap_packet_t *packet, coap_tick_t now);
+
+/**
+ * Create a new endpoint for communicating with peers.
+ *
+ * @param context     The coap context that will own the new endpoint,
+ * @param listen_addr Address the endpoint will listen for incoming requests
+ *                    on or originate outgoing requests from. Use NULL to
+ *                    specify that no incoming request will be accepted and
+ *                    use a random endpoint.
+ * @param proto       Protocol used on this endpoint,
+ *
+ * @return The new endpoint or @c NULL on failure.
+ */
+coap_endpoint_t *coap_new_endpoint_lkd(coap_context_t *context, const coap_address_t *listen_addr,
+                                       coap_proto_t proto);
+
 #endif /* COAP_SERVER_SUPPORT */
 
 /**
@@ -371,6 +387,110 @@ coap_session_t *coap_endpoint_get_session(coap_endpoint_t *endpoint,
  * @return maximum PDU size, not including header (but including token).
  */
 size_t coap_session_max_pdu_rcv_size(const coap_session_t *session);
+
+/**
+ * Creates a new client session to the designated server.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL to let
+ *                 the operating system choose a suitable local interface. If an
+ *                 address is specified, the port number should be zero, which means
+ *                 that a free port is automatically selected.
+ * @param server The server's address. If the port number is zero, the default port
+ *               for the protocol will be used.
+ * @param proto Protocol.
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release to free.
+ */
+coap_session_t *coap_new_client_session_lkd(
+    coap_context_t *ctx,
+    const coap_address_t *local_if,
+    const coap_address_t *server,
+    coap_proto_t proto
+);
+
+/**
+ * Creates a new client session to the designated server with PKI credentials
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL to
+ *                 let the operating system choose a suitable local interface.
+ *                 If an address is specified, the port number should be zero,
+ *                 which means that a free port is automatically selected.
+ * @param server The server's address. If the port number is zero, the default
+ *               port for the protocol will be used.
+ * @param proto CoAP Protocol.
+ * @param setup_data PKI parameters.
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release()
+ *         to free.
+ */
+coap_session_t *coap_new_client_session_pki_lkd(coap_context_t *ctx,
+                                                const coap_address_t *local_if,
+                                                const coap_address_t *server,
+                                                coap_proto_t proto,
+                                                coap_dtls_pki_t *setup_data
+                                               );
+
+/**
+ * Creates a new client session to the designated server with PSK credentials
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @deprecated Use coap_new_client_session_psk2_lkd() instead.
+ *
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL to let
+ *                 the operating system choose a suitable local interface. If an
+ *                 address is specified, the port number should be zero, which means
+ *                 that a free port is automatically selected.
+ * @param server The server's address. If the port number is zero, the default port
+ *               for the protocol will be used.
+ * @param proto Protocol.
+ * @param identity PSK client identity
+ * @param key PSK shared key
+ * @param key_len PSK shared key length
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release to free.
+ */
+coap_session_t *coap_new_client_session_psk_lkd(coap_context_t *ctx,
+                                                const coap_address_t *local_if,
+                                                const coap_address_t *server,
+                                                coap_proto_t proto,
+                                                const char *identity,
+                                                const uint8_t *key,
+                                                unsigned key_len
+                                               );
+
+/**
+ * Creates a new client session to the designated server with PSK credentials
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param ctx The CoAP context.
+ * @param local_if Address of local interface. It is recommended to use NULL to
+ *                 let the operating system choose a suitable local interface.
+ *                 If an address is specified, the port number should be zero,
+ *                 which means that a free port is automatically selected.
+ * @param server The server's address. If the port number is zero, the default
+ *               port for the protocol will be used.
+ * @param proto CoAP Protocol.
+ * @param setup_data PSK parameters.
+ *
+ * @return A new CoAP session or NULL if failed. Call coap_session_release()
+ *         to free.
+ */
+coap_session_t *coap_new_client_session_psk2_lkd(coap_context_t *ctx,
+                                                 const coap_address_t *local_if,
+                                                 const coap_address_t *server,
+                                                 coap_proto_t proto,
+                                                 coap_dtls_cpsk_t *setup_data
+                                                );
+
 
 /**
  * Create a new DTLS session for the @p session.

--- a/include/coap3/coap_threadsafe_internal.h
+++ b/include/coap3/coap_threadsafe_internal.h
@@ -22,27 +22,14 @@
 /* *INDENT-OFF* */
 #ifndef COAP_THREAD_IGNORE_LOCKED_MAPPING
 
-#define coap_context_oscore_server(c,o)                 coap_context_oscore_server_locked(c,o)
 #define coap_context_set_block_mode(c,b)                coap_context_set_block_mode_locked(c,b)
 #define coap_context_set_max_block_size(c,m)            coap_context_set_max_block_size_locked(c,m)
 #define coap_context_set_pki(c,s)                       coap_context_set_pki_locked(c,s)
 #define coap_context_set_pki_root_cas(c,f,d)            coap_context_set_pki_root_cas_locked(c,f,d)
 #define coap_context_set_psk(c,h,k,l)                   coap_context_set_psk_locked(c,h,k,l)
 #define coap_context_set_psk2(c,s)                      coap_context_set_psk2_locked(c,s)
-#define coap_delete_oscore_recipient(s,r)               coap_delete_oscore_recipient_locked(s,r)
 #define coap_free_endpoint(e)                           coap_free_endpoint_locked(e)
 #define coap_join_mcast_group_intf(c,g,i)               coap_join_mcast_group_intf_locked(c,g,i)
-#define coap_new_client_session(c,l,s,p)                coap_new_client_session_locked(c,l,s,p)
-#define coap_new_client_session_oscore(c,l,s,p,o)       coap_new_client_session_oscore_locked(c,l,s,p,o)
-#define coap_new_client_session_oscore_pki(c,l,s,p,d,o) coap_new_client_session_oscore_pki_locked(c,l,s,p,d,o)
-#define coap_new_client_session_oscore_psk(c,l,s,p,d,o) coap_new_client_session_oscore_psk_locked(c,l,s,p,d,o)
-#define coap_new_client_session_pki(c,l,s,p,d)          coap_new_client_session_pki_locked(c,l,s,p,d)
-#define coap_new_client_session_psk(c,l,s,p,i,k,m)      coap_new_client_session_psk_locked(c,l,s,p,i,k,m)
-#define coap_new_client_session_psk2(c,l,s,p,d)         coap_new_client_session_psk2_locked(c,l,s,p,d)
-#define coap_new_endpoint(c,l,t)                        coap_new_endpoint_locked(c,l,t)
-#define coap_new_message_id(s)                          coap_new_message_id_locked(s)
-#define coap_new_oscore_recipient(c,r)                  coap_new_oscore_recipient_locked(c,r)
-#define coap_new_pdu(t,c,s)                             coap_new_pdu_locked(t,c,s)
 #define coap_persist_observe_add(c,p,l,a,r,o)           coap_persist_observe_add_locked(c,p,l,a,r,o)
 #define coap_persist_startup(c,d,o,m,s)                 coap_persist_startup_locked(c,d,o,m,s)
 #define coap_persist_stop(c)                            coap_persist_stop_locked(c)
@@ -63,8 +50,6 @@
 
 /* Locked equivalend functions */
 
-int                  coap_context_oscore_server_locked(coap_context_t *context,
-                                                       coap_oscore_conf_t *oscore_conf);
 void                 coap_context_set_block_mode_locked(coap_context_t *context,
                                                         uint32_t block_mode);
 int                  coap_context_set_max_block_size_locked(coap_context_t *context,
@@ -77,8 +62,6 @@ int                  coap_context_set_psk_locked(coap_context_t *ctx, const char
                                                  const uint8_t *key, size_t key_len);
 int                  coap_context_set_psk2_locked(coap_context_t *ctx,
                                                   coap_dtls_spsk_t *setup_data);
-int                  coap_delete_oscore_recipient_locked(coap_context_t *context,
-                                                         coap_bin_const_t *recipient_id);
 void                 coap_free_endpoint_locked(coap_endpoint_t *ep);
 int                  coap_join_mcast_group_intf_locked(coap_context_t *ctx, const char *group_name,
                                                        const char *ifname);
@@ -95,50 +78,6 @@ int                  coap_persist_startup_locked(coap_context_t *context,
                                                  uint32_t save_freq);
 void                 coap_persist_stop_locked(coap_context_t *context);
 size_t               coap_session_max_pdu_size_locked(const coap_session_t *session);
-coap_session_t      *coap_new_client_session_locked(coap_context_t *ctx,
-                                                    const coap_address_t *local_if,
-                                                    const coap_address_t *server,
-                                                    coap_proto_t proto);
-coap_session_t      *coap_new_client_session_oscore_locked(coap_context_t *ctx,
-                                                           const coap_address_t *local_if,
-                                                           const coap_address_t *server,
-                                                           coap_proto_t proto,
-                                                           coap_oscore_conf_t *oscore_conf);
-coap_session_t      *coap_new_client_session_oscore_pki_locked(coap_context_t *ctx,
-                                                               const coap_address_t *local_if,
-                                                               const coap_address_t *server,
-                                                               coap_proto_t proto,
-                                                               coap_dtls_pki_t *pki_data,
-                                                               coap_oscore_conf_t *oscore_conf);
-coap_session_t      *coap_new_client_session_oscore_psk_locked(coap_context_t *ctx,
-                                                               const coap_address_t *local_if,
-                                                               const coap_address_t *server,
-                                                               coap_proto_t proto,
-                                                               coap_dtls_cpsk_t *psk_data,
-                                                               coap_oscore_conf_t *oscore_conf);
-coap_session_t      *coap_new_client_session_pki_locked(coap_context_t *ctx,
-                                                        const coap_address_t *local_if,
-                                                        const coap_address_t *server,
-                                                        coap_proto_t proto,
-                                                        coap_dtls_pki_t *setup_data);
-coap_session_t      *coap_new_client_session_psk_locked(coap_context_t *ctx,
-                                                        const coap_address_t *local_if,
-                                                        const coap_address_t *server,
-                                                        coap_proto_t proto, const char *identity,
-                                                        const uint8_t *key, unsigned key_len);
-coap_session_t      *coap_new_client_session_psk2_locked(coap_context_t *ctx,
-                                                         const coap_address_t *local_if,
-                                                         const coap_address_t *server,
-                                                         coap_proto_t proto,
-                                                         coap_dtls_cpsk_t *setup_data);
-coap_endpoint_t     *coap_new_endpoint_locked(coap_context_t *context,
-                                              const coap_address_t *listen_addr,
-                                              coap_proto_t proto);
-uint16_t             coap_new_message_id_locked(coap_session_t *session);
-int                  coap_new_oscore_recipient_locked(coap_context_t *context,
-                                                      coap_bin_const_t *recipient_id);
-coap_pdu_t          *coap_new_pdu_locked(coap_pdu_type_t type, coap_pdu_code_t code,
-                                         coap_session_t *session);
 coap_pdu_t          *coap_pdu_duplicate_locked(const coap_pdu_t *old_pdu,
                                                coap_session_t *session,
                                                size_t token_length,

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -1508,7 +1508,7 @@ pdu_408_build(coap_session_t *session, coap_lg_srcv_t *p) {
 
   pdu = coap_pdu_init(COAP_MESSAGE_NON,
                       COAP_RESPONSE_CODE(408),
-                      coap_new_message_id(session),
+                      coap_new_message_id_lkd(session),
                       coap_session_max_pdu_size(session));
   if (!pdu)
     return NULL;
@@ -1769,7 +1769,7 @@ expire:
 
         pdu = coap_pdu_init(COAP_MESSAGE_NON,
                             COAP_RESPONSE_CODE(408),
-                            coap_new_message_id(session),
+                            coap_new_message_id_lkd(session),
                             coap_session_max_pdu_size(session));
         if (pdu) {
           if (p->last_token)
@@ -2165,7 +2165,7 @@ coap_block_test_q_block(coap_session_t *session, coap_pdu_t *actual) {
   coap_log_debug("Testing for Q-Block support\n");
   /* RFC9177 Section 4.1 when checking if available */
   pdu = coap_pdu_init(COAP_MESSAGE_CON, COAP_REQUEST_CODE_GET,
-                      coap_new_message_id(session),
+                      coap_new_message_id_lkd(session),
                       coap_session_max_pdu_size(session));
   if (!pdu) {
     return COAP_INVALID_MID;

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -591,7 +591,7 @@ coap_new_context(const coap_address_t *listen_addr) {
 
 #if COAP_SERVER_SUPPORT
   if (listen_addr) {
-    coap_endpoint_t *endpoint = coap_new_endpoint(c, listen_addr, COAP_PROTO_UDP);
+    coap_endpoint_t *endpoint = coap_new_endpoint_lkd(c, listen_addr, COAP_PROTO_UDP);
     if (endpoint == NULL) {
       goto onerror;
     }
@@ -1033,7 +1033,7 @@ coap_send_test_extended_token(coap_session_t *session) {
   coap_log_debug("Testing for Extended Token support\n");
   /* https://rfc-editor.org/rfc/rfc8974#section-2.2.2 */
   pdu = coap_pdu_init(COAP_MESSAGE_CON, COAP_REQUEST_CODE_GET,
-                      coap_new_message_id(session),
+                      coap_new_message_id_lkd(session),
                       coap_session_max_pdu_size(session));
   if (!pdu)
     return COAP_INVALID_MID;

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -62,14 +62,28 @@ coap_oscore_initiate(coap_session_t *session, coap_oscore_conf_t *oscore_conf) {
   return 1;
 }
 
-coap_session_t *
+COAP_API coap_session_t *
 coap_new_client_session_oscore(coap_context_t *ctx,
                                const coap_address_t *local_if,
                                const coap_address_t *server,
                                coap_proto_t proto,
                                coap_oscore_conf_t *oscore_conf) {
+  coap_session_t *session;
+
+  coap_lock_lock(ctx, return NULL);
+  session = coap_new_client_session_oscore_lkd(ctx, local_if, server, proto, oscore_conf);
+  coap_lock_unlock(ctx);
+  return session;
+}
+
+coap_session_t *
+coap_new_client_session_oscore_lkd(coap_context_t *ctx,
+                                   const coap_address_t *local_if,
+                                   const coap_address_t *server,
+                                   coap_proto_t proto,
+                                   coap_oscore_conf_t *oscore_conf) {
   coap_session_t *session =
-      coap_new_client_session(ctx, local_if, server, proto);
+      coap_new_client_session_lkd(ctx, local_if, server, proto);
 
   if (!session)
     return NULL;
@@ -81,7 +95,7 @@ coap_new_client_session_oscore(coap_context_t *ctx,
   return session;
 }
 
-coap_session_t *
+COAP_API coap_session_t *
 coap_new_client_session_oscore_psk(coap_context_t *ctx,
                                    const coap_address_t *local_if,
                                    const coap_address_t *server,
@@ -90,8 +104,24 @@ coap_new_client_session_oscore_psk(coap_context_t *ctx,
                                    coap_oscore_conf_t *oscore_conf) {
   coap_session_t *session;
 
+  coap_lock_lock(ctx, return NULL);
+  session = coap_new_client_session_oscore_psk_lkd(ctx, local_if, server, proto, psk_data,
+                                                   oscore_conf);
+  coap_lock_unlock(ctx);
+  return session;
+}
+
+coap_session_t *
+coap_new_client_session_oscore_psk_lkd(coap_context_t *ctx,
+                                       const coap_address_t *local_if,
+                                       const coap_address_t *server,
+                                       coap_proto_t proto,
+                                       coap_dtls_cpsk_t *psk_data,
+                                       coap_oscore_conf_t *oscore_conf) {
+  coap_session_t *session;
+
   coap_lock_check_locked(ctx);
-  session = coap_new_client_session_psk2(ctx, local_if, server, proto, psk_data);
+  session = coap_new_client_session_psk2_lkd(ctx, local_if, server, proto, psk_data);
 
   if (!session)
     return NULL;
@@ -103,7 +133,7 @@ coap_new_client_session_oscore_psk(coap_context_t *ctx,
   return session;
 }
 
-coap_session_t *
+COAP_API coap_session_t *
 coap_new_client_session_oscore_pki(coap_context_t *ctx,
                                    const coap_address_t *local_if,
                                    const coap_address_t *server,
@@ -112,8 +142,24 @@ coap_new_client_session_oscore_pki(coap_context_t *ctx,
                                    coap_oscore_conf_t *oscore_conf) {
   coap_session_t *session;
 
+  coap_lock_lock(ctx, return NULL);
+  session = coap_new_client_session_oscore_pki_lkd(ctx, local_if, server, proto, pki_data,
+                                                   oscore_conf);
+  coap_lock_unlock(ctx);
+  return session;
+}
+
+coap_session_t *
+coap_new_client_session_oscore_pki_lkd(coap_context_t *ctx,
+                                       const coap_address_t *local_if,
+                                       const coap_address_t *server,
+                                       coap_proto_t proto,
+                                       coap_dtls_pki_t *pki_data,
+                                       coap_oscore_conf_t *oscore_conf) {
+  coap_session_t *session;
+
   coap_lock_check_locked(ctx);
-  session = coap_new_client_session_pki(ctx, local_if, server, proto, pki_data);
+  session = coap_new_client_session_pki_lkd(ctx, local_if, server, proto, pki_data);
 
   if (!session)
     return NULL;
@@ -127,9 +173,20 @@ coap_new_client_session_oscore_pki(coap_context_t *ctx,
 #endif /* COAP_CLIENT_SUPPORT */
 #if COAP_SERVER_SUPPORT
 
-int
+COAP_API int
 coap_context_oscore_server(coap_context_t *context,
                            coap_oscore_conf_t *oscore_conf) {
+  int ret;
+
+  coap_lock_lock(context, return 0);
+  ret = coap_context_oscore_server_lkd(context, oscore_conf);
+  coap_lock_unlock(context);
+  return ret;
+}
+
+int
+coap_context_oscore_server_lkd(coap_context_t *context,
+                               coap_oscore_conf_t *oscore_conf) {
   oscore_ctx_t *osc_ctx;
 
   coap_lock_check_locked(context);
@@ -656,7 +713,7 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
                                       0);
     if (empty) {
       if (coap_send_internal(session, empty) != COAP_INVALID_MID) {
-        osc_pdu->mid = coap_new_message_id(session);
+        osc_pdu->mid = coap_new_message_id_lkd(session);
         osc_pdu->type = COAP_MESSAGE_CON;
       }
     }
@@ -2103,9 +2160,20 @@ coap_oscore_overhead(coap_session_t *session, coap_pdu_t *pdu) {
   return overhead;
 }
 
-int
+COAP_API int
 coap_new_oscore_recipient(coap_context_t *context,
                           coap_bin_const_t *recipient_id) {
+  int ret;
+
+  coap_lock_lock(context, return 0);
+  ret = coap_new_oscore_recipient_lkd(context, recipient_id);
+  coap_lock_unlock(context);
+  return ret;
+}
+
+int
+coap_new_oscore_recipient_lkd(coap_context_t *context,
+                              coap_bin_const_t *recipient_id) {
   coap_lock_check_locked(context);
   if (context->p_osc_ctx == NULL)
     return 0;
@@ -2114,9 +2182,22 @@ coap_new_oscore_recipient(coap_context_t *context,
   return 1;
 }
 
-int
+COAP_API int
 coap_delete_oscore_recipient(coap_context_t *context,
                              coap_bin_const_t *recipient_id) {
+  int ret;
+
+  if (!context || !recipient_id)
+    return 0;
+  coap_lock_lock(context, return 0);
+  ret = coap_delete_oscore_recipient_lkd(context, recipient_id);
+  coap_lock_unlock(context);
+  return ret;
+}
+
+int
+coap_delete_oscore_recipient_lkd(coap_context_t *context,
+                                 coap_bin_const_t *recipient_id) {
   coap_lock_check_locked(context);
   if (context->p_osc_ctx == NULL)
     return 0;

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -1092,7 +1092,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         continue;
       }
 
-      obs->pdu->mid = response->mid = coap_new_message_id(obs->session);
+      obs->pdu->mid = response->mid = coap_new_message_id_lkd(obs->session);
       /* A lot of the reliable code assumes type is CON */
       if (COAP_PROTO_NOT_RELIABLE(obs->session->proto) &&
           (r->flags & COAP_RESOURCE_FLAGS_NOTIFY_CON) == 0 &&

--- a/src/coap_threadsafe.c
+++ b/src/coap_threadsafe.c
@@ -30,127 +30,9 @@
 
 #include "coap3/coap_internal.h"
 
-#if COAP_CLIENT_SUPPORT
-
-/* Client only wrapper functions */
-
-coap_session_t *
-coap_new_client_session(coap_context_t *ctx,
-                        const coap_address_t *local_if,
-                        const coap_address_t *server,
-                        coap_proto_t proto) {
-  coap_session_t *session;
-
-  coap_lock_lock(ctx, return NULL);
-  session = coap_new_client_session_locked(ctx, local_if, server, proto);
-  coap_lock_unlock(ctx);
-  return session;
-}
-
-
-coap_session_t *
-coap_new_client_session_oscore(coap_context_t *ctx,
-                               const coap_address_t *local_if,
-                               const coap_address_t *server,
-                               coap_proto_t proto,
-                               coap_oscore_conf_t *oscore_conf) {
-  coap_session_t *session;
-
-  coap_lock_lock(ctx, return NULL);
-  session = coap_new_client_session_oscore_locked(ctx, local_if, server, proto, oscore_conf);
-  coap_lock_unlock(ctx);
-  return session;
-}
-
-coap_session_t *
-coap_new_client_session_oscore_pki(coap_context_t *ctx,
-                                   const coap_address_t *local_if,
-                                   const coap_address_t *server,
-                                   coap_proto_t proto,
-                                   coap_dtls_pki_t *pki_data,
-                                   coap_oscore_conf_t *oscore_conf) {
-  coap_session_t *session;
-
-  coap_lock_lock(ctx, return NULL);
-  session = coap_new_client_session_oscore_pki_locked(ctx, local_if, server, proto, pki_data,
-                                                      oscore_conf);
-  coap_lock_unlock(ctx);
-  return session;
-}
-
-coap_session_t *
-coap_new_client_session_oscore_psk(coap_context_t *ctx,
-                                   const coap_address_t *local_if,
-                                   const coap_address_t *server,
-                                   coap_proto_t proto,
-                                   coap_dtls_cpsk_t *psk_data,
-                                   coap_oscore_conf_t *oscore_conf) {
-  coap_session_t *session;
-
-  coap_lock_lock(ctx, return NULL);
-  session = coap_new_client_session_oscore_psk_locked(ctx, local_if, server, proto, psk_data,
-                                                      oscore_conf);
-  coap_lock_unlock(ctx);
-  return session;
-}
-
-coap_session_t *
-coap_new_client_session_pki(coap_context_t *ctx,
-                            const coap_address_t *local_if,
-                            const coap_address_t *server,
-                            coap_proto_t proto,
-                            coap_dtls_pki_t *setup_data) {
-  coap_session_t *session;
-
-  coap_lock_lock(ctx, return NULL);
-  session = coap_new_client_session_pki_locked(ctx, local_if, server, proto, setup_data);
-  coap_lock_unlock(ctx);
-  return session;
-}
-
-coap_session_t *
-coap_new_client_session_psk(coap_context_t *ctx,
-                            const coap_address_t *local_if,
-                            const coap_address_t *server,
-                            coap_proto_t proto, const char *identity,
-                            const uint8_t *key, unsigned key_len) {
-  coap_session_t *session;
-
-  coap_lock_lock(ctx, return NULL);
-  session = coap_new_client_session_psk_locked(ctx, local_if, server, proto, identity, key, key_len);
-  coap_lock_unlock(ctx);
-  return session;
-}
-
-coap_session_t *
-coap_new_client_session_psk2(coap_context_t *ctx,
-                             const coap_address_t *local_if,
-                             const coap_address_t *server,
-                             coap_proto_t proto,
-                             coap_dtls_cpsk_t *setup_data) {
-  coap_session_t *session;
-
-  coap_lock_lock(ctx, return NULL);
-  session = coap_new_client_session_psk2_locked(ctx, local_if, server, proto, setup_data);
-  coap_lock_unlock(ctx);
-  return session;
-}
-#endif /* COAP_CLIENT_SUPPORT */
-
 #if COAP_SERVER_SUPPORT
 
 /* Server only wrapper functions */
-
-int
-coap_context_oscore_server(coap_context_t *context,
-                           coap_oscore_conf_t *oscore_conf) {
-  int ret;
-
-  coap_lock_lock(context, return 0);
-  ret = coap_context_oscore_server_locked(context, oscore_conf);
-  coap_lock_unlock(context);
-  return ret;
-}
 
 int
 coap_context_set_pki(coap_context_t *ctx,
@@ -207,16 +89,6 @@ coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
   ret = coap_join_mcast_group_intf_locked(ctx, group_name, ifname);
   coap_lock_unlock(ctx);
   return ret;
-}
-
-coap_endpoint_t *
-coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, coap_proto_t proto) {
-  coap_endpoint_t *endpoint;
-
-  coap_lock_lock(context, return NULL);
-  endpoint = coap_new_endpoint_locked(context, listen_addr, proto);
-  coap_lock_unlock(context);
-  return endpoint;
 }
 
 coap_subscription_t *
@@ -299,51 +171,6 @@ coap_context_set_pki_root_cas(coap_context_t *ctx,
   ret = coap_context_set_pki_root_cas_locked(ctx, ca_file, ca_dir);
   coap_lock_unlock(ctx);
   return ret;
-}
-
-int
-coap_delete_oscore_recipient(coap_context_t *context,
-                             coap_bin_const_t *recipient_id) {
-  int ret;
-
-  if (!context || !recipient_id)
-    return 0;
-  coap_lock_lock(context, return 0);
-  ret = coap_delete_oscore_recipient_locked(context, recipient_id);
-  coap_lock_unlock(context);
-  return ret;
-}
-
-uint16_t
-coap_new_message_id(coap_session_t *session) {
-  uint16_t mid;
-
-  coap_lock_lock(session->context, return 0);
-  mid = coap_new_message_id_locked(session);
-  coap_lock_unlock(session->context);
-  return mid;
-}
-
-int
-coap_new_oscore_recipient(coap_context_t *context,
-                          coap_bin_const_t *recipient_id) {
-  int ret;
-
-  coap_lock_lock(context, return 0);
-  ret = coap_new_oscore_recipient_locked(context, recipient_id);
-  coap_lock_unlock(context);
-  return ret;
-}
-
-coap_pdu_t *
-coap_new_pdu(coap_pdu_type_t type, coap_pdu_code_t code,
-             coap_session_t *session) {
-  coap_pdu_t *pdu;
-
-  coap_lock_lock(session->context, return NULL);
-  pdu = coap_new_pdu_locked(type, code, session);
-  coap_lock_unlock(session->context);
-  return pdu;
 }
 
 coap_pdu_t *


### PR DESCRIPTION
Update the Public API equivalent of the libcoap functions that need to be called when locked with a name suffix of _lkd.

Move matching Public API functions out of coap_threadsafe.c to be coded just ahead of the newly renamed _lkd function.

Properly define the _lkd function in the appropriate _internal.h file for documentation, removing the #defines from coap_threadsafe_internal.h.

Tag all the Public API functions that have a _lkd function with COAP_API. COAP_API can then be defined as to what should be done for that function.

Check libcoap library does not call the original Public API function when it should be calling the _lkd function by marking the Public API not _lkd functions as deprecated during the libcoap library build. [Done by the new COAP_API being defined as __attribute__((deprecated)).]

Work in progress for all the functions that need to be multi-thread safe.