### PR TITLE
Supported: Break out run-time checks and libcoap build #defines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ examples/riot/pkg_libcoap/patches
 
 # the include/ folder
 include/coap3/coap.h
+include/coap3/coap_defines.h
 
 # the tests/ folder
 tests/.deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -723,6 +723,9 @@ configure_file(${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap
 configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake_coap_config.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/coap_config.h)
 
+configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake_coap_defines.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_defines.h)
+
 configure_file(${CMAKE_CURRENT_LIST_DIR}/tests/test_common.h.in
                ${CMAKE_CURRENT_LIST_DIR}/tests/test_common.h)
 
@@ -797,6 +800,7 @@ target_sources(
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_session.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_str.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_subscribe.h
+          ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_supported.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_time.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_uri.h
           ${CMAKE_CURRENT_LIST_DIR}/include/coap${LIBCOAP_API_VERSION}/coap_ws.h)

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ EXTRA_DIST = \
   LICENSE \
   CMakeLists.txt \
   cmake_coap_config.h.in \
+  cmake_coap_defines.h.in \
   cmake/Config.cmake.in \
   cmake/FindMbedTLS.cmake \
   cmake/FindTinyDTLS.cmake \
@@ -248,6 +249,7 @@ libcoap_include_HEADERS = \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_block.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_cache.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_debug.h \
+  $(top_builddir)/include/coap$(LIBCOAP_API_VERSION)/coap_defines.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_dtls.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_encode.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_event.h \
@@ -264,6 +266,7 @@ libcoap_include_HEADERS = \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_session.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_str.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_subscribe.h \
+  $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_supported.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_time.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_uri.h \
   $(top_srcdir)/include/coap$(LIBCOAP_API_VERSION)/coap_ws.h

--- a/cmake_coap_config.h.in
+++ b/cmake_coap_config.h.in
@@ -17,71 +17,7 @@
 #define _GNU_SOURCE
 #endif
 
-/* Define to 1 if the system has small stack size. */
-#cmakedefine COAP_CONSTRAINED_STACK @COAP_CONSTRAINED_STACK@
-
-/* Define to 1 if the library has client support. */
-#cmakedefine COAP_CLIENT_SUPPORT @COAP_CLIENT_SUPPORT@
-
-/* Define to 1 if the library has server support. */
-#cmakedefine COAP_SERVER_SUPPORT @COAP_SERVER_SUPPORT@
-
-/* Define to 1 if the library has proxy support. */
-#cmakedefine COAP_PROXY_SUPPORT @COAP_PROXY_SUPPORT@
-
-/* Define to 1 if the library is to have observe persistence. */
-#cmakedefine COAP_WITH_OBSERVE_PERSIST @COAP_WITH_OBSERVE_PERSIST@
-
-/* Define to 1 if the system has epoll support. */
-#cmakedefine COAP_EPOLL_SUPPORT @COAP_EPOLL_SUPPORT@
-
-/* Define to 1 if the library has OSCORE support. */
-#cmakedefine COAP_OSCORE_SUPPORT @COAP_OSCORE_SUPPORT@
-
-/* Define to 1 if the library has WebSockets support. */
-#cmakedefine COAP_WS_SUPPORT @COAP_WS_SUPPORT@
-
-/* Define to 1 if the library has async separate response support. */
-#cmakedefine COAP_ASYNC_SUPPORT @COAP_ASYNC_SUPPORT@
-
-/* Define to 1 if the library has thread safe support. */
-#cmakedefine COAP_THREAD_SAFE @COAP_THREAD_SAFE@
-
-/* Define to 1 if the library has thread deadlock detection support. */
-#cmakedefine COAP_THREAD_RECURSIVE_CHECK @COAP_THREAD_RECURSIVE_CHECK@
-
-/* Define to 0-8 for maximum logging level. */
-#cmakedefine COAP_MAX_LOGGING_LEVEL @COAP_MAX_LOGGING_LEVEL@
-
-/* Define to 1 to build without TCP support. */
-#cmakedefine01 COAP_DISABLE_TCP
-
-/* Define to 1 to build with IPv4 support. */
-#cmakedefine COAP_IPV4_SUPPORT @COAP_IPV4_SUPPORT@
-
-/* Define to 1 to build with IPv6 support. */
-#cmakedefine COAP_IPV6_SUPPORT @COAP_IPV6_SUPPORT@
-
-/* Define to 1 to build with Unix socket support. */
-#cmakedefine COAP_AF_UNIX_SUPPORT @COAP_AF_UNIX_SUPPORT@
-
-/* Define to 1 to build with Q-Block (RFC 9177) support. */
-#cmakedefine COAP_Q_BLOCK_SUPPORT @COAP_Q_BLOCK_SUPPORT@
-
-/* Define to 1 if the system has openssl */
-#cmakedefine COAP_WITH_LIBOPENSSL @COAP_WITH_LIBOPENSSL@
-
-/* Define to 1 if the system has wolfSSL */
-#cmakedefine COAP_WITH_LIBWOLFSSL @COAP_WITH_LIBWOLFSSL@
-
-/* Define to 1 if the system has libgnutls28 */
-#cmakedefine COAP_WITH_LIBGNUTLS @COAP_WITH_LIBGNUTLS@
-
-/* Define to 1 if the system has libtinydtls */
-#cmakedefine COAP_WITH_LIBTINYDTLS @COAP_WITH_LIBTINYDTLS@
-
-/* Define to 1 if the system has libmbedtls */
-#cmakedefine COAP_WITH_LIBMBEDTLS @COAP_WITH_LIBMBEDTLS@
+#include <coap@LIBCOAP_API_VERSION@/coap_defines.h>
 
 /* Define to 1 if you have the <arpa/inet.h> header file. */
 #cmakedefine HAVE_ARPA_INET_H @HAVE_ARPA_INET_H@

--- a/cmake_coap_defines.h.in
+++ b/cmake_coap_defines.h.in
@@ -1,0 +1,81 @@
+/*
+ * cmake_coap_defines.h -- optional #defines used for building libcoap
+ *
+ * Copyright (C) 2024 Jon Shallow <supjps-libcoap@jpshallow.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+#ifndef COAP_DEFINES_H_
+#define COAP_DEFINES_H_
+
+/* Define to 1 to build with Unix socket support. */
+#cmakedefine COAP_AF_UNIX_SUPPORT @COAP_AF_UNIX_SUPPORT@
+
+/* Define to 1 if the library has async separate response support. */
+#cmakedefine COAP_ASYNC_SUPPORT @COAP_ASYNC_SUPPORT@
+
+/* Define to 1 if the library has client support. */
+#cmakedefine COAP_CLIENT_SUPPORT @COAP_CLIENT_SUPPORT@
+
+/* Define to 1 if the system has small stack size. */
+#cmakedefine COAP_CONSTRAINED_STACK @COAP_CONSTRAINED_STACK@
+
+/* Define to 1 to build without TCP support. */
+#cmakedefine01 COAP_DISABLE_TCP
+
+/* Define to 1 if the system has epoll support. */
+#cmakedefine COAP_EPOLL_SUPPORT @COAP_EPOLL_SUPPORT@
+
+/* Define to 1 to build with IPv4 support. */
+#cmakedefine COAP_IPV4_SUPPORT @COAP_IPV4_SUPPORT@
+
+/* Define to 1 to build with IPv6 support. */
+#cmakedefine COAP_IPV6_SUPPORT @COAP_IPV6_SUPPORT@
+
+/* Define to 0-8 for maximum logging level. */
+#cmakedefine COAP_MAX_LOGGING_LEVEL @COAP_MAX_LOGGING_LEVEL@
+
+/* Define to 1 if the library has OSCORE support. */
+#cmakedefine COAP_OSCORE_SUPPORT @COAP_OSCORE_SUPPORT@
+
+/* Define to 1 if the library has proxy support. */
+#cmakedefine COAP_PROXY_SUPPORT @COAP_PROXY_SUPPORT@
+
+/* Define to 1 to build with Q-Block (RFC 9177) support. */
+#cmakedefine COAP_Q_BLOCK_SUPPORT @COAP_Q_BLOCK_SUPPORT@
+
+/* Define to 1 if the library has server support. */
+#cmakedefine COAP_SERVER_SUPPORT @COAP_SERVER_SUPPORT@
+
+/* Define to 1 if the library has thread deadlock detection support. */
+#cmakedefine COAP_THREAD_RECURSIVE_CHECK @COAP_THREAD_RECURSIVE_CHECK@
+
+/* Define to 1 if the library has thread safe support. */
+#cmakedefine COAP_THREAD_SAFE @COAP_THREAD_SAFE@
+
+/* Define to 1 if the system has libgnutls28 */
+#cmakedefine COAP_WITH_LIBGNUTLS @COAP_WITH_LIBGNUTLS@
+
+/* Define to 1 if the system has libmbedtls */
+#cmakedefine COAP_WITH_LIBMBEDTLS @COAP_WITH_LIBMBEDTLS@
+
+/* Define to 1 if the system has openssl */
+#cmakedefine COAP_WITH_LIBOPENSSL @COAP_WITH_LIBOPENSSL@
+
+/* Define to 1 if the system has libtinydtls */
+#cmakedefine COAP_WITH_LIBTINYDTLS @COAP_WITH_LIBTINYDTLS@
+
+/* Define to 1 if the system has wolfSSL */
+#cmakedefine COAP_WITH_LIBWOLFSSL @COAP_WITH_LIBWOLFSSL@
+
+/* Define to 1 if the library is to have observe persistence. */
+#cmakedefine COAP_WITH_OBSERVE_PERSIST @COAP_WITH_OBSERVE_PERSIST@
+
+/* Define to 1 if the library has WebSockets support. */
+#cmakedefine COAP_WS_SUPPORT @COAP_WS_SUPPORT@
+
+#endif /* COAP_DEFINES_H_ */

--- a/configure.ac
+++ b/configure.ac
@@ -1358,6 +1358,7 @@ man/coap_recovery.txt
 man/coap_resource.txt
 man/coap_session.txt
 man/coap_string.txt
+man/coap_supported.txt
 man/coap_tls_library.txt
 man/coap_uri.txt
 man/coap_websockets.txt
@@ -1549,4 +1550,9 @@ if test "x$enable_static" = "xyes"; then
     AC_MSG_RESULT([      build static library           : "yes"])
 else
     AC_MSG_RESULT([      build static library           : "no"])
+fi
+
+LT_TEMP=`grep -B2 " COAP_" coap_config.h > include/coap$LIBCOAP_API_VERSION/coap_defines.h`
+if test "x$LT_TEMP" != "x" ; then
+    AC_MSG_ERROR([Unable to build coap_defines.h])
 fi

--- a/include/coap3/coap.h.in
+++ b/include/coap3/coap.h.in
@@ -62,6 +62,7 @@ extern "C" {
 #include "coap@LIBCOAP_API_VERSION@/coap_resource.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_str.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_subscribe.h"
+#include "coap@LIBCOAP_API_VERSION@/coap_supported.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_time.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_uri.h"
 #include "coap@LIBCOAP_API_VERSION@/coap_ws.h"

--- a/include/coap3/coap.h.riot
+++ b/include/coap3/coap.h.riot
@@ -62,6 +62,7 @@ extern "C" {
 #include "coap_resource.h"
 #include "coap_str.h"
 #include "coap_subscribe.h"
+#include "coap_supported.h"
 #include "coap_time.h"
 #include "coap_uri.h"
 #include "coap_ws.h"

--- a/include/coap3/coap.h.windows
+++ b/include/coap3/coap.h.windows
@@ -62,6 +62,7 @@ extern "C" {
 #include "coap3/coap_resource.h"
 #include "coap3/coap_str.h"
 #include "coap3/coap_subscribe.h"
+#include "coap3/coap_supported.h"
 #include "coap3/coap_time.h"
 #include "coap3/coap_uri.h"
 #include "coap3/coap_ws.h"

--- a/include/coap3/coap_async.h
+++ b/include/coap3/coap_async.h
@@ -30,12 +30,6 @@
  */
 
 /**
- * Returns @c 1 if libcoap was built with separate messages enabled,
- * @c 0 otherwise.
- */
-int coap_async_is_supported(void);
-
-/**
  * Allocates a new coap_async_t object and fills its fields according to
  * the given @p request. This function returns a pointer to the registered
  * coap_async_t object or @c NULL on error. Note that this function will

--- a/include/coap3/coap_block.h
+++ b/include/coap3/coap_block.h
@@ -70,12 +70,6 @@ typedef struct {
 /* WARNING: Added defined values must not encroach into 0xff000000 which are defined elsewhere */
 
 /**
- * Returns @c 1 if libcoap was built with option Q-BlockX support,
- * @c 0 otherwise.
- */
-int coap_q_block_is_supported(void);
-
-/**
  * Returns the value of the least significant byte of a Block option @p opt.
  * For zero-length options (i.e. num == m == szx == 0), COAP_OPT_BLOCK_LAST
  * returns @c NULL.

--- a/include/coap3/coap_dtls.h
+++ b/include/coap3/coap_dtls.h
@@ -29,8 +29,6 @@
  * @{
  */
 
-int coap_dtls_cid_is_supported(void);
-
 typedef struct coap_dtls_pki_t coap_dtls_pki_t;
 
 #ifndef COAP_DTLS_HINT_LENGTH
@@ -49,48 +47,6 @@ typedef enum coap_dtls_role_t {
 } coap_dtls_role_t;
 
 #define COAP_DTLS_RPK_CERT_CN "RPK"
-
-/**
- * Check whether DTLS is available.
- *
- * @return @c 1 if support for DTLS is available, or @c 0 otherwise.
- */
-int coap_dtls_is_supported(void);
-
-/**
- * Check whether TLS is available.
- *
- * @return @c 1 if support for TLS is available, or @c 0 otherwise.
- */
-int coap_tls_is_supported(void);
-
-/**
- * Check whether (D)TLS PSK is available.
- *
- * @return @c 1 if support for (D)TLS PSK is available, or @c 0 otherwise.
- */
-int coap_dtls_psk_is_supported(void);
-
-/**
- * Check whether (D)TLS PKI is available.
- *
- * @return @c 1 if support for (D)TLS PKI is available, or @c 0 otherwise.
- */
-int coap_dtls_pki_is_supported(void);
-
-/**
- * Check whether (D)TLS PKCS11 is available.
- *
- * @return @c 1 if support for (D)TLS PKCS11 is available, or @c 0 otherwise.
- */
-int coap_dtls_pkcs11_is_supported(void);
-
-/**
- * Check whether (D)TLS RPK is available.
- *
- * @return @c 1 if support for (D)TLS RPK is available, or @c 0 otherwise.
- */
-int coap_dtls_rpk_is_supported(void);
 
 /**
  * Configure an ENGINE for a TLS library.

--- a/include/coap3/coap_io.h
+++ b/include/coap3/coap_io.h
@@ -59,13 +59,6 @@ typedef struct coap_addr_tuple_t {
 
 const char *coap_socket_strerror(void);
 
-/**
- * Check whether TCP is available.
- *
- * @return @c 1 if support for TCP is enabled, or @c 0 otherwise.
- */
-int coap_tcp_is_supported(void);
-
 typedef enum {
   COAP_NACK_TOO_MANY_RETRIES,
   COAP_NACK_NOT_DELIVERABLE,

--- a/include/coap3/coap_oscore.h
+++ b/include/coap3/coap_oscore.h
@@ -29,13 +29,6 @@
  */
 
 /**
- * Check whether OSCORE is available.
- *
- * @return @c 1 if support for OSCORE is enabled, or @c 0 otherwise.
- */
-int coap_oscore_is_supported(void);
-
-/**
  * Creates a new client session to the designated server, protecting the data
  * using OSCORE.
  *

--- a/include/coap3/coap_proxy.h
+++ b/include/coap3/coap_proxy.h
@@ -17,8 +17,6 @@
 #ifndef COAP_PROXY_H_
 #define COAP_PROXY_H_
 
-int coap_proxy_is_supported(void);
-
 /**
  * @ingroup application_api
  * @defgroup proxy Proxy

--- a/include/coap3/coap_supported.h
+++ b/include/coap3/coap_supported.h
@@ -1,0 +1,183 @@
+/*
+ * coap_supported.h -- CoAP optional functionality
+ *
+ * Copyright (C) 2024 Olaf Bergmann <bergmann@tzi.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of the CoAP library libcoap. Please see README for terms
+ * of use.
+ */
+
+/**
+ * @file coap_supported.h
+ * @brief CoAP optional functionality
+ */
+
+#ifndef COAP_SUPPORTED_H_
+#define COAP_SUPPORTED_H_
+
+/**
+ * @ingroup application_api
+ * @defgroup supported Optional functionality
+ * API for determining functionality optionally compiled into libcoap
+ * @{
+ */
+
+/**
+ * Check whether socket type AF_UNIX is available.
+ *
+ * @return @c 1 if support for AF_UNIX is available, or @c 0 otherwise.
+ */
+int coap_af_unix_is_supported(void);
+
+/**
+ * Check whether ASYNC (separate responses) is available.
+ *
+ * @return @c 1 if support for ASYNC is available, or @c 0 otherwise.
+ */
+int coap_async_is_supported(void);
+
+/**
+ * Check whether Client code is available.
+ *
+ * @return @c 1 if support for Client is available, or @c 0 otherwise.
+ */
+int coap_client_is_supported(void);
+
+/**
+ * Check whether DTLS is available.
+ *
+ * @return @c 1 if support for DTLS is available, or @c 0 otherwise.
+ */
+int coap_dtls_is_supported(void);
+
+/**
+ * Check whether (D)TLS CID is available.
+ *
+ * @return @c 1 if support for (D)TLS CID is available, or @c 0 otherwise.
+ */
+int coap_dtls_cid_is_supported(void);
+
+/**
+ * Check whether (D)TLS PSK is available.
+ *
+ * @return @c 1 if support for (D)TLS PSK is available, or @c 0 otherwise.
+ */
+int coap_dtls_psk_is_supported(void);
+
+/**
+ * Check whether (D)TLS PKI is available.
+ *
+ * @return @c 1 if support for (D)TLS PKI is available, or @c 0 otherwise.
+ */
+int coap_dtls_pki_is_supported(void);
+
+/**
+ * Check whether (D)TLS PKCS11 is available.
+ *
+ * @return @c 1 if support for (D)TLS PKCS11 is available, or @c 0 otherwise.
+ */
+int coap_dtls_pkcs11_is_supported(void);
+
+/**
+ * Check whether (D)TLS RPK is available.
+ *
+ * @return @c 1 if support for (D)TLS RPK is available, or @c 0 otherwise.
+ */
+int coap_dtls_rpk_is_supported(void);
+
+/**
+ * Determine whether epoll is supported or not.
+ *
+ * @return @c 1 if libcoap is compiled with epoll support, @c 0 if not.
+ */
+int coap_epoll_is_supported(void);
+
+/**
+ * Check whether IPv4 is available.
+ *
+ * @return @c 1 if support for IPv4 is available, or @c 0 otherwise.
+ */
+int coap_ipv4_is_supported(void);
+
+/**
+ * Check whether IPv6 is available.
+ *
+ * @return @c 1 if support for IPv6 is available, or @c 0 otherwise.
+ */
+int coap_ipv6_is_supported(void);
+
+/**
+ * Check whether Observe Persist is available.
+ *
+ * @return @c 1 if support for Observe Persist is available, or @c 0 otherwise.
+ */
+int coap_observe_persist_is_supported(void);
+
+/**
+ * Check whether OSCORE is available.
+ *
+ * @return @c 1 if support for OSCORE is enabled, or @c 0 otherwise.
+ */
+int coap_oscore_is_supported(void);
+
+/**
+ * Check whether Proxy code is available.
+ *
+ * @return @c 1 if support for Proxy code is enabled, or @c 0 otherwise.
+ */
+int coap_proxy_is_supported(void);
+
+/**
+ * Check whether Q-BlockX is available.
+ *
+ * @return @c 1 if support for Q-BLockX is available, or @c 0 otherwise.
+ */
+int coap_q_block_is_supported(void);
+
+/**
+ * Check whether Server code is available.
+ *
+ * @return @c 1 if support for Server is available, or @c 0 otherwise.
+ */
+int coap_server_is_supported(void);
+
+/**
+ * Check whether TCP is available.
+ *
+ * @return @c 1 if support for TCP is enabled, or @c 0 otherwise.
+ */
+int coap_tcp_is_supported(void);
+
+/**
+ * Determine whether libcoap is threadsafe or not.
+ *
+ * @return @c 1 if libcoap is compiled with threadsafe support, @c 0 if not.
+ */
+int coap_threadsafe_is_supported(void);
+
+/**
+ * Check whether TLS is available.
+ *
+ * @return @c 1 if support for TLS is available, or @c 0 otherwise.
+ */
+int coap_tls_is_supported(void);
+
+/**
+ * Check whether WebSockets is available.
+ *
+ * @return @c 1 if support for WebSockets is available, or @c 0 otherwise.
+ */
+int coap_ws_is_supported(void);
+
+/**
+ * Check whether Secure WebSockets is available.
+ *
+ * @return @c 1 if support for Secure WebSockets is available, or @c 0 otherwise.
+ */
+int coap_wss_is_supported(void);
+
+/**@}*/
+
+#endif /* COAP_SUPPORTED_H_ */

--- a/include/coap3/coap_ws.h
+++ b/include/coap3/coap_ws.h
@@ -26,20 +26,6 @@
  */
 
 /**
- * Check whether WebSockets is available.
- *
- * @return @c 1 if support for WebSockets is available, or @c 0 otherwise.
- */
-int coap_ws_is_supported(void);
-
-/**
- * Check whether Secure WebSockets is available.
- *
- * @return @c 1 if support for Secure WebSockets is available, or @c 0 otherwise.
- */
-int coap_wss_is_supported(void);
-
-/**
  * Set the host for the HTTP Host: Header in the WebSockets Request.
  *
  * @return @c 1 if successful, else @c 0 if failure of some sort.

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -18,6 +18,7 @@ global:
   coap_address_init;
   coap_address_set_port;
   coap_address_set_unix_domain;
+  coap_af_unix_is_supported;
   coap_async_get_app_data;
   coap_async_is_supported;
   coap_async_set_app_data;
@@ -39,6 +40,7 @@ global:
   coap_check_option;
   coap_cleanup;
   coap_clear_event_handler;
+  coap_client_is_supported;
   coap_clock_init;
   coap_clone_uri;
   coap_context_get_app_data;
@@ -94,6 +96,7 @@ global:
   coap_encode_var_safe;
   coap_endpoint_set_default_mtu;
   coap_endpoint_str;
+  coap_epoll_is_supported;
   coap_find_async;
   coap_find_attr;
   coap_fls;
@@ -124,6 +127,8 @@ global:
   coap_io_prepare_io;
   coap_io_process;
   coap_io_process_with_fds;
+  coap_ipv4_is_supported;
+  coap_ipv6_is_supported;
   coap_is_af_unix;
   coap_is_bcast;
   coap_is_mcast;
@@ -156,6 +161,7 @@ global:
   coap_new_str_const;
   coap_new_string;
   coap_new_uri;
+  coap_observe_persist_is_supported;
   coap_opt_block_num;
   coap_opt_encode;
   coap_opt_encode_size;
@@ -232,6 +238,7 @@ global:
   coap_send_error;
   coap_send_message_type;
   coap_send_rst;
+  coap_server_is_supported;
   coap_session_disconnected;
   coap_session_get_ack_random_factor;
   coap_session_get_ack_timeout;
@@ -295,6 +302,7 @@ global:
   coap_string_tls_support;
   coap_string_tls_version;
   coap_tcp_is_supported;
+  coap_threadsafe_is_supported;
   coap_ticks;
   coap_ticks_from_rt_us;
   coap_ticks_to_rt;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -16,6 +16,7 @@ coap_address_get_port
 coap_address_init
 coap_address_set_port
 coap_address_set_unix_domain
+coap_af_unix_is_supported
 coap_async_get_app_data
 coap_async_is_supported
 coap_async_set_app_data
@@ -37,6 +38,7 @@ coap_check_notify
 coap_check_option
 coap_cleanup
 coap_clear_event_handler
+coap_client_is_supported
 coap_clock_init
 coap_clone_uri
 coap_context_get_app_data
@@ -92,6 +94,7 @@ coap_encode_var_safe
 coap_encode_var_safe8
 coap_endpoint_set_default_mtu
 coap_endpoint_str
+coap_epoll_is_supported
 coap_find_async
 coap_find_attr
 coap_fls
@@ -122,6 +125,8 @@ coap_io_prepare_epoll
 coap_io_prepare_io
 coap_io_process
 coap_io_process_with_fds
+coap_ipv4_is_supported
+coap_ipv6_is_supported
 coap_is_af_unix
 coap_is_bcast
 coap_is_mcast
@@ -154,6 +159,7 @@ coap_new_pdu
 coap_new_str_const
 coap_new_string
 coap_new_uri
+coap_observe_persist_is_supported
 coap_opt_block_num
 coap_opt_encode
 coap_opt_encode_size
@@ -230,6 +236,7 @@ coap_send_ack
 coap_send_error
 coap_send_message_type
 coap_send_rst
+coap_server_is_supported
 coap_session_disconnected
 coap_session_get_ack_random_factor
 coap_session_get_ack_timeout
@@ -293,6 +300,7 @@ coap_startup
 coap_string_tls_support
 coap_string_tls_version
 coap_tcp_is_supported
+coap_threadsafe_is_supported
 coap_ticks
 coap_ticks_from_rt_us
 coap_ticks_to_rt

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -45,6 +45,7 @@ TXT3 = coap_address.txt \
 	coap_resource.txt \
 	coap_session.txt \
 	coap_string.txt \
+	coap_supported.txt \
 	coap_tls_library.txt \
 	coap_uri.txt \
 	coap_websockets.txt
@@ -132,6 +133,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_deprecated.3" > coap_run_once.3
 	@echo ".so man3/coap_deprecated.3" > coap_set_event_handler.3
 	@echo ".so man3/coap_deprecated.3" > coap_write.3
+	@echo ".so man3/coap_io.3" > coap_io_pending.3
 	@echo ".so man3/coap_io.3" > coap_can_exit.3
 	@echo ".so man3/coap_locking.3" > coap_lock_callback_ret_release.3
 	@echo ".so man3/coap_locking.3" > coap_lock_invert.3
@@ -155,7 +157,6 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_logging.3" > coap_session_str.3
 	@echo ".so man3/coap_logging.3" > coap_print_addr.3
 	@echo ".so man3/coap_logging.3" > coap_print_ip_addr.3
-	@echo ".so man3/coap_oscore.3" > coap_context_oscore_server.3
 	@echo ".so man3/coap_pdu_access.3" > coap_option_filter_set.3
 	@echo ".so man3/coap_pdu_access.3" > coap_option_filter_unset.3
 	@echo ".so man3/coap_pdu_access.3" > coap_option_iterator_init.3
@@ -214,11 +215,19 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_string.3" > coap_make_str_const.3
 	@echo ".so man3/coap_string.3" > coap_string_equal.3
 	@echo ".so man3/coap_string.3" > coap_binary_equal.3
-	@echo ".so man3/coap_tls_library.3" > coap_string_tls_support.3
-	@echo ".so man3/coap_tls_library.3" > coap_string_tls_version.3
-	@echo ".so man3/coap_tls_library.3" > coap_show_tls_version.3
-	@echo ".so man3/coap_tls_library.3" > coap_tls_engine_configure.3
-	@echo ".so man3/coap_tls_library.3" > coap_tls_engine_remove.3
+	@echo ".so man3/coap_supported.3" > coap_dtls_rpk_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_epoll_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_ipv4_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_ipv6_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_observe_persist_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_oscore_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_proxy_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_server_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_tcp_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_threadsafe_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_tls_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_ws_is_supported.3
+	@echo ".so man3/coap_supported.3" > coap_wss_is_supported.3
 	$(INSTALL_DATA) $(A2X_EXTRA_PAGES_3) "$(DESTDIR)$(man3dir)"
 	$(INSTALL_DATA) $(A2X_EXTRA_PAGES_5) "$(DESTDIR)$(man5dir)"
 

--- a/man/coap_async.txt.in
+++ b/man/coap_async.txt.in
@@ -11,7 +11,6 @@ coap_async(3)
 NAME
 ----
 coap_async,
-coap_async_is_supported,
 coap_register_async,
 coap_async_trigger,
 coap_async_set_delay,
@@ -24,8 +23,6 @@ coap_async_get_app_data
 SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
-
-*int coap_async_is_supported(void);*
 
 *coap_async_t *coap_register_async(coap_session_t *_session_,
 const coap_pdu_t *_request_, coap_tick_t _delay_);*
@@ -74,11 +71,6 @@ when received, so no need to use the async support.
 
 FUNCTIONS
 ---------
-
-*Function: coap_async_is_supported()*
-
-The *coap_async_is_supported*() function is used to determine if there is
-async support or not compiled into libcoap.
 
 *Function: coap_register_async()*
 
@@ -129,8 +121,6 @@ application data from the  _async_ definition.
 
 RETURN VALUES
 -------------
-
-*coap_async_is_supported*() returns 1 if support is available, 0 otherwise.
 
 *coap_register_async*() and *coap_find_async*() return a pointer to an async
 definition or NULL if there is an error.
@@ -208,7 +198,7 @@ hnd_get_with_delay(coap_session_t *session,
 
 SEE ALSO
 --------
-*coap_handler*(3)
+*coap_handler*(3) and *coap_supported*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -495,7 +495,7 @@ main(int argc, char *argv[]) {
 
 SEE ALSO
 --------
-*coap_block*(3), *coap_context*(3) and *coap_init*(3)
+*coap_block*(3), *coap_context*(3), *coap_init*(3) and *coap_supported*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/man/coap_locking.txt.in
+++ b/man/coap_locking.txt.in
@@ -172,6 +172,10 @@ get unlocked, _locking_function_ with all of its parameters called, and then
 *global_lock* re-locked.  If for any reason locking fails, then _failed_statement_
 will get executed.
 
+SEE ALSO
+--------
+*coap_supported*(3)
+
 FURTHER INFORMATION
 -------------------
 See

--- a/man/coap_oscore.txt.in
+++ b/man/coap_oscore.txt.in
@@ -11,7 +11,6 @@ coap_oscore(3)
 NAME
 ----
 coap_oscore,
-coap_oscore_is_supported,
 coap_new_oscore_conf,
 coap_delete_oscore_conf,
 coap_new_oscore_recipient,
@@ -25,8 +24,6 @@ coap_context_oscore_server
 SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
-
-*int coap_oscore_is_supported(void);*
 
 *coap_oscore_conf_t *coap_new_oscore_conf(coap_str_const_t _conf_mem_,
 coap_oscore_save_seq_num_t _save_seq_num_func_,
@@ -96,11 +93,6 @@ typedef int (*coap_oscore_save_seq_num_t)(uint64_t sender_seq_num, void *param);
 
 FUNCTIONS
 ---------
-
-*Function: coap_oscore_is_supported()*
-
-The *coap_oscore_is_supported*() function returns 1 if OSCORE is supported,
-otherwise 0.
 
 *Function: coap_new_oscore_conf()*
 
@@ -210,9 +202,9 @@ client session or NULL if there is a malloc or parameter failure.
 *coap_new_oscore_conf*() returns a _coap_oscore_conf_t_
 or NULL on failure.
 
-*coap_oscore_is_supported*(), *coap_context_oscore_server*(),
-*coap_delete_oscore_conf*(), *coap_new_oscore_recipient*() and
-*coap_delete_oscore_recipient*() return 0 on failure, 1 on success.
+*coap_context_oscore_server*(), *coap_delete_oscore_conf*(),
+*coap_new_oscore_recipient*() and *coap_delete_oscore_recipient*()
+return 0 on failure, 1 on success.
 
 EXAMPLES
 --------
@@ -380,7 +372,8 @@ setup_context(void) {
 
 SEE ALSO
 --------
-*coap_endpoint_client*(3), *coap_endpoint_server*(3) and *coap-oscore-conf*(5)
+*coap_endpoint_client*(3), *coap_endpoint_server*(3), *coap-oscore-conf*(5) and
+*coap_supported*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/man/coap_supported.txt.in
+++ b/man/coap_supported.txt.in
@@ -1,0 +1,254 @@
+// -*- mode:doc; -*-
+// vim: set syntax=asciidoc tw=0
+
+coap_supported(3)
+=================
+:doctype: manpage
+:man source:   coap_supported
+:man version:  @PACKAGE_VERSION@
+:man manual:   libcoap Manual
+
+NAME
+----
+coap_supported,
+coap_af_unix_is_supported,
+coap_async_is_supported,
+coap_client_is_supported,
+coap_dtls_is_supported,
+coap_dtls_cid_is_supported,
+coap_dtls_psk_is_supported,
+coap_dtls_pki_is_supported,
+coap_dtls_pkcs11_is_supported,
+coap_dtls_rpk_is_supported,
+coap_epoll_is_supported,
+coap_ipv4_is_supported,
+coap_ipv6_is_supported,
+coap_observe_persist_is_supported,
+coap_oscore_is_supported,
+coap_proxy_is_supported,
+coap_server_is_supported,
+coap_tcp_is_supported,
+coap_threadsafe_is_supported,
+coap_tls_is_supported,
+coap_ws_is_supported,
+coap_wss_is_supported
+- Work with CoAP runtime functionality
+
+SYNOPSIS
+--------
+*#include <coap@LIBCOAP_API_VERSION@/coap.h>*
+
+*int coap_af_unix_is_supported(void);*
+
+*int coap_async_is_supported(void);*
+
+*int coap_client_is_supported(void);*
+
+*int coap_dtls_is_supported(void);*
+
+*int coap_dtls_cid_is_supported(void);*
+
+*int coap_dtls_pkcs11_is_supported(void);*
+
+*int coap_dtls_pki_is_supported(void);*
+
+*int coap_dtls_psk_is_supported(void);*
+
+*int coap_dtls_rpk_is_supported(void);*
+
+*int coap_epoll_is_supported(void)*;
+
+*int coap_ipv4_is_supported(void);*
+
+*int coap_ipv6_is_supported(void);*
+
+*int coap_observe_persist_is_supported(void);*
+
+*int coap_oscore_is_supported(void);*
+
+*int coap_proxy_is_supported(void);*
+
+*int coap_server_is_supported(void);*
+
+*int coap_tcp_is_supported(void);*
+
+*int coap_threadsafe_is_supported(void);*
+
+*int coap_tls_is_supported(void);*
+
+*int coap_ws_is_supported(void);*
+
+*int coap_wss_is_supported(void);*
+
+For specific (D)TLS library support, link with
+*-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
+*-lcoap-@LIBCOAP_API_VERSION@-openssl*, *-lcoap-@LIBCOAP_API_VERSION@-mbedtls*,
+*-lcoap-@LIBCOAP_API_VERSION@-wolfssl*
+or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
+*-lcoap-@LIBCOAP_API_VERSION@* to get the default (D)TLS library support.
+
+DESCRIPTION
+-----------
+These functions are used to determine run-time support in the libcoap library.
+
+libcoap has optional support that can be configured at library compilation time,
+as well as any underlying (D)TLS may, or may not, have certain functionality.
+
+The optional #include file *<coap@LIBCOAP_API_VERSION@/coap_defines.h>*, which
+is created whenever ./configure or cmake is run, has a list of #define that
+were used when the local libcoap library was built and can be used in
+applications for determining what support is available.
+
+*NOTE:* If doing cross-compiling, it is unsafe to use
+*<coap@LIBCOAP_API_VERSION@/coap_defines.h>* as the list of #define may not
+be correct.
+
+FUNCTIONS
+---------
+
+*Function: coap_af_unix_is_supported()*
+
+The *coap_af_unix_is_supported*() function is used to determine if there is
+socket type AF_UNIX support, or not, compiled into libcoap.
+
+*Function: coap_async_is_supported()*
+
+The *coap_async_is_supported*() function is used to determine if there is
+async support, or not, compiled into libcoap.
+
+*Function: coap_client_is_supported()*
+
+The *coap_client_is_supported*() function is used to determine if there is
+CoAP client support, or not, compiled into libcoap.
+
+*Function: coap_dtls_is_supported()*
+
+The *coap_dtls_is_supported*() function is used to determine if there is
+DTLS support available with the configured underlying TLS library.
+
+*Function: coap_dtls_cid_is_supported()*
+
+The *coap_dtls_cid_is_supported*() function is used to determine if there is
+Connection-ID (CID) support available with the configured underlying TLS library.
+
+*Function: coap_dtls_pkcs11_is_supported()*
+
+The *coap_dtls_pkcs11_is_supported*() function is used to determine if there is
+PKCS11 support available with the configured underlying TLS library.
+
+*Function: coap_dtls_pki_is_supported()*
+
+The *coap_dtls_pki_is_supported*() function is used to determine if there is
+PKI support available with the configured underlying TLS library.
+
+*Function: coap_dtls_psk_is_supported()*
+
+The *coap_dtls_psk_is_supported*() function is used to determine if there is
+PSK support available with the configured underlying TLS library.
+
+*Function: coap_dtls_rpk_is_supported()*
+
+The *coap_dtls_rpk_is_supported*() function is used to determine if there is
+RPK support available with the configured underlying TLS library.
+
+*Function: coap_epoll_is_supported()*
+
+The *coap_epoll_is_supported*() function is used to determine if there is
+epoll support, or not, compiled into libcoap.
+
+*Function: coap_ipv4_is_supported()*
+
+The *coap_ipv4_is_supported*() function is used to determine if there is
+IPv4 support, or not, compiled into libcoap.
+
+*Function: coap_ipv6_is_supported()*
+
+The *coap_ipv6_is_supported*() function is used to determine if there is
+IPv6 support, or not, compiled into libcoap.
+
+*Function: coap_observe_persist_is_supported()*
+
+The *coap_observe_persist_is_supported*() function is used to determine if there is
+Observe persist  support, or not, compiled into libcoap.
+
+*Function: coap_oscore_is_supported()*
+
+The *coap_oscore_is_supported*() function is used to determine if there is
+oscore support, or not, compiled into libcoap.
+
+*Function: coap_proxy_is_supported()*
+
+The *coap_proxy_is_supported*() function is used to determine if there is
+proxy code support, or not, compiled into libcoap.
+
+*Function: coap_server_is_supported()*
+
+The *coap_server_is_supported*() function is used to determine if there is
+CoAP server support, or not, compiled into libcoap.
+
+*Function: coap_tcp_is_supported()*
+
+The *coap_tcp_is_supported*() function is used to determine if there is
+TCP support, or not, compiled into libcoap.
+
+*Function: coap_threadsafe_is_supported()*
+
+The *coap_threadsafe_is_supported*() function is used to determine if there is
+thread safe support, or not, compiled into libcoap.
+
+*Function: coap_tls_is_supported()*
+
+The *coap_tls_is_supported*() function is used to determine if there is
+TLS support available with the configured underlying TLS library.
+
+*Function: coap_ws_is_supported()*
+
+The *coap_ws_is_supported*() function is used to determine if there is
+WebSockets support, or not, compiled into libcoap.
+
+*Function: coap_wss_is_supported()*
+
+The *coap_wss_is_supported*() function is used to determine if there is
+Secuere WebSockets support, or not, compiled into libcoap.
+
+RETURN VALUES
+-------------
+*coap_af_unix_is_supported*(), *coap_async_is_supported*(),
+*coap_client_is_supported*(), *coap_dtls_is_supported*(),
+*coap_dtls_cid_is_supported*(),*coap_dtls_pkcs11_is_supported*(),
+*coap_dtls_pki_is_supported*(), *coap_dtls_psk_is_supported*(),
+*coap_dtls_rpk_is_supported*(), *coap_epoll_is_supported*(),
+*coap_ipv4_is_supported*(), *coap_ipv6_is_supported*(),
+*coap_observe_persist_is_supported*(), *coap_oscore_is_supported*(),
+*coap_proxy_is_supported*(), *coap_server_is_supported*(),
+*coap_tcp_is_supported*(), *coap_threadsafe_is_supported*(),
+*coap_tls_is_supported*(), *coap_ws_is_supported*() and
+*coap_wss_is_supported*() return 0 if there is no support, 1 if
+support is available.
+
+SEE ALSO
+--------
+*coap_async*(3), *coap_io*(3), *coap_locking*(3), *coap_oscore*(3),
+*coap_proxy*(3), *coap_tls_library*(3) and *coap_websockets*(3).
+
+FURTHER INFORMATION
+-------------------
+See
+
+"https://rfc-editor.org/rfc/rfc7252[RFC7252: The Constrained Application Protocol (CoAP)]"
+
+"https://rfc-editor.org/rfc/rfc8323[RFC8323: CoAP (Constrained Application Protocol) over TCP, TLS, and WebSockets]"
+
+for further information.
+
+BUGS
+----
+Please raise an issue on GitHub at
+https://github.com/obgm/libcoap/issues to report any bugs.
+
+Please raise a Pull Request at https://github.com/obgm/libcoap/pulls
+for any fixes.
+
+AUTHORS
+-------
+The libcoap project <libcoap-developers@lists.sourceforge.net>

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -11,13 +11,6 @@ coap_tls_library(3)
 NAME
 ----
 coap_tls_library,
-coap_dtls_is_supported,
-coap_tls_is_supported,
-coap_dtls_psk_is_supported,
-coap_dtls_pki_is_supported,
-coap_dtls_pkcs11_is_supported,
-coap_dtls_rpk_is_supported,
-coap_tcp_is_supported,
 coap_get_tls_library_version,
 coap_string_tls_support,
 coap_string_tls_version,
@@ -29,20 +22,6 @@ coap_tls_engine_remove
 SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
-
-*int coap_dtls_is_supported(void);*
-
-*int coap_tls_is_supported(void);*
-
-*int coap_dtls_psk_is_supported(void);*
-
-*int coap_dtls_pki_is_supported(void);*
-
-*int coap_dtls_pkcs11_is_supported(void);*
-
-*int coap_dtls_rpk_is_supported(void);*
-
-*int coap_tcp_is_supported(void);*
 
 *coap_tls_version_t *coap_get_tls_library_version(void);*
 
@@ -98,41 +77,6 @@ match the TLS implementation type.
 
 FUNCTIONS
 ---------
-
-*Function: coap_dtls_is_supported()*
-
-The *coap_dtls_is_supported*() function returns 1 if support for DTLS is
-available, otherwise 0;
-
-*Function: coap_tls_is_supported()*
-
-The *coap_tls_is_supported*() function returns 1 if support for TLS is
-available, otherwise 0;
-
-*Function: coap_dtls_psk_is_supported()*
-
-The *coap_dtls_psk_is_supported*() function returns 1 if support for (D)TLS PSK
-is available, otherwise 0;
-
-*Function: coap_dtls_pki_is_supported()*
-
-The *coap_dtls_pki_is_supported*() function returns 1 if support for (D)TLS PKI
-is available, otherwise 0;
-
-*Function: coap_dtls_pkcs11_is_supported()*
-
-The *coap_dtls_pkcs11_is_supported*() function returns 1 if support for (D)TLS
-PKCS11 is available, otherwise 0;
-
-*Function: coap_dtls_rpk_is_supported()*
-
-The *coap_dtls_rpk_is_supported*() function returns 1 if support for (D)TLS RPK
-is available, otherwise 0;
-
-*Function: coap_tcp_is_supported()*
-
-The *coap_tcp_is_supported*() function returns 1 if support for TCP is
-available, otherwise 0.
 
 *Function: coap_get_tls_library_version()*
 
@@ -194,16 +138,9 @@ ENGINE.  This function is called when coap_free_context() is called.
 
 RETURN VALUES
 -------------
-*coap_dtls_is_supported*(), *coap_tls_is_supported*(),
-*coap_dtls_psk_is_supported*(), *coap_dtls_pki_is_supported*(),
-*coap_dtls_pkcs11_is_supported*() and *coap_dtls_rpk_is_supported*()
-return 0 if there is no support, 1 if support is available.
 
 *coap_get_tls_library_version*() returns the TLS implementation type
 and library version in a coap_tls_version_t* structure.
-
-*coap_tcp_is_supported*() returns 1 if support for TCP is
-available, otherwise 0.
 
 *coap_string_tls_version*() and *coap_string_tls_support*() return
 a pointer to the provided buffer.
@@ -237,7 +174,7 @@ setup_server_context_pki(const char *public_cert_file,
   coap_context_t *context;
   coap_str_const_t *engine_conf = coap_make_str_const(ENGINE_CONFIG);
 
-  /* See coap_tls_library(3) */
+  /* See coap_supported(3) */
   if (!coap_dtls_is_supported())
     return NULL;
 
@@ -301,7 +238,7 @@ setup_server_context_pki(const char *public_cert_file,
 
 SEE ALSO
 --------
-*coap_encryption*(3)
+*coap_encryption*(3) and *coap_supported*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/man/coap_websockets.txt.in
+++ b/man/coap_websockets.txt.in
@@ -11,18 +11,12 @@ coap_websockets(3)
 NAME
 ----
 coap_websockets,
-coap_ws_is_supported,
-coap_wss_is_supported,
 coap_ws_set_host_request
 - Work with CoAP WebSockets
 
 SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
-
-*int coap_ws_is_supported(void);*
-
-*int coap_wss_is_supported(void);*
 
 *int coap_ws_set_host_request(coap_session_t *_session_,
 coap_str_const_t *_ws_host_);*
@@ -39,16 +33,6 @@ and coaps+ws://.
 FUNCTIONS
 ---------
 
-*Function: coap_ws_is_supported()*
-
-The *coap_ws_is_supported*() function is used to determine whether WebSockets
-support is available in libcoap.
-
-*Function: coap_wss_is_supported()*
-
-The *coap_wss_is_supported*() function is used to determine whether Secure
-WebSockets support is available in libcoap.
-
 *Function: coap_ws_set_host_request()*
 
 The *coap_ws_set_host_request*() function is used to set _ws_host_ as the HTTP
@@ -56,17 +40,11 @@ Host: for the _session_ in a WebSockets request.
 
 RETURN VALUES
 -------------
-*coap_ws_is_supported*() returns 0 if there is no support, 1 if support is
-available.
-
-*coap_wss_is_supported*() returns 0 if there is no support, 1 if support is
-available.
-
 *coap_ws_set_host_request*() returns 1 if successful, else 0 if a failure.
 
 SEE ALSO
 --------
-*coap_uri*(3)
+*coap_supported*(3) and *coap_uri*(3)
 
 FURTHER INFORMATION
 -------------------

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -563,6 +563,69 @@ coap_context_get_coap_fd(const coap_context_t *context) {
 #endif /* ! COAP_EPOLL_SUPPORT */
 }
 
+int
+coap_epoll_is_supported(void) {
+#ifdef COAP_EPOLL_SUPPORT
+  return 1;
+#else /* ! COAP_EPOLL_SUPPORT */
+  return 0;
+#endif /* ! COAP_EPOLL_SUPPORT */
+}
+
+int
+coap_threadsafe_is_supported(void) {
+#ifdef COAP_THREAD_SAFE
+  return 1;
+#else /* ! COAP_THREAD_SAFE */
+  return 0;
+#endif /* ! COAP_THREAD_SAFE */
+}
+
+int
+coap_ipv4_is_supported(void) {
+#ifdef COAP_IPV4_SUPPORT
+  return 1;
+#else /* ! COAP_IPV4_SUPPORT */
+  return 0;
+#endif /* ! COAP_IPV4_SUPPORT */
+}
+
+int
+coap_ipv6_is_supported(void) {
+#ifdef COAP_IPV6_SUPPORT
+  return 1;
+#else /* ! COAP_IPV6_SUPPORT */
+  return 0;
+#endif /* ! COAP_IPV6_SUPPORT */
+}
+
+int
+coap_client_is_supported(void) {
+#ifdef COAP_CLIENT_SUPPORT
+  return 1;
+#else /* ! COAP_CLIENT_SUPPORT */
+  return 0;
+#endif /* ! COAP_CLIENT_SUPPORT */
+}
+
+int
+coap_server_is_supported(void) {
+#ifdef COAP_SERVER_SUPPORT
+  return 1;
+#else /* ! COAP_SERVER_SUPPORT */
+  return 0;
+#endif /* ! COAP_SERVER_SUPPORT */
+}
+
+int
+coap_af_unix_is_supported(void) {
+#ifdef COAP_AF_UNIX_SUPPORT
+  return 1;
+#else /* ! COAP_AF_UNIX_SUPPORT */
+  return 0;
+#endif /* ! COAP_AF_UNIX_SUPPORT */
+}
+
 void
 coap_context_set_app_data(coap_context_t *context, void *app_data) {
   assert(context);

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -20,6 +20,15 @@
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #endif
 
+int
+coap_observe_persist_is_supported(void) {
+#if COAP_SERVER_SUPPORT && COAP_WITH_OBSERVE_PERSIST
+  return 1;
+#else /* ! (COAP_SERVER_SUPPORT && COAP_WITH_OBSERVE_PERSIST) */
+  return 0;
+#endif /* ! (COAP_SERVER_SUPPORT && COAP_WITH_OBSERVE_PERSIST) */
+}
+
 #if COAP_SERVER_SUPPORT
 void
 coap_subscription_init(coap_subscription_t *s) {

--- a/win32/libcoap.vcxproj
+++ b/win32/libcoap.vcxproj
@@ -126,6 +126,7 @@
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_str.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_subscribe.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_subscribe_internal.h" />
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_supported.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_tcp_internal.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_threadsafe_internal.h" />
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_time.h" />

--- a/win32/libcoap.vcxproj.filters
+++ b/win32/libcoap.vcxproj.filters
@@ -268,6 +268,9 @@
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_subscribe_internal.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_supported.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\$(LibCoAPIncludeDir)\coap_tcp_internal.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
Group together and document the run-time checks available for checking the libcoap built-in functionality based on the ./cconfigure and / or CMakeLists.txt options.

Create include/coap3/coap_defines.h file that contains a list of COAP_ #defines created from the options defined when running ./configure or cmake.

Add 2 functions, coap_epoll_is_supported() and coap_threadsafe_is_supported().