### PR TITLE
Contiki: Fix heapmem_free() warning

### DIFF
--- a/src/coap_mem.c
+++ b/src/coap_mem.c
@@ -654,7 +654,8 @@ coap_free_type(coap_memory_tag_t type, void *ptr) {
   if (ptr)
     track_counts[type]--;
 #endif /* COAP_MEMORY_TYPE_TRACK */
-  heapmem_free(ptr);
+  if (ptr)
+    heapmem_free(ptr);
 }
 
 #endif /* WITH_CONTIKI */


### PR DESCRIPTION
heapmem_free() warns if ptr is NULL.