### PR TITLE
NACK handling: simplify libcoap code

### DIFF
--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -585,6 +585,11 @@ void coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t
 
 void coap_connect_session(coap_session_t *session, coap_tick_t now);
 
+void coap_handle_nack(coap_session_t *session,
+                      coap_pdu_t *sent,
+                      const coap_nack_reason_t reason,
+                      const coap_mid_t mid);
+
 #define COAP_SESSION_REF(s) ((s)->ref
 
 /* RFC7252 */

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -1470,11 +1470,8 @@ coap_block_check_lg_crcv_timeouts(coap_session_t *session, coap_tick_t now,
 
       if (lg_crcv->rec_blocks.retry >= COAP_NON_MAX_RETRANSMIT(session)) {
         /* Done NON_MAX_RETRANSMIT retries */
-        coap_update_token(&lg_crcv->pdu, lg_crcv->app_token->length, lg_crcv->app_token->s);
-        coap_lock_callback(session->context,
-                           session->context->nack_handler(session, &lg_crcv->pdu,
-                                                          COAP_NACK_TOO_MANY_RETRIES,
-                                                          lg_crcv->pdu.mid));
+        coap_handle_nack(session, &lg_crcv->pdu,
+                         COAP_NACK_TOO_MANY_RETRIES, lg_crcv->pdu.mid);
         goto expire;
       }
       if (lg_crcv->rec_blocks.last_seen + scaled_timeout <= now) {


### PR DESCRIPTION
Remove a lot of code duplication by providing new coap_handle_nack() function.