### PR TITLE
coap_delete_pdu: Add in multi-threaded lock protection

### DIFF
--- a/include/coap3/coap_pdu.h
+++ b/include/coap3/coap_pdu.h
@@ -400,14 +400,19 @@ COAP_API coap_pdu_t *coap_new_pdu(coap_pdu_type_t type, coap_pdu_code_t code,
                                   coap_session_t *session);
 
 /**
- * Dispose of an CoAP PDU and frees associated storage.
- * Not that in general you should not call this function directly.
+ * Dispose of an CoAP PDU and free off associated storage.
+ *
+ * Note: In general you should not call this function directly.
  * When a PDU is sent with coap_send(), coap_delete_pdu() will be called
- * automatically for you.
+ * automatically for you. This is not for the case for coap_send_recv()
+ * where the sending and receiving PDUs need to be explicitly deleted.
+ *
+ * Note: If called with a reference count > 0, the reference count is
+ * decremented and the PDU still exists.
  *
  * @param pdu The PDU for free off.
  */
-void coap_delete_pdu(coap_pdu_t *pdu);
+COAP_API void coap_delete_pdu(coap_pdu_t *pdu);
 
 /**
  * Duplicate an existing PDU. Specific options can be ignored and not copied

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -375,6 +375,23 @@ coap_pdu_t *coap_new_pdu_lkd(coap_pdu_type_t type, coap_pdu_code_t code,
                              coap_session_t *session);
 
 /**
+ * Dispose of an CoAP PDU and free off associated storage.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * Note: In general you should not call this function directly.
+ * When a PDU is sent with coap_send(), coap_delete_pdu() will be called
+ * automatically for you. This is not for the case for coap_send_recv()
+ * where the sending and receiving PDUs need to be explicitly deleted.
+ *
+ * Note: If called with a reference count > 0, the reference count is
+ * decremented and the PDU still exists.
+ *
+ * @param pdu The PDU for free off.
+ */
+void coap_delete_pdu_lkd(coap_pdu_t *pdu);
+
+/**
  * Duplicate an existing PDU. Specific options can be ignored and not copied
  * across.  The PDU data payload is not copied across.
  *

--- a/include/coap3/coap_threadsafe_internal.h
+++ b/include/coap3/coap_threadsafe_internal.h
@@ -319,7 +319,6 @@ int coap_lock_lock_func(void);
  * @param c Context.
  */
 #define coap_lock_unlock(c) do { \
-    assert(c); \
     coap_lock_unlock_func(); \
   } while (0)
 

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -186,7 +186,7 @@ coap_free_async_sub(coap_context_t *context, coap_async_t *s) {
       coap_session_release_lkd(s->session);
     }
     if (s->pdu) {
-      coap_delete_pdu(s->pdu);
+      coap_delete_pdu_lkd(s->pdu);
       s->pdu = NULL;
     }
     coap_free_type(COAP_STRING, s);

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -1930,7 +1930,7 @@ coap_send_q_blocks(coap_session_t *session,
   if (send_pdu == COAP_SEND_INC_PDU &&
       (mid = coap_send_internal(session, pdu)) == COAP_INVALID_MID) {
     /* Not expected, underlying issue somewhere */
-    coap_delete_pdu(block_pdu);
+    coap_delete_pdu_lkd(block_pdu);
     return COAP_INVALID_MID;
   }
 
@@ -1973,8 +1973,8 @@ coap_send_q_blocks(coap_session_t *session,
                                                  block.szx),
                             buf)) {
       coap_log_warn("Internal update issue option\n");
-      coap_delete_pdu(block_pdu);
-      coap_delete_pdu(t_pdu);
+      coap_delete_pdu_lkd(block_pdu);
+      coap_delete_pdu_lkd(t_pdu);
       break;
     }
 
@@ -1984,8 +1984,8 @@ coap_send_q_blocks(coap_session_t *session,
                         block.num,
                         block.szx)) {
       coap_log_warn("Internal update issue data\n");
-      coap_delete_pdu(block_pdu);
-      coap_delete_pdu(t_pdu);
+      coap_delete_pdu_lkd(block_pdu);
+      coap_delete_pdu_lkd(t_pdu);
       break;
     }
     if (COAP_PDU_IS_RESPONSE(block_pdu)) {
@@ -1994,7 +1994,7 @@ coap_send_q_blocks(coap_session_t *session,
     mid = coap_send_internal(session, block_pdu);
     if (mid == COAP_INVALID_MID) {
       /* Not expected, underlying issue somewhere */
-      coap_delete_pdu(t_pdu);
+      coap_delete_pdu_lkd(t_pdu);
       return COAP_INVALID_MID;
     }
     block_pdu = t_pdu;

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -195,7 +195,7 @@ coap_new_cache_entry_lkd(coap_session_t *session, const coap_pdu_t *pdu,
     entry->pdu = coap_pdu_init(pdu->type, pdu->code, pdu->mid, pdu->alloc_size);
     if (entry->pdu) {
       if (!coap_pdu_resize(entry->pdu, pdu->alloc_size)) {
-        coap_delete_pdu(entry->pdu);
+        coap_delete_pdu_lkd(entry->pdu);
         coap_free_type(COAP_CACHE_ENTRY, entry);
         return NULL;
       }
@@ -288,7 +288,7 @@ coap_delete_cache_entry(coap_context_t *ctx, coap_cache_entry_t *cache_entry) {
     HASH_DELETE(hh, ctx->cache, cache_entry);
   }
   if (cache_entry->pdu) {
-    coap_delete_pdu(cache_entry->pdu);
+    coap_delete_pdu_lkd(cache_entry->pdu);
   }
   coap_delete_cache_key(cache_entry->cache_key);
   if (cache_entry->callback && cache_entry->app_data) {

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -209,7 +209,7 @@ coap_recvc(void *arg, struct udp_pcb *upcb, struct pbuf *p,
 #if NO_SYS == 0
   sys_sem_signal(&coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   return;
 
 error:
@@ -219,7 +219,7 @@ error:
    */
   if (session)
     coap_send_rst_lkd(session, pdu);
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   return;
 }
 #endif /* ! COAP_CLIENT_SUPPORT */
@@ -299,7 +299,7 @@ coap_udp_recvs(void *arg, struct udp_pcb *upcb, struct pbuf *p,
     coap_dispatch(ep->context, session, pdu);
   }
 
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   coap_free_packet(packet);
   coap_lock_unlock(ep->context);
 #if NO_SYS == 0
@@ -317,7 +317,7 @@ error:
    */
   if (session && pdu)
     coap_send_rst_lkd(session, pdu);
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   coap_free_packet(packet);
   coap_lock_unlock(ep->context);
   return;

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -228,7 +228,7 @@ coap_delete_node_lkd(coap_queue_t *node) {
   if (!node)
     return 0;
 
-  coap_delete_pdu(node->pdu);
+  coap_delete_pdu_lkd(node->pdu);
   if (node->session) {
     /*
      * Need to remove out of context->sendqueue as added in by coap_wait_ack()
@@ -1203,7 +1203,7 @@ coap_send_test_extended_token(coap_session_t *session) {
 
   token = coap_new_binary(session->max_token_size);
   if (token == NULL) {
-    coap_delete_pdu(pdu);
+    coap_delete_pdu_lkd(pdu);
     return COAP_INVALID_MID;
   }
   for (i = 0; i < session->max_token_size; i++) {
@@ -1495,7 +1495,7 @@ coap_send_lkd(coap_session_t *session, coap_pdu_t *pdu) {
       ret = coap_cancel_observe_lkd(session, &tmp, pdu->type);
       if (ret == 1) {
         /* Observe Cancel successfully sent */
-        coap_delete_pdu(pdu);
+        coap_delete_pdu_lkd(pdu);
         return ret;
       }
       /* Some mismatch somewhere - continue to send original packet */
@@ -1671,7 +1671,7 @@ coap_send_lkd(coap_session_t *session, coap_pdu_t *pdu) {
   return mid;
 
 error:
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   return COAP_INVALID_MID;
 }
 
@@ -1725,13 +1725,13 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
         if (hop_limit == 1) {
           coap_log_warn("Proxy loop detected '%s'\n",
                         (char *)pdu->data);
-          coap_delete_pdu(pdu);
+          coap_delete_pdu_lkd(pdu);
           return (coap_mid_t)COAP_DROPPED_RESPONSE;
         } else if (hop_limit < 1 || hop_limit > 255) {
           /* Something is bad - need to drop this pdu (TODO or delete option) */
           coap_log_warn("Proxy return has bad hop limit count '%zu'\n",
                         hop_limit);
-          coap_delete_pdu(pdu);
+          coap_delete_pdu_lkd(pdu);
           return (coap_mid_t)COAP_DROPPED_RESPONSE;
         }
         hop_limit--;
@@ -1761,7 +1761,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
              a_match[len] == ' ')) {
           coap_log_warn("Proxy loop detected '%s'\n",
                         (char *)pdu->data);
-          coap_delete_pdu(pdu);
+          coap_delete_pdu_lkd(pdu);
           return (coap_mid_t)COAP_DROPPED_RESPONSE;
         }
       }
@@ -1856,7 +1856,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
       goto error;
     }
     bytes_written = coap_send_pdu(session, osc_pdu, NULL);
-    coap_delete_pdu(pdu);
+    coap_delete_pdu_lkd(pdu);
     pdu = osc_pdu;
   } else
 #endif /* COAP_OSCORE_SUPPORT */
@@ -1886,7 +1886,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
   if (pdu->type != COAP_MESSAGE_CON
       || COAP_PROTO_RELIABLE(session->proto)) {
     coap_mid_t id = pdu->mid;
-    coap_delete_pdu(pdu);
+    coap_delete_pdu_lkd(pdu);
     return id;
   }
 
@@ -1903,7 +1903,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
   node->timeout = coap_calc_timeout(session, r);
   return coap_wait_ack(session->context, session, node);
 error:
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   return COAP_INVALID_MID;
 }
 
@@ -2033,7 +2033,7 @@ fail:
   session->doing_send_recv = 0;
   if (session->resp_pdu && session->resp_pdu->ref)
     session->resp_pdu->ref--;
-  coap_delete_pdu(session->resp_pdu);
+  coap_delete_pdu_lkd(session->resp_pdu);
   session->resp_pdu = NULL;
   coap_delete_bin_const(session->req_token);
   session->req_token = NULL;
@@ -2278,12 +2278,12 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
       if (!coap_pdu_parse(session->proto, packet->payload, bytes_read, pdu)) {
         coap_handle_event_lkd(session->context, COAP_EVENT_BAD_PACKET, session);
         coap_log_warn("discard malformed PDU\n");
-        coap_delete_pdu(pdu);
+        coap_delete_pdu_lkd(pdu);
         return;
       }
 
       coap_dispatch(ctx, session, pdu);
-      coap_delete_pdu(pdu);
+      coap_delete_pdu_lkd(pdu);
       return;
     }
   } else {
@@ -2315,7 +2315,7 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
                 && coap_pdu_parse_opt(session->partial_pdu)) {
               coap_dispatch(ctx, session, session->partial_pdu);
             }
-            coap_delete_pdu(session->partial_pdu);
+            coap_delete_pdu_lkd(session->partial_pdu);
             session->partial_pdu = NULL;
             session->partial_read = 0;
           } else {
@@ -2362,7 +2362,7 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
               if (coap_pdu_parse_header(session->partial_pdu, session->proto)) {
                 coap_dispatch(ctx, session, session->partial_pdu);
               }
-              coap_delete_pdu(session->partial_pdu);
+              coap_delete_pdu_lkd(session->partial_pdu);
               session->partial_pdu = NULL;
               session->partial_read = 0;
             }
@@ -2661,7 +2661,7 @@ coap_handle_dgram(coap_context_t *ctx, coap_session_t *session,
   }
 
   coap_dispatch(ctx, session, pdu);
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   return 0;
 
 error:
@@ -2670,7 +2670,7 @@ error:
    * https://rfc-editor.org/rfc/rfc7252#section-4.3 MAY send RST
    */
   coap_send_rst_lkd(session, pdu);
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   return -1;
 }
 
@@ -2878,7 +2878,7 @@ coap_new_error_response(const coap_pdu_t *request, coap_pdu_code_t code,
     if (!coap_add_token(response, request->actual_token.length,
                         request->actual_token.s)) {
       coap_log_debug("cannot add token to error response\n");
-      coap_delete_pdu(response);
+      coap_delete_pdu_lkd(response);
       return NULL;
     }
 
@@ -3754,7 +3754,7 @@ skip_handler:
                    response->mid);
     coap_show_pdu(COAP_LOG_DEBUG, response);
 drop_it_no_debug:
-    coap_delete_pdu(response);
+    coap_delete_pdu_lkd(response);
   }
   if (query)
     coap_delete_string(query);
@@ -3781,7 +3781,7 @@ finish:
   return;
 
 fail_response:
-  coap_delete_pdu(response);
+  coap_delete_pdu_lkd(response);
   response =
       coap_new_error_response(pdu, COAP_RESPONSE_CODE(resp),
                               &opt_filter);
@@ -4414,7 +4414,7 @@ cleanup:
   }
   coap_delete_node_lkd(sent);
 #if COAP_OSCORE_SUPPORT
-  coap_delete_pdu(dec_pdu);
+  coap_delete_pdu_lkd(dec_pdu);
 #endif /* COAP_OSCORE_SUPPORT */
 }
 

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -660,7 +660,7 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
   coap_free_type(COAP_OSCORE_BUF, ciphertext_buffer);
   ciphertext_buffer = NULL;
 
-  coap_delete_pdu(plain_pdu);
+  coap_delete_pdu_lkd(plain_pdu);
   plain_pdu = NULL;
 
   if (association && association->is_observe == 0)
@@ -718,7 +718,7 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
       if (association->partial_iv == NULL)
         goto error;
       association->recipient_ctx = rcp_ctx;
-      coap_delete_pdu(association->sent_pdu);
+      coap_delete_pdu_lkd(association->sent_pdu);
       if (session->b_2_step != COAP_OSCORE_B_2_NONE && !session->done_b_1_2) {
         size_t size;
 
@@ -750,8 +750,8 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
 error:
   if (ciphertext_buffer)
     coap_free_type(COAP_OSCORE_BUF, ciphertext_buffer);
-  coap_delete_pdu(osc_pdu);
-  coap_delete_pdu(plain_pdu);
+  coap_delete_pdu_lkd(osc_pdu);
+  coap_delete_pdu_lkd(plain_pdu);
   return NULL;
 }
 
@@ -800,7 +800,7 @@ build_and_send_error_pdu(coap_session_t *session,
       goto fail_resp;
     session->oscore_encryption = 0;
     coap_send_internal(session, osc_pdu);
-    coap_delete_pdu(err_pdu);
+    coap_delete_pdu_lkd(err_pdu);
     err_pdu = NULL;
   } else {
     coap_send_internal(session, err_pdu);
@@ -808,7 +808,7 @@ build_and_send_error_pdu(coap_session_t *session,
   }
 fail_resp:
   session->oscore_encryption = oscore_encryption;
-  coap_delete_pdu(err_pdu);
+  coap_delete_pdu_lkd(err_pdu);
   return;
 }
 
@@ -1602,7 +1602,7 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
       goto error;
     }
   }
-  coap_delete_pdu(plain_pdu);
+  coap_delete_pdu_lkd(plain_pdu);
   plain_pdu = NULL;
 
   /* Make sure headers are correctly set up */
@@ -1647,8 +1647,8 @@ error:
 error_no_ack:
   if (association && association->is_observe == 0)
     oscore_delete_association(session, association);
-  coap_delete_pdu(decrypt_pdu);
-  coap_delete_pdu(plain_pdu);
+  coap_delete_pdu_lkd(decrypt_pdu);
+  coap_delete_pdu_lkd(plain_pdu);
   return NULL;
 }
 

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -179,8 +179,15 @@ coap_new_pdu_lkd(coap_pdu_type_t type, coap_pdu_code_t code,
   return pdu;
 }
 
-void
+COAP_API void
 coap_delete_pdu(coap_pdu_t *pdu) {
+  coap_lock_lock(NULL, return);
+  coap_delete_pdu_lkd(pdu);
+  coap_lock_unlock(NULL);
+}
+
+void
+coap_delete_pdu_lkd(coap_pdu_t *pdu) {
   if (pdu != NULL) {
     if (pdu->ref) {
       pdu->ref--;
@@ -278,7 +285,7 @@ coap_pdu_duplicate_lkd(const coap_pdu_t *old_pdu,
   return pdu;
 
 fail:
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   return NULL;
 }
 

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -42,7 +42,7 @@ coap_proxy_cleanup(coap_context_t *context) {
 
   for (i = 0; i < context->proxy_list_count; i++) {
     for (j = 0; j < context->proxy_list[i].req_count; j++) {
-      coap_delete_pdu(context->proxy_list[i].req_list[j].pdu);
+      coap_delete_pdu_lkd(context->proxy_list[i].req_list[j].pdu);
       coap_delete_cache_key(context->proxy_list[i].req_list[j].cache_key);
     }
     coap_free_type(COAP_STRING, context->proxy_list[i].req_list);
@@ -352,7 +352,7 @@ coap_proxy_remove_association(coap_session_t *session, int send_failure) {
     /* Check for incoming match */
     for (j = 0; j < proxy_list[i].req_count; j++) {
       if (proxy_list[i].req_list[j].incoming == session) {
-        coap_delete_pdu(proxy_list[i].req_list[j].pdu);
+        coap_delete_pdu_lkd(proxy_list[i].req_list[j].pdu);
         coap_delete_bin_const(proxy_list[i].req_list[j].token_used);
         coap_delete_cache_key(proxy_list[i].req_list[j].cache_key);
         if (proxy_list[i].req_count-j > 1) {
@@ -398,7 +398,7 @@ coap_proxy_remove_association(coap_session_t *session, int send_failure) {
             coap_log_info("Failed to send PDU with 5.02 gateway issue\n");
           }
 cleanup:
-          coap_delete_pdu(proxy_list[i].req_list[j].pdu);
+          coap_delete_pdu_lkd(proxy_list[i].req_list[j].pdu);
           coap_delete_bin_const(proxy_list[i].req_list[j].token_used);
           coap_delete_cache_key(proxy_list[i].req_list[j].cache_key);
         }
@@ -734,7 +734,7 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
 
 failed:
   response->code = COAP_RESPONSE_CODE(500);
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   return 0;
 }
 
@@ -889,7 +889,7 @@ remove_match:
   option = coap_check_option(received, COAP_OPTION_OBSERVE, &opt_iter);
   /* Need to remove matching token entry (apart from on Observe response) */
   if (option == NULL && proxy_entry->req_count) {
-    coap_delete_pdu(proxy_entry->req_list[j].pdu);
+    coap_delete_pdu_lkd(proxy_entry->req_list[j].pdu);
     coap_delete_bin_const(proxy_entry->req_list[j].token_used);
     /* Do not delete cache key here - caller's responsibility */
     proxy_entry->req_count--;

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -517,7 +517,7 @@ coap_free_resource(coap_resource_t *resource) {
       resource->context->observe_deleted(obs->session, obs,
                                          resource->context->observe_user_data);
     coap_session_release_lkd(obs->session);
-    coap_delete_pdu(obs->pdu);
+    coap_delete_pdu_lkd(obs->pdu);
     coap_delete_cache_key(obs->cache_key);
     coap_free_type(COAP_SUBSCRIPTION, obs);
   }
@@ -867,7 +867,7 @@ coap_add_observer(coap_resource_t *resource,
                                                cache_ignore_options,
                                                sizeof(cache_ignore_options)/sizeof(cache_ignore_options[0]));
     if (cache_key == NULL) {
-      coap_delete_pdu(s->pdu);
+      coap_delete_pdu_lkd(s->pdu);
       coap_delete_cache_key(cache_key);
       coap_free_type(COAP_SUBSCRIPTION, s);
       return NULL;
@@ -1025,7 +1025,7 @@ coap_delete_observer_internal(coap_resource_t *resource, coap_session_t *session
     coap_session_release_lkd(session);
     assert(session->ref_subscriptions > 0);
     session->ref_subscriptions--;
-    coap_delete_pdu(s->pdu);
+    coap_delete_pdu_lkd(s->pdu);
     coap_delete_cache_key(s->cache_key);
     coap_free_type(COAP_SUBSCRIPTION, s);
   }
@@ -1089,7 +1089,7 @@ coap_delete_observers(coap_context_t *context, coap_session_t *session) {
         assert(resource->subscribers);
         LL_DELETE(resource->subscribers, s);
         coap_session_release_lkd(session);
-        coap_delete_pdu(s->pdu);
+        coap_delete_pdu_lkd(s->pdu);
         coap_delete_cache_key(s->cache_key);
         coap_free_type(COAP_SUBSCRIPTION, s);
       }
@@ -1165,7 +1165,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         context->observe_pending = 1;
         coap_log_debug("coap_check_notify: cannot add token, resource stays "
                        "partially dirty\n");
-        coap_delete_pdu(response);
+        coap_delete_pdu_lkd(response);
         continue;
       }
 
@@ -1228,7 +1228,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
           coap_log_warn("handle_request: Invalid PDU response code (%d.%02d)\n",
                         COAP_RESPONSE_CLASS(response->code),
                         response->code & 0x1f);
-          coap_delete_pdu(response);
+          coap_delete_pdu_lkd(response);
           return;
         }
 

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -515,7 +515,7 @@ coap_session_mfree(coap_session_t *session) {
 #endif /* COAP_CLIENT_SUPPORT */
 
   if (session->partial_pdu)
-    coap_delete_pdu(session->partial_pdu);
+    coap_delete_pdu_lkd(session->partial_pdu);
   if (session->sock.lfunc[COAP_LAYER_SESSION].l_close)
     session->sock.lfunc[COAP_LAYER_SESSION].l_close(session);
   if (session->psk_identity)
@@ -778,7 +778,7 @@ coap_session_send_csm(coap_session_t *session) {
     }
   }
   if (pdu)
-    coap_delete_pdu(pdu);
+    coap_delete_pdu_lkd(pdu);
 }
 #endif /* !COAP_DISABLE_TCP */
 
@@ -1011,7 +1011,7 @@ coap_session_disconnected_lkd(coap_session_t *session, coap_nack_reason_t reason
   session->con_active = 0;
 
   if (session->partial_pdu) {
-    coap_delete_pdu(session->partial_pdu);
+    coap_delete_pdu_lkd(session->partial_pdu);
     session->partial_pdu = NULL;
   }
   session->partial_read = 0;

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -305,14 +305,14 @@ oscore_fail:
 #else /* ! COAP_OSCORE_SUPPORT */
   (void)oscore_info;
 #endif /* ! COAP_OSCORE_SUPPORT */
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   return s;
 
 malformed:
   coap_log_warn("coap_persist_observe_add: discard malformed PDU\n");
 fail:
   coap_delete_string(uri_path);
-  coap_delete_pdu(pdu);
+  coap_delete_pdu_lkd(pdu);
   return NULL;
 }
 
@@ -967,9 +967,9 @@ coap_op_dyn_resource_load_disk(coap_context_t *ctx) {
                                  goto fail);
       coap_delete_string(query);
       query = NULL;
-      coap_delete_pdu(request);
+      coap_delete_pdu_lkd(request);
       request = NULL;
-      coap_delete_pdu(response);
+      coap_delete_pdu_lkd(response);
       response = NULL;
     }
     coap_delete_string(name);
@@ -979,8 +979,8 @@ fail:
   coap_delete_string(name);
   coap_delete_binary(raw_packet);
   coap_delete_string(query);
-  coap_delete_pdu(request);
-  coap_delete_pdu(response);
+  coap_delete_pdu_lkd(request);
+  coap_delete_pdu_lkd(response);
   fclose(fp_orig);
   coap_free_type(COAP_SESSION, session);
 }

--- a/src/oscore/oscore_context.c
+++ b/src/oscore/oscore_context.c
@@ -673,7 +673,7 @@ oscore_delete_recipient(oscore_ctx_t *osc_ctx, coap_bin_const_t *rid) {
 void
 oscore_free_association(oscore_association_t *association) {
   if (association) {
-    coap_delete_pdu(association->sent_pdu);
+    coap_delete_pdu_lkd(association->sent_pdu);
     coap_delete_bin_const(association->token);
     coap_delete_bin_const(association->aad);
     coap_delete_bin_const(association->nonce);


### PR DESCRIPTION
The reference counter needs to be protected.