### PR TITLE
enable HAVE_STRUCT_CMSGHDR when building with mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,7 +300,7 @@ check_function_exists(random HAVE_RANDOM)
 check_function_exists(if_nametoindex HAVE_IF_NAMETOINDEX)
 
 # check for symbols
-if(WIN32 AND NOT MINGW)
+if(WIN32)
   set(HAVE_STRUCT_CMSGHDR 1)
   message(STATUS "setting HAVE_STRUCT_CMSGHDR")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL QNX)

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -300,7 +300,7 @@ check_function_exists(random HAVE_RANDOM)
 check_function_exists(if_nametoindex HAVE_IF_NAMETOINDEX)
 
 # check for symbols
-if(WIN32 AND NOT MINGW)
+if(WIN32)
   set(HAVE_STRUCT_CMSGHDR 1)
   message(STATUS "setting HAVE_STRUCT_CMSGHDR")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL QNX)


### PR DESCRIPTION
When building libcoap with mingw, I noticed that coap_session_get_ifindex() always return zero. In the code, it looks like this is always set to zero if HAVE_STRUCT_CMSGHDR is unset in line: https://github.com/obgm/libcoap/blob/7d5e5f3b8c31f7af60b697659f9a97de7db9a3cc/src/coap_io.c#L1165

Wouldn't -1 be a better value to indicate an undefined value?

If libcoap is built for Windows without mingw, HAVE_STRUCT_CMSGHDR is always defined. In this PR, I removed the special handling of mingw, added a few aliases and the code seems to work with HAVE_STRUCT_CMSGHDR defined and mingw.