### PR TITLE
mcast: Support specifying output interface for IPv6 multicast packets

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -651,6 +651,7 @@ usage(const char *program, const char *version) {
           "\tcoap-client -m get coap+tcp://%%2Funix%%2Fdomain%%2Fpath%%2Fstream/.well-known/core\n"
           "\tcoap-client -m get coaps://[::1]/.well-known/core\n"
           "\tcoap-client -m get coaps+tcp://[::1]/.well-known/core\n"
+          "\tcoap-client -m get -N coap://[ff02::fd%%ens32]/.well-known/core\n"
           "\tcoap-client -m get coaps://%%2Funix%%2Fdomain%%2Fpath%%2Fdtls/.well-known/core\n"
           "\tcoap-client -m get coaps+tcp://%%2Funix%%2Fdomain%%2Fpath%%2Ftls/.well-known/core\n"
           "\tcoap-client -m get -T cafe coap://[::1]/time\n"
@@ -1613,11 +1614,11 @@ get_session(coap_context_t *ctx,
 
     local.s = (const uint8_t *)local_addr;
     local.length = strlen(local_addr);
-    /* resolve local address where data should be sent from */
+    /* resolve local address where data should be sent from (don't update port number */
     info_list = coap_resolve_address_info(&local, port, port, port, port,
                                           AI_PASSIVE | AI_NUMERICHOST | AI_NUMERICSERV | AI_ALL,
                                           1 << scheme,
-                                          COAP_RESOLVE_TYPE_LOCAL);
+                                          COAP_RESOLVE_TYPE_REMOTE);
     if (!info_list) {
       fprintf(stderr, "coap_resolve_address_info: %s: failed\n", local_addr);
       return NULL;

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -321,6 +321,13 @@ the known resources along with their attribute definitions.
 
 * Example
 ----
+coap-client -m get -N coap://[ff02::fd%ens32]/.well-known/core
+----
+Discover the available resources along with their attribute definitions using
+a multicast IP sent out over the ethernet interface ens32.
+
+* Example
+----
 echo -n "mode=on" | coap-client -m put \
 coap://[2001:db8:c001:f00d:221:2eff:ff00:2704]:5683/actuators/leds?color=r -f-
 ----

--- a/src/coap_address.c
+++ b/src/coap_address.c
@@ -547,7 +547,7 @@ coap_resolve_address_info(const coap_str_const_t *address,
   error = getaddrinfo(addrstr, NULL, &hints, &res);
 
   if (error != 0) {
-    coap_log_warn("getaddrinfo: %s\n", gai_strerror(error));
+    coap_log_warn("getaddrinfo: %s: %s\n", addrstr, gai_strerror(error));
     return NULL;
   }
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -920,7 +920,11 @@ coap_socket_send(coap_socket_t *sock, coap_session_t *session,
 
           pktinfo = (struct in6_pktinfo *)CMSG_DATA(cmsg);
 
-          pktinfo->ipi6_ifindex = session->ifindex;
+          if (coap_is_mcast(&session->addr_info.remote)) {
+            pktinfo->ipi6_ifindex = session->addr_info.remote.addr.sin6.sin6_scope_id;
+          } else {
+            pktinfo->ipi6_ifindex = session->ifindex;
+          }
           memcpy(&pktinfo->ipi6_addr,
                  &session->addr_info.local.addr.sin6.sin6_addr,
                  sizeof(pktinfo->ipi6_addr));


### PR DESCRIPTION
Specify the interface or scope_id in the IP address as a %suffix.

For example:-

examples/coap-client -N coap://[ff02::fd%interface]