### PR TITLE
App Data: Provide new set of storing app data in various structures

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -516,6 +516,7 @@ hnd_put_example_data(coap_resource_t *resource,
 
   if (coap_get_data_large(request, &size, &data, &offset, &total) &&
       size != total) {
+    coap_binary_t *old_data_in_cache;
     /*
      * A part of the data has been received (COAP_BLOCK_SINGLE_BODY not set).
      * However, total unfortunately is only an indication, so it is not safe to
@@ -543,8 +544,8 @@ hnd_put_example_data(coap_resource_t *resource,
                                            COAP_CACHE_NOT_RECORD_PDU,
                                            COAP_CACHE_IS_SESSION_BASED, 0);
       } else {
-        coap_delete_binary(coap_cache_get_app_data(cache_entry));
-        coap_cache_set_app_data(cache_entry, NULL, NULL);
+        old_data_in_cache = coap_cache_set_app_data2(cache_entry, NULL, NULL);
+        coap_delete_binary(old_data_in_cache);
       }
     }
     if (!cache_entry) {
@@ -563,12 +564,11 @@ hnd_put_example_data(coap_resource_t *resource,
       data_so_far = coap_block_build_body(data_so_far, size, data,
                                           offset, total);
       /* Yes, data_so_far can be NULL if error */
-      coap_cache_set_app_data(cache_entry, data_so_far, cache_free_app_data);
+      coap_cache_set_app_data2(cache_entry, data_so_far, cache_free_app_data);
     }
     if (offset + size == total) {
       /* All the data is now in */
-      data_so_far = coap_cache_get_app_data(cache_entry);
-      coap_cache_set_app_data(cache_entry, NULL, NULL);
+      data_so_far = coap_cache_set_app_data2(cache_entry, NULL, NULL);
     } else {
       /* Give us the next block response */
       coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTINUE);
@@ -867,6 +867,7 @@ hnd_put_post(coap_resource_t *resource,
 
   if (coap_get_data_large(request, &size, &data, &offset, &total) &&
       size != total) {
+    coap_binary_t *old_data_in_cache;
     /*
      * A part of the data has been received (COAP_BLOCK_SINGLE_BODY not set).
      * However, total unfortunately is only an indication, so it is not safe to
@@ -889,8 +890,8 @@ hnd_put_post(coap_resource_t *resource,
                                            COAP_CACHE_NOT_RECORD_PDU,
                                            COAP_CACHE_IS_SESSION_BASED, 0);
       } else {
-        coap_delete_binary(coap_cache_get_app_data(cache_entry));
-        coap_cache_set_app_data(cache_entry, NULL, NULL);
+        old_data_in_cache = coap_cache_set_app_data2(cache_entry, NULL, NULL);
+        coap_delete_binary(old_data_in_cache);
       }
     }
     if (!cache_entry) {
@@ -924,12 +925,11 @@ hnd_put_post(coap_resource_t *resource,
         }
       }
       /* Yes, data_so_far can be NULL */
-      coap_cache_set_app_data(cache_entry, data_so_far, cache_free_app_data);
+      coap_cache_set_app_data2(cache_entry, data_so_far, cache_free_app_data);
     }
     if (offset + size == total) {
       /* All the data is now in */
-      data_so_far = coap_cache_get_app_data(cache_entry);
-      coap_cache_set_app_data(cache_entry, NULL, NULL);
+      data_so_far = coap_cache_set_app_data2(cache_entry, NULL, NULL);
     } else {
       coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTINUE);
       return;

--- a/include/coap3/coap_async.h
+++ b/include/coap3/coap_async.h
@@ -99,10 +99,12 @@ COAP_API coap_async_t *coap_find_async(coap_session_t *session, coap_bin_const_t
  * Set the application data pointer held in @p async. This overwrites any
  * existing data pointer.
  *
+ * @deprecated Use coap_async_set_app_data2() instead.
+ *
  * @param async The async state object.
  * @param app_data The pointer to the data.
  */
-void coap_async_set_app_data(coap_async_t *async, void *app_data);
+COAP_DEPRECATED void coap_async_set_app_data(coap_async_t *async, void *app_data);
 
 /**
  * Gets the application data pointer held in @p async.
@@ -112,6 +114,26 @@ void coap_async_set_app_data(coap_async_t *async, void *app_data);
  * @return The applicaton data pointer.
  */
 void *coap_async_get_app_data(const coap_async_t *async);
+
+/**
+ * Stores @p data with the given async, returning the previously stored
+ * value or NULL. The data @p callback can be defined if the data is to be
+ * released when the cache_entry is deleted.
+ *
+ * Note: It is the responsibility of the caller to free off (if appropriate) any
+ * returned data.
+ *
+ * @param async_entry The async state object.
+ * @param data The pointer to the data to store or NULL to just clear out the
+ *             previous data.
+ * @param callback The optional release call-back for data on async
+ *                 removal or NULL.
+ *
+ * @return The previous data (if any) stored in the async.
+ */
+COAP_API void *coap_async_set_app_data2(coap_async_t *async_entry,
+                                        void *data,
+                                        coap_app_data_free_callback_t callback);
 
 /** @} */
 

--- a/include/coap3/coap_async_internal.h
+++ b/include/coap3/coap_async_internal.h
@@ -38,7 +38,9 @@ struct coap_async_t {
                              0 indicates never trigger */
   coap_session_t *session;         /**< transaction session */
   coap_pdu_t *pdu;                 /**< copy of request pdu */
-  void *appdata;                   /**< User definable data pointer */
+  void *app_data;                   /**< User definable data pointer */
+  coap_app_data_free_callback_t app_cb; /**< callcack to call when async is
+                                             being released (or NULL) */
 };
 
 /**
@@ -118,6 +120,28 @@ void coap_async_trigger_lkd(coap_async_t *async);
  *                 wait forever.
  */
 void coap_async_set_delay_lkd(coap_async_t *async, coap_tick_t delay);
+
+/**
+ * Stores @p data with the given async, returning the previously stored
+ * value or NULL. The data @p callback can be defined if the data is to be
+ * released when the cache_entry is deleted.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * Note: It is the responsibility of the caller to free off (if appropriate) any
+ * returned data.
+ *
+ * @param async_entry The async state object.
+ * @param data The pointer to the data to store or NULL to just clear out the
+ *             previous data.
+ * @param callback The optional release call-back for data on async
+ *                 removal or NULL.
+ *
+ * @return The previous data (if any) stored in the async.
+ */
+void *coap_async_set_app_data2_lkd(coap_async_t *async_entry,
+                                   void *data,
+                                   coap_app_data_free_callback_t callback);
 
 /**
  * Releases the memory that was allocated by coap_register_async() for the

--- a/include/coap3/coap_cache.h
+++ b/include/coap3/coap_cache.h
@@ -209,14 +209,37 @@ const coap_pdu_t *coap_cache_get_pdu(const coap_cache_entry_t *cache_entry);
  * overwrites any value that has previously been stored with @p
  * cache_entry.
  *
+ * @deprecated Use coap_cache_set_app_data2() instead.
+ *
  * @param cache_entry The CoAP cache entry.
  * @param data The data pointer to store with wih the cache entry. Note that
  *             this data must be valid during the lifetime of @p cache_entry.
  * @param callback The callback to call to free off this data when the
  *                 cache-entry is deleted, or @c NULL if not required.
  */
-void coap_cache_set_app_data(coap_cache_entry_t *cache_entry, void *data,
-                             coap_cache_app_data_free_callback_t callback);
+COAP_DEPRECATED void coap_cache_set_app_data(coap_cache_entry_t *cache_entry,
+                                             void *data,
+                                             coap_app_data_free_callback_t callback);
+
+/**
+ * Stores @p data with the given cache_entry, returning the previously stored
+ * value or NULL. The data @p callback can be defined if the data is to be
+ * released when the cache_entry is deleted.
+ *
+ * Note: It is the responsibility of the caller to free off (if appropriate) any
+ * returned data.
+ *
+ * @param cache_entry The CoAP cache entry.
+ * @param data The pointer to the data to store or NULL to just clear out the
+ *             previous data.
+ * @param callback The optional release call-back for data on cache_entry
+ *                 removal or NULL.
+ *
+ * @return The previous data (if any) stored in the cache_entry.
+ */
+COAP_API void *coap_cache_set_app_data2(coap_cache_entry_t *cache_entry,
+                                        void *data,
+                                        coap_app_data_free_callback_t callback);
 
 /**
  * Returns any application-specific data that has been stored with @p

--- a/include/coap3/coap_cache_internal.h
+++ b/include/coap3/coap_cache_internal.h
@@ -46,7 +46,7 @@ struct coap_cache_entry_t {
   void *app_data;
   coap_tick_t expire_ticks;
   unsigned int idle_timeout;
-  coap_cache_app_data_free_callback_t callback;
+  coap_app_data_free_callback_t app_cb;
 };
 
 /**
@@ -138,6 +138,28 @@ coap_cache_entry_t *coap_new_cache_entry_lkd(coap_session_t *session,
                                              coap_cache_record_pdu_t record_pdu,
                                              coap_cache_session_based_t session_based,
                                              unsigned int idle_time);
+
+/**
+ * Stores @p data with the given cache_entry, returning the previously stored
+ * value or NULL. The data @p callback can be defined if the data is to be
+ * released when the cache_entry is deleted.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * Note: It is the responsibility of the caller to free off (if appropriate) any
+ * returned data.
+ *
+ * @param cache_entry The CoAP cache entry.
+ * @param data The pointer to the data to store or NULL to just clear out the
+ *             previous data.
+ * @param callback The optional release call-back for data on cache_entry
+ *                 removal or NULL.
+ *
+ * @return The previous data (if any) stored in the cache_entry.
+ */
+void *coap_cache_set_app_data2_lkd(coap_cache_entry_t *cache_entry,
+                                   void *data,
+                                   coap_app_data_free_callback_t callback);
 
 typedef void coap_digest_ctx_t;
 

--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -417,7 +417,7 @@ COAP_API void coap_free_context(coap_context_t *context);
  * @param data The data to store with wih the context. Note that this data
  *             must be valid during the lifetime of @p context.
  */
-void coap_set_app_data(coap_context_t *context, void *data);
+COAP_DEPRECATED void coap_set_app_data(coap_context_t *context, void *data);
 
 /**
  * @deprecated Use coap_context_get_app_data() instead.
@@ -430,7 +430,7 @@ void coap_set_app_data(coap_context_t *context, void *data);
  *
  * @return The data previously stored or @c NULL if not data stored.
  */
-void *coap_get_app_data(const coap_context_t *context);
+COAP_DEPRECATED void *coap_get_app_data(const coap_context_t *context);
 
 /**
  * Creates a new ACK PDU with specified error @p code. The options specified by
@@ -634,10 +634,32 @@ void coap_mcast_per_resource(coap_context_t *context);
  * Stores @p data with the given context. This function overwrites any value
  * that has previously been stored with @p context.
  *
+ * @deprecated Use coap_context_set_app_data2() instead.
+ *
  * @param context The CoAP context.
  * @param data The pointer to the data to store.
  */
-void coap_context_set_app_data(coap_context_t *context, void *data);
+COAP_DEPRECATED void coap_context_set_app_data(coap_context_t *context,
+                                               void *data);
+
+/**
+ * Stores @p data with the given context, returning the previously stored
+ * value or NULL. The data @p callback can be defined if the data is to be
+ * released when the context is deleted.
+ *
+ * Note: It is the responsibility of the caller to free off (if appropriate) any
+ * returned data.
+ *
+ * @param context The CoAP context.
+ * @param data The pointer to the data to store or NULL to just clear out the
+ *             previous data.
+ * @param callback The optional release call-back for data on context
+ *                 removal or NULL.
+ *
+ * @return The previous data (if any) stored in the context.
+ */
+COAP_API void *coap_context_set_app_data2(coap_context_t *context, void *data,
+                                          coap_app_data_free_callback_t callback);
 
 /**
  * Returns any application-specific data that has been stored with @p

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -171,7 +171,8 @@ struct coap_context_t {
   size_t cache_ignore_count;       /**< The number of CoAP options to ignore
                                         when creating a cache-key */
 #endif /* COAP_SERVER_SUPPORT */
-  void *app;                       /**< application-specific data */
+  void *app_data;                  /**< application-specific data */
+  coap_app_data_free_callback_t app_cb; /**< call-back to release app_data */
   uint32_t max_token_size;         /**< Largest token size supported RFC8974 */
   coap_tick_t next_timeout;        /**< When the next timeout is to occur */
 #ifdef COAP_EPOLL_SUPPORT
@@ -476,6 +477,27 @@ int coap_client_delay_first(coap_session_t *session);
  * @param context The current coap_context_t object to free off.
  */
 void coap_free_context_lkd(coap_context_t *context);
+
+/**
+ * Stores @p data with the given context, returning the previously stored
+ * value or NULL. The data @p callback can be defined if the data is to be
+ * released when the context is deleted.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * Note: It is the responsibility of the caller to free off (if appropriate) any
+ * returned data.
+ *
+ * @param context The CoAP context.
+ * @param data The pointer to the data to store or NULL to just clear out the
+ *             previous data.
+ * @param callback The optional release call-back for data on context
+ *                 removal or NULL.
+ *
+ * @return The previous data (if any) stored in the context.
+ */
+void *coap_context_set_app_data2_lkd(coap_context_t *context, void *data,
+                                     coap_app_data_free_callback_t callback);
 
 /**
  * Invokes the event handler of @p context for the given @p event and

--- a/include/coap3/coap_session.h
+++ b/include/coap3/coap_session.h
@@ -91,21 +91,52 @@ COAP_API void coap_session_disconnected(coap_session_t *session,
  * Stores @p data with the given session. This function overwrites any value
  * that has previously been stored with @p session.
  *
+ * @deprecated Use coap_session_set_app_data2() instead.
+ *
  * @param session The CoAP session.
  * @param data The pointer to the data to store.
  */
-void coap_session_set_app_data(coap_session_t *session, void *data);
+COAP_DEPRECATED void coap_session_set_app_data(coap_session_t *session,
+                                               void *data);
 
 /**
  * Returns any application-specific data that has been stored with @p
- * session using the function coap_session_set_app_data(). This function will
- * return @c NULL if no data has been stored.
+ * session using the function coap_session_set_app_data() or
+ * coap_session_set_app_data2(). This function will return @c NULL if no
+ * data has been stored.
  *
  * @param session The CoAP session.
  *
  * @return Pointer to the stored data or @c NULL.
  */
 void *coap_session_get_app_data(const coap_session_t *session);
+
+/**
+ * Callback to free off the app data when the entry is
+ * being deleted / freed off.
+ *
+ * @param data  The app data to be freed off.
+ */
+typedef void (*coap_app_data_free_callback_t)(void *data);
+
+/**
+ * Stores @p data with the given session, returning the previously stored
+ * value or NULL. The data @p callback can be defined if the data is to be
+ * released when the session is deleted.
+ *
+ * Note: It is the responsibility of the caller to free off (if appropriate) any
+ * returned data.
+ *
+ * @param session The CoAP session.
+ * @param data The pointer to the data to store or NULL to just clear out the
+ *             previous data.
+ * @param callback The optional release call-back for data on session
+ *                 removal or NULL.
+ *
+ * @return The previous data (if any) stored in the session.
+ */
+COAP_API void *coap_session_set_app_data2(coap_session_t *session, void *data,
+                                          coap_app_data_free_callback_t callback);
 
 /**
  * Get the remote IP address and port from the session.

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -143,7 +143,8 @@ struct coap_session_t {
                                       contained in context->spsk_setup_data
 
                                       Value maintained internally */
-  void *app;                        /**< application-specific data */
+  void *app_data;                     /**< application-specific data */
+  coap_app_data_free_callback_t app_cb; /**< call-back to release app_data */
   coap_fixed_point_t ack_timeout;   /**< timeout waiting for ack
                                          (default 2.0 secs) */
   coap_fixed_point_t ack_random_factor; /**< ack random factor backoff (default
@@ -613,6 +614,27 @@ coap_session_t *coap_session_new_dtls_session(coap_session_t *session,
  *
  */
 void coap_session_server_keepalive_failed(coap_session_t *session);
+
+/**
+ * Stores @p data with the given session, returning the previously stored
+ * value or NULL. The data @p callback can be defined if the data is to be
+ * released when the session is deleted.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * Note: It is the responsibility of the caller to free off (if appropriate) any
+ * returned data.
+ *
+ * @param session The CoAP session.
+ * @param data The pointer to the data to store or NULL to just clear out the
+ *             previous data.
+ * @param callback The optional release call-back for data on session
+ *                 removal or NULL.
+ *
+ * @return The previous data (if any) stored in the session.
+ */
+void *coap_session_set_app_data2_lkd(coap_session_t *session, void *data,
+                                     coap_app_data_free_callback_t callback);
 
 void coap_session_free(coap_session_t *session);
 void coap_session_mfree(coap_session_t *session);

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -21,6 +21,7 @@ global:
   coap_af_unix_is_supported;
   coap_async_get_app_data;
   coap_async_is_supported;
+  coap_async_set_app_data2;
   coap_async_set_app_data;
   coap_async_set_delay;
   coap_async_trigger;
@@ -33,6 +34,7 @@ global:
   coap_cache_get_by_pdu;
   coap_cache_get_pdu;
   coap_cache_ignore_options;
+  coap_cache_set_app_data2;
   coap_cache_set_app_data;
   coap_can_exit;
   coap_cancel_observe;
@@ -52,6 +54,7 @@ global:
   coap_context_get_max_idle_sessions;
   coap_context_get_session_timeout;
   coap_context_oscore_server;
+  coap_context_set_app_data2;
   coap_context_set_app_data;
   coap_context_set_block_mode;
   coap_context_set_cid_tuple_change;
@@ -277,6 +280,7 @@ global:
   coap_session_send_ping;
   coap_session_set_ack_random_factor;
   coap_session_set_ack_timeout;
+  coap_session_set_app_data2;
   coap_session_set_app_data;
   coap_session_set_default_leisure;
   coap_session_set_max_payloads;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -20,6 +20,7 @@ coap_af_unix_is_supported
 coap_async_get_app_data
 coap_async_is_supported
 coap_async_set_app_data
+coap_async_set_app_data2
 coap_async_set_delay
 coap_async_trigger
 coap_attr_get_value
@@ -32,6 +33,7 @@ coap_cache_get_by_pdu
 coap_cache_get_pdu
 coap_cache_ignore_options
 coap_cache_set_app_data
+coap_cache_set_app_data2
 coap_can_exit
 coap_cancel_observe
 coap_check_notify
@@ -51,6 +53,7 @@ coap_context_get_max_idle_sessions
 coap_context_get_session_timeout
 coap_context_oscore_server
 coap_context_set_app_data
+coap_context_set_app_data2
 coap_context_set_block_mode
 coap_context_set_cid_tuple_change
 coap_context_set_csm_max_message_size
@@ -276,6 +279,7 @@ coap_session_send_ping
 coap_session_set_ack_random_factor
 coap_session_set_ack_timeout
 coap_session_set_app_data
+coap_session_set_app_data2
 coap_session_set_default_leisure
 coap_session_set_max_payloads
 coap_session_set_max_retransmit

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -117,12 +117,12 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_address.3" > coap_is_af_unix.3
 	@echo ".so man3/coap_cache.3" > coap_cache_get_pdu.3
 	@echo ".so man3/coap_cache.3" > coap_cache_get_app_data.3
-	@echo ".so man3/coap_cache.3" > coap_cache_set_app_data.3
+	@echo ".so man3/coap_cache.3" > coap_cache_set_app_data2.3
 	@echo ".so man3/coap_context.3" > coap_context_get_session_timeout.3
 	@echo ".so man3/coap_context.3" > coap_context_set_csm_timeout_ms.3
 	@echo ".so man3/coap_context.3" > coap_context_get_csm_timeout_ms.3
 	@echo ".so man3/coap_context.3" > coap_context_set_max_token_size.3
-	@echo ".so man3/coap_context.3" > coap_context_set_app_data.3
+	@echo ".so man3/coap_context.3" > coap_context_set_app_data2.3
 	@echo ".so man3/coap_context.3" > coap_context_get_app_data.3
 	@echo ".so man3/coap_context.3" > coap_context_set_cid_tuple_change.3
 	@echo ".so man3/coap_deprecated.3" > coap_set_app_data.3
@@ -134,6 +134,10 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_deprecated.3" > coap_run_once.3
 	@echo ".so man3/coap_deprecated.3" > coap_set_event_handler.3
 	@echo ".so man3/coap_deprecated.3" > coap_write.3
+	@echo ".so man3/coap_deprecated.3" > coap_async_set_app_data.3
+	@echo ".so man3/coap_deprecated.3" > coap_cache_set_app_data.3
+	@echo ".so man3/coap_deprecated.3" > coap_context_set_app_data.3
+	@echo ".so man3/coap_deprecated.3" > coap_session_set_app_data.3
 	@echo ".so man3/coap_io.3" > coap_io_pending.3
 	@echo ".so man3/coap_io.3" > coap_io_get_fds.3
 	@echo ".so man3/coap_io.3" > coap_can_exit.3

--- a/man/coap_async.txt.in
+++ b/man/coap_async.txt.in
@@ -16,7 +16,7 @@ coap_async_trigger,
 coap_async_set_delay,
 coap_find_async,
 coap_free_async,
-coap_async_set_app_data,
+coap_async_set_app_data2,
 coap_async_get_app_data
 - Work with CoAP async support
 
@@ -36,7 +36,8 @@ const coap_pdu_t *_request_, coap_tick_t _delay_);*
 *coap_async_t *coap_find_async(coap_session_t *_session_,
 coap_bin_const_t _token_);*
 
-*void coap_async_set_app_data(coap_async_t *_async_, void *_app_data_);*
+*void *coap_async_set_app_data2(coap_async_t *_async_, void *_app_data_,
+coap_cache_app_data_free_callback_t _app_cb_);*
 
 *void *coap_async_get_app_data(const coap_async_t *_async_);*
 
@@ -107,12 +108,26 @@ The *coap_free_async*() function is used to delete an _async_ definition.
 The *coap_find_async*() function is used to determine if there is an async
 definition based on the _session_ and token _token_.
 
-*Function: coap_async_set_app_data()*
+*Function: coap_async_set_app_data2()*
 
-The *coap_async_set_app_data*() function is used to add in user defined
-_app_data_ to the _async_ definition.  It is the responsibility of the
-application to release this data if appropriate.  This would usually be done
-when the application request handler is called under 'async' control.
+The *coap_async_set_app_data2*() function is used to define a _app_data_ pointer
+for the _async_ which can then be retrieved at a later date. There is an
+additional callback _app_cb_ (if set) to be used if the data is to be released
+when the _async_ is deleted. If this is a subsequent call for the
+_async_, then the existing data is returned, and it is the responsibility
+of the caller to release this previous data.  On the first call, NULL is returned.
+
+The _app_cb_ handler function prototype is defined as:
+[source, c]
+----
+/**
+ * Callback to free off the app data when the cache-entry is
+ * being deleted / freed off.
+ *
+ * @param data  The app data to be freed off.
+ */
+typedef void (*coap_app_data_free_callback_t)(void *data);
+----
 
 *Function: coap_async_get_app_data()*
 
@@ -126,6 +141,8 @@ RETURN VALUES
 definition or NULL if there is an error.
 
 *coap_async_get_app_data*() returns a pointer to the user defined data.
+
+*coap_async_set_app_data2*() returns a previously defined pointer or NULL.
 
 EXAMPLES
 --------

--- a/man/coap_cache.txt.in
+++ b/man/coap_cache.txt.in
@@ -20,7 +20,7 @@ coap_delete_cache_entry,
 coap_cache_get_by_key,
 coap_cache_get_by_pdu,
 coap_cache_get_pdu,
-coap_cache_set_app_data,
+coap_cache_set_app_data2,
 coap_cache_get_app_data
 - Work with CoAP cache functions
 
@@ -56,8 +56,8 @@ const coap_pdu_t *_pdu_, coap_cache_session_based_t _session_based_);*
 
 *const coap_pdu_t *coap_cache_get_pdu(const coap_cache_entry_t *_cache_entry_);*
 
-*void coap_cache_set_app_data(coap_cache_entry_t *_cache_entry_, void *_data_,
-coap_cache_app_data_free_callback_t _callback_);*
+*void *coap_cache_set_app_data2(coap_cache_entry_t *_cache_entry_,
+void *_app_data_, coap_cache_app_data_free_callback_t _app_cb_);*
 
 *void *coap_cache_get_app_data(const coap_cache_entry_t *_cache_entry_);*
 
@@ -155,7 +155,7 @@ The *coap_new_cache_entry*() function will create a new Cache Entry based on
 the Cache Key derived from the _pdu_, _session_based_ and _session_. If
 _record_pdu_ is COAP_CACHE_RECORD_PDU, then a copy of the _pdu_ is stored in
 the Cache Entry for subsequent retrieval. The Cache Entry can also store
-application specific data (*coap_cache_set_app_data*() and
+application specific data (*coap_cache_set_app_data2*() and
 *coap_cache_get_app_data*()).  _idle_timeout_ in seconds defines the length of
 time not being used before it gets deleted.  If _idle_timeout_ is set to
 0, then the Cache Entry will not get idle expired. The created Cache
@@ -194,15 +194,16 @@ returned. +
 *NOTE:* A copy of the returned PDU must be taken for use in sending a CoAP
 packet using *coap_pdu_duplicate*().
 
-*Function: coap_cache_set_app_data()*
+*Function: coap_cache_set_app_data2()*
 
-The *coap_cache_set_app_data*() function is used to associate _data_ with the
-_cache_entry_.  If _callback_ is not NULL, it points to a function to free off
-_data_ when the _cache_entry_ is deleted.  If any data has been previously
-stored in the _cache_entry_, the pointer to the old data will get overwritten,
-but the old data will not get freed off.
+The *coap_cache_set_app_data2*() function is used to define a _app_data_ pointer
+for the _cache_entry_ which can then be retrieved at a later date. There is an
+additional callback _app_cb_ (if set) to be used if the data is to be released
+when the _cache_entry_ is deleted. If this is a subsequent call for the
+_cache_entry_, then the existing data is returned, and it is the responsibility
+of the caller to release this previous data.  On the first call, NULL is returned.
 
-The _callback_ handler function prototype is defined as:
+The _app_cb_ handler function prototype is defined as:
 [source, c]
 ----
 /**
@@ -211,7 +212,7 @@ The _callback_ handler function prototype is defined as:
  *
  * @param data  The app data to be freed off.
  */
-typedef void (*coap_cache_app_data_free_callback_t)(void *data);
+typedef void (*coap_app_data_free_callback_t)(void *data);
 ----
 
 *Function: coap_cache_get_app_data()*
@@ -232,6 +233,8 @@ is a failure.
 
 *coap_cache_get_pdu*() returns the PDU that is held within the Cache Entry or
 NULL if there is no PDU available.
+
+*coap_cache_set_app_data2*() returns a previously defined pointer or NULL.
 
 *coap_cache_get_app_data*() returns the application data value
 previously set by the *coap_cache_set_app_data*() function or NULL.
@@ -312,7 +315,7 @@ hnd_put_example_data(coap_context_t *ctx,
           coap_delete_binary(data_so_far);
           data_so_far = NULL;
         }
-        coap_cache_set_app_data(cache_entry, NULL, NULL);
+        coap_cache_set_app_data2(cache_entry, NULL, NULL);
       }
     }
     if (!cache_entry) {
@@ -332,12 +335,11 @@ hnd_put_example_data(coap_context_t *ctx,
       data_so_far = coap_block_build_body(data_so_far, size, data,
                                           offset, total);
       /* Yes, data_so_far can be NULL if error */
-      coap_cache_set_app_data(cache_entry, data_so_far, cache_free_app_data);
+      coap_cache_set_app_data2(cache_entry, data_so_far, cache_free_app_data);
     }
     if (offset + size == total) {
       /* All the data is now in */
-      data_so_far = coap_cache_get_app_data(cache_entry);
-      coap_cache_set_app_data(cache_entry, NULL, NULL);
+      data_so_far = coap_cache_set_app_data2(cache_entry, NULL, NULL);
     } else {
       /* Give us the next block response */
       coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTINUE);

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -22,7 +22,7 @@ coap_context_get_session_timeout,
 coap_context_set_csm_timeout_ms,
 coap_context_get_csm_timeout_ms,
 coap_context_set_max_token_size,
-coap_context_set_app_data,
+coap_context_set_app_data2,
 coap_context_get_app_data,
 coap_context_set_cid_tuple_change
 - Work with CoAP contexts
@@ -61,7 +61,8 @@ unsigned int _csm_timeout_ms_);*
 *void coap_context_set_max_token_size(coap_context_t *_context_,
 size_t _max_token_size_);*
 
-*void coap_context_set_app_data(coap_context_t *_context_, void *_app_data_);*
+*void *coap_context_set_app_data2(coap_context_t *_context_, void *_app_data_,
+coap_app_data_free_callback_t _app_cb_);*
 
 *void *coap_context_get_app_data(const coap_context_t *_context_);*
 
@@ -176,15 +177,31 @@ bytes, else 8 to disable https://rfc-editor.org/rfc/rfc8974[RFC8974]
 supports the requested extended token size as per
 "https://rfc-editor.org/rfc/rfc8974.html#section-2.2.2[RFC8794 Section 2.2.2]"
 
-*Function: coap_context_set_app_data()*
+*Function: coap_context_set_app_data2()*
 
-The *coap_context_set_app_data*() function is used to define a _app_data_
-pointer for the _context_ which can then be retrieved at a later date.
+The *coap_context_set_app_data2*() function is used to define a _app_data_ pointer
+for the _context_ which can then be retrieved at a later date. There is an
+additional callback _app_cb_ (if set) to be used if the data is to be released
+when the _context_ is deleted. If this is a subsequent call for the _context_,
+then the existing data is returned, and it is the responsibility of the caller to
+release this previous data.  On the first call, NULL is returned.
+
+The _app_cb_ handler function prototype is defined as:
+[source, c]
+----
+/**
+ * Callback to free off the app data when the cache-entry is
+ * being deleted / freed off.
+ *
+ * @param data  The app data to be freed off.
+ */
+typedef void (*coap_app_data_free_callback_t)(void *data);
+----
 
 *Function: coap_context_get_app_data()*
 
 The *coap_context_get_app_data*() function is used to retrieve the app_data
-pointer previously defined by *coap_context_set_app_data*().
+pointer previously defined by *coap_context_set_app_data2*().
 
 *Function: coap_context_set_cid_tuple_change()*
 
@@ -211,6 +228,8 @@ out an idle server session.
 (TCP) CSM negotiation response from the peer.
 
 *coap_context_get_app_data*() returns a previously defined pointer.
+
+*coap_context_set_app_data2*() returns a previously defined pointer or NULL.
 
 *coap_context_set_cid_tuple_change*() returns 1 on success, else 0;
 

--- a/man/coap_deprecated.txt.in
+++ b/man/coap_deprecated.txt.in
@@ -27,7 +27,11 @@ coap_run_once,
 coap_set_event_handler,
 coap_write,
 coap_get_app_data,
-coap_set_app_data
+coap_set_app_data,
+coap_async_set_app_data,
+coap_cache_set_app_data,
+coap_context_set_app_data,
+coap_session_set_app_data
 - Work with CoAP deprecated functions
 
 SYNOPSIS
@@ -76,6 +80,18 @@ unsigned int _max_sockets_, unsigned int *_num_sockets_, coap_tick_t _now_);*
 *void coap_set_app_data(coap_context_t *_context_, void *_app_data_);*
 
 *void *coap_get_app_data(const coap_context_t *_context_);*
+
+*void coap_async_set_app_data(coap_async_t *_async_entry_,
+void *_data_);*
+
+*void coap_cache_set_app_data(coap_cache_entry_t *_cache_entry_,
+void *_data_, coap_app_data_free_callback_t _callback_);*
+
+*void coap_context_set_app_data(coap_context_t *_context_,
+void *_data_);*
+
+*void coap_session_set_app_data(coap_session_t *_session_,
+void *_data_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -180,6 +196,18 @@ The *coap_set_app_data*() function is replaced by
 The *coap_get_app_data*() function is replaced by
 *coap_context_get_app_data*(3).
 
+The *coap_async_set_app_data*() function is replaced by
+*coap_async_set_app_data2*(3), using NULL for _app_cb_.
+
+The *coap_cache_set_app_data*() function is replaced by
+*coap_cache_set_app_data2*(3), returning the existing _data_ value.
+
+The *coap_context_set_app_data*() function is replaced by
+*coap_context_set_app_data2*(3), using NULL for _app_cb_.
+
+The *coap_session_set_app_data*() function is replaced by
+*coap_session_set_app_data2*(3), using NULL for _app_cb_.
+
 RETURN VALUES
 -------------
 *coap_context_get_csm_timeout*() returns the seconds to wait for a (TCP) CSM
@@ -211,9 +239,9 @@ before the function should next be called.
 
 SEE ALSO
 --------
-*coap_context*(3), *coap_endpoint_client*(3), *coap_endpoint_server*(3),
-*coap_handler*(3), *coap_io*(3), *coap_observe*(3), *coap_pdu_access*(3) and
-*coap_pdu_setup*(3).
+*coap_async*(3), *coap_cache*(3), *coap_context*(3), *coap_endpoint_client*(3),
+*coap_endpoint_server*(3), *coap_handler*(3), *coap_io*(3), *coap_observe*(3),
+*coap_pdu_access*(3), *coap_pdu_setup*(3) and *coap_session*(3).
 
 FURTHER INFORMATION
 -------------------

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -15,7 +15,7 @@ coap_session_reference,
 coap_session_release,
 coap_session_disconnected,
 coap_session_set_type_client,
-coap_session_set_app_data,
+coap_session_set_app_data2,
 coap_session_get_app_data,
 coap_session_get_addr_local,
 coap_session_get_addr_mcast,
@@ -42,7 +42,8 @@ SYNOPSIS
 
 *int coap_session_set_type_client(coap_session_t *_session_);*
 
-*void coap_session_set_app_data(coap_session_t *_session_, void *_data_);*
+*void *coap_session_set_app_data2(coap_session_t *_session_, void *_app_data_,
+coap_app_data_free_callback_t _app_cb_);*
 
 *void *coap_session_get_app_data(const coap_session_t *_session_);*
 
@@ -134,15 +135,31 @@ the now type Client _session_ does not expire until a *coap_session_release*()
 is done. *NOTE:* This function will fail for a DTLS server type session if done
 before the ClientHello is seen.
 
-*Function: coap_session_set_app_data()*
+*Function: coap_session_set_app_data2()*
 
-The *coap_session_set_app_data*() function is used to define a _data_ pointer
-for the _session_ which can then be retrieved at a later date.
+The *coap_session_set_app_data2*() function is used to define a _app_data_ pointer
+for the _session_ which can then be retrieved at a later date. There is an
+additional callback _app_cb_ (if set) to be used if the data is to be released
+when the _session_ is deleted. If this is a subsequent call for the _session_,
+then the existing data is returned, and it is the responsibility of the caller to
+release this previous data.  On the first call, NULL is returned.
+
+The _app_cb_ handler function prototype is defined as:
+[source, c]
+----
+/**
+ * Callback to free off the app data when the cache-entry is
+ * being deleted / freed off.
+ *
+ * @param data  The app data to be freed off.
+ */
+typedef void (*coap_app_data_free_callback_t)(void *data);
+----
 
 *Function: coap_session_get_app_data()*
 
 The *coap_session_get_app_data*() function is used to retrieve the data
-pointer previously defined by *coap_session_set_app_data*().
+pointer previously defined by *coap_session_set_app_data2*() in _session_.
 
 *Function: coap_session_get_addr_local()*
 
@@ -233,6 +250,8 @@ RETURN VALUES
 *coap_session_reference*() returns a pointer to the session.
 
 *coap_session_set_type_client*() returns 1 on success, otherwise 0.
+
+*coap_session_set_app_data2*() returns a previously defined pointer or NULL.
 
 *coap_session_get_app_data*() returns a previously defined pointer.
 

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -189,6 +189,9 @@ coap_free_async_sub(coap_context_t *context, coap_async_t *s) {
       coap_delete_pdu_lkd(s->pdu);
       s->pdu = NULL;
     }
+    if (s->app_cb && s->app_data) {
+      coap_lock_callback(context, s->app_cb(s->app_data));
+    }
     coap_free_type(COAP_STRING, s);
   }
 }
@@ -215,14 +218,37 @@ coap_delete_all_async(coap_context_t *context) {
   context->async_state = NULL;
 }
 
-void
-coap_async_set_app_data(coap_async_t *async, void *app_data) {
-  async->appdata = app_data;
+COAP_API void
+coap_async_set_app_data(coap_async_t *async_entry, void *app_data) {
+  coap_lock_lock(NULL, return);
+  coap_async_set_app_data2_lkd(async_entry, app_data, NULL);
+  coap_lock_unlock(NULL);
+}
+
+COAP_API void *
+coap_async_set_app_data2(coap_async_t *async_entry, void *app_data,
+                         coap_app_data_free_callback_t callback) {
+  void *old_data;
+
+  coap_lock_lock(NULL, return NULL);
+  old_data = coap_async_set_app_data2_lkd(async_entry, app_data, callback);
+  coap_lock_unlock(NULL);
+  return old_data;
+}
+
+void *
+coap_async_set_app_data2_lkd(coap_async_t *async_entry, void *app_data,
+                             coap_app_data_free_callback_t callback) {
+  void *old_data = async_entry->app_data;
+
+  async_entry->app_data = app_data;
+  async_entry->app_cb = app_data ? callback : NULL;
+  return old_data;
 }
 
 void *
 coap_async_get_app_data(const coap_async_t *async) {
-  return async->appdata;
+  return async->app_data;
 }
 
 #else /* ! COAP_ASYNC_SUPPORT */
@@ -262,10 +288,19 @@ coap_find_async(coap_session_t *session,
   return NULL;
 }
 
-void
+COAP_API void
 coap_async_set_app_data(coap_async_t *async, void *app_data) {
   (void)async;
   (void)app_data;
+}
+
+COAP_API void *
+coap_async_set_app_data2(coap_async_t *async, void *app_data,
+                         coap_app_data_free_callback_t callback) {
+  (void)async;
+  (void)app_data;
+  (void)callback;
+  return NULL;
 }
 
 void *

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -291,8 +291,8 @@ coap_delete_cache_entry(coap_context_t *ctx, coap_cache_entry_t *cache_entry) {
     coap_delete_pdu_lkd(cache_entry->pdu);
   }
   coap_delete_cache_key(cache_entry->cache_key);
-  if (cache_entry->callback && cache_entry->app_data) {
-    coap_lock_callback(ctx, cache_entry->callback(cache_entry->app_data));
+  if (cache_entry->app_cb && cache_entry->app_data) {
+    coap_lock_callback(ctx, cache_entry->app_cb(cache_entry->app_data));
   }
   coap_free_type(COAP_CACHE_ENTRY, cache_entry);
 }
@@ -302,12 +302,34 @@ coap_cache_get_pdu(const coap_cache_entry_t *cache_entry) {
   return cache_entry->pdu;
 }
 
-void
+COAP_API void
 coap_cache_set_app_data(coap_cache_entry_t *cache_entry,
                         void *data,
-                        coap_cache_app_data_free_callback_t callback) {
-  cache_entry->app_data = data;
-  cache_entry->callback = callback;
+                        coap_app_data_free_callback_t callback) {
+  coap_lock_lock(NULL, return);
+  coap_cache_set_app_data2_lkd(cache_entry, data, callback);
+  coap_lock_unlock(NULL);
+}
+
+COAP_API void *
+coap_cache_set_app_data2(coap_cache_entry_t *cache_entry, void *app_data,
+                         coap_app_data_free_callback_t callback) {
+  void *old_data;
+
+  coap_lock_lock(NULL, return NULL);
+  old_data = coap_cache_set_app_data2_lkd(cache_entry, app_data, callback);
+  coap_lock_unlock(NULL);
+  return old_data;
+}
+
+void *
+coap_cache_set_app_data2_lkd(coap_cache_entry_t *cache_entry, void *app_data,
+                             coap_app_data_free_callback_t callback) {
+  void *old_data = cache_entry->app_data;
+
+  cache_entry->app_data = app_data;
+  cache_entry->app_cb = app_data ? callback : NULL;
+  return old_data;
 }
 
 void *

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -626,16 +626,39 @@ coap_af_unix_is_supported(void) {
 #endif /* ! COAP_AF_UNIX_SUPPORT */
 }
 
-void
+COAP_API void
 coap_context_set_app_data(coap_context_t *context, void *app_data) {
   assert(context);
-  context->app = app_data;
+  coap_lock_lock(context, return);
+  coap_context_set_app_data2_lkd(context, app_data, NULL);
+  coap_lock_unlock(context);
 }
 
 void *
 coap_context_get_app_data(const coap_context_t *context) {
   assert(context);
-  return context->app;
+  return context->app_data;
+}
+
+COAP_API void *
+coap_context_set_app_data2(coap_context_t *context, void *app_data,
+                           coap_app_data_free_callback_t callback) {
+  void *old_data;
+
+  coap_lock_lock(context, return NULL);
+  old_data = coap_context_set_app_data2_lkd(context, app_data, callback);
+  coap_lock_unlock(context);
+  return old_data;
+}
+
+void *
+coap_context_set_app_data2_lkd(coap_context_t *context, void *app_data,
+                               coap_app_data_free_callback_t callback) {
+  void *old_data = context->app_data;
+
+  context->app_data = app_data;
+  context->app_cb = app_data ? callback : NULL;
+  return old_data;
 }
 
 coap_context_t *
@@ -730,16 +753,18 @@ onerror:
 #endif /* COAP_EPOLL_SUPPORT || COAP_SERVER_SUPPORT */
 }
 
-void
-coap_set_app_data(coap_context_t *ctx, void *app_data) {
-  assert(ctx);
-  ctx->app = app_data;
+COAP_API void
+coap_set_app_data(coap_context_t *context, void *app_data) {
+  assert(context);
+  coap_lock_lock(context, return);
+  coap_context_set_app_data2_lkd(context, app_data, NULL);
+  coap_lock_unlock(context);
 }
 
 void *
 coap_get_app_data(const coap_context_t *ctx) {
   assert(ctx);
-  return ctx->app;
+  return ctx->app_data;
 }
 
 COAP_API void
@@ -838,6 +863,9 @@ coap_free_context_lkd(coap_context_t *context) {
   coap_proxy_cleanup(context);
 #endif /* COAP_PROXY_SUPPORT */
 
+  if (context->app_cb) {
+    context->app_cb(context->app_data);
+  }
   coap_free_type(COAP_CONTEXT, context);
   coap_dump_memory_type_counts(COAP_LOG_DEBUG);
 }

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -395,16 +395,39 @@ coap_session_release_lkd(coap_session_t *session) {
   }
 }
 
-void
+COAP_API void
 coap_session_set_app_data(coap_session_t *session, void *app_data) {
   assert(session);
-  session->app = app_data;
+  coap_lock_lock(session->context, return);
+  coap_session_set_app_data2_lkd(session, app_data, NULL);
+  coap_lock_unlock(session->context);
 }
 
 void *
 coap_session_get_app_data(const coap_session_t *session) {
   assert(session);
-  return session->app;
+  return session->app_data;
+}
+
+COAP_API void *
+coap_session_set_app_data2(coap_session_t *session, void *app_data,
+                           coap_app_data_free_callback_t callback) {
+  void *old_data;
+
+  coap_lock_lock(session->context, return NULL);
+  old_data = coap_session_set_app_data2_lkd(session, app_data, callback);
+  coap_lock_unlock(session->context);
+  return old_data;
+}
+
+void *
+coap_session_set_app_data2_lkd(coap_session_t *session, void *app_data,
+                               coap_app_data_free_callback_t callback) {
+  void *old_data = session->app_data;
+
+  session->app_data = app_data;
+  session->app_cb = app_data ? callback : NULL;
+  return old_data;
 }
 
 static coap_session_t *
@@ -597,6 +620,9 @@ coap_session_free(coap_session_t *session) {
   coap_log_debug("***%s: session %p: closed\n", coap_session_str(session),
                  (void *)session);
 
+  if (session->app_cb) {
+    session->app_cb(session->app_data);
+  }
   assert(session->ref == 1);
   coap_free_type(COAP_SESSION, session);
 }


### PR DESCRIPTION
New functions
 coap_async_set_app_data2()
 coap_cache_set_app_data2()
 coap_context_set_app_data2()
 coap_session_set_app_data2()
that, multi-thread safe, store an application data pointer and return the previous data pointer (if any). There is an optional callback that will be called when the respective storage object is released that can free off as appropriate the data that was stored.

These replace the existing coap_*_set_app_data() functions and coap_*_get_app_data() can be used to get the stored data pointer.