### PR TITLE
coap_oscore.c: Process queued OSCORE Observe responses after de-registration

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -798,6 +798,7 @@ get_oscore_conf(void) {
       if (oscore_seq_num_fp == NULL) {
         fprintf(stderr, "OSCORE save restart info file error: %s\n",
                 oscore_seq_save_file);
+        coap_free(buf);
         return NULL;
       }
     }

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1938,6 +1938,7 @@ get_oscore_conf(coap_context_t *context) {
       if (oscore_seq_num_fp == NULL) {
         fprintf(stderr, "OSCORE save restart info file error: %s\n",
                 oscore_seq_save_file);
+        coap_free(buf);
         return NULL;
       }
     }

--- a/examples/oscore-interop-server.c
+++ b/examples/oscore-interop-server.c
@@ -526,6 +526,7 @@ get_oscore_conf(coap_context_t *context) {
       if (oscore_seq_num_fp == NULL) {
         fprintf(stderr, "OSCORE save restart info file error: %s\n",
                 oscore_seq_save_file);
+        coap_free(buf);
         return NULL;
       }
     }

--- a/include/oscore/oscore_context.h
+++ b/include/oscore/oscore_context.h
@@ -147,6 +147,7 @@ struct oscore_association_t {
   coap_bin_const_t *aad;
   coap_bin_const_t *nonce;
   coap_bin_const_t *partial_iv;
+  coap_bin_const_t *obs_partial_iv;
   coap_tick_t last_seen;
   uint8_t is_observe;
 };

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -1843,6 +1843,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
 
 #if COAP_OSCORE_SUPPORT
   if (session->oscore_encryption &&
+      pdu->type != COAP_MESSAGE_RST &&
       !(pdu->type == COAP_MESSAGE_ACK && pdu->code == COAP_EMPTY_CODE)) {
     /* Refactor PDU as appropriate RFC8613 */
     coap_pdu_t *osc_pdu = coap_oscore_new_pdu_encrypted_lkd(session, pdu, NULL,

--- a/src/oscore/oscore_context.c
+++ b/src/oscore/oscore_context.c
@@ -678,6 +678,7 @@ oscore_free_association(oscore_association_t *association) {
     coap_delete_bin_const(association->aad);
     coap_delete_bin_const(association->nonce);
     coap_delete_bin_const(association->partial_iv);
+    coap_delete_bin_const(association->obs_partial_iv);
     coap_free_type(COAP_STRING, association);
   }
 }


### PR DESCRIPTION
If an Observe is de-registered, but an unsolicited Observe response is received before the de-register response is received, then the unsolicited response failed to get decrypted.