### PR TITLE
fix coap_socket_strerror() on Windows

### DIFF
--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -2060,7 +2060,8 @@ coap_socket_format_errno(int error) {
 #ifdef _WIN32
 const char *
 coap_socket_strerror(void) {
-  return coap_socket_format_errno(WSAGetLastError());
+  coap_win_error_to_errno();
+  return coap_socket_format_errno(errno);
 }
 #else /* _WIN32 */
 const char *


### PR DESCRIPTION
The Windows version of `coap_socket_strerror` calls `coap_socket_format_errno` with the result of `WSAGetLastError`. At least in my specific case, this results in an "unknown error" message as `WSAGetLastError` seems to use different numbers than `strerror`.

`coap_io_process_with_fds_lkd` tries to translate `WSAGetLastError` to `errno` with `coap_win_error_to_errno` but the Windows version of `coap_socket_strerror` does not use errno, so `coap_win_error_to_errno` is called in vain.

With this patch, `coap_win_error_to_errno` is always called in the Windows version of `coap_socket_strerror` and then `errno`is passed to `coap_socket_format_errno` and therefore `strerror`.