### PR TITLE
release 4.3.5rc1: Release candidate 1 for 4.3.5

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,28 @@
+2024-05-23  Olaf Bergmann  <bergmann@tzi.org>
+
+	Change summary for version 4.3.5:
+
+        * Support for wolfSSL TLS library.
+        * Support for DTLS1.3 (using wolfSSL).
+        * Support for Mbed TLS 3.6.0.
+        * TinyDTLS version update.
+        * Support for RIOT using SOCK i/f.
+        * Support for LwIP using NO_SYS set to 0.
+        * Support for (Posix based) Zephyr.
+        * Support for QNX builds.
+        * Support for ESP32 xtensa builds.
+        * Updated Contiki-NG support.
+        * Support for multi-thread safe libcoap usage.
+        * Support for defining binary PSK for coap-client and coap-server.
+        * Added new define types for defining PKI parameters.
+        * Support for user definable ENGINE for OpenSSL.
+        * Support for using noTLS and TindyDTLS with WebSockets.
+        * Additional scan-build and pre-commit checks in build tests.
+        * Updated CI build tests to use latest action versions.
+        * Fixes CVE-2023-35862.
+        * Reported bugs fixed.
+        * Documentation added and updated (Doxygen and man).
+
 2023-09-18  Olaf Bergmann  <bergmann@tzi.org>
 
 	Change summary for version 4.3.4:

--- a/coap_config.h.contiki
+++ b/coap_config.h.contiki
@@ -109,7 +109,7 @@
 
 #ifndef PACKAGE_STRING
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libcoap 4.3.4"
+#define PACKAGE_STRING "libcoap 4.3.5rc1"
 #endif /* PACKAGE_STRING */
 
 #ifndef PACKAGE_TARNAME
@@ -124,7 +124,7 @@
 
 #ifndef PACKAGE_VERSION
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3.4"
+#define PACKAGE_VERSION "4.3.5rc1"
 #endif /* PACKAGE_VERSION */
 
 #define WITH_CONTIKI 1

--- a/coap_config.h.riot
+++ b/coap_config.h.riot
@@ -362,7 +362,7 @@
 
 #ifndef PACKAGE_STRING
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libcoap 4.3.4"
+#define PACKAGE_STRING "libcoap 4.3.5rc1"
 #endif /* PACKAGE_STRING */
 
 #ifndef PACKAGE_TARNAME
@@ -377,7 +377,7 @@
 
 #ifndef PACKAGE_VERSION
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3.4"
+#define PACKAGE_VERSION "4.3.5rc1"
 #endif /* PACKAGE_VERSION */
 
 /* Define to 1 if you have the ANSI C header files. */

--- a/coap_config.h.windows
+++ b/coap_config.h.windows
@@ -164,7 +164,7 @@
 
 #ifndef PACKAGE_STRING
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libcoap 4.3.4"
+#define PACKAGE_STRING "libcoap 4.3.5rc1"
 #endif /* PACKAGE_STRING */
 
 #ifndef PACKAGE_TARNAME
@@ -179,7 +179,7 @@
 
 #ifndef PACKAGE_VERSION
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3.4"
+#define PACKAGE_VERSION "4.3.5rc1"
 #endif /* PACKAGE_VERSION */
 
 /* Define to 1 if you have the ANSI C header files. */

--- a/configure.ac
+++ b/configure.ac
@@ -15,11 +15,18 @@
 # defined later.
 m4_define([libcoap_major_version], [4])
 m4_define([libcoap_minor_version], [3])
-m4_define([libcoap_micro_version], [4])
+m4_define([libcoap_micro_version], [5])
 
 # define an appending release state if needed, for example for pre-releases
 # like 'alpha' or 'rc1', for a full release keep the value empty!
-m4_define([libcoap_release_state], [])
+m4_define([libcoap_release_state], [rc1])
+
+# Define the previous full libcoap software release version here.
+# Used if libcoap_release_state is not empty for LIBCOAP_VERSION and LIBCOAP_PACKAGE_BASE.
+# Set to libcoap software version when libcoap_release_state is reset to empty.
+m4_define([libcoap_pre_major_version], [4])
+m4_define([libcoap_pre_minor_version], [3])
+m4_define([libcoap_pre_micro_version], [4])
 
 # concatenate the full libcoap version string
 m4_define([libcoap_version], [m4_format([%s.%s.%s%s], libcoap_major_version, libcoap_minor_version, libcoap_micro_version, libcoap_release_state)])
@@ -162,23 +169,45 @@ LIBCOAP_ABI_VERSION=$LT_TEMP.$LT_LIBCOAP_AGE.$LT_LIBCOAP_REVISION
 AC_SUBST(LIBCOAP_ABI_VERSION)
 AC_SUBST(LIBCOAP_API_VERSION)
 
-# Define a numeric version string
-m4_define([version_number],
-          [m4_format([%u%03u%03u],
-                     libcoap_major_version,
-                     libcoap_minor_version,
-                     libcoap_micro_version)])
-LIBCOAP_VERSION=version_number
-AC_SUBST(LIBCOAP_VERSION)
+LT_TEMP=libcoap_release_state
+if test "x$LT_TEMP" = "x"; then
+    # Define a numeric version string
+    m4_define([version_number],
+              [m4_format([%u%03u%03u],
+                         libcoap_major_version,
+                         libcoap_minor_version,
+                         libcoap_micro_version)])
+    LIBCOAP_VERSION=version_number
+    AC_SUBST(LIBCOAP_VERSION)
 
-# Define a base version string
-m4_define([base_version],
-          [m4_format([%u.%u.%u],
-                     libcoap_major_version,
-                     libcoap_minor_version,
-                     libcoap_micro_version)])
-LIBCOAP_PACKAGE_BASE=base_version
-AC_SUBST(LIBCOAP_PACKAGE_BASE)
+    # Define a base version string
+    m4_define([base_version],
+              [m4_format([%u.%u.%u],
+                         libcoap_major_version,
+                         libcoap_minor_version,
+                         libcoap_micro_version)])
+    LIBCOAP_PACKAGE_BASE=base_version
+    AC_SUBST(LIBCOAP_PACKAGE_BASE)
+else
+    # Doing a rc1 etc., so not a full release, use previous full version numbers
+    # Define a numeric version string
+    m4_define([version_number],
+              [m4_format([%u%03u%03u],
+                         libcoap_pre_major_version,
+                         libcoap_pre_minor_version,
+                         libcoap_pre_micro_version)])
+    LIBCOAP_VERSION=version_number
+    AC_SUBST(LIBCOAP_VERSION)
+
+    # Define a base version string
+    m4_define([base_version],
+              [m4_format([%u.%u.%u],
+                         libcoap_pre_major_version,
+                         libcoap_pre_minor_version,
+                         libcoap_pre_micro_version)])
+    LIBCOAP_PACKAGE_BASE=base_version
+    AC_SUBST(LIBCOAP_PACKAGE_BASE)
+fi
 
 # Adding some default warning options for code QS
 # see https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

--- a/examples/lwip/config/coap_config.h
+++ b/examples/lwip/config/coap_config.h
@@ -86,7 +86,7 @@
 
 #ifndef PACKAGE_STRING
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libcoap 4.3.4"
+#define PACKAGE_STRING "libcoap 4.3.5rc1"
 #endif /* PACKAGE_STRING */
 
 #ifndef PACKAGE_TARNAME
@@ -101,7 +101,7 @@
 
 #ifndef PACKAGE_VERSION
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "4.3.4"
+#define PACKAGE_VERSION "4.3.5rc1"
 #endif /* PACKAGE_VERSION */
 
 #ifndef assert

--- a/include/coap3/coap.h.riot
+++ b/include/coap3/coap.h.riot
@@ -25,13 +25,13 @@
 #define LIBCOAP_PACKAGE_NAME "libcoap"
 
 /* Define the full name and version of libcoap. */
-#define LIBCOAP_PACKAGE_STRING "libcoap 4.3.4"
+#define LIBCOAP_PACKAGE_STRING "libcoap 4.3.5rc1"
 
 /* Define the home page for libcoap. */
 #define LIBCOAP_PACKAGE_URL "https://libcoap.net/"
 
 /* Define the version of libcoap this file belongs to. */
-#define LIBCOAP_PACKAGE_VERSION "4.3.4"
+#define LIBCOAP_PACKAGE_VERSION "4.3.5rc1"
 
 /* Define the numeric version identifier for libcoap */
 #define LIBCOAP_VERSION (4003004U)

--- a/include/coap3/coap.h.windows
+++ b/include/coap3/coap.h.windows
@@ -25,13 +25,13 @@
 #define LIBCOAP_PACKAGE_NAME "libcoap"
 
 /* Define the full name and version of libcoap. */
-#define LIBCOAP_PACKAGE_STRING "libcoap 4.3.4"
+#define LIBCOAP_PACKAGE_STRING "libcoap 4.3.5rc1"
 
 /* Define the home page for libcoap. */
 #define LIBCOAP_PACKAGE_URL "https://libcoap.net/"
 
 /* Define the version of libcoap this file belongs to. */
-#define LIBCOAP_PACKAGE_VERSION "4.3.4"
+#define LIBCOAP_PACKAGE_VERSION "4.3.5rc1"
 
 /* Define the numeric version identifier for libcoap */
 #define LIBCOAP_VERSION (4003004U)


### PR DESCRIPTION
LIBCOAP_VERSION and LIBCOAP_PACKAGE_BASE are unchanged until 4.3.5 is released.