### PR TITLE
blocks: Better reporting for large transfers

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -507,7 +507,7 @@ usage(const char *program, const char *version) {
   fprintf(stderr, "\n"
           "Usage: %s [-a addr] [-b [num,]size] [-e text] [-f file] [-l loss]\n"
           "\t\t[-m method] [-o file] [-p port] [-q tls_engine_conf_file] [-r]\n"
-          "\t\t[-s duration] [-t type] [-v num] [-w] [-A type] [-B seconds]\n"
+          "\t\t[-s duration] [-t type] [-v num] [-w] [-x] [-A type] [-B seconds]\n"
           "\t\t[-E oscore_conf_file[,seq_file]] [-G count] [-H hoplimit]\n"
           "\t\t[-K interval] [-N] [-O num,text] [-P scheme://address[:port]\n"
           "\t\t[-T token] [-U]  [-V num] [-X size]\n"
@@ -543,6 +543,7 @@ usage(const char *program, const char *version) {
           "\t-v num \t\tVerbosity level (default 4, maximum is 8) for general\n"
           "\t       \t\tCoAP logging\n"
           "\t-w     \t\tAppend a newline to received data\n"
+          "\t-x     \t\tDisable output of PDU data when displaying PDUs\n"
           "\t-A type\t\tAccepted media type\n"
           "\t-B seconds\tBreak operation after waiting given seconds\n"
           "\t       \t\t(default is %d)\n"
@@ -1678,7 +1679,7 @@ main(int argc, char **argv) {
   coap_startup();
 
   while ((opt = getopt(argc, argv,
-                       "a:b:c:d:e:f:h:j:k:l:m:no:p:q:rs:t:u:v:wA:B:C:E:G:H:J:K:L:M:NO:P:R:T:UV:X:2")) != -1) {
+                       "a:b:c:d:e:f:h:j:k:l:m:no:p:q:rs:t:u:v:wx:A:B:C:E:G:H:J:K:L:M:NO:P:R:T:UV:X:2")) != -1) {
     switch (opt) {
     case 'a':
       strncpy(node_str, optarg, NI_MAXHOST - 1);
@@ -1737,6 +1738,9 @@ main(int argc, char **argv) {
       break;
     case 'w':
       add_nl = 1;
+      break;
+    case 'x':
+      coap_enable_pdu_data_output(0);
       break;
     case 'N':
       msgtype = COAP_MESSAGE_NON;

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1562,7 +1562,7 @@ usage(const char *program, const char *version) {
           "Usage: %s [-a priority] [-b max_block_size] [-d max] [-e]\n"
           "\t\t[-f scheme://address[:port] [-g group] -l loss] [-p port]\n"
           "\t\t[-q tls_engine_conf_file] [-r] [-v num] [-w [port][,secure_port]]\n"
-          "\t\t[-A address] [-E oscore_conf_file[,seq_file]] [-G group_if]\n"
+          "\t\t[-x] [-A address] [-E oscore_conf_file[,seq_file]] [-G group_if]\n"
           "\t\t[-L value] [-N] [-P scheme://address[:port],[name1[,name2..]]]\n"
           "\t\t[-T max_token_size] [-U type] [-V num] [-X size]\n"
           "\t\t[[-h hint] [-i match_identity_file] [-k key]\n"
@@ -1612,6 +1612,7 @@ usage(const char *program, const char *version) {
           "\t-w [port][,secure_port]\n"
           "\t       \t\tEnable WebSockets support on port (WS) and/or secure_port\n"
           "\t       \t\t(WSS), comma separated\n"
+          "\t-x     \t\tDisable output of PDU data when displaying PDUs\n"
           "\t-A address\tInterface address to bind to\n"
           "\t-E oscore_conf_file[,seq_file]\n"
           "\t       \t\toscore_conf_file contains OSCORE configuration. See\n"
@@ -2509,6 +2510,9 @@ main(int argc, char **argv) {
         exit(1);
       }
       enable_ws = 1;
+      break;
+    case 'x':
+      coap_enable_pdu_data_output(0);
       break;
     case 'X':
       csm_max_message_size = strtol(optarg, NULL, 10);

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -30,9 +30,11 @@
  * @{
  */
 
-#define STATE_TOKEN_BASE(t) ((t) & 0xffffffffffffULL)
-#define STATE_TOKEN_RETRY(t) ((uint64_t)(t) >> 48)
-#define STATE_TOKEN_FULL(t,r) (STATE_TOKEN_BASE(t) + ((uint64_t)(r) << 48))
+/* Use the top 20 bits of a 64 bit token for tracking current block in large transfer */
+#define STATE_MAX_BLK_CNT_BITS 20
+#define STATE_TOKEN_BASE(t) ((t) & (0xffffffffffffffffULL >> STATE_MAX_BLK_CNT_BITS))
+#define STATE_TOKEN_RETRY(t) ((uint64_t)(t) >> (64 - STATE_MAX_BLK_CNT_BITS))
+#define STATE_TOKEN_FULL(t,r) (STATE_TOKEN_BASE(t) + ((uint64_t)(r) << (64 - STATE_MAX_BLK_CNT_BITS)))
 
 #if COAP_Q_BLOCK_SUPPORT
 #define COAP_BLOCK_SET_MASK (COAP_BLOCK_USE_LIBCOAP | \

--- a/include/coap3/coap_debug.h
+++ b/include/coap3/coap_debug.h
@@ -314,9 +314,20 @@ void coap_print_contiki_prefix(coap_log_t level);
 void coap_set_show_pdu_output(int use_fprintf);
 
 /**
+ * Defines whether the data is to be output or not for the
+ * coap_show_pdu() function.
+ *
+ * @param enable_data @p 1 if the data is to be output (the default)
+ *                    @p 0 if the data detail is not to be output.
+ */
+void coap_enable_pdu_data_output(int enable_data);
+
+/**
  * Display the contents of the specified @p pdu.
  * Note: The output method of coap_show_pdu() is dependent on the setting of
  * coap_set_show_pdu_output().
+ * Note: Data may, or may not be output depending on the setting of
+ * coap_enable_pdu_data_output().
  *
  * @param level The required minimum logging level.
  * @param pdu The PDU to decode.

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -92,6 +92,7 @@ global:
   coap_dtls_rpk_is_supported;
   coap_dtls_set_log_level;
   coap_dump_memory_type_counts;
+  coap_enable_pdu_data_output;
   coap_encode_var_safe8;
   coap_encode_var_safe;
   coap_endpoint_set_default_mtu;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -90,6 +90,7 @@ coap_dtls_psk_is_supported
 coap_dtls_rpk_is_supported
 coap_dtls_set_log_level
 coap_dump_memory_type_counts
+coap_enable_pdu_data_output
 coap_encode_var_safe
 coap_encode_var_safe8
 coap_endpoint_set_default_mtu

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -152,6 +152,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_logging.3" > coap_package_version.3
 	@echo ".so man3/coap_logging.3" > coap_package_build.3
 	@echo ".so man3/coap_logging.3" > coap_set_show_pdu_output.3
+	@echo ".so man3/coap_logging.3" > coap_enable_pdu_data_output.3
 	@echo ".so man3/coap_logging.3" > coap_show_pdu.3
 	@echo ".so man3/coap_logging.3" > coap_endpoint_str.3
 	@echo ".so man3/coap_logging.3" > coap_session_str.3

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -22,7 +22,7 @@ SYNOPSIS
 *coap-client* [*-a* addr] [*-b* [num,]size] [*-e* text] [*-f* file] [*-l* loss]
               [*-m* method] [*-o* file] [*-p* port] [*-q* tls_engine_conf_file]
               [*-r*] [*-s duration*]
-              [*-t* type] [*-v* num] [*-w*] [*-A* type] [*-B* seconds]
+              [*-t* type] [*-v* num] [*-w*] [*-x*] [*-A* type] [*-B* seconds]
               [*-E* oscore_conf_file[,seq_file]] [*-G* count] [*-H* hoplimit]
               [*-K* interval] [*-L* value] [*-N*] [*-O* num,text]
               [*-P* scheme://addr[:port]] [*-T* token] [*-U*] [*-V* num]
@@ -129,6 +129,9 @@ OPTIONS - General
 
 *-w*::
    Append a newline to received data.
+
+*-x*::
+  Disable output of PDU data when displaying PDUs.
 
 *-A* type::
    Accepted media type. 'type' must be either a numeric value reflecting a

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -22,7 +22,7 @@ SYNOPSIS
 *coap-server* [*-a* priority] [*-b* max_block_size] [*-d* max] [*-e*]
               [*-f* scheme://addr[:port]
               [*-g* group] [*-l* loss] [*-p* port] [*-q* tls_engine_conf_file]
-              [*-r*] [*-t*]  [*-v* num] [*-w* [port][,secure_port]]
+              [*-r*] [*-t*]  [*-v* num] [*-w* [port][,secure_port]] [*-x*]
               [*-A* address] [*-E* oscore_conf_file[,seq_file]]
               [*-G* group_if] [*-L* value] [*-N*]
               [*-P* scheme://addr[:port],[name1[,name2..]]]
@@ -108,6 +108,9 @@ OPTIONS - General
 *-w* [port][,secure_port]::
    Enable WebSockets support support on port (WS) and/or secure_port (WSS),
    comma separated.
+
+*-x*::
+  Disable output of PDU data when displaying PDUs.
 
 *-A* address::
    The local address of the interface which the server has to listen on.

--- a/man/coap_logging.txt.in
+++ b/man/coap_logging.txt.in
@@ -32,6 +32,7 @@ coap_package_name,
 coap_package_version,
 coap_package_build,
 coap_set_show_pdu_output,
+coap_enable_pdu_data_output,
 coap_show_pdu,
 coap_endpoint_str,
 coap_session_str,
@@ -84,6 +85,8 @@ SYNOPSIS
 *const char *coap_package_build(void);*
 
 *void coap_set_show_pdu_output(int _use_fprintf_);*
+
+*void coap_enable_pdu_data_output(int _enable_data_);*
 
 *void coap_show_pdu(coap_log_t _level_, const coap_pdu_t *_pdu_);*
 
@@ -277,6 +280,13 @@ The *coap_set_show_pdu_output*() function defines whether the output from
 *coap_show_pdu*() is to be either sent to stdout/stderr, or output using
 *coap_log*().  _use_fprintf_ is set to 1 for stdout/stderr (the default), and
 _use_fprintf_ is set to 0 for *coap_log*().
+
+*Function: coap_enable_pdu_data_output()*
+
+The *coap_enable_pdu_data_output*() function defines whether the output from
+*coap_show_pdu*() is to include data detail or not.  _enable_data_ is set to
+1 for data to be output (the default) or set to 0 if the data detail is
+suppressed.
 
 *Function: coap_show_pdu()*
 

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -4099,6 +4099,7 @@ give_to_app:
           if (!coap_binary_equal(&rcvd->actual_token, lg_crcv->app_token)) {
             /* need to put back original token into rcvd */
             coap_update_token(rcvd, lg_crcv->app_token->length, lg_crcv->app_token->s);
+            coap_remove_option(rcvd, COAP_OPTION_BLOCK1);
             coap_log_debug("PDU presented to app.\n");
             coap_show_pdu(COAP_LOG_DEBUG, rcvd);
           }

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -66,6 +66,7 @@ static coap_log_t maxlog = COAP_LOG_WARN;  /* default maximum CoAP log level */
 #endif /* RIOT_VERSION */
 
 static int use_fprintf_for_show_pdu = 1; /* non zero to output with fprintf */
+static int enable_data_for_show_pdu = 1; /* By default show PDU data for coap_show_pdu() */
 
 const char *
 coap_package_name(void) {
@@ -89,6 +90,11 @@ coap_package_build(void) {
 void
 coap_set_show_pdu_output(int use_fprintf) {
   use_fprintf_for_show_pdu = use_fprintf;
+}
+
+void
+coap_enable_pdu_data_output(int enable_data) {
+  enable_data_for_show_pdu = enable_data;
 }
 
 coap_log_t
@@ -1041,6 +1047,16 @@ no_more:
   snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  " ]");
 
   if (coap_get_data(pdu, &data_len, &data)) {
+    if (!enable_data_for_show_pdu) {
+      /* Only output data if wanted */
+      outbuflen = strlen(outbuf);
+      snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  " :: ");
+      outbuflen = strlen(outbuf);
+      snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
+               "data length %zu (data suppressed)\n", data_len);
+      COAP_DO_SHOW_OUTPUT_LINE;
+      return;
+    }
 
     outbuflen = strlen(outbuf);
     snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  " :: ");


### PR DESCRIPTION
Update stateless token to track 20 bits - the largest no of blocks as per RFC7959.

Make output of data detail configurable for coap_show_pdu().

Add in new function coap_enable_pdu_data_output() to do this.

Add -x option to coap-client and coap-server to enable this dropping of data detail.