### PR TITLE
websockets: accept longer header lines and specific header sent by firefox browser

### DIFF
--- a/include/coap3/coap_ws_internal.h
+++ b/include/coap3/coap_ws_internal.h
@@ -52,7 +52,7 @@ typedef struct coap_ws_state_t {
   uint8_t rd_header[COAP_MAX_FS]; /**< (Partial) frame */
   uint8_t mask_key[4];  /**< Masking key */
   uint32_t http_ofs;    /**< Current offset into http_hdr */
-  uint8_t http_hdr[80]; /**< (Partial) HTTP header */
+  uint8_t http_hdr[160]; /**< (Partial) HTTP header */
   size_t data_ofs;      /**< Offset into user provided buffer */
   size_t data_size;     /**< Data size as indicated by WebSocket frame */
   uint8_t key[16];      /**< Random, but agreed key value */

--- a/src/coap_ws.c
+++ b/src/coap_ws.c
@@ -335,7 +335,8 @@ coap_ws_rd_http_header_server(coap_session_t *session) {
       coap_log_debug("WS: Duplicate Connection: header\n");
       return 0;
     }
-    if (strcasecmp(value, "Upgrade") != 0) {
+    if (strcasecmp(value, "Upgrade") != 0 &&
+        strcasecmp(value, "keep-alive, Upgrade") != 0) {
       coap_log_debug("WS: Invalid Connection: header\n");
       return 0;
     }


### PR DESCRIPTION
The pull request as discussed in #1503.