### PR TITLE
reverse-proxy: Add in reverse proxy support to coap-server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,10 @@ option(
   "compile with support for server mode code"
   ON)
 option(
+  ENABLE_PROXY_CODE
+  "compile with support for proxy code"
+  ON)
+option(
   ENABLE_OSCORE
   "compile with support for OSCORE"
   ON)
@@ -320,6 +324,13 @@ if(${ENABLE_SERVER_MODE})
   message(STATUS "compiling with server support")
 else()
   message(STATUS "compiling without server support")
+endif()
+
+if(${ENABLE_PROXY_CODE})
+  set(COAP_PROXY_SUPPORT "1")
+  message(STATUS "compiling with proxy support")
+else()
+  message(STATUS "compiling without proxy support")
 endif()
 
 if(${ENABLE_OSCORE})
@@ -741,6 +752,7 @@ target_sources(
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_oscore.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_pdu.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_prng.c
+          ${CMAKE_CURRENT_LIST_DIR}/src/coap_proxy.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_resource.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_session.c
           ${CMAKE_CURRENT_LIST_DIR}/src/coap_sha1.c
@@ -780,6 +792,7 @@ target_sources(
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_option.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_pdu.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_prng.h
+          ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_proxy.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_resource.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_session.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_str.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -112,6 +112,7 @@ EXTRA_DIST = \
   include/coap$(LIBCOAP_API_VERSION)/coap_oscore_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_pdu_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_prng_internal.h \
+  include/coap$(LIBCOAP_API_VERSION)/coap_proxy_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_resource_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_session_internal.h \
   include/coap$(LIBCOAP_API_VERSION)/coap_sha1_internal.h \
@@ -208,6 +209,7 @@ libcoap_@LIBCOAP_NAME_SUFFIX@_la_SOURCES = \
   src/coap_option.c \
   src/coap_oscore.c \
   src/coap_pdu.c \
+  src/coap_proxy.c \
   src/coap_prng.c \
   src/coap_resource.c \
   src/coap_session.c \
@@ -257,6 +259,7 @@ libcoap_include_HEADERS = \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_oscore.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_pdu.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_prng.h \
+  $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_proxy.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_resource.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_session.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_str.h \

--- a/cmake_coap_config.h.in
+++ b/cmake_coap_config.h.in
@@ -26,6 +26,9 @@
 /* Define to 1 if the library has server support. */
 #cmakedefine COAP_SERVER_SUPPORT @COAP_SERVER_SUPPORT@
 
+/* Define to 1 if the library has proxy support. */
+#cmakedefine COAP_PROXY_SUPPORT @COAP_PROXY_SUPPORT@
+
 /* Define to 1 if the library is to have observe persistence. */
 #cmakedefine COAP_WITH_OBSERVE_PERSIST @COAP_WITH_OBSERVE_PERSIST@
 

--- a/configure.ac
+++ b/configure.ac
@@ -1181,6 +1181,22 @@ if test "x$enable_server_mode" != "xyes" -a "x$enable_client_mode" != "xyes" ; t
     AC_MSG_ERROR([==> One or both of '--enable-server-mode' and '--enable-client-mode' need to be set!])
 fi
 
+AC_ARG_ENABLE([proxy-code],
+        [AS_HELP_STRING([--enable-proxy-code],
+                        [Enable CoAP proxy supporting code [default=yes]])],
+        [enable_proxy_code="$enableval"],
+        [enable_proxy_code="yes"])
+
+if test "x$enable_proxy_code" = "xyes"; then
+    if test "x$enable_server_mode" != "xyes" -o "x$enable_client_mode" != "xyes" ; then
+        AC_MSG_WARN([==> Both of '--enable-server-mode' and '--enable-client-mode' need to be set for --enable-proxy-code!])
+        enable_proxy_code="no"
+    fi
+fi
+if test "x$enable_proxy_code" = "xyes"; then
+    AC_DEFINE(COAP_PROXY_SUPPORT, 1, [Define to 1 if libcoap supports proxy code.])
+fi
+
 AC_ARG_ENABLE([max-logging-level],
         [AS_HELP_STRING([--enable-max-logging-level],
                         [Only build logging code up to and including the specified logging level [default=8]])],
@@ -1337,6 +1353,7 @@ man/coap_oscore.txt
 man/coap_pdu_access.txt
 man/coap_pdu_setup.txt
 man/coap_persist.txt
+man/coap_proxy.txt
 man/coap_recovery.txt
 man/coap_resource.txt
 man/coap_session.txt
@@ -1382,6 +1399,11 @@ if test "x$enable_client_mode" = "xyes"; then
     AC_MSG_RESULT([      build with client support      : "yes"])
 else
     AC_MSG_RESULT([      build with client support      : "no"])
+fi
+if test "x$enable_client_mode" = "xyes"; then
+    AC_MSG_RESULT([      build with proxy support       : "yes"])
+else
+    AC_MSG_RESULT([      build with proxy support       : "no"])
 fi
 if test "x$build_ipv4" != "xno"; then
     AC_MSG_RESULT([      build with IPv4 support        : "yes"])

--- a/examples/contiki/Makefile
+++ b/examples/contiki/Makefile
@@ -31,3 +31,9 @@ server:	$(CONTIKI)
 clean:
 	$(MAKE) -f Makefile.contiki CONTIKI=$(CONTIKI) TARGET=$(TARGET) clean
 	rm -rf build
+
+distclean:
+	$(MAKE) -f Makefile.contiki CONTIKI=$(CONTIKI) TARGET=$(TARGET) distclean
+
+viewconf:
+	$(MAKE) -f Makefile.contiki CONTIKI=$(CONTIKI) TARGET=$(TARGET) viewconf

--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -148,6 +148,7 @@ COAP_SRC = coap_address.c \
 	   coap_oscore.c \
 	   coap_pdu.c \
 	   coap_prng.c \
+	   coap_proxy.c \
 	   coap_resource.c \
 	   coap_session.c \
 	   coap_sha1.c \

--- a/examples/riot/pkg_libcoap/Makefile.libcoap
+++ b/examples/riot/pkg_libcoap/Makefile.libcoap
@@ -24,6 +24,7 @@ SRC := coap_address.c \
   coap_oscore.c \
   coap_pdu.c \
   coap_prng.c \
+  coap_proxy.c \
   coap_resource.c \
   coap_session.c \
   coap_sha1.c \

--- a/include/coap3/coap.h.in
+++ b/include/coap3/coap.h.in
@@ -58,6 +58,7 @@ extern "C" {
 #include "coap@LIBCOAP_API_VERSION@/coap_oscore.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_pdu.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_prng.h"
+#include "coap@LIBCOAP_API_VERSION@/coap_proxy.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_resource.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_str.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_subscribe.h"

--- a/include/coap3/coap.h.riot
+++ b/include/coap3/coap.h.riot
@@ -58,6 +58,7 @@ extern "C" {
 #include "coap_oscore.h"
 #include "coap_pdu.h"
 #include "coap_prng.h"
+#include "coap_proxy.h"
 #include "coap_resource.h"
 #include "coap_str.h"
 #include "coap_subscribe.h"

--- a/include/coap3/coap.h.windows
+++ b/include/coap3/coap.h.windows
@@ -58,6 +58,7 @@ extern "C" {
 #include "coap3/coap_oscore.h"
 #include "coap3/coap_pdu.h"
 #include "coap3/coap_prng.h"
+#include "coap3/coap_proxy.h"
 #include "coap3/coap_resource.h"
 #include "coap3/coap_str.h"
 #include "coap3/coap_subscribe.h"

--- a/include/coap3/coap_forward_decls.h
+++ b/include/coap3/coap_forward_decls.h
@@ -89,6 +89,14 @@ typedef struct coap_oscore_conf_t coap_oscore_conf_t;
  */
 typedef struct coap_pdu_t coap_pdu_t;
 
+/* ************* coap_proxy_internal.h ***************** */
+
+/**
+ * Proxy information.
+ */
+typedef struct coap_proxy_list_t coap_proxy_list_t;
+
+
 /* ************* coap_resource_internal.h ***************** */
 
 /*

--- a/include/coap3/coap_internal.h
+++ b/include/coap3/coap_internal.h
@@ -117,6 +117,7 @@ typedef struct oscore_ctx_t oscore_ctx_t;
 #endif /* COAP_OSCORE_SUPPORT */
 #include "coap_pdu_internal.h"
 #include "coap_prng_internal.h"
+#include "coap_proxy_internal.h"
 #include "coap_resource_internal.h"
 #include "coap_session_internal.h"
 #include "coap_sha1_internal.h"

--- a/include/coap3/coap_mem.h
+++ b/include/coap3/coap_mem.h
@@ -18,6 +18,7 @@
 #define COAP_MEM_H_
 
 #include "coap3/coap_oscore.h"
+#include "coap3/coap_proxy.h"
 #include <stdlib.h>
 
 #ifndef WITH_LWIP

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -194,6 +194,10 @@ struct coap_context_t {
   uint8_t mcast_per_resource;      /**< Mcast controlled on a per resource
                                         basis */
 #endif /* COAP_SERVER_SUPPORT */
+#if COAP_PROXY_SUPPORT
+  coap_proxy_list_t *proxy_list;   /**< Set of active proxy sessions */
+  size_t proxy_list_count;         /**< Number of active proxy sessions */
+#endif /* COAP_PROXY_SUPPORT */
 #if COAP_CLIENT_SUPPORT
   uint8_t testing_cids;            /**< Change client's source port every testing_cids */
 #endif /* COAP_CLIENT_SUPPORT */

--- a/include/coap3/coap_proxy.h
+++ b/include/coap3/coap_proxy.h
@@ -1,0 +1,112 @@
+/*
+ * coap_proxy.h -- helper functions for proxy handling
+ *
+ * Copyright (C) 2024 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_proxy.h
+ * @brief Helper functions for proxy handling
+ */
+
+#ifndef COAP_PROXY_H_
+#define COAP_PROXY_H_
+
+int coap_proxy_is_supported(void);
+
+/**
+ * @ingroup application_api
+ * @defgroup proxy Proxy
+ * API for Proxies
+ * @{
+ */
+
+typedef enum {
+  COAP_PROXY_REVERSE,       /**< Act as a reverse proxy */
+  COAP_PROXY_REVERSE_STRIP, /**< Act as a reverse proxy, strip out proxy options */
+  COAP_PROXY_FORWARD,       /**< Act as a forward proxy */
+  COAP_PROXY_FORWARD_STRIP, /**< Act as a forward proxy, strip out proxy options */
+  COAP_PROXY_DIRECT,        /**< Act as a direct proxy */
+  COAP_PROXY_DIRECT_STRIP,  /**< Act as a direct proxy, strip out proxy options */
+} coap_proxy_t;
+
+typedef struct coap_proxy_server_t {
+  coap_uri_t uri;         /**< host and port define the server, scheme method */
+  coap_dtls_pki_t *dtls_pki;       /**< PKI configuration to use if not NULL */
+  coap_dtls_cpsk_t *dtls_cpsk;     /**< PSK configuration to use if not NULL */
+  coap_oscore_conf_t *oscore_conf; /**< OSCORE configuration if not NULL */
+} coap_proxy_server_t;
+
+typedef struct coap_proxy_server_list_t {
+  coap_proxy_server_t *entry; /**< Set of servers to connect to */
+  size_t entry_count;         /**< The number of servers */
+  size_t next_entry;          /**< Next server to us (% entry_count) */
+  coap_proxy_t type;          /**< The proxy type */
+  int track_client_session;   /**< If 1, track individual connections to upstream
+                                   server, else 0 */
+  unsigned int idle_timeout_secs; /**< Proxy session idle timeout (0 is no timeout) */
+} coap_proxy_server_list_t;
+
+/**
+ * Verify that the CoAP Scheme is supported for an ongoing proxy connection.
+ *
+ * @param scheme The CoAP scheme to check.
+ *
+ * @return @c 1 if supported, or @c 0 if not supported.
+ */
+int coap_verify_proxy_scheme_supported(coap_uri_scheme_t scheme);
+
+/**
+ * Forward incoming request upstream to the next proxy/server.
+ *
+ * Possible scenarios:
+ *  Acting as a reverse proxy - connect to internal server
+ *   (possibly round robin load balancing over multiple servers).
+ *  Acting as a forward proxy - connect to host defined in Proxy-Uri
+ *   or Proxy-Scheme with Uri-Host (and maybe Uri-Port).
+ *  Acting as a relay proxy - connect to defined upstream server
+ *   (possibly round robin load balancing over multiple servers).
+ *
+ * A request that should go direct to this server is not supported here.
+ *
+ * @param session The client session.
+ * @param request The client's request PDU.
+ * @param response The response PDU that will get sent back to the client.
+ * @param resource The resource associated with this request.
+ * @param cache_key A cache key generated from the request PDU or NULL.
+ * @param server_list The upstream server list to connect to.
+ *
+ * @return @c 1 if success, or @c 0 if failure (@p response code set to
+ *         appropriate value).
+ */
+int COAP_API coap_proxy_forward_request(coap_session_t *session,
+                                        const coap_pdu_t *request,
+                                        coap_pdu_t *response,
+                                        coap_resource_t *resource,
+                                        coap_cache_key_t *cache_key,
+                                        coap_proxy_server_list_t *server_list);
+
+/**
+ * Forward the returning response back to the appropriate client.
+ *
+ * @param session The session handling the response.
+ * @param received The received PDU.
+ * @param cache_key Updated with the cache key pointer provided to
+ *                  coap_proxy_forward_request().  The caller should
+ *                  delete this cach key (unless the client request set up an
+ *                  Observe and there will be unsolicited responses).
+ *
+ * @return One of COAP_RESPONSE_FAIL or COAP_RESPONSE_OK.
+ */
+coap_response_t COAP_API coap_proxy_forward_response(coap_session_t *session,
+                                                     const coap_pdu_t *received,
+                                                     coap_cache_key_t **cache_key);
+
+/** @} */
+
+#endif /* COAP_PROXY_H_ */

--- a/include/coap3/coap_proxy_internal.h
+++ b/include/coap3/coap_proxy_internal.h
@@ -1,0 +1,121 @@
+/*
+ * coap_proxy_internal.h -- Proxy functions for libcoap
+ *
+ * Copyright (C) 2024 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_proxy_internal.h
+ * @brief CoAP Proxy internal information
+ */
+
+#ifndef COAP_PROXY_INTERNAL_H_
+#define COAP_PROXY_INTERNAL_H_
+
+#include "coap_internal.h"
+
+/**
+ * @ingroup internal_api
+ * @defgroup Proxy Support
+ * Internal API for handling CoAP proxies
+ * @{
+ */
+
+typedef struct coap_proxy_req_t {
+  coap_pdu_t *pdu;
+  coap_resource_t *resource;
+  coap_session_t *incoming;
+  coap_bin_const_t *token_used;
+  coap_cache_key_t *cache_key;
+} coap_proxy_req_t;
+
+struct coap_proxy_list_t {
+  coap_session_t *ongoing;   /**< Ongoing session */
+  coap_session_t *incoming;  /**< Incoming session (used if client tracking( */
+  coap_proxy_req_t *req_list; /**< Incoming list of request info */
+  size_t req_count;          /**< Count of incoming request info */
+  coap_uri_t uri;            /**< URI info for connection */
+  coap_tick_t idle_timeout_ticks; /**< Idle timeout (0 == no timeout) */
+  coap_tick_t last_used;     /**< Last time entry was used */
+};
+
+/**
+ * Close down proxy tracking, releasing any memory used.
+ *
+ * @param context The current CoAP context.
+ */
+void coap_proxy_cleanup(coap_context_t *context);
+
+/**
+ * Idle timeout inactive proxy sessions as well as return in @p tim_rem the time
+ * to remaining to timeout the inactive proxy.
+ *
+ * @param context Context to check against.
+ * @param now Current time in ticks.
+ * @param tim_rem Where to update timeout time to the next expiry.
+ *
+ * @return Return 1 if there is a future expire time, else 0.
+ */
+int coap_proxy_check_timeouts(coap_context_t *context, coap_tick_t now,
+                              coap_tick_t *tim_rem);
+
+void coap_proxy_remove_association(coap_session_t *session, int send_failure);
+
+/**
+ * Forward incoming request upstream to the next proxy/server.
+ *
+ * Possible scenarios:
+ *  Acting as a reverse proxy - connect to internal server
+ *   (possibly round robin load balancing over multiple servers).
+ *  Acting as a forward proxy - connect to host defined in Proxy-Uri
+ *   or Proxy-Scheme with Uri-Host (and maybe Uri-Port).
+ *  Acting as a relay proxy - connect to defined upstream server
+ *   (possibly round robin load balancing over multiple servers).
+ *
+ * A request that should go direct to this server is not supported here.
+ *
+ * Note: This function must be called in the locked state,
+ *
+ * @param session The client session.
+ * @param request The client's request PDU.
+ * @param response The response PDU that will get sent back to the client.
+ * @param resource The resource associated with this request.
+ * @param cache_key A cache key generated from the request PDU or NULL.
+ * @param server_list The upstream server list to connect to.
+ *
+ * @return @c 1 if success, or @c 0 if failure (@p response code set to
+ *         appropriate value).
+ */
+int coap_proxy_forward_request_lkd(coap_session_t *session,
+                                   const coap_pdu_t *request,
+                                   coap_pdu_t *response,
+                                   coap_resource_t *resource,
+                                   coap_cache_key_t *cache_key,
+                                   coap_proxy_server_list_t *server_list);
+
+/**
+ * Forward the returning response back to the appropriate client.
+ *
+ * Note: This function must be called in the locked state,
+ *
+ * @param session The session handling the response.
+ * @param received The received PDU.
+ * @param cache_key Updated with the cache key pointer provided to
+ *                  coap_proxy_forward_request_lkd().  The caller should
+ *                  delete this cach key (unless the client request set up an
+ *                  Observe and there will be unsolicited responses).
+ *
+ * @return One of COAP_RESPONSE_FAIL or COAP_RESPONSE_OK.
+ */
+coap_response_t coap_proxy_forward_response_lkd(coap_session_t *session,
+                                                const coap_pdu_t *received,
+                                                coap_cache_key_t **cache_key);
+
+/** @} */
+
+#endif /* COAP_PROXY_INTERNAL_H_ */

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -196,6 +196,9 @@ global:
   coap_print_wellknown;
   coap_prng;
   coap_prng_init;
+  coap_proxy_forward_request;
+  coap_proxy_forward_response;
+  coap_proxy_is_supported;
   coap_q_block_is_supported;
   coap_query_into_optlist;
   coap_realloc_type;
@@ -301,6 +304,7 @@ global:
   coap_tls_is_supported;
   coap_uri_into_options;
   coap_uri_into_optlist;
+  coap_verify_proxy_scheme_supported;
   coap_write_block_b_opt;
   coap_write_block_opt;
   coap_ws_is_supported;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -194,6 +194,9 @@ coap_print_link
 coap_print_wellknown
 coap_prng
 coap_prng_init
+coap_proxy_forward_request
+coap_proxy_forward_response
+coap_proxy_is_supported
 coap_q_block_is_supported
 coap_query_into_optlist
 coap_realloc_type
@@ -299,6 +302,7 @@ coap_tls_engine_remove
 coap_tls_is_supported
 coap_uri_into_options
 coap_uri_into_optlist
+coap_verify_proxy_scheme_supported
 coap_write_block_b_opt
 coap_write_block_opt
 coap_ws_is_supported

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -40,6 +40,7 @@ TXT3 = coap_address.txt \
 	coap_pdu_access.txt \
 	coap_pdu_setup.txt \
 	coap_persist.txt \
+	coap_proxy.txt \
 	coap_recovery.txt \
 	coap_resource.txt \
 	coap_session.txt \

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -20,6 +20,7 @@ coap-server-notls
 SYNOPSIS
 --------
 *coap-server* [*-a* priority] [*-b* max_block_size] [*-d* max] [*-e*]
+              [*-f* scheme://addr[:port]
               [*-g* group] [*-l* loss] [*-p* port] [*-q* tls_engine_conf_file]
               [*-r*] [*-t*]  [*-v* num] [*-w* [port][,secure_port]]
               [*-A* address] [*-E* oscore_conf_file[,seq_file]]
@@ -58,6 +59,14 @@ OPTIONS - General
 
 *-e* ::
    Echo back the data sent with a PUT.
+
+*-f* scheme://address[:port]::
+   Act as a reverse proxy where scheme, address, optional
+   port define how to connect to the internal server.
+   Scheme is one of coap, coaps, coap+tcp, coaps+tcp,
+   coap+ws, and coaps+ws. http(s) is not currently supported.
+   This option can be repeated to provide multiple internal
+   servers that are round-robin load balanced.
 
 *-g* group::
    Join specified multicast 'group' on start up.
@@ -140,6 +149,8 @@ OPTIONS - General
    first name, then the ongoing connection will be a direct connection.
    Scheme is one of coap, coaps, coap+tcp, coaps+tcp, coap+ws, and coaps+ws.
    http and https not currently supported.
+   This option can be repeated to provide multiple upstream
+   servers that are round-robin load balanced.
 
 *-T* max_token_size::
    Set the maximum token length (8-65804).

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -249,7 +249,8 @@ transmitted. The callback function _release_func_ can be used to release
 storage that has been dynamically allocated to hold the transmit data. If not
 NULL, the callback function is called once the final block of _data_ has been
 transmitted. The user-defined parameter _app_ptr_ is the same value that was
-passed to *coap_add_data_large_request*().
+passed to *coap_add_data_large_request*(). Even if there is an error return,
+_release_func_ (if set) is always called.
 
 *NOTE:* This function must only be called once per _pdu_.
 
@@ -271,7 +272,8 @@ transmitted. The callback function _release_func_ can be used to release
 storage that has been dynamically allocated to hold the transmit data. If not
 NULL, the callback function is called once the final block of _data_ has been
 transmitted. The user-defined parameter _app_ptr_ is the same value that was
-passed to *coap_add_data_large_response*().
+passed to *coap_add_data_large_response*(). Even if there is an error return,
+_release_func_ (if set) is always called.
 
 It also adds in the appropriate CoAP options such as Block2, Size2 and ETag to
 handle block-wise transfer if the data does not fit in a single PDU.

--- a/man/coap_proxy.txt.in
+++ b/man/coap_proxy.txt.in
@@ -1,0 +1,102 @@
+// -*- mode:doc; -*-
+// vim: set syntax=asciidoc tw=0
+
+coap_proxy(3)
+=============
+:doctype: manpage
+:man source:   coap_proxy
+:man version:  @PACKAGE_VERSION@
+:man manual:   libcoap Manual
+
+NAME
+----
+coap_proxy,
+coap_proxy_forward_request,
+coap_proxy_forward_response,
+coap_verify_proxy_scheme_supported
+- Work with CoAP proxies
+
+SYNOPSIS
+--------
+*#include <coap@LIBCOAP_API_VERSION@/coap.h>*
+
+*int coap_proxy_forward_request(coap_session_t *_session_,
+const coap_pdu_t *_request_, coap_pdu_t *_response_,
+coap_resource_t *_resource_, coap_cache_key_t *_cache_key_,
+coap_proxy_server_list_t *_server_list_);*
+
+*coap_response_t coap_proxy_forward_response(coap_session_t *_session_,
+                            const coap_pdu_t *received_,
+                            coap_cache_key_t **_cache_key_);*
+
+*int coap_verify_proxy_scheme_supported(coap_uri_scheme_t _scheme_);*
+
+For specific (D)TLS library support, link with
+*-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*,
+*-lcoap-@LIBCOAP_API_VERSION@-wolfssl*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
+*-lcoap-@LIBCOAP_API_VERSION@* to get the default (D)TLS library support.
+
+DESCRIPTION
+-----------
+
+To simplify some of the CoAP proxy requirements, some of the functionaliy
+is provided by libcoap.
+
+FUNCTIONS
+---------
+
+*Function: coap_proxy_forward_request()*
+
+The *coap_proxy_forward_request*() function is called from a request handler
+when the request needs to be forwarded to an upstream server with a possible
+change in protocol.
+
+*Function: coap_proxy_forward_response()*
+
+The *coap_proxy_forward_response*() function is used to cleanup / free any information set
+up by the *coap_startup*() function and should be the last *coap_**() function
+called. The only safe function that can be called after *coap_cleanup*() is
+*coap_startup*() to re-initialize the libcoap logic.
+
+*NOTE:* Calling *coap_cleanup*() in one thread while continuing to use other
+*coap_**() function calls in a different thread is not supported - even if they
+are using a different coap_context_t.
+
+*NOTE:* All other libcoap cleanups should called prior to *coap_cleanup*(), e.g.
+*coap_free_context*(3).
+
+*Function: coap_verify_proxy_scheme_supported()*
+
+The *coap_proxy_forward_request*() function is called from a request handler
+when the request needs to be forwarded to an upstream server with a possible
+change in protocol.
+
+RETURN VALUES
+-------------
+*coap_proxy_forward_request*() and *coap_verify_proxy_scheme_supported*()
+return 1 on success and 0 on failure.
+
+*coap_proxy_forward_response*() returns one of COAP_RESPONSE_OK or
+COAP_RESPONSE_FAIL.
+
+FURTHER INFORMATION
+-------------------
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+for further information.
+
+BUGS
+----
+Please raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues to report any bugs.
+
+Please raise a Pull Request at https://github.com/obgm/libcoap/pulls
+for any fixes.
+
+AUTHORS
+-------
+The libcoap project <libcoap-developers@lists.sourceforge.net>

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -127,6 +127,7 @@ const char *number_list[] = {
   "coap_pdu_code_t ",
   "coap_print_status_t ",
   "coap_proto_t ",
+  "coap_response_t ",
   "coap_session_state_t ",
   "coap_session_type_t ",
   "int ",

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -2346,6 +2346,8 @@ coap_dtls_send(coap_session_t *c_session,
   assert(g_env != NULL);
 
   c_session->dtls_event = -1;
+  coap_log_debug("*  %s: dtls:  sent %4d bytes\n",
+                 coap_session_str(c_session), (int)data_len);
   if (g_env->established) {
     ret = gnutls_record_send(g_env->g_session, data, data_len);
 
@@ -2390,14 +2392,6 @@ coap_dtls_send(coap_session_t *c_session,
     }
   }
 
-  if (ret > 0) {
-    if (ret == (ssize_t)data_len)
-      coap_log_debug("*  %s: dtls:  sent %4d bytes\n",
-                     coap_session_str(c_session), ret);
-    else
-      coap_log_debug("*  %s: dtls:  sent %4d of %4zd bytes\n",
-                     coap_session_str(c_session), ret, data_len);
-  }
   return ret;
 }
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1377,6 +1377,12 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
 #endif /* COAP_SERVER_SUPPORT */
     }
   }
+#if COAP_PROXY_SUPPORT
+  if (coap_proxy_check_timeouts(ctx, now, &s_timeout)) {
+    if (timeout == 0 || s_timeout < timeout)
+      timeout = s_timeout;
+  }
+#endif /* COAP_PROXY_SUPPORT */
 #if COAP_SERVER_SUPPORT
   coap_endpoint_t *ep;
   coap_tick_t session_timeout;

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -771,6 +771,9 @@ coap_free_context_lkd(coap_context_t *context) {
   coap_persist_cleanup(context);
 #endif /* COAP_WITH_OBSERVE_PERSIST */
 #endif /* COAP_SERVER_SUPPORT */
+#if COAP_PROXY_SUPPORT
+  coap_proxy_cleanup(context);
+#endif /* COAP_PROXY_SUPPORT */
 
   coap_free_type(COAP_CONTEXT, context);
   coap_dump_memory_type_counts(COAP_LOG_DEBUG);
@@ -4297,6 +4300,10 @@ coap_handle_event_lkd(coap_context_t *context, coap_event_t event,
     int ret;
 
     coap_lock_callback_ret(ret, context, context->handle_event(session, event));
+#if COAP_PROXY_SUPPORT
+    if (event == COAP_EVENT_SERVER_SESSION_DEL)
+      coap_proxy_remove_association(session, 0);
+#endif /* COAP_PROXY_SUPPORT */
     return ret;
   }
   return 0;

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -1,0 +1,906 @@
+/* coap_proxy.c -- helper functions for proxy handling
+ *
+ * Copyright (C) 2024 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see
+ * README for terms of use.
+ */
+
+/**
+ * @file coap_proxy.c
+ * @brief Proxy handling functions
+ */
+
+#include "coap3/coap_libcoap_build.h"
+
+#if COAP_PROXY_SUPPORT
+#include <stdio.h>
+
+#ifdef _WIN32
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#endif
+
+int
+coap_proxy_is_supported(void) {
+  return 1;
+}
+
+void
+coap_proxy_cleanup(coap_context_t *context) {
+  size_t i;
+  size_t j;
+
+  for (i = 0; i < context->proxy_list_count; i++) {
+    for (j = 0; j < context->proxy_list[i].req_count; j++) {
+      coap_delete_pdu(context->proxy_list[i].req_list[j].pdu);
+      coap_delete_cache_key(context->proxy_list[i].req_list[j].cache_key);
+    }
+    coap_free_type(COAP_STRING, context->proxy_list[i].req_list);
+  }
+  coap_free_type(COAP_STRING, context->proxy_list);
+}
+
+/*
+ * return 1 if there is a future expire time, else 0.
+ * update tim_rem with remaining value if return is 1.
+ */
+int
+coap_proxy_check_timeouts(coap_context_t *context, coap_tick_t now,
+                          coap_tick_t *tim_rem) {
+  size_t i;
+  int ret = 0;
+
+  *tim_rem = -1;
+  for (i = 0; i < context->proxy_list_count; i++) {
+    coap_proxy_list_t *proxy_list = &context->proxy_list[i];
+
+    if (proxy_list->ongoing && proxy_list->idle_timeout_ticks) {
+      if (proxy_list->last_used + proxy_list->idle_timeout_ticks <= now) {
+        /* Drop session to upstream server */
+        coap_session_release_lkd(proxy_list->ongoing);
+        proxy_list->ongoing = NULL;
+      } else {
+        if (*tim_rem > proxy_list->last_used + proxy_list->idle_timeout_ticks - now) {
+          *tim_rem = proxy_list->last_used + proxy_list->idle_timeout_ticks - now;
+        }
+        ret = 1;
+      }
+    }
+  }
+  return ret;
+}
+
+static int
+coap_get_uri_proxy_scheme_info(const coap_pdu_t *request,
+                               coap_opt_t *opt,
+                               coap_uri_t *uri,
+                               coap_string_t **uri_path,
+                               coap_string_t **uri_query) {
+
+  const char *opt_val = (const char *)coap_opt_value(opt);
+  int opt_len = coap_opt_length(opt);
+  coap_opt_iterator_t opt_iter;
+
+  if (opt_len == 9 &&
+      strncasecmp(opt_val, "coaps+tcp", 9) == 0) {
+    uri->scheme = COAP_URI_SCHEME_COAPS_TCP;
+    uri->port = COAPS_DEFAULT_PORT;
+  } else if (opt_len == 8 &&
+             strncasecmp(opt_val, "coap+tcp", 8) == 0) {
+    uri->scheme = COAP_URI_SCHEME_COAP_TCP;
+    uri->port = COAP_DEFAULT_PORT;
+  } else if (opt_len == 5 &&
+             strncasecmp(opt_val, "coaps", 5) == 0) {
+    uri->scheme = COAP_URI_SCHEME_COAPS;
+    uri->port = COAPS_DEFAULT_PORT;
+  } else if (opt_len == 4 &&
+             strncasecmp(opt_val, "coap", 4) == 0) {
+    uri->scheme = COAP_URI_SCHEME_COAP;
+    uri->port = COAP_DEFAULT_PORT;
+  } else if (opt_len == 7 &&
+             strncasecmp(opt_val, "coap+ws", 7) == 0) {
+    uri->scheme = COAP_URI_SCHEME_COAP_WS;
+    uri->port = 80;
+  } else if (opt_len == 8 &&
+             strncasecmp(opt_val, "coaps+ws", 8) == 0) {
+    uri->scheme = COAP_URI_SCHEME_COAPS_WS;
+    uri->port = 443;
+  } else {
+    coap_log_warn("Unsupported Proxy Scheme '%*.*s'\n",
+                  opt_len, opt_len, opt_val);
+    return 0;
+  }
+
+  opt = coap_check_option(request, COAP_OPTION_URI_HOST, &opt_iter);
+  if (opt) {
+    uri->host.length = coap_opt_length(opt);
+    uri->host.s = coap_opt_value(opt);
+  } else {
+    coap_log_warn("Proxy Scheme requires Uri-Host\n");
+    return 0;
+  }
+  opt = coap_check_option(request, COAP_OPTION_URI_PORT, &opt_iter);
+  if (opt) {
+    uri->port =
+        coap_decode_var_bytes(coap_opt_value(opt),
+                              coap_opt_length(opt));
+  }
+  *uri_path = coap_get_uri_path(request);
+  if (*uri_path) {
+    uri->path.s = (*uri_path)->s;
+    uri->path.length = (*uri_path)->length;
+  } else {
+    uri->path.s = NULL;
+    uri->path.length = 0;
+  }
+  *uri_query = coap_get_query(request);
+  if (*uri_query) {
+    uri->query.s = (*uri_query)->s;
+    uri->query.length = (*uri_query)->length;
+  } else {
+    uri->query.s = NULL;
+    uri->query.length = 0;
+  }
+  return 1;
+}
+
+int
+coap_verify_proxy_scheme_supported(coap_uri_scheme_t scheme) {
+
+  /* Sanity check that the connection can be forwarded on */
+  switch (scheme) {
+  case COAP_URI_SCHEME_HTTP:
+  case COAP_URI_SCHEME_HTTPS:
+    coap_log_warn("Proxy URI http or https not supported\n");
+    return 0;
+  case COAP_URI_SCHEME_COAP:
+    break;
+  case COAP_URI_SCHEME_COAPS:
+    if (!coap_dtls_is_supported()) {
+      coap_log_warn("coaps URI scheme not supported for proxy\n");
+      return 0;
+    }
+    break;
+  case COAP_URI_SCHEME_COAP_TCP:
+    if (!coap_tcp_is_supported()) {
+      coap_log_warn("coap+tcp URI scheme not supported for proxy\n");
+      return 0;
+    }
+    break;
+  case COAP_URI_SCHEME_COAPS_TCP:
+    if (!coap_tls_is_supported()) {
+      coap_log_warn("coaps+tcp URI scheme not supported for proxy\n");
+      return 0;
+    }
+    break;
+  case COAP_URI_SCHEME_COAP_WS:
+    if (!coap_ws_is_supported()) {
+      coap_log_warn("coap+ws URI scheme not supported for proxy\n");
+      return 0;
+    }
+    break;
+  case COAP_URI_SCHEME_COAPS_WS:
+    if (!coap_wss_is_supported()) {
+      coap_log_warn("coaps+ws URI scheme not supported for proxy\n");
+      return 0;
+    }
+    break;
+  case COAP_URI_SCHEME_LAST:
+  default:
+    coap_log_warn("%d URI scheme not supported\n", scheme);
+    return 0;
+  }
+  return 1;
+}
+
+static coap_proxy_list_t *
+coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
+                       coap_pdu_t *response,
+                       coap_proxy_server_list_t *server_list,
+                       coap_proxy_server_t *server_use) {
+  size_t i;
+  coap_proxy_list_t *new_proxy_list;
+  coap_proxy_list_t *proxy_list = session->context->proxy_list;
+  size_t proxy_list_count = session->context->proxy_list_count;
+
+  coap_opt_iterator_t opt_iter;
+  coap_opt_t *proxy_scheme;
+  coap_opt_t *proxy_uri;
+  coap_string_t *uri_path = NULL;
+  coap_string_t *uri_query = NULL;
+
+  /* Round robin the defined next server list (which usually is just one */
+  server_list->next_entry++;
+  if (server_list->next_entry >= server_list->entry_count)
+    server_list->next_entry = 0;
+
+  memcpy(server_use, &server_list->entry[server_list->next_entry], sizeof(*server_use));
+
+  switch (server_list->type) {
+  case COAP_PROXY_REVERSE:
+  case COAP_PROXY_FORWARD:
+  case COAP_PROXY_DIRECT:
+    /* Nothing else needs to be done */
+    break;
+  case COAP_PROXY_REVERSE_STRIP:
+  case COAP_PROXY_FORWARD_STRIP:
+  case COAP_PROXY_DIRECT_STRIP:
+    /* Need to get actual server from CoAP options */
+    /*
+     * See if Proxy-Scheme
+     */
+    proxy_scheme = coap_check_option(request, COAP_OPTION_PROXY_SCHEME, &opt_iter);
+    if (proxy_scheme) {
+      if (!coap_get_uri_proxy_scheme_info(request, proxy_scheme, &server_use->uri, &uri_path,
+                                          &uri_query)) {
+        response->code = COAP_RESPONSE_CODE(505);
+        return NULL;
+      }
+    }
+    /*
+     * See if Proxy-Uri
+     */
+    proxy_uri = coap_check_option(request, COAP_OPTION_PROXY_URI, &opt_iter);
+    if (proxy_uri) {
+      coap_log_info("Proxy URI '%.*s'\n",
+                    coap_opt_length(proxy_uri),
+                    (const char *)coap_opt_value(proxy_uri));
+      if (coap_split_proxy_uri(coap_opt_value(proxy_uri),
+                               coap_opt_length(proxy_uri),
+                               &server_use->uri) < 0) {
+        /* Need to return a 5.05 RFC7252 Section 5.7.2 */
+        coap_log_warn("Proxy URI not decodable\n");
+        response->code = COAP_RESPONSE_CODE(505);
+        return NULL;
+      }
+    }
+
+    if (!(proxy_scheme || proxy_uri)) {
+      response->code = COAP_RESPONSE_CODE(404);
+      return NULL;
+    }
+
+    if (server_use->uri.host.length == 0) {
+      /* Ongoing connection not well formed */
+      response->code = COAP_RESPONSE_CODE(505);
+      return NULL;
+    }
+
+    if (!coap_verify_proxy_scheme_supported(server_use->uri.scheme)) {
+      response->code = COAP_RESPONSE_CODE(505);
+      return NULL;
+    }
+    break;
+  default:
+    assert(0);
+    return NULL;
+  }
+
+  /* See if we are already connected to the Server */
+  for (i = 0; i < proxy_list_count; i++) {
+    if (coap_string_equal(&proxy_list[i].uri.host, &server_use->uri.host) &&
+        proxy_list[i].uri.port == server_use->uri.port &&
+        proxy_list[i].uri.scheme == server_use->uri.scheme) {
+      if (!server_list->track_client_session) {
+        coap_ticks(&proxy_list[i].last_used);
+        return &proxy_list[i];
+      } else {
+        if (proxy_list[i].incoming == session) {
+          coap_ticks(&proxy_list[i].last_used);
+          return &proxy_list[i];
+        }
+      }
+    }
+  }
+
+  /* Need to create a new forwarding mapping */
+  new_proxy_list = coap_realloc_type(COAP_STRING, proxy_list, (i+1)*sizeof(proxy_list[0]));
+
+  if (new_proxy_list == NULL) {
+    response->code = COAP_RESPONSE_CODE(500);
+    return NULL;
+  }
+  session->context->proxy_list = proxy_list = new_proxy_list;
+  memset(&proxy_list[i], 0, sizeof(proxy_list[i]));
+
+  proxy_list[i].uri = server_use->uri;
+  if (server_list->track_client_session) {
+    proxy_list[i].incoming = session;
+  }
+  session->context->proxy_list_count++;
+  proxy_list[i].idle_timeout_ticks = server_list->idle_timeout_secs * COAP_TICKS_PER_SECOND;
+  coap_ticks(&proxy_list[i].last_used);
+  return &proxy_list[i];
+}
+
+void
+coap_proxy_remove_association(coap_session_t *session, int send_failure) {
+
+  size_t i;
+  size_t j;
+  coap_proxy_list_t *proxy_list = session->context->proxy_list;
+  size_t proxy_list_count = session->context->proxy_list_count;
+
+  for (i = 0; i < proxy_list_count; i++) {
+    /* Check for incoming match */
+    for (j = 0; j < proxy_list[i].req_count; j++) {
+      if (proxy_list[i].req_list[j].incoming == session) {
+        coap_delete_pdu(proxy_list[i].req_list[j].pdu);
+        coap_delete_bin_const(proxy_list[i].req_list[j].token_used);
+        coap_delete_cache_key(proxy_list[i].req_list[j].cache_key);
+        if (proxy_list[i].req_count-j > 1) {
+          memmove(&proxy_list[i].req_list[j], &proxy_list[i].req_list[j+1],
+                  (proxy_list[i].req_count-j-1) * sizeof(proxy_list[i].req_list[0]));
+        }
+        proxy_list[i].req_count--;
+        break;
+      }
+    }
+    if (proxy_list[i].incoming == session) {
+      /* Only if there is a one-to-one tracking */
+      coap_session_release_lkd(proxy_list[i].ongoing);
+      break;
+    }
+
+    /* Check for outgoing match */
+    if (proxy_list[i].ongoing == session) {
+      coap_session_t *ongoing;
+
+      for (j = 0; j < proxy_list[i].req_count; j++) {
+        if (send_failure) {
+          coap_pdu_t *response;
+          coap_bin_const_t l_token;
+
+          /* Need to send back a gateway failure */
+          response = coap_pdu_init(proxy_list[i].req_list[j].pdu->type,
+                                   COAP_RESPONSE_CODE(502),
+                                   coap_new_message_id_lkd(proxy_list[i].incoming),
+                                   coap_session_max_pdu_size_lkd(proxy_list[i].incoming));
+          if (!response) {
+            coap_log_info("PDU creation issue\n");
+            goto cleanup;
+          }
+
+          l_token = coap_pdu_get_token(proxy_list[i].req_list[j].pdu);
+          if (!coap_add_token(response, l_token.length,
+                              l_token.s)) {
+            coap_log_debug("Cannot add token to incoming proxy response PDU\n");
+          }
+
+          if (coap_send_lkd(proxy_list[i].incoming, response) == COAP_INVALID_MID) {
+            coap_log_info("Failed to send PDU with 5.02 gateway issue\n");
+          }
+cleanup:
+          coap_delete_pdu(proxy_list[i].req_list[j].pdu);
+          coap_delete_bin_const(proxy_list[i].req_list[j].token_used);
+          coap_delete_cache_key(proxy_list[i].req_list[j].cache_key);
+        }
+      }
+      ongoing = proxy_list[i].ongoing;
+      coap_free_type(COAP_STRING, proxy_list[i].req_list);
+      if (proxy_list_count-i > 1) {
+        memmove(&proxy_list[i],
+                &proxy_list[i+1],
+                (proxy_list_count-i-1) * sizeof(proxy_list[0]));
+      }
+      session->context->proxy_list_count--;
+      coap_session_release_lkd(ongoing);
+      break;
+    }
+  }
+}
+
+static coap_proxy_list_t *
+coap_proxy_get_ongoing_session(coap_session_t *session,
+                               const coap_pdu_t *request,
+                               coap_pdu_t *response,
+                               coap_proxy_server_list_t *server_list,
+                               coap_proxy_server_t *server_use) {
+
+  coap_address_t dst;
+  coap_proto_t proto;
+  coap_addr_info_t *info_list = NULL;
+  coap_proxy_list_t *proxy_entry;
+  coap_context_t *context = session->context;
+  static char client_sni[256];
+
+  proxy_entry = coap_proxy_get_session(session, request, response, server_list, server_use);
+  if (!proxy_entry) {
+    /* Response code should be set */
+    return NULL;
+  }
+
+  if (!proxy_entry->ongoing) {
+    /* Need to create a new session */
+
+    /* resolve destination address where data should be sent */
+    info_list = coap_resolve_address_info(&server_use->uri.host,
+                                          server_use->uri.port,
+                                          server_use->uri.port,
+                                          server_use->uri.port,
+                                          server_use->uri.port,
+                                          0,
+                                          1 << server_use->uri.scheme,
+                                          COAP_RESOLVE_TYPE_REMOTE);
+
+    if (info_list == NULL) {
+      response->code = COAP_RESPONSE_CODE(502);
+      coap_proxy_remove_association(session, 0);
+      return NULL;
+    }
+    proto = info_list->proto;
+    memcpy(&dst, &info_list->addr, sizeof(dst));
+    coap_free_address_info(info_list);
+
+    snprintf(client_sni, sizeof(client_sni), "%*.*s", (int)server_use->uri.host.length,
+             (int)server_use->uri.host.length, server_use->uri.host.s);
+
+    switch (server_use->uri.scheme) {
+    case COAP_URI_SCHEME_COAP:
+    case COAP_URI_SCHEME_COAP_TCP:
+    case COAP_URI_SCHEME_COAP_WS:
+#if COAP_OSCORE_SUPPORT
+      if (server_use->oscore_conf) {
+        proxy_entry->ongoing =
+            coap_new_client_session_oscore_lkd(context, NULL, &dst,
+                                               proto, server_use->oscore_conf);
+      } else {
+#endif /* COAP_OSCORE_SUPPORT */
+        proxy_entry->ongoing =
+            coap_new_client_session_lkd(context, NULL, &dst, proto);
+#if COAP_OSCORE_SUPPORT
+      }
+#endif /* COAP_OSCORE_SUPPORT */
+      break;
+    case COAP_URI_SCHEME_COAPS:
+    case COAP_URI_SCHEME_COAPS_TCP:
+    case COAP_URI_SCHEME_COAPS_WS:
+#if COAP_OSCORE_SUPPORT
+      if (server_use->oscore_conf) {
+        if (server_use->dtls_pki) {
+          server_use->dtls_pki->client_sni = client_sni;
+          proxy_entry->ongoing =
+              coap_new_client_session_oscore_pki_lkd(context, NULL, &dst,
+                                                     proto, server_use->dtls_pki, server_use->oscore_conf);
+        } else if (server_use->dtls_pki) {
+          server_use->dtls_cpsk->client_sni = client_sni;
+          proxy_entry->ongoing =
+              coap_new_client_session_oscore_psk_lkd(context, NULL, &dst,
+                                                     proto, server_use->dtls_cpsk, server_use->oscore_conf);
+        } else {
+          coap_log_warn("Proxy: (D)TLS not configured for secure session\n");
+        }
+      } else {
+#endif /* COAP_OSCORE_SUPPORT */
+        /* Not doing OSCORE */
+        if (server_use->dtls_pki) {
+          server_use->dtls_pki->client_sni = client_sni;
+          proxy_entry->ongoing =
+              coap_new_client_session_pki_lkd(context, NULL, &dst,
+                                              proto, server_use->dtls_pki);
+        } else if (server_use->dtls_cpsk) {
+          server_use->dtls_cpsk->client_sni = client_sni;
+          proxy_entry->ongoing =
+              coap_new_client_session_psk2_lkd(context, NULL, &dst,
+                                               proto, server_use->dtls_cpsk);
+        } else {
+          coap_log_warn("Proxy: (D)TLS not configured for secure session\n");
+        }
+#if COAP_OSCORE_SUPPORT
+      }
+#endif /* COAP_OSCORE_SUPPORT */
+      break;
+    case COAP_URI_SCHEME_HTTP:
+    case COAP_URI_SCHEME_HTTPS:
+    case COAP_URI_SCHEME_LAST:
+    default:
+      assert(0);
+      break;
+    }
+    if (proxy_entry->ongoing == NULL) {
+      response->code = COAP_RESPONSE_CODE(505);
+      coap_proxy_remove_association(session, 0);
+      return NULL;
+    }
+  }
+
+  return proxy_entry;
+}
+
+static void
+coap_proxy_release_body_data(coap_session_t *session COAP_UNUSED,
+                             void *app_ptr) {
+  coap_delete_binary(app_ptr);
+}
+
+int COAP_API
+coap_proxy_forward_request(coap_session_t *session,
+                           const coap_pdu_t *request,
+                           coap_pdu_t *response,
+                           coap_resource_t *resource,
+                           coap_cache_key_t *cache_key,
+                           coap_proxy_server_list_t *server_list) {
+  int ret;
+
+  coap_lock_lock(session->context, return 0);
+  ret = coap_proxy_forward_request_lkd(session,
+                                       request,
+                                       response,
+                                       resource,
+                                       cache_key,
+                                       server_list);
+  coap_lock_unlock(session->context);
+  return ret;
+}
+
+int
+coap_proxy_forward_request_lkd(coap_session_t *session,
+                               const coap_pdu_t *request,
+                               coap_pdu_t *response,
+                               coap_resource_t *resource,
+                               coap_cache_key_t *cache_key,
+                               coap_proxy_server_list_t *server_list) {
+  coap_proxy_list_t *proxy_entry;
+  size_t size;
+  size_t offset;
+  size_t total;
+  coap_binary_t *body_data = NULL;
+  const uint8_t *data;
+  coap_pdu_t *pdu;
+  coap_bin_const_t r_token = coap_pdu_get_token(request);
+  uint8_t token[8];
+  size_t token_len;
+  coap_proxy_req_t *new_req_list;
+  coap_optlist_t *optlist = NULL;
+  coap_opt_t *option;
+  coap_opt_iterator_t opt_iter;
+  coap_proxy_server_t server_use;
+
+  /* Set up ongoing session (if not already done) */
+
+  proxy_entry = coap_proxy_get_ongoing_session(session, request, response,
+                                               server_list, &server_use);
+  if (!proxy_entry)
+    /* response code already set */
+    return 0;
+
+  /* Need to save the request pdu entry */
+  new_req_list = coap_realloc_type(COAP_STRING, proxy_entry->req_list,
+                                   (proxy_entry->req_count + 1)*sizeof(coap_proxy_req_t));
+
+  if (new_req_list == NULL) {
+    goto failed;
+  }
+  proxy_entry->req_list = new_req_list;
+  /* Get a new token for ongoing session */
+  coap_session_new_token(proxy_entry->ongoing, &token_len, token);
+  new_req_list[proxy_entry->req_count].token_used = coap_new_bin_const(token, token_len);
+  if (new_req_list[proxy_entry->req_count].token_used == NULL) {
+    goto failed;
+  }
+  new_req_list[proxy_entry->req_count].pdu = coap_pdu_duplicate_lkd(request, session,
+                                             r_token.length, r_token.s, NULL);
+  if (new_req_list[proxy_entry->req_count].pdu == NULL) {
+    coap_delete_bin_const(new_req_list[proxy_entry->req_count].token_used);
+    new_req_list[proxy_entry->req_count].token_used = NULL;
+    goto failed;
+  }
+  new_req_list[proxy_entry->req_count].resource = resource;
+  new_req_list[proxy_entry->req_count].incoming = session;
+  new_req_list[proxy_entry->req_count].cache_key = cache_key;
+  proxy_entry->req_count++;
+
+  switch (server_list->type) {
+  case COAP_PROXY_REVERSE_STRIP:
+  case COAP_PROXY_FORWARD_STRIP:
+  case COAP_PROXY_DIRECT_STRIP:
+    /*
+     * Need to replace Proxy-Uri with Uri-Host (and Uri-Port)
+     * or strip out Proxy-Scheme.
+     */
+
+    /*
+     * Build up the ongoing PDU that we are going to send
+     */
+    pdu = coap_pdu_init(request->type, request->code,
+                        coap_new_message_id_lkd(proxy_entry->ongoing),
+                        coap_session_max_pdu_size_lkd(proxy_entry->ongoing));
+    if (!pdu) {
+      goto failed;
+    }
+
+    if (!coap_add_token(pdu, token_len, token)) {
+      coap_delete_pdu(pdu);
+      goto failed;
+    }
+
+    if (!coap_uri_into_optlist(&server_use.uri,
+                               &proxy_entry->ongoing->addr_info.remote,
+                               &optlist, 1)) {
+      coap_log_err("Failed to create options for URI\n");
+      goto failed;
+    }
+
+    /* Copy the remaining options across */
+    coap_option_iterator_init(request, &opt_iter, COAP_OPT_ALL);
+    while ((option = coap_option_next(&opt_iter))) {
+      switch (opt_iter.number) {
+      case COAP_OPTION_PROXY_URI:
+        break;
+      case COAP_OPTION_PROXY_SCHEME:
+        break;
+      case COAP_OPTION_BLOCK1:
+      case COAP_OPTION_BLOCK2:
+      case COAP_OPTION_Q_BLOCK1:
+      case COAP_OPTION_Q_BLOCK2:
+        /* These are not passed on */
+        break;
+      default:
+        coap_insert_optlist(&optlist,
+                            coap_new_optlist(opt_iter.number,
+                                             coap_opt_length(option),
+                                             coap_opt_value(option)));
+        break;
+      }
+    }
+
+    /* Update pdu with options */
+    coap_add_optlist_pdu(pdu, &optlist);
+    coap_delete_optlist(optlist);
+    break;
+  case COAP_PROXY_REVERSE:
+  case COAP_PROXY_FORWARD:
+  case COAP_PROXY_DIRECT:
+  default:
+    /*
+     * Duplicate request PDU for onward transmission (with new token).
+     */
+    pdu = coap_pdu_duplicate_lkd(request, proxy_entry->ongoing, token_len, token, NULL);
+    if (!pdu) {
+      coap_log_debug("proxy: PDU generation error\n");
+      goto failed;
+    }
+    break;
+  }
+
+  if (coap_get_data_large(request, &size, &data, &offset, &total)) {
+    /* COAP_BLOCK_SINGLE_BODY is set, so single body should be given */
+    assert(size == total);
+    /*
+     * Need to take a copy of the data as request PDU may go away before
+     * all data is transmitted.
+     */
+    body_data = coap_new_binary(total);
+    if (!body_data) {
+      coap_log_debug("proxy: body build memory error\n");
+      goto failed;
+    }
+    memcpy(body_data->s, data, size);
+    if (!coap_add_data_large_request_lkd(proxy_entry->ongoing, pdu, total, data,
+                                         coap_proxy_release_body_data, body_data)) {
+      coap_log_debug("proxy: add data error\n");
+      goto failed;
+    }
+  }
+
+  if (coap_send_lkd(proxy_entry->ongoing, pdu) == COAP_INVALID_MID) {
+    coap_log_debug("proxy: upstream PDU send error\n");
+    goto failed;
+  }
+
+  /*
+   * Do not update the response code (hence empty ACK) as will be sending
+   * separate response when response comes back from upstream server
+   */
+
+  return 1;
+
+failed:
+  response->code = COAP_RESPONSE_CODE(500);
+  return 0;
+}
+
+coap_response_t COAP_API
+coap_proxy_forward_response(coap_session_t *session,
+                            const coap_pdu_t *received,
+                            coap_cache_key_t **cache_key) {
+  int ret;
+
+  coap_lock_lock(session->context, return 0);
+  ret = coap_proxy_forward_response_lkd(session,
+                                        received,
+                                        cache_key);
+  coap_lock_unlock(session->context);
+  return ret;
+}
+
+coap_response_t
+coap_proxy_forward_response_lkd(coap_session_t *session,
+                                const coap_pdu_t *received,
+                                coap_cache_key_t **cache_key) {
+  coap_pdu_t *pdu = NULL;
+  coap_session_t *incoming = NULL;
+  size_t i;
+  size_t j = 0;
+  size_t size;
+  const uint8_t *data;
+  coap_optlist_t *optlist = NULL;
+  coap_opt_t *option;
+  coap_opt_iterator_t opt_iter;
+  size_t offset;
+  size_t total;
+  coap_proxy_list_t *proxy_entry = NULL;
+  uint16_t media_type = COAP_MEDIATYPE_TEXT_PLAIN;
+  int maxage = -1;
+  uint64_t etag = 0;
+  coap_pdu_code_t rcv_code = coap_pdu_get_code(received);
+  coap_bin_const_t rcv_token = coap_pdu_get_token(received);
+  coap_bin_const_t req_token;
+  coap_binary_t *body_data = NULL;
+  coap_pdu_t *req_pdu;
+  coap_proxy_list_t *proxy_list = session->context->proxy_list;
+  size_t proxy_list_count = session->context->proxy_list_count;
+  coap_resource_t *resource;
+  struct coap_proxy_req_t *proxy_req = NULL;
+
+  for (i = 0; i < proxy_list_count; i++) {
+    proxy_entry = &proxy_list[i];
+    for (j = 0; j < proxy_entry->req_count; j++) {
+      if (coap_binary_equal(&rcv_token, proxy_entry->req_list[j].token_used)) {
+        proxy_req = &proxy_entry->req_list[j];
+        break;
+      }
+    }
+    if (j != proxy_entry->req_count) {
+      break;
+    }
+  }
+  if (i == proxy_list_count) {
+    coap_log_warn("Unknown proxy ongoing session response received\n");
+    return COAP_RESPONSE_OK;
+  }
+
+  req_pdu = proxy_req->pdu;
+  req_token = coap_pdu_get_token(req_pdu);
+  resource = proxy_req->resource;
+  incoming = proxy_req->incoming;
+
+  coap_log_debug("** process upstream incoming %d.%02d response:\n",
+                 COAP_RESPONSE_CLASS(rcv_code), rcv_code & 0x1F);
+
+  if (coap_get_data_large(received, &size, &data, &offset, &total)) {
+    /* COAP_BLOCK_SINGLE_BODY is set, so single body should be given */
+    assert(size == total);
+    body_data = coap_new_binary(total);
+    if (!body_data) {
+      coap_log_debug("body build memory error\n");
+      goto remove_match;
+    }
+    memcpy(body_data->s, data, size);
+    data = body_data->s;
+  }
+
+  /*
+   * Build up the ongoing PDU that we are going to send to proxy originator
+   * as separate response
+   */
+  pdu = coap_pdu_init(req_pdu->type, rcv_code,
+                      coap_new_message_id_lkd(incoming),
+                      coap_session_max_pdu_size_lkd(incoming));
+  if (!pdu) {
+    coap_log_debug("Failed to create ongoing proxy response PDU\n");
+    goto remove_match;
+  }
+
+  if (!coap_add_token(pdu, req_token.length, req_token.s)) {
+    coap_log_debug("cannot add token to ongoing proxy response PDU\n");
+  }
+
+  /*
+   * Copy the options across, skipping those needed for
+   * coap_add_data_response_large()
+   */
+  coap_option_iterator_init(received, &opt_iter, COAP_OPT_ALL);
+  while ((option = coap_option_next(&opt_iter))) {
+    switch (opt_iter.number) {
+    case COAP_OPTION_CONTENT_FORMAT:
+      media_type = coap_decode_var_bytes(coap_opt_value(option),
+                                         coap_opt_length(option));
+      break;
+    case COAP_OPTION_MAXAGE:
+      maxage = coap_decode_var_bytes(coap_opt_value(option),
+                                     coap_opt_length(option));
+      break;
+    case COAP_OPTION_ETAG:
+      etag = coap_decode_var_bytes8(coap_opt_value(option),
+                                    coap_opt_length(option));
+      break;
+    case COAP_OPTION_BLOCK2:
+    case COAP_OPTION_Q_BLOCK2:
+    case COAP_OPTION_SIZE2:
+      break;
+    default:
+      coap_insert_optlist(&optlist,
+                          coap_new_optlist(opt_iter.number,
+                                           coap_opt_length(option),
+                                           coap_opt_value(option)));
+      break;
+    }
+  }
+  coap_add_optlist_pdu(pdu, &optlist);
+  coap_delete_optlist(optlist);
+
+  if (size > 0) {
+    coap_string_t *l_query = coap_get_query(req_pdu);
+
+    coap_add_data_large_response_lkd(resource, incoming, req_pdu, pdu,
+                                     l_query,
+                                     media_type, maxage, etag, size, data,
+                                     coap_proxy_release_body_data,
+                                     body_data);
+    coap_delete_string(l_query);
+  }
+
+  if (cache_key)
+    *cache_key = proxy_req->cache_key;
+
+  coap_send_lkd(incoming, pdu);
+
+remove_match:
+  option = coap_check_option(received, COAP_OPTION_OBSERVE, &opt_iter);
+  /* Need to remove matching token entry (apart from on Observe response) */
+  if (option == NULL && proxy_entry->req_count) {
+    coap_delete_pdu(proxy_entry->req_list[j].pdu);
+    coap_delete_bin_const(proxy_entry->req_list[j].token_used);
+    /* Do not delete cache key here - caller's responsibility */
+    proxy_entry->req_count--;
+    if (proxy_entry->req_count-j > 0) {
+      memmove(&proxy_entry->req_list[j], &proxy_entry->req_list[j+1],
+              (proxy_entry->req_count-j) * sizeof(proxy_entry->req_list[0]));
+    }
+  }
+  return COAP_RESPONSE_OK;
+}
+
+#else /* ! COAP_PROXY_SUPPORT */
+
+int
+coap_proxy_is_supported(void) {
+  return 0;
+}
+
+COAP_API int
+coap_proxy_forward_request(coap_session_t *session,
+                           const coap_pdu_t *request,
+                           coap_pdu_t *response,
+                           coap_resource_t *resource,
+                           coap_cache_key_t *cache_key,
+                           coap_proxy_server_list_t *server_list) {
+  (void)session;
+  (void)request;
+  (void)resource;
+  (void)cache_key;
+  (void)server_list;
+  response->code = COAP_RESPONSE_CODE(500);
+  return 0;
+}
+
+COAP_API coap_response_t
+coap_proxy_forward_response(coap_session_t *session,
+                            const coap_pdu_t *received,
+                            coap_cache_key_t **cache_key) {
+  (void)session;
+  (void)received;
+  (void)cache_key;
+  return COAP_RESPONSE_OK;
+}
+
+int
+coap_verify_proxy_scheme_supported(coap_uri_scheme_t scheme) {
+  (void)scheme;
+  return 0;
+}
+#endif /* ! COAP_PROXY_SUPPORT */

--- a/win32/libcoap.vcxproj
+++ b/win32/libcoap.vcxproj
@@ -61,6 +61,7 @@
     <ClCompile Include="..\src\coap_oscore.c" />
     <ClCompile Include="..\src\coap_pdu.c" />
     <ClCompile Include="..\src\coap_prng.c" />
+    <ClCompile Include="..\src\coap_proxy.c" />
     <ClCompile Include="..\src\coap_resource.c" />
     <ClCompile Include="..\src\coap_session.c" />
     <ClCompile Include="..\src\coap_sha1.c" />
@@ -116,6 +117,7 @@
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_pdu_internal.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_prng.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_prng_internal.h" />
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_proxy.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_resource.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_resource_internal.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_session.h" />

--- a/win32/libcoap.vcxproj.filters
+++ b/win32/libcoap.vcxproj.filters
@@ -77,6 +77,9 @@
     <ClCompile Include="..\src\coap_pdu.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\coap_proxy.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\coap_resource.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -236,6 +239,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_prng_internal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_proxy.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_resource.h">


### PR DESCRIPTION
Tidy up the general proxy logic by moving common functionality into libcoap.

New functions coap_proxy_forward_request() and coap_proxy_forward_response() added.

Support for common shared connection to next hop.

Support for round-robin balancing across multiple next hops.