### PR TITLE
client-coap.c: Fix client spin loop for NO_SYS == 0

### DIFF
--- a/examples/lwip/client-coap.c
+++ b/examples/lwip/client-coap.c
@@ -239,8 +239,6 @@ client_coap_finished(void) {
 
 int
 client_coap_poll(void) {
-#if NO_SYS
   coap_io_process(main_coap_context, 1000);
-#endif /* NO_SYS */
   return quit;
 }

--- a/examples/lwip/client.c
+++ b/examples/lwip/client.c
@@ -53,9 +53,7 @@ static void
 handle_sigint(int signum) {
   (void)signum;
 
-  client_coap_finished();
-  printf("Client Application finished.\n");
-  exit(0);
+  quit = 1;
 }
 
 /*

--- a/examples/lwip/config/lwipopts.h
+++ b/examples/lwip/config/lwipopts.h
@@ -10,6 +10,13 @@
  * of use.
  */
 
+/*
+ * NO_SYS = 0
+ *  Use lwIP OS-awareness (multi threaded, semaphores, mutexes and mboxes).
+ *
+ * NO_SYS = 1
+ *  Use lwIP without OS-awareness (no thread, semaphores, mutexes or mboxes).
+ */
 #define NO_SYS                     0
 #define LWIP_SOCKET                (NO_SYS==0)
 #define LWIP_NETCONN               (NO_SYS==0)

--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -218,6 +218,8 @@ void coap_packet_get_memmapped(coap_packet_t *packet,
 
 #ifdef WITH_LWIP
 void coap_io_process_timeout(void *arg);
+void coap_io_lwip_init(void);
+void coap_io_lwip_cleanup(void);
 #endif
 
 struct coap_packet_t {

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4448,6 +4448,9 @@ coap_startup(void) {
 #endif /* WITH_CONTIKI */
   coap_memory_init();
   coap_dtls_startup();
+#ifdef WITH_LWIP
+  coap_io_lwip_init();
+#endif /* WITH_LWIP */
 #if COAP_SERVER_SUPPORT
   static coap_str_const_t well_known = { sizeof(".well-known/core")-1,
                                          (const uint8_t *)".well-known/core"
@@ -4469,6 +4472,9 @@ coap_cleanup(void) {
 #elif defined(WITH_CONTIKI)
   coap_stop_io_process();
 #endif
+#ifdef WITH_LWIP
+  coap_io_lwip_cleanup();
+#endif /* WITH_LWIP */
   coap_dtls_shutdown();
 
 #if COAP_CONSTRAINED_STACK


### PR DESCRIPTION
Do not call coap_free_context() from within sigint handler. Always call coap_io_process().
Use sys_arch_sem_wait() for timeouts while waiting for input.