### PR TITLE
Proxy: Update documentation, streamline the code

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -627,7 +627,7 @@ static ssize_t user_length = -1;
 
 static size_t proxy_host_name_count = 0;
 static const char **proxy_host_name_list = NULL;
-static coap_proxy_server_list_t forward_proxy = { NULL, 0, 0, COAP_PROXY_FORWARD, 0, 300};
+static coap_proxy_server_list_t forward_proxy = { NULL, 0, 0, COAP_PROXY_FORWARD_STATIC, 0, 300};
 static coap_proxy_server_list_t reverse_proxy = { NULL, 0, 0, COAP_PROXY_REVERSE_STRIP, 0, 10};
 
 static coap_dtls_cpsk_t *
@@ -646,12 +646,12 @@ setup_cpsk(char *client_sni) {
 
 static void
 hnd_forward_proxy_uri(coap_resource_t *resource,
-                      coap_session_t *session,
+                      coap_session_t *req_session,
                       const coap_pdu_t *request,
                       const coap_string_t *query COAP_UNUSED,
                       coap_pdu_t *response) {
 
-  if (!coap_proxy_forward_request(session, request, response, resource,
+  if (!coap_proxy_forward_request(req_session, request, response, resource,
                                   NULL, &forward_proxy)) {
     coap_log_debug("hnd_forward_proxy_uri: Failed to forward PDU\n");
     /* Non ACK response code set on error detection */
@@ -662,12 +662,12 @@ hnd_forward_proxy_uri(coap_resource_t *resource,
 
 static void
 hnd_reverse_proxy_uri(coap_resource_t *resource,
-                      coap_session_t *session,
+                      coap_session_t *rsp_session,
                       const coap_pdu_t *request,
                       const coap_string_t *query COAP_UNUSED,
                       coap_pdu_t *response) {
 
-  if (!coap_proxy_forward_request(session, request, response, resource,
+  if (!coap_proxy_forward_request(rsp_session, request, response, resource,
                                   NULL, &reverse_proxy)) {
     coap_log_debug("hnd_reverse_proxy_uri: Failed to forward PDU\n");
     /* Non ACK response code set on error detection */
@@ -1085,11 +1085,11 @@ proxy_event_handler(coap_session_t *session COAP_UNUSED,
 }
 
 static coap_response_t
-reverse_response_handler(coap_session_t *session,
+reverse_response_handler(coap_session_t *rsp_session,
                          const coap_pdu_t *sent COAP_UNUSED,
                          const coap_pdu_t *received,
                          const coap_mid_t id COAP_UNUSED) {
-  return coap_proxy_forward_response(session, received, NULL);
+  return coap_proxy_forward_response(rsp_session, received, NULL);
 }
 
 static void
@@ -1517,7 +1517,9 @@ proxy_dtls_setup(coap_context_t *ctx, coap_proxy_server_list_t *proxy_info) {
   for (i = 0; i < proxy_info->entry_count; i++) {
     coap_proxy_server_t *proxy_server = &proxy_info->entry[i];
 
-    if (proxy_info->type == COAP_PROXY_DIRECT || proxy_info->type == COAP_PROXY_DIRECT_STRIP) {
+    if (proxy_info->type == COAP_PROXY_FORWARD_DYNAMIC ||
+        proxy_info->type == COAP_PROXY_FORWARD_DYNAMIC_STRIP) {
+      /* This will get filled in by the libcoap proxy logic */
       memset(client_sni, 0, sizeof(client_sni));
     } else {
       snprintf(client_sni, sizeof(client_sni), "%*.*s", (int)proxy_server->uri.host.length,
@@ -1581,7 +1583,7 @@ usage(const char *program, const char *version) {
           "\t       \t\tuntil one of the dynamic resources has been deleted\n"
           "\t-e     \t\tEcho back the data sent with a PUT\n"
           "\t-f scheme://address[:port]\n"
-          "\t       \t\tAct as a reverse proxy where scheme, address, optional\n"
+          "\t       \t\tAct as a reverse proxy where scheme, address and optional\n"
           "\t       \t\tport define how to connect to the internal server.\n"
           "\t       \t\tScheme is one of coap, coaps, coap+tcp, coaps+tcp,\n"
           "\t       \t\tcoap+ws, and coaps+ws. http(s) is not currently supported.\n"
@@ -1826,10 +1828,12 @@ cmdline_proxy(char *arg) {
       coap_log_err("Unsupported CoAP Proxy protocol\n");
       return 0;
     }
-    forward_proxy.type = COAP_PROXY_FORWARD;
+    forward_proxy.type = COAP_PROXY_FORWARD_STATIC;
+    forward_proxy.idle_timeout_secs = 300;
   } else {
     memset(&uri, 0, sizeof(uri));
-    forward_proxy.type = COAP_PROXY_DIRECT_STRIP;
+    forward_proxy.type = COAP_PROXY_FORWARD_DYNAMIC_STRIP;
+    forward_proxy.idle_timeout_secs = 10;
   }
 
   new_entry = realloc(forward_proxy.entry,

--- a/include/coap3/coap_proxy.h
+++ b/include/coap3/coap_proxy.h
@@ -25,12 +25,23 @@
  */
 
 typedef enum {
-  COAP_PROXY_REVERSE,       /**< Act as a reverse proxy */
-  COAP_PROXY_REVERSE_STRIP, /**< Act as a reverse proxy, strip out proxy options */
-  COAP_PROXY_FORWARD,       /**< Act as a forward proxy */
-  COAP_PROXY_FORWARD_STRIP, /**< Act as a forward proxy, strip out proxy options */
-  COAP_PROXY_DIRECT,        /**< Act as a direct proxy */
-  COAP_PROXY_DIRECT_STRIP,  /**< Act as a direct proxy, strip out proxy options */
+  COAP_PROXY_REVERSE,               /**< Act as a reverse proxy */
+  COAP_PROXY_REVERSE_STRIP,         /**< Act as a reverse proxy,
+                                         strip out proxy options */
+  COAP_PROXY_FORWARD_STATIC,        /**< Act as a forward-static proxy */
+  COAP_PROXY_FORWARD_STATIC_STRIP,  /**< Act as a forward-static proxy,
+                                         strip out proxy options */
+  COAP_PROXY_FORWARD_DYNAMIC,       /**< Act as a forward-dynamic proxy
+                                         using the request's Proxy-Uri or
+                                         Proxy-Scheme options to determine
+                                         server */
+  COAP_PROXY_FORWARD_DYNAMIC_STRIP, /**< Act as a forward-dynamic proxy,
+                                         strip out proxy options */
+  /* For backward compatability */
+  COAP_PROXY_FORWARD = COAP_PROXY_FORWARD_STATIC,
+  COAP_PROXY_FORWARD_STRIP = COAP_PROXY_FORWARD_STATIC_STRIP,
+  COAP_PROXY_DIRECT = COAP_PROXY_FORWARD_DYNAMIC,
+  COAP_PROXY_DIRECT_STRIP = COAP_PROXY_FORWARD_DYNAMIC_STRIP,
 } coap_proxy_t;
 
 typedef struct coap_proxy_server_t {
@@ -42,13 +53,14 @@ typedef struct coap_proxy_server_t {
 
 typedef struct coap_proxy_server_list_t {
   coap_proxy_server_t *entry; /**< Set of servers to connect to */
-  size_t entry_count;         /**< The number of servers */
+  size_t entry_count;         /**< The number of servers in entry list */
   size_t next_entry;          /**< Next server to use (% entry_count) */
   coap_proxy_t type;          /**< The proxy type */
   int track_client_session;   /**< If 1, track individual connections to upstream
                                    server, else 0 for all clients to share the same
                                    ongoing session */
-  unsigned int idle_timeout_secs; /**< Proxy session idle timeout (0 is no timeout) */
+  unsigned int idle_timeout_secs; /**< Proxy upstream session idle timeout
+                                       (0 is no timeout) */
 } coap_proxy_server_list_t;
 
 /**
@@ -64,16 +76,16 @@ int coap_verify_proxy_scheme_supported(coap_uri_scheme_t scheme);
  * Forward incoming request upstream to the next proxy/server.
  *
  * Possible scenarios:
- *  Acting as a reverse proxy - connect to internal server
+ *  Acting as a reverse proxy - connect to defined internal server
  *   (possibly round robin load balancing over multiple servers).
- *  Acting as a forward proxy - connect to host defined in Proxy-Uri
+ *  Acting as a forward-dynamic proxy - connect to host defined in Proxy-Uri
  *   or Proxy-Scheme with Uri-Host (and maybe Uri-Port).
- *  Acting as a relay proxy - connect to defined upstream server
+ *  Acting as a forward-static proxy - connect to defined upstream server
  *   (possibly round robin load balancing over multiple servers).
  *
  * A request that should go direct to this server is not supported here.
  *
- * @param session The client session.
+ * @param req_session The client session.
  * @param request The client's request PDU.
  * @param response The response PDU that will get sent back to the client.
  * @param resource The resource associated with this request.
@@ -83,7 +95,7 @@ int coap_verify_proxy_scheme_supported(coap_uri_scheme_t scheme);
  * @return @c 1 if success, or @c 0 if failure (@p response code set to
  *         appropriate value).
  */
-int COAP_API coap_proxy_forward_request(coap_session_t *session,
+int COAP_API coap_proxy_forward_request(coap_session_t *req_session,
                                         const coap_pdu_t *request,
                                         coap_pdu_t *response,
                                         coap_resource_t *resource,
@@ -93,7 +105,7 @@ int COAP_API coap_proxy_forward_request(coap_session_t *session,
 /**
  * Forward the returning response back to the appropriate client.
  *
- * @param session The session handling the response.
+ * @param rsp_session The upstream session receiving the response.
  * @param received The received PDU.
  * @param cache_key Updated with the cache key pointer provided to
  *                  coap_proxy_forward_request().  The caller should
@@ -102,7 +114,7 @@ int COAP_API coap_proxy_forward_request(coap_session_t *session,
  *
  * @return One of COAP_RESPONSE_FAIL or COAP_RESPONSE_OK.
  */
-coap_response_t COAP_API coap_proxy_forward_response(coap_session_t *session,
+coap_response_t COAP_API coap_proxy_forward_response(coap_session_t *rsp_session,
                                                      const coap_pdu_t *received,
                                                      coap_cache_key_t **cache_key);
 

--- a/include/coap3/coap_proxy_internal.h
+++ b/include/coap3/coap_proxy_internal.h
@@ -71,7 +71,7 @@ void coap_proxy_remove_association(coap_session_t *session, int send_failure);
  * Forward incoming request upstream to the next proxy/server.
  *
  * Possible scenarios:
- *  Acting as a reverse proxy - connect to internal server
+ *  Acting as a reverse proxy - connect to defined internal server
  *   (possibly round robin load balancing over multiple servers).
  *  Acting as a forward proxy - connect to host defined in Proxy-Uri
  *   or Proxy-Scheme with Uri-Host (and maybe Uri-Port).

--- a/include/coap3/coap_resource_internal.h
+++ b/include/coap3/coap_resource_internal.h
@@ -58,6 +58,7 @@ struct coap_resource_t {
   unsigned int cacheable:1;      /**< can be cached */
   unsigned int is_unknown:1;     /**< resource created for unknown handler */
   unsigned int is_proxy_uri:1;   /**< resource created for proxy URI handler */
+  unsigned int is_reverse_proxy:1; /**< resource created for reverse proxy URI handler */
 
   /**
    * Used to store handlers for the seven coap methods @c GET, @c POST, @c PUT,

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -61,7 +61,7 @@ OPTIONS - General
    Echo back the data sent with a PUT.
 
 *-f* scheme://address[:port]::
-   Act as a reverse proxy where scheme, address, optional
+   Act as a reverse proxy where scheme, address and optional
    port define how to connect to the internal server.
    Scheme is one of coap, coaps, coap+tcp, coaps+tcp,
    coap+ws, and coaps+ws. http(s) is not currently supported.

--- a/man/coap_proxy.txt.in
+++ b/man/coap_proxy.txt.in
@@ -20,12 +20,12 @@ SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
 
-*int coap_proxy_forward_request(coap_session_t *_session_,
+*int coap_proxy_forward_request(coap_session_t *_req_session_,
 const coap_pdu_t *_request_, coap_pdu_t *_response_,
 coap_resource_t *_resource_, coap_cache_key_t *_cache_key_,
 coap_proxy_server_list_t *_server_list_);*
 
-*coap_response_t coap_proxy_forward_response(coap_session_t *_session_,
+*coap_response_t coap_proxy_forward_response(coap_session_t *_rsp_session_,
                             const coap_pdu_t *_received_,
                             coap_cache_key_t **_cache_key_);*
 
@@ -41,11 +41,63 @@ or *-lcoap-@LIBCOAP_API_VERSION@-tinydtls*.   Otherwise, link with
 DESCRIPTION
 -----------
 
-To simplify some of the CoAP proxy requirements, some of the proxy forwarding
-functionality is provided by libcoap.
+To simplify CoAP proxy requirements, proxy forwarding functionality is
+provided by libcoap for matching forwarded requests with returning responses.
 
-The resourse handlers to handle forward or reverse proxy requests are defined using
-*coap_resource_proxy_uri_init2*(3) or *coap_resource_reverse_proxy_init*(3).
+Two principal types of Proxy are supported.
+
+*Reverse*
+
+The *reverse* proxy intercepts all the traffic from the clients and sends off
+all of the requests to a defined (usually internal and protected) upstream
+server and passes back any responses to the requesting client. There is no
+differentiation between requests that contain a Proxy-Uri or Proxy-Scheme
+option and those that do not.
+
+*Forward*
+
+The *forward* proxy receives any request from the client that contains a Proxy-Uri
+or Proxy-Scheme option and then forwards the request to an upstream server. This
+server can either be derived from the Proxy-Uri or Proxy-Scheme option or be an
+explicitly configured server. The returning response is then sent back to the
+initiating client. If the determined IP address of the forward server matches
+one of the list of defined names this proxy server is known by, then the
+request is handled locally and not forwarded.
+
+The *forward* proxy has two modes of working.  The first, *forward-dynamic*,
+takes the information from the Proxy-Uri or Proxy-Scheme and forwards the
+request to the dynamically derived upstream server.  The second, *forward-static*
+always forwards the request to the defined upstream server.
+
+Before any of the proxy types pass on any information they, optionally,
+can strip out and appropriately replace any Proxy-Uri or Proxy-Scheme options to
+stop the upstream server from trying to do any further Proxy operations.
+
+*NOTE:* In the general case, *reverse* and *forward-dynamic* should be stripped,
+but *forward-static* not.
+
+It is possible to define multiple upstream servers for *reverse* and
+*forward-static* proxy types.  These will then be allocated to each new client
+session in a round-robin fashion.
+
+For the *forward-dynamic* proxy type, a dummy server needs to be defined if any
+specific PKI/PSK or OSCORE is required for the ongoing session to the dynamically
+determined upstream server. If client anonymous PKI only is required for
+ongoing encrypted sessions, then this dummy server does not need to be defined.
+
+For each upstream server, client sessions can all be multiplexed over a single
+upstream server session, or there can be the same number of upstream server
+sessions as there are client sessions.
+
+The proxy logic will convert between supported protocals - e.g. coap <> coaps+tcp
+for the incoming and upstream session. Conversions to/from http(s) are not
+currently supported.
+
+The resourse handler to handle *forward* proxy requests is defined using
+*coap_resource_proxy_uri_init2*(3).
+
+The resource handler to handle *reverse* proxy requests is defined using
+*coap_resource_reverse_proxy_init*(3).
 
 FUNCTIONS
 ---------
@@ -55,12 +107,18 @@ FUNCTIONS
 [source, c]
 ----
 typedef enum {
-  COAP_PROXY_REVERSE,       /* Act as a reverse proxy */
-  COAP_PROXY_REVERSE_STRIP, /* Act as a reverse proxy, strip out proxy options */
-  COAP_PROXY_FORWARD,       /* Act as a forward proxy */
-  COAP_PROXY_FORWARD_STRIP, /* Act as a forward proxy, strip out proxy options */
-  COAP_PROXY_DIRECT,        /* Act as a direct proxy */
-  COAP_PROXY_DIRECT_STRIP,  /* Act as a direct proxy, strip out proxy options */
+  COAP_PROXY_REVERSE,               /* Act as a reverse proxy */
+  COAP_PROXY_REVERSE_STRIP,         /* Act as a reverse proxy,
+                                       strip out any proxy options */
+  COAP_PROXY_FORWARD_STATIC,        /* Act as a forward-static proxy */
+  COAP_PROXY_FORWARD_STATIC_STRIP,  /* Act as a forward-static proxy,
+                                       strip out any proxy options */
+  COAP_PROXY_FORWARD_DYNAMIC,       /* Act as a forward-dynamic proxy
+                                       using the request's Proxy-Uri or
+                                       Proxy-Scheme options to determine
+                                       server */
+  COAP_PROXY_FORWARD_DYNAMIC_STRIP, /* Act as a forward-dynamic proxy,
+                                       strip out proxy options */
 } coap_proxy_t;
 
 typedef struct coap_proxy_server_t {
@@ -72,53 +130,61 @@ typedef struct coap_proxy_server_t {
 
 typedef struct coap_proxy_server_list_t {
   coap_proxy_server_t *entry; /* Set of servers to connect to */
-  size_t entry_count;         /* The number of servers */
+  size_t entry_count;         /* The number of servers in entry list */
   size_t next_entry;          /* Next server to use (% entry_count) */
   coap_proxy_t type;          /* The proxy type */
   int track_client_session;   /* If 1, track individual connections to upstream
-                                 server, else 0 for all clients to share the same
-                                 ongoing session */
-  unsigned int idle_timeout_secs; /* Proxy session idle timeout (0 is no timeout) */
+                                 server, else 0 for all clients to share the
+                                 same ongoing session */
+  unsigned int idle_timeout_secs; /* Proxy upstream session idle timeout
+                                     (0 is no timeout) */
 } coap_proxy_server_list_t;
 ----
 
 The *coap_proxy_forward_request*() function is called from a request handler
 when the request needs to be forwarded to an upstream server with a possible
-change in protocol. _server_, _request_, _response_ and _resource_ are provided to
-the application's request handler. _cache_key_ can be a cache_key generated from
-the _request_ PDU or NULL.  This _cache_key_ will get passed into
-*coap_proxy_forward_response*(). _server_list_ defines the characteristics of one
-or more of the upstream servers to connect to. The definitions can cover the following
+change in protocol. _req_session_, _request_, _response_ and _resource_ are as
+provided to the application's request handler. _cache_key_ can be a cache_key
+generated from the _request_ PDU or NULL.  This _cache_key_ will get passed into
+*coap_proxy_forward_response*() when handling the response. _server_list_ defines
+the characteristics of zero or more of the upstream servers to connect to. The
+definitions can cover the following
 
 [source, c]
 ----
-Acting as a reverse proxy - connect to internal server
+Acting as a reverse proxy - connect to defined internal server
  (possibly round robin load balancing over multiple servers).
-Acting as a forward proxy - connect to host defined in Proxy-Uri
+Acting as a forward-dynamic proxy - connect to host defined in Proxy-Uri
  or Proxy-Scheme with Uri-Host (and maybe Uri-Port).
-Acting as a relay proxy - connect to defined upstream server
+Acting as a forward-static proxy - connect to defined upstream server
  (possibly round robin load balancing over multiple servers).
 ----
 
-If the entry_count of coap_proxy_server_list_t is more than 1, then the
+If the entry_count of *coap_proxy_server_list_t* is more than 1, then the
 ongoing session for each new request will get round-robined through the set
-of defined servers.
+of defined servers. If the entry_count of *coap_proxy_server_list_t* is 0,
+then the proxy type can only be *forward-dynamic*.
 
 The _response_ PDU is updated with the appropriate CoAP response code, and so the
-caller does not need to update this on error detection.
+caller does not need to update this on error detection after calling
+*coap_proxy_forward_request*().
+
+*coap_proxy_forward_request*() will establish a new ongoing session to the upstream
+server as and when required.
 
 *Function: coap_proxy_forward_response()*
 
 The *coap_proxy_forward_response*() function is used to forward on any response
 that comes back from the back-end server and given to the application's response
 handler. It will be forwarded on to the originating client doing any necessary
-changes in protocol. _session_ is the session given to the application's
-response handler, _received_ is the received PDU.  If the _cache_key_ parameter
-is not NULL, then it will get updated with the _cache_key_ provided to the
-*coap_proxy_forward_request*(). The caller should delete this cache key (unless
-the client request set up an Observe and there will be unsolicited responses).
-If _cache_key_ is not defined, but if a _cache_key_ was passed into
-*coap_proxy_forward_request*() it will get deleted.
+changes in protocol. _rsp_session_ is the session given to the application's
+response handler (created by *coap_proxy_forward_request*()), _received_ is the
+received PDU.  If the _cache_key_ parameter is not NULL, then it will get updated
+with the _cache_key_ provided to the *coap_proxy_forward_request*() request. The
+caller should delete this cache key (unless the client request set up an Observe
+and there will be unsolicited responses).
+If _cache_key_ is not defined, but a _cache_key_ was passed into
+*coap_proxy_forward_request*() then it will get deleted.
 
 *Function: coap_verify_proxy_scheme_supported()*
 
@@ -135,93 +201,48 @@ COAP_RESPONSE_FAIL.
 
 EXAMPLES
 --------
-*Forward Proxy Set Up*
-
-[source, c]
-----
-#include <coap@LIBCOAP_API_VERSION@/coap.h>
-
-static size_t proxy_host_name_count = 0;
-static const char **proxy_host_name_list = NULL;
-static coap_proxy_server_list_t forward_proxy = { NULL, 0, 0, COAP_PROXY_FORWARD, 0, 300};
-
-static void
-hnd_forward_proxy_uri(coap_resource_t *resource,
-                      coap_session_t *session,
-                      const coap_pdu_t *request,
-                      const coap_string_t *query COAP_UNUSED,
-                      coap_pdu_t *response) {
-
-  if (!coap_proxy_forward_request(session, request, response, resource,
-                                  NULL, &forward_proxy)) {
-    coap_log_debug("hnd_forward_proxy_uri: Failed to forward PDU\n");
-    /* Non ACK response code set on error detection */
-  }
-
-  /* Leave response code as is */
-}
-
-static coap_response_t
-proxy_response_handler(coap_session_t *session,
-                       const coap_pdu_t *sent COAP_UNUSED,
-                       const coap_pdu_t *received,
-                       const coap_mid_t id COAP_UNUSED) {
-  return coap_proxy_forward_response(session, received, NULL);
-}
-
-static void
-init_resources(coap_context_t *ctx) {
-
-  coap_resource_t *r;
-
-  /* See coap_resource_proxy_uri_init2(3) */
-  r = coap_resource_proxy_uri_init2(hnd_forward_proxy_uri, proxy_host_name_count,
-                                    proxy_host_name_list, 0);
-  coap_add_resource(ctx, r);
-  coap_register_response_handler(ctx, proxy_response_handler);
-  /* Add in event or nack handlers if required */
-}
-
-static void
-init_proxy_info(coap_uri_t *proxy_uri, const char *proxy_host_name) {
-  coap_proxy_server_t *new_entry;
-
-  new_entry = realloc(forward_proxy.entry,
-                      (forward_proxy.entry_count + 1)*sizeof(forward_proxy.entry[0]));
-
-  if (!new_entry) {
-    coap_log_err("CoAP Proxy realloc() error\n");
-    return;
-  }
-  /* Can have multiple of these upstream proxy hosts for doing round robin etc. */
-  forward_proxy.entry = new_entry;
-  memset(&forward_proxy.entry[forward_proxy.entry_count], 0, sizeof(forward_proxy.entry[0]));
-  forward_proxy.entry[forward_proxy.entry_count].uri = *proxy_uri;
-  forward_proxy.entry_count++;
-
-  /* The proxy host could be known by multile names - add them all in */
-  proxy_host_name_count = 0;
-  proxy_host_name_list = coap_malloc(proxy_host_name_count * sizeof(char *));
-  proxy_host_name_list[0] = proxy_host_name;
-}
-----
-
 *Reverse Proxy Set Up*
 
 [source, c]
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
-static coap_proxy_server_list_t reverse_proxy = { NULL, 0, 0, COAP_PROXY_REVERSE_STRIP, 0, 10};
+static const coap_uri_t uri = {
+  .host = {sizeof("1.2.3.4")-1, (const uint8_t *)"1.2.3.4"},
+  .port = 5683,
+  .path = {0, NULL},
+  .query = {0, NULL},
+  .scheme = COAP_URI_SCHEME_COAP /* Set to COAPS or COAPS_TCP for PSK/PKI */
+};
+static coap_proxy_server_t redirect_server[] = {
+  /*
+   * Could be multiple of these with different uri/encryption for doing
+   * a round-robin
+   */
+  {
+    .uri = uri,
+    .dtls_pki = NULL,     /* Define if PKI is to be used for upstream session */
+    .dtls_cpsk = NULL,    /* Define if PSK is to be used for upstream session */
+    .oscore_conf = NULL   /* Define if OSCORE is to be used for upstream session */
+  }
+};
+static coap_proxy_server_list_t reverse_proxy = {
+  .entry = redirect_server,
+  .entry_count = sizeof(redirect_server)/sizeof(redirect_server[0]),
+  .next_entry = 0,
+  .type = COAP_PROXY_REVERSE_STRIP,
+  .track_client_session = 0,
+  .idle_timeout_secs = 300
+};
 
 static void
 hnd_reverse_proxy_uri(coap_resource_t *resource,
-                      coap_session_t *session,
+                      coap_session_t *req_session,
                       const coap_pdu_t *request,
                       const coap_string_t *query COAP_UNUSED,
                       coap_pdu_t *response) {
 
-  if (!coap_proxy_forward_request(session, request, response, resource,
+  if (!coap_proxy_forward_request(req_session, request, response, resource,
                                   NULL, &reverse_proxy)) {
     coap_log_debug("hnd_reverse_proxy: Failed to forward PDU\n");
     /* Non ACK response code set on error detection */
@@ -231,11 +252,11 @@ hnd_reverse_proxy_uri(coap_resource_t *resource,
 }
 
 static coap_response_t
-proxy_response_handler(coap_session_t *session,
+proxy_response_handler(coap_session_t *rsp_session,
                        const coap_pdu_t *sent COAP_UNUSED,
                        const coap_pdu_t *received,
                        const coap_mid_t id COAP_UNUSED) {
-  return coap_proxy_forward_response(session, received, NULL);
+  return coap_proxy_forward_response(rsp_session, received, NULL);
 }
 
 static void
@@ -245,6 +266,138 @@ init_resources(coap_context_t *ctx) {
 
   /* See coap_resource_reverse_proxy_init(3) */
   r = coap_resource_reverse_proxy_init(hnd_reverse_proxy_uri, 0);
+  coap_add_resource(ctx, r);
+  coap_register_response_handler(ctx, proxy_response_handler);
+  /* Add in event or nack handlers if required */
+}
+----
+
+*Forward-dynamic Proxy Set Up (server derived from Proxy-Uri or Proxy-Scheme options*
+
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+static const char *proxy_host_name_list[2] = {
+  "myservername",
+  "1.2.3.5"          /* my server IP */
+};
+static coap_proxy_server_list_t forward_dynamic_proxy = {
+  .entry = NULL, /* Include dummy server with encryption definitions if needed */
+  .entry_count = 0, /* if 0 and encryption, client anonymous PKI used */
+  .next_entry = 0,
+  .type = COAP_PROXY_FORWARD_DYNAMIC_STRIP,
+  .track_client_session = 0,
+  .idle_timeout_secs = 10
+};
+
+static void
+hnd_forward_proxy_uri(coap_resource_t *resource,
+                      coap_session_t *req_session,
+                      const coap_pdu_t *request,
+                      const coap_string_t *query COAP_UNUSED,
+                      coap_pdu_t *response) {
+
+  if (!coap_proxy_forward_request(req_session, request, response, resource,
+                                  NULL, &forward_dynamic_proxy)) {
+    coap_log_debug("hnd_forward_proxy_uri: Failed to forward PDU\n");
+    /* Non ACK response code set on error detection */
+  }
+
+  /* Leave response code as is */
+}
+
+static coap_response_t
+proxy_response_handler(coap_session_t *rsp_session,
+                       const coap_pdu_t *sent COAP_UNUSED,
+                       const coap_pdu_t *received,
+                       const coap_mid_t id COAP_UNUSED) {
+  return coap_proxy_forward_response(rsp_session, received, NULL);
+}
+
+static void
+init_resources(coap_context_t *ctx) {
+
+  coap_resource_t *r;
+
+  /* See coap_resource_proxy_uri_init2(3) */
+  r = coap_resource_proxy_uri_init2(hnd_forward_proxy_uri,
+                                    sizeof(proxy_host_name_list)/sizeof(proxy_host_name_list[0]),
+                                    proxy_host_name_list, 0);
+  coap_add_resource(ctx, r);
+  coap_register_response_handler(ctx, proxy_response_handler);
+  /* Add in event or nack handlers if required */
+}
+----
+
+*Forward-static Proxy Set Up (to relay to defined server)*
+
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+static const char *proxy_host_name_list[2] = {
+  "myservername",
+  "1.2.3.5"          /* my server IP */
+};
+static const coap_uri_t uri = {
+  .host = {sizeof("1.2.3.4")-1, (const uint8_t *)"1.2.3.4"},
+  .port = 5683,
+  .path = {0, NULL},
+  .query = {0, NULL},
+  .scheme = COAP_URI_SCHEME_COAP /* Set to COAPS or COAPS_TCP for PSK/PKI */
+};
+static coap_proxy_server_t forward_static_server[] = {
+  /* Could be multiple of these with different uri for doing a round-robin */
+  {
+    .uri = uri,
+    .dtls_pki = NULL,     /* Define if PKI is to be used for upstream session */
+    .dtls_cpsk = NULL,    /* Define if PSK is to be used for upstream session */
+    .oscore_conf = NULL   /* Define if OSCORE is to be used for upstream session */
+  }
+};
+static coap_proxy_server_list_t forward_static_proxy = {
+  .entry = forward_static_server,
+  .entry_count = sizeof(forward_static_server)/sizeof(forward_static_server[0]),
+  .next_entry = 0,
+  .type = COAP_PROXY_FORWARD_STATIC,
+  .track_client_session = 0,
+  .idle_timeout_secs = 300
+};
+
+static void
+hnd_onward_proxy_uri(coap_resource_t *resource,
+                     coap_session_t *req_session,
+                     const coap_pdu_t *request,
+                     const coap_string_t *query COAP_UNUSED,
+                     coap_pdu_t *response) {
+
+  if (!coap_proxy_forward_request(req_session, request, response, resource,
+                                  NULL, &forward_static_proxy)) {
+    coap_log_debug("hnd_onward_proxy: Failed to forward PDU\n");
+    /* Non ACK response code set on error detection */
+  }
+
+  /* Leave response code as is */
+}
+
+static coap_response_t
+proxy_response_handler(coap_session_t *rsp_session,
+                       const coap_pdu_t *sent COAP_UNUSED,
+                       const coap_pdu_t *received,
+                       const coap_mid_t id COAP_UNUSED) {
+  return coap_proxy_forward_response(rsp_session, received, NULL);
+}
+
+static void
+init_resources(coap_context_t *ctx) {
+
+  coap_resource_t *r;
+
+  /* See coap_resource_proxy_uri_init2(3) */
+  r = coap_resource_proxy_uri_init2(hnd_onward_proxy_uri,
+                                    sizeof(proxy_host_name_list)/sizeof(proxy_host_name_list[0]),
+                                    proxy_host_name_list, 0);
   coap_add_resource(ctx, r);
   coap_register_response_handler(ctx, proxy_response_handler);
   /* Add in event or nack handlers if required */

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -236,7 +236,8 @@ context - attaching a new one overrides the previous definition.
 The *coap_resource_proxy_uri_init*() function returns a newly created
 _resource_ of type _coap_resource_t_ *. _proxy_handler_ is automatically added
 to the _resource_ to handle PUT/POST/GET etc. requests that use the Proxy-Uri
-option.  There is no need to add explicit request type handlers. One or more
+or Proxy-Scheme option.  There is no need to add explicit request type handlers.
+One or more
 names by which the proxy is known by (IP address, DNS name etc.) must be
 supplied in the array defined by _host_name_list_[] which has a count of
 _host_name_count_.  This is used to check whether the current endpoint is
@@ -248,12 +249,16 @@ server.
 The *coap_resource_proxy_uri_init2*() function returns a newly created
 _resource_ of type _coap_resource_t_ *. _proxy_handler_ is automatically added
 to the _resource_ to handle PUT/POST/GET etc. requests that use the Proxy-Uri
-option.  There is no need to add explicit request type handlers. One or more
+or Proxy-Scheme option.  There is no need to add explicit request type handlers.
+One or more
 names by which the proxy is known by (IP address, DNS name etc.) must be
 supplied in the array defined by _host_name_list_[] which has a count of
 _host_name_count_.  This is used to check whether the current endpoint is
 the proxy target address, or the request has to be passed on to an upstream
 server. _flags_ can be zero or more COAP_RESOURCE_FLAGS MCAST definitions.
+
+*NOTE:* If _host_name_count_ is 0, then _proxy_handler_ is not invoked and
+all traffic is handled on the local server.
 
 *NOTE:* There can only be one proxy resource handler per
 context - attaching a new one overrides the previous definition.
@@ -265,6 +270,9 @@ _resource_ of type _coap_resource_t_ *. _rev_proxy_handler_ is automatically add
 to the _resource_ to handle all the PUT/POST/GET etc. requests including
 .well-known/core. There is no need to add explicit request type handlers.
 _flags_ can be zero or more COAP_RESOURCE_FLAGS MCAST definitions.
+
+*NOTE:* All incoming request packets (including for .well-known/core) will
+get passed into _rev_proxy_handler_ unless it is for a locally defined resource.
 
 *NOTE:* There can only be one reverse-proxy or unknown resource handler per
 context - attaching a new one overrides the previous definition.

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -3286,20 +3286,22 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
 #endif /* COAP_ASYNC_SUPPORT */
 
   coap_option_filter_clear(&opt_filter);
-  opt = coap_check_option(pdu, COAP_OPTION_PROXY_SCHEME, &opt_iter);
-  if (opt) {
-    opt = coap_check_option(pdu, COAP_OPTION_URI_HOST, &opt_iter);
-    if (!opt) {
-      coap_log_debug("Proxy-Scheme requires Uri-Host\n");
-      resp = 402;
-      goto fail_response;
+  if (!(context->unknown_resource && context->unknown_resource->is_reverse_proxy)) {
+    opt = coap_check_option(pdu, COAP_OPTION_PROXY_SCHEME, &opt_iter);
+    if (opt) {
+      opt = coap_check_option(pdu, COAP_OPTION_URI_HOST, &opt_iter);
+      if (!opt) {
+        coap_log_debug("Proxy-Scheme requires Uri-Host\n");
+        resp = 402;
+        goto fail_response;
+      }
+      is_proxy_scheme = 1;
     }
-    is_proxy_scheme = 1;
-  }
 
-  opt = coap_check_option(pdu, COAP_OPTION_PROXY_URI, &opt_iter);
-  if (opt)
-    is_proxy_uri = 1;
+    opt = coap_check_option(pdu, COAP_OPTION_PROXY_URI, &opt_iter);
+    if (opt)
+      is_proxy_uri = 1;
+  }
 
   if (is_proxy_scheme || is_proxy_uri) {
     coap_uri_t uri;

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -84,9 +84,7 @@ coap_proxy_check_timeouts(coap_context_t *context, coap_tick_t now,
 static int
 coap_get_uri_proxy_scheme_info(const coap_pdu_t *request,
                                coap_opt_t *opt,
-                               coap_uri_t *uri,
-                               coap_string_t **uri_path,
-                               coap_string_t **uri_query) {
+                               coap_uri_t *uri) {
   const char *opt_val = (const char *)coap_opt_value(opt);
   int opt_len = coap_opt_length(opt);
   coap_opt_iterator_t opt_iter;
@@ -136,22 +134,6 @@ coap_get_uri_proxy_scheme_info(const coap_pdu_t *request,
     uri->port =
         coap_decode_var_bytes(coap_opt_value(opt),
                               coap_opt_length(opt));
-  }
-  *uri_path = coap_get_uri_path(request);
-  if (*uri_path) {
-    uri->path.s = (*uri_path)->s;
-    uri->path.length = (*uri_path)->length;
-  } else {
-    uri->path.s = NULL;
-    uri->path.length = 0;
-  }
-  *uri_query = coap_get_query(request);
-  if (*uri_query) {
-    uri->query.s = (*uri_query)->s;
-    uri->query.length = (*uri_query)->length;
-  } else {
-    uri->query.s = NULL;
-    uri->query.length = 0;
   }
   return 1;
 }
@@ -209,9 +191,7 @@ static coap_proxy_list_t *
 coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
                        coap_pdu_t *response,
                        coap_proxy_server_list_t *server_list,
-                       coap_proxy_server_t *server_use,
-                       coap_string_t **uri_path,
-                       coap_string_t **uri_query) {
+                       coap_proxy_server_t *server_use) {
   size_t i;
   coap_proxy_list_t *new_proxy_list;
   coap_proxy_list_t *proxy_list = session->context->proxy_list;
@@ -226,26 +206,28 @@ coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
   if (server_list->next_entry >= server_list->entry_count)
     server_list->next_entry = 0;
 
-  memcpy(server_use, &server_list->entry[server_list->next_entry], sizeof(*server_use));
+  if (server_list->entry_count) {
+    memcpy(server_use, &server_list->entry[server_list->next_entry], sizeof(*server_use));
+  } else {
+    memset(server_use, 0, sizeof(*server_use));
+  }
 
   switch (server_list->type) {
   case COAP_PROXY_REVERSE:
-  case COAP_PROXY_FORWARD:
-  case COAP_PROXY_DIRECT:
-    /* Nothing else needs to be done */
-    break;
   case COAP_PROXY_REVERSE_STRIP:
-  case COAP_PROXY_FORWARD_STRIP:
-  case COAP_PROXY_DIRECT_STRIP:
-    /* Need to get actual server from CoAP options */
+  case COAP_PROXY_FORWARD_STATIC:
+  case COAP_PROXY_FORWARD_STATIC_STRIP:
+    /* Nothing else needs to be done here */
+    break;
+  case COAP_PROXY_FORWARD_DYNAMIC:
+  case COAP_PROXY_FORWARD_DYNAMIC_STRIP:
+    /* Need to get actual server from CoAP Proxy-Uri or Proxy-Scheme options */
     /*
      * See if Proxy-Scheme
      */
     proxy_scheme = coap_check_option(request, COAP_OPTION_PROXY_SCHEME, &opt_iter);
     if (proxy_scheme) {
-      if (!coap_get_uri_proxy_scheme_info(request, proxy_scheme, &server_use->uri,
-                                          uri_path,
-                                          uri_query)) {
+      if (!coap_get_uri_proxy_scheme_info(request, proxy_scheme, &server_use->uri)) {
         response->code = COAP_RESPONSE_CODE(505);
         return NULL;
       }
@@ -272,20 +254,20 @@ coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
       response->code = COAP_RESPONSE_CODE(404);
       return NULL;
     }
-
-    if (server_use->uri.host.length == 0) {
-      /* Ongoing connection not well formed */
-      response->code = COAP_RESPONSE_CODE(505);
-      return NULL;
-    }
-
-    if (!coap_verify_proxy_scheme_supported(server_use->uri.scheme)) {
-      response->code = COAP_RESPONSE_CODE(505);
-      return NULL;
-    }
     break;
   default:
     assert(0);
+    return NULL;
+  }
+
+  if (server_use->uri.host.length == 0) {
+    /* Ongoing connection not well formed */
+    response->code = COAP_RESPONSE_CODE(505);
+    return NULL;
+  }
+
+  if (!coap_verify_proxy_scheme_supported(server_use->uri.scheme)) {
+    response->code = COAP_RESPONSE_CODE(505);
     return NULL;
   }
 
@@ -316,16 +298,18 @@ coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
   session->context->proxy_list = proxy_list = new_proxy_list;
   memset(&proxy_list[i], 0, sizeof(proxy_list[i]));
 
-  /* Keep a copy of the host as PDU pointed to will be going away */
+  /* Keep a copy of the host as server_use->uri pointed to will be going away */
   proxy_list[i].uri = server_use->uri;
   proxy_list[i].uri_host_keep = coap_malloc_type(COAP_STRING,
                                                  server_use->uri.host.length);
-  if (! proxy_list[i].uri_host_keep)
+  if (!proxy_list[i].uri_host_keep) {
+    response->code = COAP_RESPONSE_CODE(500);
     return NULL;
+  }
   memcpy(proxy_list[i].uri_host_keep, server_use->uri.host.s,
          server_use->uri.host.length);
   proxy_list[i].uri.host.s = proxy_list[i].uri_host_keep;
-  /* Unset uri parts which point to going away PDU */
+  /* Unset uri parts which point to going away information */
   proxy_list[i].uri.path.s = NULL;
   proxy_list[i].uri.path.length = 0;
   proxy_list[i].uri.query.s = NULL;
@@ -421,10 +405,7 @@ static coap_proxy_list_t *
 coap_proxy_get_ongoing_session(coap_session_t *session,
                                const coap_pdu_t *request,
                                coap_pdu_t *response,
-                               coap_proxy_server_list_t *server_list,
-                               coap_proxy_server_t *server_use,
-                               coap_string_t **uri_path,
-                               coap_string_t **uri_query) {
+                               coap_proxy_server_list_t *server_list) {
 
   coap_address_t dst;
   coap_proto_t proto;
@@ -432,25 +413,27 @@ coap_proxy_get_ongoing_session(coap_session_t *session,
   coap_proxy_list_t *proxy_entry;
   coap_context_t *context = session->context;
   static char client_sni[256];
+  coap_proxy_server_t server_use;
 
   proxy_entry = coap_proxy_get_session(session, request, response, server_list,
-                                       server_use, uri_path, uri_query);
+                                       &server_use);
   if (!proxy_entry) {
-    /* Response code should be set */
+    /* Error response code already set */
     return NULL;
   }
 
   if (!proxy_entry->ongoing) {
     /* Need to create a new session */
+    coap_address_t *local_addr = NULL;
 
     /* resolve destination address where data should be sent */
-    info_list = coap_resolve_address_info(&server_use->uri.host,
-                                          server_use->uri.port,
-                                          server_use->uri.port,
-                                          server_use->uri.port,
-                                          server_use->uri.port,
+    info_list = coap_resolve_address_info(&server_use.uri.host,
+                                          server_use.uri.port,
+                                          server_use.uri.port,
+                                          server_use.uri.port,
+                                          server_use.uri.port,
                                           0,
-                                          1 << server_use->uri.scheme,
+                                          1 << server_use.uri.scheme,
                                           COAP_RESOLVE_TYPE_REMOTE);
 
     if (info_list == NULL) {
@@ -462,22 +445,42 @@ coap_proxy_get_ongoing_session(coap_session_t *session,
     memcpy(&dst, &info_list->addr, sizeof(dst));
     coap_free_address_info(info_list);
 
-    snprintf(client_sni, sizeof(client_sni), "%*.*s", (int)server_use->uri.host.length,
-             (int)server_use->uri.host.length, server_use->uri.host.s);
+#if COAP_AF_UNIX_SUPPORT
+    coap_address_t bind_addr;
+    if (coap_is_af_unix(&dst)) {
+      char buf[COAP_UNIX_PATH_MAX];
 
-    switch (server_use->uri.scheme) {
+      /* Need a unique 'client' address */
+      snprintf(buf, COAP_UNIX_PATH_MAX,
+               "/tmp/coap-proxy-client");
+      if (!coap_address_set_unix_domain(&bind_addr, (const uint8_t *)buf,
+                                        strlen(buf))) {
+        fprintf(stderr, "coap_address_set_unix_domain: %s: failed\n",
+                buf);
+        remove(buf);
+        return NULL;
+      }
+      (void)remove(buf);
+      local_addr = &bind_addr;
+    }
+#endif /* COAP_AF_UNIX_SUPPORT */
+
+    snprintf(client_sni, sizeof(client_sni), "%*.*s", (int)server_use.uri.host.length,
+             (int)server_use.uri.host.length, server_use.uri.host.s);
+
+    switch (server_use.uri.scheme) {
     case COAP_URI_SCHEME_COAP:
     case COAP_URI_SCHEME_COAP_TCP:
     case COAP_URI_SCHEME_COAP_WS:
 #if COAP_OSCORE_SUPPORT
-      if (server_use->oscore_conf) {
+      if (server_use.oscore_conf) {
         proxy_entry->ongoing =
-            coap_new_client_session_oscore_lkd(context, NULL, &dst,
-                                               proto, server_use->oscore_conf);
+            coap_new_client_session_oscore_lkd(context, local_addr, &dst,
+                                               proto, server_use.oscore_conf);
       } else {
 #endif /* COAP_OSCORE_SUPPORT */
         proxy_entry->ongoing =
-            coap_new_client_session_lkd(context, NULL, &dst, proto);
+            coap_new_client_session_lkd(context, local_addr, &dst, proto);
 #if COAP_OSCORE_SUPPORT
       }
 #endif /* COAP_OSCORE_SUPPORT */
@@ -486,35 +489,37 @@ coap_proxy_get_ongoing_session(coap_session_t *session,
     case COAP_URI_SCHEME_COAPS_TCP:
     case COAP_URI_SCHEME_COAPS_WS:
 #if COAP_OSCORE_SUPPORT
-      if (server_use->oscore_conf) {
-        if (server_use->dtls_pki) {
-          server_use->dtls_pki->client_sni = client_sni;
+      if (server_use.oscore_conf) {
+        if (server_use.dtls_pki) {
+          server_use.dtls_pki->client_sni = client_sni;
           proxy_entry->ongoing =
-              coap_new_client_session_oscore_pki_lkd(context, NULL, &dst,
-                                                     proto, server_use->dtls_pki, server_use->oscore_conf);
-        } else if (server_use->dtls_cpsk) {
-          server_use->dtls_cpsk->client_sni = client_sni;
+              coap_new_client_session_oscore_pki_lkd(context, local_addr, &dst,
+                                                     proto, server_use.dtls_pki, server_use.oscore_conf);
+        } else if (server_use.dtls_cpsk) {
+          server_use.dtls_cpsk->client_sni = client_sni;
           proxy_entry->ongoing =
-              coap_new_client_session_oscore_psk_lkd(context, NULL, &dst,
-                                                     proto, server_use->dtls_cpsk, server_use->oscore_conf);
+              coap_new_client_session_oscore_psk_lkd(context, local_addr, &dst,
+                                                     proto, server_use.dtls_cpsk, server_use.oscore_conf);
         } else {
           coap_log_warn("Proxy: (D)TLS not configured for secure session\n");
         }
       } else {
 #endif /* COAP_OSCORE_SUPPORT */
         /* Not doing OSCORE */
-        if (server_use->dtls_pki) {
-          server_use->dtls_pki->client_sni = client_sni;
+        if (server_use.dtls_pki) {
+          server_use.dtls_pki->client_sni = client_sni;
           proxy_entry->ongoing =
-              coap_new_client_session_pki_lkd(context, NULL, &dst,
-                                              proto, server_use->dtls_pki);
-        } else if (server_use->dtls_cpsk) {
-          server_use->dtls_cpsk->client_sni = client_sni;
+              coap_new_client_session_pki_lkd(context, local_addr, &dst,
+                                              proto, server_use.dtls_pki);
+        } else if (server_use.dtls_cpsk) {
+          server_use.dtls_cpsk->client_sni = client_sni;
           proxy_entry->ongoing =
-              coap_new_client_session_psk2_lkd(context, NULL, &dst,
-                                               proto, server_use->dtls_cpsk);
+              coap_new_client_session_psk2_lkd(context, local_addr, &dst,
+                                               proto, server_use.dtls_cpsk);
         } else {
-          coap_log_warn("Proxy: (D)TLS not configured for secure session\n");
+          /* Using client anonymous PKI */
+          proxy_entry->ongoing =
+              coap_new_client_session_lkd(context, local_addr, &dst, proto);
         }
 #if COAP_OSCORE_SUPPORT
       }
@@ -584,17 +589,14 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
   coap_optlist_t *optlist = NULL;
   coap_opt_t *option;
   coap_opt_iterator_t opt_iter;
-  coap_proxy_server_t server_use;
-  coap_string_t *uri_path = NULL;
-  coap_string_t *uri_query = NULL;
+  coap_uri_t uri;
 
   /* Set up ongoing session (if not already done) */
 
   proxy_entry = coap_proxy_get_ongoing_session(session, request, response,
-                                               server_list, &server_use,
-                                               &uri_path, &uri_query);
+                                               server_list);
   if (!proxy_entry) {
-    /* response code already set */
+    /* Error response code already set */
     return 0;
   }
 
@@ -626,11 +628,11 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
 
   switch (server_list->type) {
   case COAP_PROXY_REVERSE_STRIP:
-  case COAP_PROXY_FORWARD_STRIP:
-  case COAP_PROXY_DIRECT_STRIP:
+  case COAP_PROXY_FORWARD_STATIC_STRIP:
+  case COAP_PROXY_FORWARD_DYNAMIC_STRIP:
     /*
      * Need to replace Proxy-Uri with Uri-Host (and Uri-Port)
-     * or strip out Proxy-Scheme.
+     * and strip out Proxy-Scheme.
      */
 
     /*
@@ -647,21 +649,23 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
       goto failed;
     }
 
-    if (!coap_uri_into_optlist(&server_use.uri,
-                               &proxy_entry->ongoing->addr_info.remote,
-                               &optlist, 1)) {
-      coap_log_err("Failed to create options for URI\n");
-      goto failed;
-    }
-    /* Finished with server_use, so release computed options */
-    coap_delete_string(uri_path);
-    coap_delete_string(uri_query);
-
     /* Copy the remaining options across */
     coap_option_iterator_init(request, &opt_iter, COAP_OPT_ALL);
     while ((option = coap_option_next(&opt_iter))) {
       switch (opt_iter.number) {
       case COAP_OPTION_PROXY_URI:
+        if (coap_split_proxy_uri(coap_opt_value(option),
+                                 coap_opt_length(option),
+                                 &uri) < 0) {
+          /* Need to return a 5.05 RFC7252 Section 5.7.2 */
+          coap_log_warn("Proxy URI not decodable\n");
+          coap_delete_pdu_lkd(pdu);
+          return 0;
+        }
+        if (!coap_uri_into_optlist(&uri, NULL, &optlist, 0)) {
+          coap_log_err("Failed to create options for URI\n");
+          goto failed;
+        }
         break;
       case COAP_OPTION_PROXY_SCHEME:
         break;
@@ -670,6 +674,9 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
       case COAP_OPTION_Q_BLOCK1:
       case COAP_OPTION_Q_BLOCK2:
         /* These are not passed on */
+        break;
+      case COAP_OPTION_URI_HOST:
+      case COAP_OPTION_URI_PORT:
         break;
       default:
         coap_insert_optlist(&optlist,
@@ -685,8 +692,8 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
     coap_delete_optlist(optlist);
     break;
   case COAP_PROXY_REVERSE:
-  case COAP_PROXY_FORWARD:
-  case COAP_PROXY_DIRECT:
+  case COAP_PROXY_FORWARD_STATIC:
+  case COAP_PROXY_FORWARD_DYNAMIC:
   default:
     /*
      * Duplicate request PDU for onward transmission (with new token).

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -325,10 +325,6 @@ coap_resource_proxy_uri_init2(coap_method_handler_t handler,
                               const char *host_name_list[], int flags) {
   coap_resource_t *r;
 
-  if (host_name_count == 0) {
-    coap_log_err("coap_resource_proxy_uri_init: Must have one or more host names defined\n");
-    return NULL;
-  }
   r = (coap_resource_t *)coap_malloc_type(COAP_RESOURCE, sizeof(coap_resource_t));
   if (r) {
     size_t i;
@@ -386,6 +382,7 @@ coap_resource_reverse_proxy_init(coap_method_handler_t handler, int flags) {
   if (r) {
     memset(r, 0, sizeof(coap_resource_t));
     r->is_unknown = 1;
+    r->is_reverse_proxy = 1;
     /* Something unlikely to be used, but it shows up in the logs */
     r->uri_path = coap_new_str_const(coap_rev_proxy_resource_uri,
                                      sizeof(coap_rev_proxy_resource_uri)-1);


### PR DESCRIPTION
Tidy up naming to reduce confusion between supported proxy types.

Provides simpler proxy examples.

Fixes issue with COAP_PROXY_REVERSE_STRIP.

Support upstream server using AF_UNIX.