### PR TITLE
Constrained Stack: No need for individual locks

### DIFF
--- a/include/coap3/coap_mutex_internal.h
+++ b/include/coap3/coap_mutex_internal.h
@@ -150,15 +150,4 @@ typedef int coap_mutex_t;
 
 #endif /* !WITH_CONTIKI && !WITH_LWIP && !RIOT_VERSION && !HAVE_PTHREAD_H && !HAVE_PTHREAD_MUTEX_LOCK */
 
-#if COAP_CONSTRAINED_STACK
-
-extern coap_mutex_t m_show_pdu;
-extern coap_mutex_t m_log_impl;
-extern coap_mutex_t m_dtls_recv;
-extern coap_mutex_t m_read_session;
-extern coap_mutex_t m_read_endpoint;
-extern coap_mutex_t m_persist_add;
-
-#endif /* COAP_CONSTRAINED_STACK */
-
 #endif /* COAP_MUTEX_INTERNAL_H_ */


### PR DESCRIPTION
If a proxy reads in a packet via coap_read_endpoint, which then invokes an ongoing proxy TCP connection, while waiting for the CSM response of the new session, coap_read_endpoint would get invoked again if there is any data to read on any of the listening endpoints..

With a Constrained Stack, the read in data is protected by mutex m_read_enpoint - which is still locked when trying to wait for the CSM.

As the code is either single threaded, or protected by global_lock if multi-threaded, there is no need to maintain mutexes such as m_read_endpoint.  This PR removes these not needed mutexes.