### PR TITLE
Locking: Make sure all app callbacks are properly locked.

### DIFF
--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -292,7 +292,7 @@ coap_delete_cache_entry(coap_context_t *ctx, coap_cache_entry_t *cache_entry) {
   }
   coap_delete_cache_key(cache_entry->cache_key);
   if (cache_entry->callback && cache_entry->app_data) {
-    cache_entry->callback(cache_entry->app_data);
+    coap_lock_callback(ctx, cache_entry->callback(cache_entry->app_data));
   }
   coap_free_type(COAP_CACHE_ENTRY, cache_entry);
 }

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -467,13 +467,17 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
     *flags &= ~MBEDTLS_X509_BADCERT_CN_MISMATCH;
   }
   if (setup_data->validate_cn_call_back) {
-    if (!setup_data->validate_cn_call_back(cn,
-                                           crt->raw.p,
-                                           crt->raw.len,
-                                           c_session,
-                                           depth,
-                                           *flags == 0,
-                                           setup_data->cn_call_back_arg)) {
+    int ret;
+
+    coap_lock_callback_ret(ret, c_session->context,
+                           setup_data->validate_cn_call_back(cn,
+                                                             crt->raw.p,
+                                                             crt->raw.len,
+                                                             c_session,
+                                                             depth,
+                                                             *flags == 0,
+                                                             setup_data->cn_call_back_arg));
+    if (!ret) {
       *flags |= MBEDTLS_X509_BADCERT_CN_MISMATCH;
     }
   }
@@ -886,9 +890,9 @@ pki_sni_callback(void *p_info, mbedtls_ssl_context *ssl,
     coap_dtls_key_t *new_entry;
     pki_sni_entry *pki_sni_entry_list;
 
-    new_entry =
-        m_context->setup_data.validate_sni_call_back(name,
-                                                     m_context->setup_data.sni_call_back_arg);
+    coap_lock_callback_ret(new_entry, c_session->context,
+                           m_context->setup_data.validate_sni_call_back(name,
+                               m_context->setup_data.sni_call_back_arg));
     if (!new_entry) {
       mbedtls_free(name);
       return -1;
@@ -964,10 +968,10 @@ psk_sni_callback(void *p_info, mbedtls_ssl_context *ssl,
     const coap_dtls_spsk_info_t *new_entry;
     psk_sni_entry *psk_sni_entry_list;
 
-    new_entry =
-        c_session->context->spsk_setup_data.validate_sni_call_back(name,
-            c_session,
-            c_session->context->spsk_setup_data.sni_call_back_arg);
+    coap_lock_callback_ret(new_entry, c_session->context,
+                           c_session->context->spsk_setup_data.validate_sni_call_back(name,
+                               c_session,
+                               c_session->context->spsk_setup_data.sni_call_back_arg));
     if (!new_entry) {
       mbedtls_free(name);
       return -1;

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -471,8 +471,9 @@ coap_free_resource(coap_resource_t *resource) {
     resource->context->resource_deleted(resource->context, resource->uri_path,
                                         resource->context->observe_user_data);
 
-  if (resource->context->release_userdata && resource->user_data)
-    resource->context->release_userdata(resource->user_data);
+  if (resource->context->release_userdata && resource->user_data) {
+    coap_lock_callback(resource->context, resource->context->release_userdata(resource->user_data));
+  }
 
   /* delete registered attributes */
   LL_FOREACH_SAFE(resource->link_attr, attr, tmp) coap_delete_attr(attr);


### PR DESCRIPTION
Recursive lock issues happen for some of the app callbacks that then call a libcoap public API that tries to lock up the CoAP context.

All libcoap callbacks into app code should now be fixed.