### PR TITLE
Connection-ID: Only change source port when CID has been negotiated

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -1924,8 +1924,12 @@ main(int argc, char **argv) {
   coap_register_nack_handler(ctx, nack_handler);
   if (the_token.length > COAP_TOKEN_DEFAULT_MAX)
     coap_context_set_max_token_size(ctx, the_token.length);
-  if (cid_every)
-    coap_context_set_cid_tuple_change(ctx, cid_every);
+  if (cid_every) {
+    if (!coap_context_set_cid_tuple_change(ctx, cid_every)) {
+      coap_log_warn("coap_context_set_cid_tuple_change: "
+                    "Unable to set CID tuple change\n");
+    }
+  }
 
   session = get_session(ctx,
                         node_str[0] ? node_str : NULL,

--- a/include/coap3/coap_dtls.h
+++ b/include/coap3/coap_dtls.h
@@ -29,6 +29,8 @@
  * @{
  */
 
+int coap_dtls_cid_is_supported(void);
+
 typedef struct coap_dtls_pki_t coap_dtls_pki_t;
 
 #ifndef COAP_DTLS_HINT_LENGTH

--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -481,6 +481,17 @@ int coap_dtls_define_issue(coap_define_issue_key_t type,
                            coap_dtls_key_t *key,
                            const coap_dtls_role_t role,
                            int ret);
+
+/**
+ * Set the Connection ID client tuple frequency change for testing CIDs.
+ *
+ * @param context        The coap_context_t object.
+ * @param every          Change the client's source port @p every packets sent.
+ *
+ * @return @c 1 if frequency change set (CID supported), else @c 0.
+ */
+int coap_dtls_set_cid_tuple_change(coap_context_t *context, uint8_t every);
+
 /** @} */
 
 #endif /* COAP_DTLS_INTERNAL_H */

--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -235,8 +235,10 @@ void coap_context_set_keepalive(coap_context_t *context, unsigned int seconds);
  *
  * @param context        The coap_context_t object.
  * @param every          Change the client's source port @p every packets sent.
+ *
+ * @return @c 1 if frequency change set (CID supported), else @c 0.
  */
-void coap_context_set_cid_tuple_change(coap_context_t *context, uint8_t every);
+int coap_context_set_cid_tuple_change(coap_context_t *context, uint8_t every);
 
 /**
  * Set the maximum token size (RFC8974).

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -203,6 +203,10 @@ struct coap_session_t {
 #endif /* COAP_OSCORE_SUPPORT */
   volatile uint8_t max_token_checked; /**< Check for max token size
                                            coap_ext_token_check_t */
+#if COAP_CLIENT_SUPPORT
+  uint8_t negotiated_cid;         /**< Set for a client if CID negotiated */
+#endif /* COAP_CLIENT_SUPPORT */
+  uint8_t is_dtls13;              /**< Set if session is DTLS1.3 */
   coap_mid_t remote_test_mid;     /**< mid used for checking remote
                                        support */
   uint32_t max_token_size;        /**< Largest token size supported RFC8974 */

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -81,6 +81,7 @@ global:
   coap_delete_str_const;
   coap_delete_string;
   coap_delete_uri;
+  coap_dtls_cid_is_supported;
   coap_dtls_get_log_level;
   coap_dtls_is_supported;
   coap_dtls_pkcs11_is_supported;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -79,6 +79,7 @@ coap_delete_resource
 coap_delete_str_const
 coap_delete_string
 coap_delete_uri
+coap_dtls_cid_is_supported
 coap_dtls_get_log_level
 coap_dtls_is_supported
 coap_dtls_pkcs11_is_supported

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -65,7 +65,7 @@ size_t _max_token_size_);*
 
 *void *coap_context_get_app_data(const coap_context_t *_context_);*
 
-*void coap_context_set_cid_tuple_change(coap_context_t *_context_context, uint8_t _every_);*
+*int coap_context_set_cid_tuple_change(coap_context_t *_context_context, uint8_t _every_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -190,7 +190,8 @@ pointer previously defined by *coap_context_set_app_data*().
 
 The *coap_context_set_cid_tuple_change*() function is used to define to a client
 to force the client's port to change _every_ packets sent, providing the ability
-to test a CID (RFC9146) enabled server.
+to test a CID (RFC9146) enabled server. Only supported by DTLS libraries that
+support CID.
 
 RETURN VALUES
 -------------
@@ -210,6 +211,8 @@ out an idle server session.
 (TCP) CSM negotiation response from the peer.
 
 *coap_context_get_app_data*() returns a previously defined pointer.
+
+*coap_context_set_cid_tuple_change*() returns 1 on success, else 0;
 
 SEE ALSO
 --------

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -1233,6 +1233,7 @@ coap_string_tls_support(char *buffer, size_t bufsize) {
   const int have_pki = coap_dtls_pki_is_supported();
   const int have_pkcs11 = coap_dtls_pkcs11_is_supported();
   const int have_rpk = coap_dtls_rpk_is_supported();
+  const int have_cid = coap_dtls_cid_is_supported();
   const int have_oscore = coap_oscore_is_supported();
   const int have_ws = coap_ws_is_supported();
 
@@ -1241,13 +1242,14 @@ coap_string_tls_support(char *buffer, size_t bufsize) {
     return buffer;
   }
   snprintf(buffer, bufsize,
-           "(%sDTLS and %sTLS support; %sPSK, %sPKI, %sPKCS11, and %sRPK support)\n(%sOSCORE)\n(%sWebSockets)",
+           "(%sDTLS and %sTLS support; %sPSK, %sPKI, %sPKCS11, %sRPK and %sCID support)\n(%sOSCORE)\n(%sWebSockets)",
            have_dtls ? "" : "No ",
            have_tls ? "" : "no ",
            have_psk ? "" : "no ",
            have_pki ? "" : "no ",
            have_pkcs11 ? "" : "no ",
            have_rpk ? "" : "no ",
+           have_cid ? "" : "no ",
            have_oscore ? "Have " : "No ",
            have_ws ? "Have " : "No ");
   return buffer;

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -243,6 +243,24 @@ coap_dtls_rpk_is_supported(void) {
 #endif /* GNUTLS_VERSION_NUMBER < 0x030606 */
 }
 
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_cid_is_supported(void) {
+  return 0;
+}
+
+#if COAP_CLIENT_SUPPORT
+int
+coap_dtls_set_cid_tuple_change(coap_context_t *c_context, uint8_t every) {
+  (void)c_context;
+  (void)every;
+  return 0;
+}
+#endif /* COAP_CLIENT_SUPPORT */
+
 coap_tls_version_t *
 coap_get_tls_library_version(void) {
   static coap_tls_version_t version;

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -782,8 +782,9 @@ static uint32_t cid_track_counter;
 static void
 coap_test_cid_tuple_change(coap_session_t *session) {
   if (session->type == COAP_SESSION_TYPE_CLIENT &&
+      session->negotiated_cid &&
       session->state == COAP_SESSION_STATE_ESTABLISHED &&
-      COAP_PROTO_NOT_RELIABLE(session->proto) && session->context->testing_cids) {
+      session->proto == COAP_PROTO_DTLS && session->context->testing_cids) {
     if ((++cid_track_counter) % session->context->testing_cids == 0) {
       coap_address_t local_if = session->addr_info.local;
       uint16_t port = coap_address_get_port(&local_if);

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -459,13 +459,14 @@ coap_context_set_keepalive(coap_context_t *context, unsigned int seconds) {
   context->ping_timeout = seconds;
 }
 
-void
+int
 coap_context_set_cid_tuple_change(coap_context_t *context, uint8_t every) {
 #if COAP_CLIENT_SUPPORT
-  context->testing_cids = every;
+  return coap_dtls_set_cid_tuple_change(context, every);
 #else /* ! COAP_CLIENT_SUPPORT */
   (void)context;
   (void)every;
+  return 0;
 #endif /* ! COAP_CLIENT_SUPPORT */
 }
 

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -78,6 +78,24 @@ coap_dtls_rpk_is_supported(void) {
   return 0;
 }
 
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_cid_is_supported(void) {
+  return 0;
+}
+
+#if COAP_CLIENT_SUPPORT
+int
+coap_dtls_set_cid_tuple_change(coap_context_t *c_context, uint8_t every) {
+  (void)c_context;
+  (void)every;
+  return 0;
+}
+#endif /* COAP_CLIENT_SUPPORT */
+
 coap_tls_version_t *
 coap_get_tls_library_version(void) {
   static coap_tls_version_t version;

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -256,6 +256,24 @@ coap_dtls_rpk_is_supported(void) {
   return 0;
 }
 
+/*
+ * return 0 failed
+ *        1 passed
+ */
+int
+coap_dtls_cid_is_supported(void) {
+  return 0;
+}
+
+#if COAP_CLIENT_SUPPORT
+int
+coap_dtls_set_cid_tuple_change(coap_context_t *c_context, uint8_t every) {
+  (void)c_context;
+  (void)every;
+  return 0;
+}
+#endif /* COAP_CLIENT_SUPPORT */
+
 coap_tls_version_t *
 coap_get_tls_library_version(void) {
   static coap_tls_version_t version;


### PR DESCRIPTION
Only support changing the client's source port if the DTLS library has support / configured for CID.

Used when debugging server handling source address changes and CID is in use.

Add in support for TinyDTLS (Client only) if TinyDTLS is patched appropriately.