### PR TITLE
coap_join_mcast_group_intf: fix interface selection on windows

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4706,7 +4706,14 @@ coap_join_mcast_group_intf_lkd(coap_context_t *ctx, const char *group_name,
       }
     }
   }
-#endif /* ! _WIN32 */
+#else /* _WIN32 */
+  /*
+   * On Windows this function ignores the ifname variable so we unset this
+   * variable on this platform in any case in order to enable the interface
+   * selection from the bind address below.
+   */
+  ifname = 0;
+#endif /* _WIN32 */
 
   /* Add in mcast address(es) to appropriate interface */
   for (ainfo = resmulti; ainfo != NULL; ainfo = ainfo->ai_next) {


### PR DESCRIPTION
On the Windows platform, a set `ifname` parameter of the `coap_join_mcast_group_intf` function is only used for debug output. Only if it is `NULL`, the interface which should join a multicast group is derived from the bind address. So, setting the `ifname` parameter on the windows platform is counterproductive.

With this patch, `ifname` is always set to `NULL` on the windows platform and libcoap can try to derive the interface from the bind address.