### PR TITLE
doc: fix invisible text if browser is set to prefer dark mode

### DIFF
--- a/doc/docbook.local.css
+++ b/doc/docbook.local.css
@@ -45,3 +45,26 @@ a.st-synopsis:visited {
 a.st-synopsis:hover {
 	text-decoration: underline;
 }
+
+/* Set appropriate text colors if dark mode is used. */
+@media(prefers-color-scheme: dark) {
+	body pre {
+		color: deepskyblue;
+	}
+
+	a.st-desc {
+		color: white;
+	}
+
+	a.st-desc:visited {
+		color: white;
+	}
+
+	a.st-synopsis {
+		color: white;
+	}
+
+	a.st-synopsis:visited {
+		color: white;
+	}
+}


### PR DESCRIPTION
Recent builds of the libcoap documentation use a Doxygen version that supports and automatically enables dark mode if a preference for dark mode has been indicated by the user.

Unfortunately, this caused some issues with the CSS overrides for text colors set in `doc/docbook.local.css`, which make some text invisible or hard to read in dark mode.

This PR fixes the issue by setting different (more readable) text colors if in dark mode (while leaving the text colors for light mode untouched).

For comparison:

Current build on `develop` branch:
![image](https://github.com/user-attachments/assets/ebef062e-7050-43f4-97cd-22edb6aa427e)

With the changes made in this PR:
![image](https://github.com/user-attachments/assets/905174bc-6b09-4111-91c8-9d518e1ed63c)
