### PR TITLE
coap_io: do not call select() for contexts without sockets on Windows

### DIFF
--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1848,13 +1848,18 @@ coap_io_process_with_fds_lkd(coap_context_t *ctx, uint32_t timeout_ms,
     tv.tv_sec = (long)(timeout / 1000);
   }
 
-  /* Unlock so that other threads can lock/update ctx */
-  coap_lock_unlock(ctx);
+  /* on Windows select will return an error if called without FDs */
+  if (nfds > 0) {
+    /* Unlock so that other threads can lock/update ctx */
+    coap_lock_unlock(ctx);
 
-  result = select((int)nfds, &ctx->readfds, &ctx->writefds, &ctx->exceptfds,
-                  timeout > 0 ? &tv : NULL);
+    result = select((int)nfds, &ctx->readfds, &ctx->writefds, &ctx->exceptfds,
+                    timeout > 0 ? &tv : NULL);
 
-  coap_lock_lock(ctx, return -1);
+    coap_lock_lock(ctx, return -1);
+  } else {
+    result = 0;
+  }
 
   if (result < 0) {   /* error */
 #ifdef _WIN32


### PR DESCRIPTION
Hello,

in a NodeJS environment, my wrapper library for libcoap maintains the list of created contexts and provides a loop() function that will call `coap_io_process` with every context and `COAP_IO_NO_WAIT` every few milliseconds (as we do not have threads or proper access to the internal event loop). If I create an "empty" context without sessions or endpoints early on while this loop is running, we see errors from the `select()` call in coap_io.c if we start this application on Windows. In this application, we start client sessions in this context later on certain events.

After comparing the documentation for `select()` on Windows [1] and Linux [2], it looks to me like the Windows version does not like being called without file descriptors/sockets. I applied this patch and it seems to work without error messages so far.

I could add code in my wrapper to call `coap_io_process` only for contexts with active sockets but I think this patch might also benefit others. Maybe it would even make sense to skip more code in this function if the context has no sockets. What do you think?

Thank you!

[1] https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-select
[2] https://man7.org/linux/man-pages/man2/select.2.html