### PR TITLE
Contiki-NG: Fix "unknown type name 'u_char'"

### DIFF
--- a/include/coap3/coap_proxy_internal.h
+++ b/include/coap3/coap_proxy_internal.h
@@ -40,7 +40,7 @@ struct coap_proxy_list_t {
   coap_proxy_req_t *req_list; /**< Incoming list of request info */
   size_t req_count;          /**< Count of incoming request info */
   coap_uri_t uri;            /**< URI info for connection */
-  u_char *uri_host_keep;     /**< memory for uri.host */
+  uint8_t *uri_host_keep;     /**< memory for uri.host */
   coap_tick_t idle_timeout_ticks; /**< Idle timeout (0 == no timeout) */
   coap_tick_t last_used;     /**< Last time entry was used */
 };

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -2249,9 +2249,9 @@ coap_block_test_q_block(coap_session_t *session, coap_pdu_t *actual) {
   coap_add_token(pdu, token_len, token);
   /* Use a resource that the server MUST support (.well-known/core) */
   coap_add_option(pdu, COAP_OPTION_URI_PATH,
-                  11, (const u_char *)".well-known");
+                  11, (const uint8_t *)".well-known");
   coap_add_option(pdu, COAP_OPTION_URI_PATH,
-                  4, (const u_char *)"core");
+                  4, (const uint8_t *)"core");
   /*
    * M needs to be unset as 'asking' for only the first block using
    * Q-Block2 as a test for server support.

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -1809,7 +1809,7 @@ coap_dtls_new_mbedtls_env(coap_session_t *c_session,
 #endif /* COAP_CLIENT_SUPPORT */
       } else {
 #if COAP_SERVER_SUPPORT
-        u_char cid[COAP_DTLS_CID_LENGTH];
+        uint8_t cid[COAP_DTLS_CID_LENGTH];
         /*
          * Enable server DTLS CID support.
          *

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -981,7 +981,7 @@ coap_sock_read(BIO *a, char *out, int outl) {
   coap_session_t *session = (coap_session_t *)BIO_get_data(a);
 
   if (out != NULL) {
-    ret =(int)session->sock.lfunc[COAP_LAYER_TLS].l_read(session, (u_char *)out,
+    ret =(int)session->sock.lfunc[COAP_LAYER_TLS].l_read(session, (uint8_t *)out,
                                                          outl);
     /* Translate layer returns into what OpenSSL expects */
     if (ret == 0) {

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -1711,8 +1711,8 @@ parse_hex_bin(const char *begin, const char *end) {
   binary = coap_new_binary((end - begin) / 2);
   if (binary == NULL)
     goto bad_entry;
-  for (i = 0; (i < (size_t)(end - begin)) && isxdigit((u_char)begin[i]) &&
-       isxdigit((u_char)begin[i + 1]);
+  for (i = 0; (i < (size_t)(end - begin)) && isxdigit((uint8_t)begin[i]) &&
+       isxdigit((uint8_t)begin[i + 1]);
        i += 2) {
     binary->s[i / 2] = (hex2char(begin[i]) << 4) + hex2char(begin[i + 1]);
   }

--- a/src/coap_wolfssl.c
+++ b/src/coap_wolfssl.c
@@ -831,7 +831,7 @@ coap_sock_read(WOLFSSL *ssl, char *out, int outl, void *ctx) {
     }
   }
   if (out != NULL) {
-    ret =(int)session->sock.lfunc[COAP_LAYER_TLS].l_read(session, (u_char *)out,
+    ret =(int)session->sock.lfunc[COAP_LAYER_TLS].l_read(session, (uint8_t *)out,
                                                          outl);
     if (ret == 0) {
       ret = WANT_READ;
@@ -1948,7 +1948,7 @@ coap_dtls_new_server_session(coap_session_t *session) {
 
   if (wolfSSL_dtls_cid_use(ssl) != WOLFSSL_SUCCESS)
     goto error;
-  u_char cid[COAP_DTLS_CID_LENGTH];
+  uint8_t cid[COAP_DTLS_CID_LENGTH];
   /*
    * Enable server DTLS CID support.
    */


### PR DESCRIPTION
When compiling for an embedded target, Contiki-NG fails with `unknown type name 'u_char'`. This PR fixes this problem.