### PR TITLE
coap_send_internal: Update parameters

### DIFF
--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -446,11 +446,13 @@ int coap_check_code_class(coap_session_t *session, coap_pdu_t *pdu);
  *
  * @param session   The CoAP session.
  * @param pdu       The CoAP PDU to send.
+ * @param request_pdu Not currently used.
  *
  * @return          The message id of the sent message or @c
  *                  COAP_INVALID_MID on error.
  */
-coap_mid_t coap_send_internal(coap_session_t *session, coap_pdu_t *pdu);
+coap_mid_t coap_send_internal(coap_session_t *session, coap_pdu_t *pdu,
+                              coap_pdu_t *request_pdu);
 
 /**
  * Delay the sending of the first client request until some other negotiation

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -552,10 +552,10 @@ coap_cancel_observe_lkd(coap_session_t *session, coap_binary_t *token,
         if (using_q_block1) {
           mid = coap_send_q_block1(session, block, pdu, COAP_SEND_INC_PDU);
         } else {
-          mid = coap_send_internal(session, pdu);
+          mid = coap_send_internal(session, pdu, NULL);
         }
 #else /* ! COAP_Q_BLOCK_SUPPORT */
-        mid = coap_send_internal(session, pdu);
+        mid = coap_send_internal(session, pdu, NULL);
 #endif /* ! COAP_Q_BLOCK_SUPPORT */
         if (mid != COAP_INVALID_MID)
           return 1;
@@ -614,7 +614,7 @@ coap_retransmit_oscore_pdu(coap_session_t *session,
       coap_add_data(resend_pdu, data_len, data);
     }
 
-    return coap_send_internal(session, resend_pdu);
+    return coap_send_internal(session, resend_pdu, NULL);
   }
 error:
   return COAP_INVALID_MID;
@@ -1489,7 +1489,7 @@ coap_request_missing_q_block2(coap_session_t *session, coap_lg_crcv_t *lg_crcv) 
   }
 send_it:
   if (pdu)
-    coap_send_internal(session, pdu);
+    coap_send_internal(session, pdu, NULL);
   lg_crcv->rec_blocks.retry++;
   if (block_payload_set != -1)
     lg_crcv->rec_blocks.processing_payload_set = block_payload_set;
@@ -1810,7 +1810,7 @@ coap_block_check_lg_srcv_timeouts(coap_session_t *session, coap_tick_t now,
           }
         }
         if (pdu)
-          coap_send_internal(session, pdu);
+          coap_send_internal(session, pdu, NULL);
         lg_srcv->rec_blocks.retry++;
         coap_ticks(&lg_srcv->rec_blocks.last_seen);
       }
@@ -1846,7 +1846,7 @@ expire:
             coap_add_token(pdu, lg_srcv->last_token->length, lg_srcv->last_token->s);
           coap_add_data(pdu, sizeof("Missing interim block")-1,
                         (const uint8_t *)"Missing interim block");
-          coap_send_internal(session, pdu);
+          coap_send_internal(session, pdu, NULL);
         }
       }
       LL_DELETE(session->lg_srcv, lg_srcv);
@@ -1884,7 +1884,7 @@ coap_send_q_blocks(coap_session_t *session,
 
   if (!lg_xmit) {
     if (send_pdu == COAP_SEND_INC_PDU)
-      return coap_send_internal(session, pdu);
+      return coap_send_internal(session, pdu, NULL);
     return COAP_INVALID_MID;
   }
 
@@ -1928,7 +1928,7 @@ coap_send_q_blocks(coap_session_t *session,
 
   /* Send initial pdu (which deletes 'pdu') */
   if (send_pdu == COAP_SEND_INC_PDU &&
-      (mid = coap_send_internal(session, pdu)) == COAP_INVALID_MID) {
+      (mid = coap_send_internal(session, pdu, NULL)) == COAP_INVALID_MID) {
     /* Not expected, underlying issue somewhere */
     coap_delete_pdu_lkd(block_pdu);
     return COAP_INVALID_MID;
@@ -1991,7 +1991,7 @@ coap_send_q_blocks(coap_session_t *session,
     if (COAP_PDU_IS_RESPONSE(block_pdu)) {
       lg_xmit->last_block = block.num;
     }
-    mid = coap_send_internal(session, block_pdu);
+    mid = coap_send_internal(session, block_pdu, NULL);
     if (mid == COAP_INVALID_MID) {
       /* Not expected, underlying issue somewhere */
       coap_delete_pdu_lkd(t_pdu);
@@ -2267,7 +2267,7 @@ coap_block_test_q_block(coap_session_t *session, coap_pdu_t *actual) {
                                           (0 << 4) | (0 << 3) | 0),
                      buf);
   set_block_mode_probe_q(session->block_mode);
-  mid = coap_send_internal(session, pdu);
+  mid = coap_send_internal(session, pdu, NULL);
   if (mid == COAP_INVALID_MID)
     return COAP_INVALID_MID;
   session->remote_test_mid = mid;
@@ -2759,7 +2759,7 @@ coap_handle_request_send_block(coap_session_t *session,
     }
     if (i + 1 < request_cnt) {
       coap_ticks(&lg_xmit->last_sent);
-      coap_send_internal(session, out_pdu);
+      coap_send_internal(session, out_pdu, NULL);
     }
   }
   coap_ticks(&lg_xmit->last_payload);
@@ -3171,7 +3171,7 @@ coap_handle_request_put_block(coap_context_t *context,
                                                      NULL);
         if (tmp_pdu) {
           tmp_pdu->code = COAP_RESPONSE_CODE(231);
-          coap_send_internal(session, tmp_pdu);
+          coap_send_internal(session, tmp_pdu, NULL);
         }
         if (lg_srcv->last_token) {
           coap_update_token(response, lg_srcv->last_token->length, lg_srcv->last_token->s);
@@ -3350,7 +3350,7 @@ check_freshness(coap_session_t *session, coap_pdu_t *rcvd, coap_pdu_t *sent,
         }
       }
 #endif /* COAP_OSCORE_SUPPORT */
-      mid = coap_send_internal(session, echo_pdu);
+      mid = coap_send_internal(session, echo_pdu, NULL);
       if (mid == COAP_INVALID_MID)
         goto not_sent;
       return 1;
@@ -3531,10 +3531,10 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *sent,
                                  COAP_SEND_INC_PDU) == COAP_INVALID_MID)
             goto fail_body;
           return 1;
-        } else if (coap_send_internal(session, pdu) == COAP_INVALID_MID)
+        } else if (coap_send_internal(session, pdu, NULL) == COAP_INVALID_MID)
           goto fail_body;
 #else /* ! COAP_Q_BLOCK_SUPPORT */
-        if (coap_send_internal(session, pdu) == COAP_INVALID_MID)
+        if (coap_send_internal(session, pdu, NULL) == COAP_INVALID_MID)
           goto fail_body;
 #endif /* ! COAP_Q_BLOCK_SUPPORT */
         return 1;
@@ -3642,7 +3642,7 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *sent,
                               block.num,
                               block.szx))
             goto fail_body;
-          if (coap_send_internal(session, pdu) == COAP_INVALID_MID)
+          if (coap_send_internal(session, pdu, NULL) == COAP_INVALID_MID)
             goto fail_body;
         }
         return 1;
@@ -3919,7 +3919,7 @@ reinit:
                                                     (0 << 4) | (0 << 3) | block.aszx),
                                buf);
 
-            if (coap_send_internal(session, pdu) == COAP_INVALID_MID)
+            if (coap_send_internal(session, pdu, NULL) == COAP_INVALID_MID)
               goto fail_resp;
 
             goto skip_app_handler;
@@ -4055,7 +4055,7 @@ reinit:
                 (void)coap_get_data(&lg_crcv->pdu, &length, &data);
                 coap_add_data_large_internal(session, NULL, pdu, NULL, NULL, -1, 0, length, data, NULL, NULL, 0, 0);
               }
-              if (coap_send_internal(session, pdu) == COAP_INVALID_MID)
+              if (coap_send_internal(session, pdu, NULL) == COAP_INVALID_MID)
                 goto fail_resp;
             }
             if ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) ||  block.bert)

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -992,7 +992,7 @@ coap_send_ack_lkd(coap_session_t *session, const coap_pdu_t *request) {
       COAP_PROTO_NOT_RELIABLE(session->proto)) {
     response = coap_pdu_init(COAP_MESSAGE_ACK, 0, request->mid, 0);
     if (response)
-      result = coap_send_internal(session, response);
+      result = coap_send_internal(session, response, NULL);
   }
   return result;
 }
@@ -1075,7 +1075,7 @@ coap_send_error_lkd(coap_session_t *session,
 
   response = coap_new_error_response(request, code, opts);
   if (response)
-    result = coap_send_internal(session, response);
+    result = coap_send_internal(session, response, NULL);
 
   return result;
 }
@@ -1101,7 +1101,7 @@ coap_send_message_type_lkd(coap_session_t *session, const coap_pdu_t *request,
   if (request && COAP_PROTO_NOT_RELIABLE(session->proto)) {
     response = coap_pdu_init(type, 0, request->mid, 0);
     if (response)
-      result = coap_send_internal(session, response);
+      result = coap_send_internal(session, response, NULL);
   }
   return result;
 }
@@ -1215,7 +1215,7 @@ coap_send_test_extended_token(coap_session_t *session) {
   coap_insert_option(pdu, COAP_OPTION_IF_NONE_MATCH, 0, NULL);
 
   session->max_token_checked = COAP_EXT_T_CHECKING; /* Checking out this one */
-  if ((mid = coap_send_internal(session, pdu)) == COAP_INVALID_MID)
+  if ((mid = coap_send_internal(session, pdu, NULL)) == COAP_INVALID_MID)
     return COAP_INVALID_MID;
   session->remote_test_mid = mid;
   return mid;
@@ -1447,7 +1447,7 @@ coap_send_lkd(coap_session_t *session, coap_pdu_t *pdu) {
 #endif /* COAP_OSCORE_SUPPORT */
 
   if (!(session->block_mode & COAP_BLOCK_USE_LIBCOAP)) {
-    return coap_send_internal(session, pdu);
+    return coap_send_internal(session, pdu, NULL);
   }
 
   if (COAP_PDU_IS_REQUEST(pdu)) {
@@ -1655,9 +1655,9 @@ coap_send_lkd(coap_session_t *session, coap_pdu_t *pdu) {
     mid = coap_send_q_block1(session, block, pdu, COAP_SEND_INC_PDU);
   } else
 #endif /* COAP_Q_BLOCK_SUPPORT */
-    mid = coap_send_internal(session, pdu);
+    mid = coap_send_internal(session, pdu, NULL);
 #else /* !COAP_CLIENT_SUPPORT */
-  mid = coap_send_internal(session, pdu);
+  mid = coap_send_internal(session, pdu, NULL);
 #endif /* !COAP_CLIENT_SUPPORT */
 #if COAP_CLIENT_SUPPORT
   if (lg_crcv) {
@@ -1676,10 +1676,12 @@ error:
 }
 
 coap_mid_t
-coap_send_internal(coap_session_t *session, coap_pdu_t *pdu) {
+coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request_pdu) {
   uint8_t r;
   ssize_t bytes_written;
   coap_opt_iterator_t opt_iter;
+
+  (void)request_pdu;
 
   pdu->session = session;
   if (pdu->code == COAP_RESPONSE_CODE(508)) {
@@ -3715,7 +3717,7 @@ skip_handler:
         goto finish;
       }
 #endif /* COAP_Q_BLOCK_SUPPORT */
-      if (coap_send_internal(session, response) == COAP_INVALID_MID) {
+      if (coap_send_internal(session, response, NULL) == COAP_INVALID_MID) {
         coap_log_debug("cannot send response for mid=0x%04x\n", mid);
       }
     } else {
@@ -3972,7 +3974,7 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
     }
     if (pong) {
       coap_add_option_internal(pong, COAP_SIGNALING_OPTION_CUSTODY, 0, NULL);
-      coap_send_internal(session, pong);
+      coap_send_internal(session, pong, NULL);
     }
   } else if (pdu->code == COAP_SIGNALING_CODE_PONG) {
     session->last_pong = session->last_rx_tx;
@@ -4008,7 +4010,7 @@ check_token_size(coap_session_t *session, const coap_pdu_t *pdu) {
          * Note - have to leave in oversize token as per
          * https://rfc-editor.org/rfc/rfc7252#section-5.3.1
          */
-        if (coap_send_internal(session, response) == COAP_INVALID_MID)
+        if (coap_send_internal(session, response, NULL) == COAP_INVALID_MID)
           coap_log_warn("coap_dispatch: error sending response\n");
       }
     } else {
@@ -4067,7 +4069,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
         if (!response) {
           coap_log_warn("coap_dispatch: cannot create error response\n");
         } else {
-          if (coap_send_internal(session, response) == COAP_INVALID_MID)
+          if (coap_send_internal(session, response, NULL) == COAP_INVALID_MID)
             coap_log_warn("coap_dispatch: error sending response\n");
         }
       } else {
@@ -4341,7 +4343,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
         if (!response) {
           coap_log_warn("coap_dispatch: cannot create error response\n");
         } else {
-          if (coap_send_internal(session, response) == COAP_INVALID_MID)
+          if (coap_send_internal(session, response, NULL) == COAP_INVALID_MID)
             coap_log_warn("coap_dispatch: error sending response\n");
         }
       } else {

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -680,7 +680,7 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
                                       osc_pdu->mid,
                                       0);
     if (empty) {
-      if (coap_send_internal(session, empty) != COAP_INVALID_MID) {
+      if (coap_send_internal(session, empty, NULL) != COAP_INVALID_MID) {
         osc_pdu->mid = coap_new_message_id_lkd(session);
         osc_pdu->type = COAP_MESSAGE_CON;
       }
@@ -799,11 +799,11 @@ build_and_send_error_pdu(coap_session_t *session,
     if (!osc_pdu)
       goto fail_resp;
     session->oscore_encryption = 0;
-    coap_send_internal(session, osc_pdu);
+    coap_send_internal(session, osc_pdu, NULL);
     coap_delete_pdu_lkd(err_pdu);
     err_pdu = NULL;
   } else {
-    coap_send_internal(session, err_pdu);
+    coap_send_internal(session, err_pdu, NULL);
     err_pdu = NULL;
   }
 fail_resp:

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -1272,7 +1272,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         }
 #endif /* COAP_Q_BLOCK_SUPPORT */
       }
-      mid = coap_send_internal(obs_session, response);
+      mid = coap_send_internal(obs_session, response, NULL);
 
 #if COAP_Q_BLOCK_SUPPORT
 finish:

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -811,7 +811,7 @@ coap_session_send_ping_lkd(coap_session_t *session) {
 #endif /* !COAP_DISABLE_TCP */
   if (!ping)
     return COAP_INVALID_MID;
-  return coap_send_internal(session, ping);
+  return coap_send_internal(session, ping, NULL);
 }
 
 void


### PR DESCRIPTION
Preparatory work for supporting caching responses by updating coap_send_internal() parameters.