### PR TITLE
block: Handle separate responses that then are followed with Block2

### DIFF
--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -30,6 +30,10 @@
  * @{
  */
 
+#define STATE_TOKEN_BASE(t) ((t) & 0xffffffffffffULL)
+#define STATE_TOKEN_RETRY(t) ((uint64_t)(t) >> 48)
+#define STATE_TOKEN_FULL(t,r) (STATE_TOKEN_BASE(t) + ((uint64_t)(r) << 48))
+
 #if COAP_Q_BLOCK_SUPPORT
 #define COAP_BLOCK_SET_MASK (COAP_BLOCK_USE_LIBCOAP | \
                              COAP_BLOCK_SINGLE_BODY | \


### PR DESCRIPTION
Set up lg_crcv if separate ACK response received for a coap_send() CON request to be able to handle Block2 responses.

Handle Block1 request getting back a Block2 request that has an initial separate response once the Block1 has completed by adjusting the stateless token counter.

Separate response is typical for proxy support (OSCORE previously handled)..