### PR TITLE
coap_threadsafe_internal.h: Fix coap_lock_invert.

### DIFF
--- a/include/coap3/coap_threadsafe_internal.h
+++ b/include/coap3/coap_threadsafe_internal.h
@@ -567,7 +567,7 @@ typedef coap_mutex_t coap_lock_t;
  * @param failed Code to execute on lock failure.
  *
  */
-#define coap_lock_invert(c,alt_lock,failed) func
+#define coap_lock_invert(c,alt_lock,failed) alt_lock
 
 #endif /* ! COAP_THREAD_SAFE */
 


### PR DESCRIPTION
This code fails to compile if COAP_THREAD_SAFE is false as the macro parameter is "alt_lock" not "func".