### PR TITLE
coap_net: Fix preprocessor guard

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -3569,7 +3569,7 @@ drop_it_no_debug:
   }
 #endif /* COAP_Q_BLOCK_SUPPORT */
 
-#if COAP_Q_BLOCK_SUPPORT || COAP_THREADSAFE
+#if COAP_Q_BLOCK_SUPPORT || COAP_THREAD_SAFE
 finish:
 #endif /* COAP_Q_BLOCK_SUPPORT || COAP_THREAD_SAFE */
   coap_delete_string(uri_path);


### PR DESCRIPTION
A preprocessor guard in `coap_net.c` does not take effect since it is misspelled.