### PR TITLE
coap_subscribe_internal.h: Fix "unbalanced grouping commands"

### DIFF
--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -20,8 +20,6 @@
 
 #include "coap_internal.h"
 
-#if COAP_SERVER_SUPPORT
-
 /**
  * @ingroup internal_api
  * @defgroup subscribe_internal Observe Subscription
@@ -29,6 +27,7 @@
  * @{
  */
 
+#if COAP_SERVER_SUPPORT
 /**
  * Number of notifications that may be sent non-confirmable before a confirmable
  * message is sent to detect if observers are alive. The maximum allowed value


### PR DESCRIPTION
This fixes that the CI task `documentation` sometimes failed with "unbalanced grouping commands".