### PR TITLE
TLS: EC-JPAKE support (RFC8236)

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -154,6 +154,7 @@ static coap_oscore_conf_t *oscore_conf = NULL;
 static int doing_oscore = 0;
 static int doing_tls_engine = 0;
 static char *tls_engine_conf = NULL;
+static int ec_jpake = 0;
 
 static int quit = 0;
 
@@ -509,7 +510,7 @@ usage(const char *program, const char *version) {
           "\t\t[-E oscore_conf_file[,seq_file]] [-G count] [-H hoplimit]\n"
           "\t\t[-K interval] [-N] [-O num,text] [-P scheme://address[:port]\n"
           "\t\t[-T token] [-U]  [-V num] [-X size]\n"
-          "\t\t[[-h match_hint_file] [-k key] [-u user]]\n"
+          "\t\t[[-h match_hint_file] [-k key] [-u user] [-2]]\n"
           "\t\t[[-c certfile] [-j keyfile] [-n] [-C cafile]\n"
           "\t\t[-J pkcs11_pin] [-M raw_pk] [-R trust_casfile]] URI\n"
           "\tURI can be an absolute URI or a URI prefixed with scheme and host\n\n"
@@ -590,6 +591,7 @@ usage(const char *program, const char *version) {
           "\t       \t\tkey begins with 0x, then the hex text (two [0-9a-f] per\n"
           "\t       \t\tbyte) is converted to binary data\n"
           "\t-u user\t\tUser identity to send for pre-shared key mode\n"
+          "\t-2     \t\tUse EC-JPAKE negotiation (if supported)\n"
           "PKI Options (if supported by underlying (D)TLS library)\n"
           "\tNote: If any one of '-c certfile', '-j keyfile' or '-C cafile' is in\n"
           "\tPKCS11 URI naming format (pkcs11: prefix), then any remaining non\n"
@@ -1467,6 +1469,7 @@ setup_psk(const uint8_t *identity,
 
   memset(&dtls_psk, 0, sizeof(dtls_psk));
   dtls_psk.version = COAP_DTLS_CPSK_SETUP_VERSION;
+  dtls_psk.ec_jpake = ec_jpake;
   if (valid_ihs.count) {
     dtls_psk.validate_ih_call_back = verify_ih_callback;
   }
@@ -1663,7 +1666,7 @@ main(int argc, char **argv) {
   coap_startup();
 
   while ((opt = getopt(argc, argv,
-                       "a:b:c:e:f:h:j:k:l:m:no:p:q:rs:t:u:v:wA:B:C:E:G:H:J:K:L:M:NO:P:R:T:UV:X:")) != -1) {
+                       "a:b:c:e:f:h:j:k:l:m:no:p:q:rs:t:u:v:wA:B:C:E:G:H:J:K:L:M:NO:P:R:T:UV:X:2")) != -1) {
     switch (opt) {
     case 'a':
       strncpy(node_str, optarg, NI_MAXHOST - 1);
@@ -1815,6 +1818,9 @@ main(int argc, char **argv) {
     case 'q':
       tls_engine_conf = optarg;
       doing_tls_engine = 1;
+      break;
+    case '2':
+      ec_jpake = 1;
       break;
     default:
       usage(argv[0], LIBCOAP_PACKAGE_VERSION);

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -75,6 +75,7 @@ static coap_oscore_conf_t *oscore_conf;
 static int doing_oscore = 0;
 static int doing_tls_engine = 0;
 static char *tls_engine_conf = NULL;
+static int ec_jpake = 0;
 
 /* set to 1 to request clean server shutdown */
 static int quit = 0;
@@ -2079,6 +2080,7 @@ setup_spsk(void) {
 
   memset(&dtls_spsk, 0, sizeof(dtls_spsk));
   dtls_spsk.version = COAP_DTLS_SPSK_SETUP_VERSION;
+  dtls_spsk.ec_jpake = ec_jpake;
   dtls_spsk.validate_id_call_back = valid_ids.count ?
                                     verify_id_callback : NULL;
   dtls_spsk.validate_sni_call_back = valid_psk_snis.count ?
@@ -2145,7 +2147,7 @@ usage(const char *program, const char *version) {
           "\t\t[-L value] [-N] [-P scheme://address[:port],[name1[,name2..]]]\n"
           "\t\t[-T max_token_size] [-U type] [-V num] [-X size]\n"
           "\t\t[[-h hint] [-i match_identity_file] [-k key]\n"
-          "\t\t[-s match_psk_sni_file] [-u user]]\n"
+          "\t\t[-s match_psk_sni_file] [-u user] [-2]]\n"
           "\t\t[[-c certfile] [-j keyfile] [-m] [-n] [-C cafile]\n"
           "\t\t[-J pkcs11_pin] [-M rpk_file] [-R trust_casfile]\n"
           "\t\t[-S match_pki_sni_file]]\n"
@@ -2252,6 +2254,7 @@ usage(const char *program, const char *version) {
           "\t       \t\t-s followed by -i\n"
           "\t-u user\t\tUser identity for pre-shared key mode (only used if\n"
           "\t       \t\toption -P is set)\n"
+          "\t-2     \t\tUse EC-JPAKE negotiation (if supported)\n"
          );
   fprintf(stderr,
           "PKI Options (if supported by underlying (D)TLS library)\n"
@@ -2850,7 +2853,7 @@ main(int argc, char **argv) {
   clock_offset = time(NULL);
 
   while ((opt = getopt(argc, argv,
-                       "a:b:c:d:eg:h:i:j:k:l:mnp:q:rs:tu:v:w:A:C:E:G:J:L:M:NP:R:S:T:U:V:X:")) != -1) {
+                       "a:b:c:d:eg:h:i:j:k:l:mnp:q:rs:tu:v:w:A:C:E:G:J:L:M:NP:R:S:T:U:V:X:2")) != -1) {
     switch (opt) {
 #ifndef _WIN32
     case 'a':
@@ -3015,6 +3018,9 @@ main(int argc, char **argv) {
       break;
     case 'X':
       csm_max_message_size = strtol(optarg, NULL, 10);
+      break;
+    case '2':
+      ec_jpake = 1;
       break;
     default:
       usage(argv[0], LIBCOAP_PACKAGE_VERSION);

--- a/include/coap3/coap_dtls.h
+++ b/include/coap3/coap_dtls.h
@@ -451,9 +451,11 @@ typedef struct coap_dtls_cpsk_t {
                        to support this version of the struct */
 
   /* Options to enable different TLS functionality in libcoap */
-  uint8_t reserved[7];             /**< Reserved - must be set to 0 for
-                                        future compatibility */
-  /* Size of 7 chosen to align to next
+  uint8_t ec_jpake;        /**< Set to 1 if EC-JPAKE is to be used.
+                                Currently Mbed TLS only */
+  uint8_t reserved[6];     /**< Reserved - must be set to 0 for
+                                future compatibility */
+  /* Size of 6 chosen to align to next
    * parameter, so if newly defined option
    * it can use one of the reserverd slot so
    * no need to change
@@ -539,9 +541,11 @@ typedef struct coap_dtls_spsk_t {
                        to support this version of the struct */
 
   /* Options to enable different TLS functionality in libcoap */
-  uint8_t reserved[7];             /**< Reserved - must be set to 0 for
-                                        future compatibility */
-  /* Size of 7 chosen to align to next
+  uint8_t ec_jpake;        /**< Set to 1 if EC-JPAKE can be used.
+                                Currently Mbed TLS only */
+  uint8_t reserved[6];     /**< Reserved - must be set to 0 for
+                                future compatibility */
+  /* Size of 6 chosen to align to next
    * parameter, so if newly defined option
    * it can use one of the reserverd slot so
    * no need to change

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -27,7 +27,7 @@ SYNOPSIS
               [*-K* interval] [*-L* value] [*-N*] [*-O* num,text]
               [*-P* scheme://addr[:port]] [*-T* token] [*-U*] [*-V* num]
               [*-X* size]
-              [[*-h* match_hint_file] [*-k* key] [*-u* user]]
+              [[*-h* match_hint_file] [*-k* key] [*-u* user] [*-2*]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
               [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* trust_casfile]] URI
 
@@ -216,6 +216,9 @@ OPTIONS - PSK
 
 *-u* user::
    User identity to send for pre-shared key mode (*-k* option also required).
+
+*-2* ::
+   Use EC-JPAKE negotiation (if supported).
 
 OPTIONS - PKI
 -------------

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -27,7 +27,7 @@ SYNOPSIS
               [*-P* scheme://addr[:port],[name1[,name2..]]]
               [*-T* max_token_size] [*-U* type] [*-V* num] [*-X* size]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
-              [*-s* match_psk_sni_file] [*-u* user]]
+              [*-s* match_psk_sni_file] [*-u* user] [*-2*]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
               [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* trust_casfile]
               [*-S* match_pki_sni_file]]
@@ -195,6 +195,9 @@ OPTIONS - PSK
 
 *-u* user ::
    User identity for pre-shared key mode (only used if option *-P* is set).
+
+*-2* ::
+   Use EC-JPAKE negotiation (if supported).
 
 OPTIONS - PKI
 -------------

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -140,7 +140,11 @@ typedef struct coap_dtls_cpsk_t {
                        to support the version of the struct */
 
   /* Options to enable different TLS functionality in libcoap */
-  uint8_t reserved[7];             /* Reserved - must be set to 0 for
+  uint8_t ec_jpake;        /* Set to 1 if DC-JPAKE is to be used.
+                              Currently Mbed TLS only */
+
+  /* Options to enable different TLS functionality in libcoap */
+  uint8_t reserved[6];             /* Reserved - must be set to 0 for
                                       future compatibility */
 
   /** Identity Hint check callback function.
@@ -177,6 +181,11 @@ definition.
 
 *version* is set to COAP_DTLS_CPSK_SETUP_VERSION.  This will then allow
 support for different versions of the coap_dtls_cpsk_t structure in the future.
+
+*SECTION: PSK Server: coap_dtls_spsk_t: ec_jpake*
+
+*ec_jpake* Set to 1 if EC-JPAKE negotiation is to be used. Currently only
+supported by suitably compiled Mbed TLS library.
 
 *SECTION: PSK Client: coap_dtls_cpsk_t: Reserved*
 
@@ -262,11 +271,15 @@ environment.
 [source, c]
 ----
 typedef struct coap_dtls_spsk_t {
-  uint8_t version; /** Set to COAP_DTLS_SPSK_SETUP_VERSION
+  uint8_t version; /* Set to COAP_DTLS_SPSK_SETUP_VERSION
                        to support the version of the struct */
 
   /* Options to enable different TLS functionality in libcoap */
-  uint8_t reserved[7];             /* Reserved - must be set to 0 for
+  uint8_t ec_jpake;        /* Set to 1 if DC-JPAKE can be used.
+                              Currently Mbed TLS only */
+
+  /* Options to enable different TLS functionality in libcoap */
+  uint8_t reserved[6];             /* Reserved - must be set to 0 for
                                       future compatibility */
 
   /** Identity check callback function.
@@ -303,6 +316,11 @@ definition.
 
 *version* is set to COAP_DTLS_SPSK_SETUP_VERSION.  This will then allow
 support for different versions of the coap_dtls_spsk_t structure in the future.
+
+*SECTION: PSK Server: coap_dtls_spsk_t: ec_jpake*
+
+*ec_jpake* Set to 1 if EC-JPAKE negotiation can be used. Currently only
+supported by suitably compiled Mbed TLS library.
 
 *SECTION: PSK Server: coap_dtls_spsk_t: Reserved*
 

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -394,6 +394,9 @@ coap_dtls_context_set_spsk(coap_context_t *c_context,
   if (!g_context || !setup_data)
     return 0;
 
+  if (setup_data->ec_jpake) {
+    coap_log_warn("GnuTLS has no EC-JPAKE support\n");
+  }
   g_context->psk_pki_enabled |= IS_PSK;
   return 1;
 }
@@ -414,6 +417,9 @@ coap_dtls_context_set_cpsk(coap_context_t *c_context,
   if (!g_context || !setup_data)
     return 0;
 
+  if (setup_data->ec_jpake) {
+    coap_log_warn("GnuTLS has no EC-JPAKE support\n");
+  }
   g_context->psk_pki_enabled |= IS_PSK;
   return 1;
 }

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -1222,6 +1222,9 @@ coap_dtls_context_set_spsk(coap_context_t *c_context,
     SSL_set_options(o_context->dtls.ssl, SSL_OP_COOKIE_EXCHANGE);
     SSL_set_mtu(o_context->dtls.ssl, COAP_DEFAULT_MTU);
   }
+  if (setup_data->ec_jpake) {
+    coap_log_warn("OpenSSL has no EC-JPAKE support\n");
+  }
   o_context->psk_pki_enabled |= IS_PSK;
   return 1;
 }
@@ -1254,6 +1257,9 @@ coap_dtls_context_set_cpsk(coap_context_t *c_context,
     SSL_set_app_data(o_context->dtls.ssl, NULL);
     SSL_set_options(o_context->dtls.ssl, SSL_OP_COOKIE_EXCHANGE);
     SSL_set_mtu(o_context->dtls.ssl, COAP_DEFAULT_MTU);
+  }
+  if (setup_data->ec_jpake) {
+    coap_log_warn("OpenSSL has no EC-JPAKE support\n");
   }
   o_context->psk_pki_enabled |= IS_PSK;
   return 1;

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -1473,6 +1473,9 @@ coap_dtls_context_set_cpsk(coap_context_t *coap_context COAP_UNUSED,
     return 0;
 
 #ifdef DTLS_PSK
+  if (setup_data->ec_jpake) {
+    coap_log_warn("TinyDTLS has no EC-JPAKE support\n");
+  }
   return 1;
 #else /* ! DTLS_PSK */
   coap_log_warn("TinyDTLS not compiled with PSK support\n");
@@ -1494,6 +1497,9 @@ coap_dtls_context_set_spsk(coap_context_t *coap_context COAP_UNUSED,
     coap_log_warn("CoAP Server with TinyDTLS does not support SNI selection\n");
   }
 
+  if (setup_data->ec_jpake) {
+    coap_log_warn("TinyDTLS has no EC-JPAKE support\n");
+  }
   return 1;
 #else /* ! DTLS_PSK */
   coap_log_warn("TinyDTLS not compiled with PSK support\n");

--- a/src/coap_wolfssl.c
+++ b/src/coap_wolfssl.c
@@ -1044,6 +1044,9 @@ coap_dtls_context_set_spsk(coap_context_t *c_context,
                                                psk_tls_server_name_call_back);
 #endif /* !COAP_DISABLE_TCP */
   }
+  if (setup_data->ec_jpake) {
+    coap_log_warn("wolfSSL has no EC-JPAKE support\n");
+  }
   w_context->psk_pki_enabled |= IS_PSK;
   return 1;
 }
@@ -1060,6 +1063,9 @@ coap_dtls_context_set_cpsk(coap_context_t *c_context,
   if (!setup_data || !w_context)
     return 0;
 
+  if (setup_data->ec_jpake) {
+    coap_log_warn("wolfSSL has no EC-JPAKE support\n");
+  }
   w_context->psk_pki_enabled |= IS_PSK;
   return 1;
 }


### PR DESCRIPTION
Currently only supported by Mbed TLS if the optional MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED is defined for the Mbed TLS library build.