### PR TITLE
coap_block.c: Fix returning 2.03 for ETag match

### DIFF
--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -163,7 +163,6 @@ struct coap_context_t {
   uint32_t csm_timeout_ms;         /**< Timeout for waiting for a CSM from
                                            the remote side. */
   uint32_t csm_max_message_size;   /**< Value for CSM Max-Message-Size */
-  uint64_t etag;                   /**< Next ETag to use */
 
 #if COAP_SERVER_SUPPORT
   coap_cache_entry_t *cache;       /**< CoAP cache-entry cache */

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -290,7 +290,7 @@ according to
 Model]").
 
 The application request handler for the resource is only called once instead of
-potentially multiple times.
+potentially multiple times, unless if COAP_BLOCK_STLESS_BLOCK2 is set.
 
 *NOTE:* This function must only be called once per _pdu_.
 

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -535,6 +535,13 @@ The *coap_add_data*() function adds in the specified payload _data_ of length
 _length_ to the PDU _pdu_. Adding the payload data must be done after any
 token or options are added.  This function must only be called once per _pdu_.
 
+*NOTE:* *coap_add_data*() cannot add data that will exceed the available space
+within a single CoAP PDU.
+It is recommended that *coap_add_data_large_request*(3) or
+*coap_add_data_large_response*(3) (depending on whether _pdu_ is a request or response)
+is used instead if there is a possibility of the PDU space being insufficient.
+See *coap_block*(3).
+
 *Function: coap_add_data_blocked_response()*
 
 The *coap_add_data_blocked_response*() function adds in the appropriate part
@@ -552,7 +559,7 @@ received a part of the data and request the next block (with the appropriate
 Block options) from the server.  Returning the next requested block is handled
 by this function.
 
-*NOTE:* This function has been superseded by *coap_add_data_large_response*().
+*NOTE:* This function has been superseded by *coap_add_data_large_response*(3).
 See *coap_block*(3).
 
 RETURN VALUES


### PR DESCRIPTION
Tag server returned data with a digest computed ETag option value so requests with an ETag option can return 2.03 if there is a match.

The size of bytes hash that is computed for the ETag can be overwritten by localy defining COAP_ETAG_MAX_BYTES to be a value between 1 and 8 bytes inclusive.  It is set to 4 by default.