### PR TITLE
coap_openssl.c: Clear thread errors before doing read/write for TLS

### DIFF
--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -3932,6 +3932,7 @@ coap_tls_write(coap_session_t *session, const uint8_t *data, size_t data_len) {
 
   in_init = !SSL_is_init_finished(ssl);
   session->dtls_event = -1;
+  ERR_clear_error();
   r = SSL_write(ssl, data, (int)data_len);
 
   if (r <= 0) {
@@ -4011,6 +4012,7 @@ coap_tls_read(coap_session_t *session, uint8_t *data, size_t data_len) {
 
   in_init = !SSL_is_init_finished(ssl);
   session->dtls_event = -1;
+  ERR_clear_error();
   r = SSL_read(ssl, data, (int)data_len);
   if (r <= 0) {
     int err = SSL_get_error(ssl, r);


### PR DESCRIPTION
When using multi-threads, if a thread does i/o, but previously that thread had an SSL error which has not been properly cleared, then the read or write will fail with SSL_ERROR_SSL.

Make sure that there are no errors before doing `SSL_read()` or `SSL_write()`.