### PR TITLE
locking: app call-backs when coap_free_context() called

### DIFF
--- a/man/coap_locking.txt.in
+++ b/man/coap_locking.txt.in
@@ -71,7 +71,10 @@ functions.
 
 So, _failed_statement_ is the C code to execute if the
 locking fails for any reason. This should only happen when an another
-thread has called *coap_free_context*(3).
+thread has called *coap_free_context*(3). This code should prevent
+execution of the following code that would have been under the lock protection
+and certainly not cause the corresponding *coap_lock_unlock*() function to be
+called.
 
 Likewise, _callback_function_ is the callback handler function with all of
 its parameters.
@@ -97,11 +100,11 @@ be carefully analyzed as to any potential issues being created by the
 app call-back if it calls any Public API, updating any data that is relied on
 after lock takes place.
 
-coap_lock_callback() (or coap_lock_callback_ret()) wrapper leaves the _context_
+*coap_lock_callback*() (or *coap_lock_callback_ret*()) wrapper leaves the _context_
 locked when calling app call-back, but allows the app call-back to call a
 Public API when in the locked state.
 
-coap_lock_callback_release() (or coap_lock_callback_ret_release()) unlocks
+*coap_lock_callback_release*() (or *coap_lock_callback_ret_release*()) unlocks
 _context_ when calling app call-back. The allows the app call-back to go off
 and do other slow/blocking activity.  Any calls to a Public API then locks up
 _context_ before preceding.

--- a/src/coap_threadsafe.c
+++ b/src/coap_threadsafe.c
@@ -32,7 +32,11 @@ coap_lock_unlock_func(coap_lock_t *lock, const char *file, int line) {
 }
 
 int
-coap_lock_lock_func(coap_lock_t *lock, const char *file, int line) {
+coap_lock_lock_func(coap_lock_t *lock, int force, const char *file, int line) {
+  if (!force && lock->being_freed) {
+    /* context is going away */
+    return 0;
+  }
   if (coap_mutex_trylock(&lock->mutex)) {
     if (coap_thread_pid == lock->pid) {
       /* This thread locked the mutex */
@@ -40,7 +44,7 @@ coap_lock_lock_func(coap_lock_t *lock, const char *file, int line) {
         /* This is called from within an app callback */
         lock->lock_count++;
         assert(lock->in_callback == lock->lock_count);
-        goto being_freed_check;
+        return 1;
       } else {
         coap_log_alert("Thread Deadlock: Last %s: %u, this %s: %u\n",
                        lock->lock_file, lock->lock_line, file, line);
@@ -50,20 +54,21 @@ coap_lock_lock_func(coap_lock_t *lock, const char *file, int line) {
     /* Wait for the other thread to unlock */
     coap_mutex_lock(&lock->mutex);
   }
+  /* Just got the lock, so should not be in a locked callback */
+  assert(!lock->in_callback);
   lock->pid = coap_thread_pid;
   lock->lock_file = file;
   lock->lock_line = line;
-  if (lock->in_callback) {
-    /* This is when called from within an app callback and context is going away */
-    lock->lock_count++;
-    assert(lock->in_callback == lock->lock_count);
-  }
-being_freed_check:
-  if (lock->being_freed) {
-    /* context is in the process of being deleted */
+#ifndef __COVERITY__
+  if (!force && lock->being_freed) {
+    /*
+     * lock->being_freed set when previous thread had lock locked.
+     * Have to unlock to let the next context locking user clean up.
+     */
     coap_lock_unlock_func(lock, file, line);
     return 0;
   }
+#endif /* __COVERITY__ */
   return 1;
 }
 
@@ -82,30 +87,34 @@ coap_lock_unlock_func(coap_lock_t *lock) {
 }
 
 int
-coap_lock_lock_func(coap_lock_t *lock) {
+coap_lock_lock_func(coap_lock_t *lock, int force) {
+  if (!force && lock->being_freed) {
+    /* context is going away */
+    return 0;
+  }
   /*
    * Some OS do not have support for coap_mutex_trylock() so
    * cannot use that here and have to rely on lock-pid being stable
    */
   if (lock->in_callback && coap_thread_pid == lock->pid) {
-    if (lock->being_freed) {
-      return 0;
-    }
     lock->lock_count++;
     assert(lock->in_callback == lock->lock_count);
-  } else {
-    coap_mutex_lock(&lock->mutex);
-    lock->pid = coap_thread_pid;
-    if (lock->in_callback) {
-      /* This is when called from within an app callback and context is going away */
-      lock->lock_count++;
-      assert(lock->in_callback == lock->lock_count);
-    }
-    if (lock->being_freed) {
-      coap_lock_unlock_func(lock);
-      return 0;
-    }
+    return 1;
   }
+  coap_mutex_lock(&lock->mutex);
+  /* Just got the lock, so should not be in a locked callback */
+  assert(!lock->in_callback);
+  lock->pid = coap_thread_pid;
+#ifndef __COVERITY__
+  if (!force && lock->being_freed) {
+    /*
+     * lock->being_freed set when previous thread had lock locked.
+     * Have to unlock to let the next context locking user clean up.
+     */
+    coap_lock_unlock_func(lock);
+    return 0;
+  }
+#endif /* __COVERITY__ */
   return 1;
 }
 #endif /* ! COAP_THREAD_RECURSIVE_CHECK */


### PR DESCRIPTION
Attempt to simplify locking to prevent Coverity issues being generated.