### PR TITLE
Proxy: Make upstream server handling more rigorous

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -55,6 +55,7 @@ strndup(const char *s1, size_t n) {
 
 int flags = 0;
 
+static coap_session_t *global_session;
 static unsigned char _token_data[24]; /* With support for RFC8974 */
 static coap_binary_t the_token = { 0, _token_data };
 
@@ -77,6 +78,7 @@ static int proxy_scheme_option = 0;
 static int uri_host_option = 0;
 static unsigned int ping_seconds = 0;
 static int setup_cid = 0;
+static uint32_t reconnect_secs = 0;
 
 #define REPEAT_DELAY_MS 1000
 static size_t repeat_count = 1;
@@ -312,8 +314,11 @@ event_handler(coap_session_t *session COAP_UNUSED,
               const coap_event_t event) {
 
   switch (event) {
-  case COAP_EVENT_DTLS_CLOSED:
   case COAP_EVENT_TCP_CLOSED:
+  case COAP_EVENT_DTLS_CLOSED:
+    if (!reconnect_secs)
+      quit = 1;
+    break;
   case COAP_EVENT_SESSION_CLOSED:
   case COAP_EVENT_OSCORE_DECRYPTION_FAILURE:
   case COAP_EVENT_OSCORE_NOT_ENABLED:
@@ -360,9 +365,13 @@ nack_handler(coap_session_t *session COAP_UNUSED,
   }
 
   switch (reason) {
-  case COAP_NACK_TOO_MANY_RETRIES:
   case COAP_NACK_NOT_DELIVERABLE:
   case COAP_NACK_TLS_FAILED:
+    coap_log_err("cannot send CoAP pdu\n");
+    if (!reconnect_secs)
+      quit = 1;
+    break;
+  case COAP_NACK_TOO_MANY_RETRIES:
   case COAP_NACK_WS_FAILED:
   case COAP_NACK_TLS_LAYER_FAILED:
   case COAP_NACK_WS_LAYER_FAILED:
@@ -508,10 +517,11 @@ usage(const char *program, const char *version) {
   fprintf(stderr, "\n"
           "Usage: %s [-a addr] [-b [num,]size] [-e text] [-f file] [-l loss]\n"
           "\t\t[-m method] [-o file] [-p port] [-q tls_engine_conf_file] [-r]\n"
-          "\t\t[-s duration] [-t type] [-v num] [-w] [-x] [-A type] [-B seconds]\n"
+          "\t\t[-s duration] [-t type] [-v num] [-w] [-x]  [-y rec_secs]\n"
+          "\t\t[-A type] [-B seconds]\n"
           "\t\t[-E oscore_conf_file[,seq_file]] [-G count] [-H hoplimit]\n"
           "\t\t[-K interval] [-N] [-O num,text] [-P scheme://address[:port]\n"
-          "\t\t[-T token] [-U]  [-V num] [-X size]\n"
+          "\t\t[-T token] [-U] [-V num] [-X size]\n"
           "\t\t[[-d count]]\n"
           "\t\t[[h match_hint_file] [-k key] [-u user] [-2]]\n"
           "\t\t[[-c certfile] [-j keyfile] [-n] [-C cafile]\n"
@@ -545,6 +555,7 @@ usage(const char *program, const char *version) {
           "\t       \t\tCoAP logging\n"
           "\t-w     \t\tAppend a newline to received data\n"
           "\t-x     \t\tDisable output of PDU data when displaying PDUs\n"
+          "\t-y rec_secs\tAttempt to reconnect a failed session every rec_secs\n"
           "\t-A type\t\tAccepted media type\n"
           "\t-B seconds\tBreak operation after waiting given seconds\n"
           "\t       \t\t(default is %d)\n"
@@ -1705,7 +1716,7 @@ main(int argc, char **argv) {
   coap_startup();
 
   while ((opt = getopt(argc, argv,
-                       "a:b:c:d:e:f:h:j:k:l:m:no:p:q:rs:t:u:v:wx:A:B:C:E:G:H:J:K:L:M:NO:P:R:T:UV:X:Y2")) != -1) {
+                       "a:b:c:d:e:f:h:j:k:l:m:no:p:q:rs:t:u:v:wx:y:A:B:C:E:G:H:J:K:L:M:NO:P:R:T:UV:X:Y2")) != -1) {
     switch (opt) {
     case 'a':
       strncpy(node_str, optarg, NI_MAXHOST - 1);
@@ -1770,6 +1781,9 @@ main(int argc, char **argv) {
       break;
     case 'x':
       coap_enable_pdu_data_output(0);
+      break;
+    case 'y':
+      reconnect_secs = atoi(optarg);
       break;
     case 'N':
       msgtype = COAP_MESSAGE_NON;
@@ -1948,6 +1962,7 @@ main(int argc, char **argv) {
       goto failed;
   }
 
+  coap_context_set_session_reconnect_time(ctx, reconnect_secs);
   coap_context_set_keepalive(ctx, ping_seconds);
   coap_context_set_block_mode(ctx, block_mode);
   if (csm_max_message_size)
@@ -1980,6 +1995,7 @@ main(int argc, char **argv) {
     coap_log_err("cannot create client session\n");
     goto failed;
   }
+  global_session = session;
   /*
    * Prime the base token value, which coap_session_new_token() will increment
    * every time it is called to get an unique token.
@@ -2155,7 +2171,10 @@ main(int argc, char **argv) {
           ready = 0;
           if (coap_send(session, pdu) == COAP_INVALID_MID) {
             coap_log_err("cannot send CoAP pdu\n");
-            quit = 1;
+            if (reconnect_secs)
+              ready = 1;
+            else
+              quit = 1;
           }
           repeat_count--;
         }

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -135,6 +135,7 @@ static coap_proto_t use_unix_proto = COAP_PROTO_NONE;
 static int enable_ws = 0;
 static int ws_port = 80;
 static int wss_port = 443;
+static uint32_t reconnect_secs = 0;
 
 static coap_dtls_pki_t *setup_pki(coap_context_t *ctx, coap_dtls_role_t role, char *sni);
 
@@ -1578,9 +1579,10 @@ usage(const char *program, const char *version) {
   fprintf(stderr, "%s\n", coap_string_tls_support(buffer, sizeof(buffer)));
   fprintf(stderr, "\n"
           "Usage: %s [-a priority] [-b max_block_size] [-d max] [-e]\n"
-          "\t\t[-f scheme://address[:port] [-g group] -l loss] [-p port]\n"
+          "\t\t[-f scheme://address[:port] [-g group] -l loss] [-o] [-p port]\n"
           "\t\t[-q tls_engine_conf_file] [-r] [-v num] [-w [port][,secure_port]]\n"
-          "\t\t[-x] [-A address] [-E oscore_conf_file[,seq_file]] [-G group_if]\n"
+          "\t\t[-x] [-y rec_secs] [-A address] [-E oscore_conf_file[,seq_file]]\n"
+          "\t\t[-G group_if]\n"
           "\t\t[-L value] [-N] [-P scheme://address[:port],[name1[,name2..]]]\n"
           "\t\t[-T max_token_size] [-U type] [-V num] [-X size]\n"
           "\t\t[[-h hint] [-i match_identity_file] [-k key]\n"
@@ -1613,6 +1615,7 @@ usage(const char *program, const char *version) {
           "\t-l loss%%\tRandomly fail to send datagrams with the specified\n"
           "\t       \t\tprobability - 100%% all datagrams, 0%% no datagrams\n"
           "\t       \t\t(for debugging only)\n"
+          "\t-o     \t\tDisable sending observe failures on shutdown\n"
           "\t-p port\t\tListen on specified port for UDP and TCP. If (D)TLS is\n"
           "\t       \t\tenabled, then the coap-server will also listen on\n"
           "\t       \t\t'port'+1 for DTLS and TLS.  The default port is 5683\n"
@@ -1632,6 +1635,8 @@ usage(const char *program, const char *version) {
           "\t       \t\tEnable WebSockets support on port (WS) and/or secure_port\n"
           "\t       \t\t(WSS), comma separated\n"
           "\t-x     \t\tDisable output of PDU data when displaying PDUs\n"
+          "\t-y rec_secs\tAttempt to reconnect a failed proxy session every\n"
+          "\t       \t\trec_secs\n"
           "\t-A address\tInterface address to bind to\n"
           "\t-E oscore_conf_file[,seq_file]\n"
           "\t       \t\toscore_conf_file contains OSCORE configuration. See\n"
@@ -2351,6 +2356,7 @@ main(int argc, char **argv) {
   size_t i;
   int exit_code = 0;
   uint32_t max_block_size = 0;
+  int shutdown_no_observe = 0;
 #ifndef _WIN32
   int use_syslog = 0;
 #endif /* ! _WIN32 */
@@ -2371,7 +2377,7 @@ main(int argc, char **argv) {
   clock_offset = time(NULL);
 
   while ((opt = getopt(argc, argv,
-                       "a:b:c:d:ef:g:h:i:j:k:l:mnp:q:rs:tu:v:w:A:C:E:G:J:L:M:NP:R:S:T:U:V:X:Y2")) != -1) {
+                       "a:b:c:d:ef:g:h:i:j:k:l:mnop:q:rs:tu:v:w:y:A:C:E:G:J:L:M:NP:R:S:T:U:V:X:Y2")) != -1) {
     switch (opt) {
 #ifndef _WIN32
     case 'a':
@@ -2477,6 +2483,9 @@ main(int argc, char **argv) {
     case 'N':
       resource_flags = COAP_RESOURCE_FLAGS_NOTIFY_NON;
       break;
+    case 'o':
+      shutdown_no_observe = 1;
+      break;
     case 'p' :
       port_str = optarg;
       break;
@@ -2555,6 +2564,9 @@ main(int argc, char **argv) {
     case 'X':
       csm_max_message_size = strtol(optarg, NULL, 10);
       break;
+    case 'y':
+      reconnect_secs = atoi(optarg);
+      break;
     case 'Y':
       no_trust_store = 1;
       break;
@@ -2600,8 +2612,11 @@ main(int argc, char **argv) {
   init_resources(ctx);
   if (mcast_per_resource)
     coap_mcast_per_resource(ctx);
+  if (shutdown_no_observe)
+    coap_context_set_shutdown_no_observe(ctx);
   coap_context_set_block_mode(ctx, block_mode);
   coap_context_set_max_block_size(ctx, max_block_size);
+  coap_context_set_session_reconnect_time(ctx, reconnect_secs);
   coap_context_set_keepalive(ctx, 30);
   if (csm_max_message_size)
     coap_context_set_csm_max_message_size(ctx, csm_max_message_size);

--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -302,6 +302,24 @@ void coap_context_set_session_timeout(coap_context_t *context,
                                       unsigned int session_timeout);
 
 /**
+ * Set the session reconnect delay time after a working client session has
+ * failed.  0 (the default) means use no restart.
+ *
+ * If a session is reconnected, then any active observe subscriptions are
+ * automatically restarted.
+ *
+ * However, if the session failure was caused by a server restart, a restart
+ * observe subscription attempt for a previously dynamically created resource
+ * will not cause the resource to be recreated.  This can be done by using
+ * coap_persist(3) in the server.
+ *
+ * @param context        The coap_context_t object.
+ * @param reconnect_time The time before a failed client session is reconnected
+                         in seconds. 0 if reconnection is to be disabled.
+ */
+void coap_context_set_session_reconnect_time(coap_context_t *context,
+                                             unsigned int reconnect_time);
+/**
  * Get the session timeout value
  *
  * @param context The coap_context_t object.

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -164,6 +164,10 @@ struct coap_context_t {
                                            the remote side. */
   uint32_t csm_max_message_size;   /**< Value for CSM Max-Message-Size */
 
+#if COAP_CLIENT_SUPPORT
+  unsigned int reconnect_time;     /**< Time to wait before reconnecting a failed
+                                        client session. 0 means disabled */
+#endif /* COAP_CLIENT_SUPPORT */
 #if COAP_SERVER_SUPPORT
   coap_cache_entry_t *cache;       /**< CoAP cache-entry cache */
   uint16_t *cache_ignore_options;  /**< CoAP options to ignore when creating a

--- a/include/coap3/coap_proxy.h
+++ b/include/coap3/coap_proxy.h
@@ -97,7 +97,7 @@ int coap_verify_proxy_scheme_supported(coap_uri_scheme_t scheme);
  * @return @c 1 if success, or @c 0 if failure (@p response code set to
  *         appropriate value).
  */
-int COAP_API coap_proxy_forward_request(coap_session_t *req_session,
+COAP_API int coap_proxy_forward_request(coap_session_t *req_session,
                                         const coap_pdu_t *request,
                                         coap_pdu_t *response,
                                         coap_resource_t *resource,

--- a/include/coap3/coap_proxy_internal.h
+++ b/include/coap3/coap_proxy_internal.h
@@ -45,8 +45,6 @@ struct coap_proxy_list_t {
                                        is ignored if there are any active
                                        upstream Observe requests */
   coap_tick_t last_used;     /**< Last time entry was used */
-  uint64_t res_tx_token;     /**< Copy of ongoing session tx_token for restart */
-  coap_lg_crcv_t *res_lg_crcv; /**< Copy of ongoing session lg_crcv for restart */
 };
 
 /**

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -77,6 +77,9 @@ struct coap_session_t {
   coap_addr_hash_t addr_hash;  /**< Address hash for server incoming packets */
   UT_hash_handle hh;
   coap_addr_tuple_t addr_info;      /**< remote/local address info */
+#if COAP_CLIENT_SUPPORT
+  coap_address_t local_reconnect;   /**< local address to initiate reconnect from */
+#endif /* COAP_CLIENT_SUPPORT */
   int ifindex;                      /**< interface index */
   unsigned ref_subscriptions;       /**< reference count of current subscriptions */
   coap_socket_t sock;               /**< socket object for the session, if
@@ -208,6 +211,7 @@ struct coap_session_t {
 #if COAP_CLIENT_SUPPORT
   uint8_t negotiated_cid;         /**< Set for a client if CID negotiated */
   uint8_t doing_send_recv;        /**< Set if coap_send_recv() active */
+  uint8_t session_failed;         /**< Set if session failed and can try re-connect */
 #endif /* COAP_CLIENT_SUPPORT */
   uint8_t is_dtls13;              /**< Set if session is DTLS1.3 */
   coap_mid_t remote_test_mid;     /**< mid used for checking remote
@@ -593,6 +597,13 @@ coap_session_t *coap_new_client_session_psk2_lkd(coap_context_t *ctx,
                                                  coap_dtls_cpsk_t *setup_data
                                                 );
 
+/**
+ * Close the current session (if not already closed) and reconnect to
+ * server (client session only).
+ *
+ * @param session The session to reconnect.
+ */
+int coap_session_reconnect(coap_session_t *session);
 
 /**
  * Create a new DTLS session for the @p session.
@@ -650,6 +661,20 @@ void coap_handle_nack(coap_session_t *session,
                       coap_pdu_t *sent,
                       const coap_nack_reason_t reason,
                       const coap_mid_t mid);
+
+/**
+ * Session has failed due to a socket error.
+ *
+ * @param session The session that has failed.
+ */
+void coap_session_failed(coap_session_t *session);
+
+/**
+ * Session has been re-connected to server.
+ *
+ * @param session The session that has been re-established.
+ */
+void coap_session_reestablished(coap_session_t *session);
 
 #define COAP_SESSION_REF(s) ((s)->ref
 

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -71,6 +71,7 @@ global:
   coap_context_set_pki_root_cas;
   coap_context_set_psk2;
   coap_context_set_psk;
+  coap_context_set_session_reconnect_time;
   coap_context_set_session_timeout;
   coap_context_set_shutdown_no_observe;
   coap_debug_set_packet_loss;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -69,6 +69,7 @@ coap_context_set_pki
 coap_context_set_pki_root_cas
 coap_context_set_psk
 coap_context_set_psk2
+coap_context_set_session_reconnect_time
 coap_context_set_session_timeout
 coap_context_set_shutdown_no_observe
 coap_debug_set_packet_loss

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -127,6 +127,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_get_app_data.3
 	@echo ".so man3/coap_context.3" > coap_context_set_cid_tuple_change.3
 	@echo ".so man3/coap_context.3" > coap_context_set_shutdown_no_observe.3
+	@echo ".so man3/coap_context.3" > coap_context_set_session_reconnect_time.3
 	@echo ".so man3/coap_deprecated.3" > coap_set_app_data.3
 	@echo ".so man3/coap_deprecated.3" > coap_get_app_data.3
 	@echo ".so man3/coap_deprecated.3" > coap_option_setb.3

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -21,13 +21,13 @@ SYNOPSIS
 --------
 *coap-client* [*-a* addr] [*-b* [num,]size] [*-e* text] [*-f* file] [*-l* loss]
               [*-m* method] [*-o* file] [*-p* port] [*-q* tls_engine_conf_file]
-              [*-r*] [*-s duration*]
-              [*-t* type] [*-v* num] [*-w*] [*-x*] [*-A* type] [*-B* seconds]
+              [*-r*] [*-s duration*] [*-t* type] [*-v* num] [*-w*] [*-x*]
+              [*-y* rec_secs] [*-A* type] [*-B* seconds]
               [*-E* oscore_conf_file[,seq_file]] [*-G* count] [*-H* hoplimit]
               [*-K* interval] [*-L* value] [*-N*] [*-O* num,text]
               [*-P* scheme://addr[:port]] [*-T* token] [*-U*] [*-V* num]
               [*-X* size]
-              [*-d* value]
+              [[*-d* value]]
               [[*-h* match_hint_file] [*-k* key] [*-u* user] [*-2*]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
               [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* trust_casfile] [*-Y*]] URI
@@ -132,6 +132,9 @@ OPTIONS - General
 
 *-x*::
   Disable output of PDU data when displaying PDUs.
+
+*-y* rec_secs::
+   Attempt to reconnect a failed session every rec_secs.
 
 *-A* type::
    Accepted media type. 'type' must be either a numeric value reflecting a

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -20,9 +20,10 @@ coap-server-notls
 SYNOPSIS
 --------
 *coap-server* [*-a* priority] [*-b* max_block_size] [*-d* max] [*-e*]
-              [*-f* scheme://addr[:port]
-              [*-g* group] [*-l* loss] [*-p* port] [*-q* tls_engine_conf_file]
+              [*-f* scheme://addr[:port] [*-g* group]
+              [*-l* loss] [*-o*] [*-p* port] [*-q* tls_engine_conf_file]
               [*-r*] [*-t*]  [*-v* num] [*-w* [port][,secure_port]] [*-x*]
+              [*-y* rec_secs]
               [*-A* address] [*-E* oscore_conf_file[,seq_file]]
               [*-G* group_if] [*-L* value] [*-N*]
               [*-P* scheme://addr[:port],[name1[,name2..]]]
@@ -80,6 +81,9 @@ OPTIONS - General
    Randomly failed to send datagrams with the specified probability - 100%
    all datagrams, 0% no datagrams (debugging only).
 
+*-o* ::
+   Disable sending observe failures on shutdown.
+
 *-p* port::
    The 'port' on the given address will be listening for incoming connections.
    If (D)TLS is supported, then 'port' + 1 will also be listened on for
@@ -109,8 +113,11 @@ OPTIONS - General
    Enable WebSockets support support on port (WS) and/or secure_port (WSS),
    comma separated.
 
-*-x*::
+*-x* ::
   Disable output of PDU data when displaying PDUs.
+
+*-y* rec_secs::
+   Attempt to reconnect a failed proxy session every rec_secs.
 
 *-A* address::
    The local address of the interface which the server has to listen on.

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -25,7 +25,8 @@ coap_context_set_max_token_size,
 coap_context_set_app_data2,
 coap_context_get_app_data,
 coap_context_set_cid_tuple_change,
-coap_context_set_shutdown_no_observe
+coap_context_set_shutdown_no_observe,
+coap_context_set_session_reconnect_time
 - Work with CoAP contexts
 
 SYNOPSIS
@@ -70,6 +71,9 @@ coap_app_data_free_callback_t _app_cb_);*
 *int coap_context_set_cid_tuple_change(coap_context_t *_context_context, uint8_t _every_);*
 
 *void coap_context_set_shutdown_no_observe(coap_context_t *_context_);
+
+*void coap_context_set_session_reconnect_time(coap_context_t *_context_,
+unsigned int _reconnect_time_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -220,6 +224,20 @@ so that no unsolicited observe responses are sent out by the server when
 *coap_free_context*() is called. If *coap_context_set_shutdown_no_observe*()
 is not called, then 5.03 responses are sent out indicating that the observed
 resource is temporarily unavailable.
+
+*Function: coap_context_set_session_reconnect_time()*
+
+The *coap_context_set_session_reconnect_time*() function is used to set the
+_reconnect_time_ time (in seconds) for a failed client session to retry a
+reconnection. A value of 0 (the default) disables a reconnection attempt.
+
+If a session is reconnected, then any active observe subscriptions are
+automatically restarted.
+
+However, if the session failure was caused by a server restart, a restart
+observe subscription attempt for a previously dynamically created resource
+will not cause the resource to be recreated.  This can be done by using
+*coap_persist*(3) in the server.
 
 RETURN VALUES
 -------------

--- a/man/coap_persist.txt.in
+++ b/man/coap_persist.txt.in
@@ -60,7 +60,8 @@ and maintaining OSCORE protection.
 There are callbacks provided to support doing this as an alternative persist
 storage in the coap-server application.
 
-*NOTE:* The observe persist support is only available for UDP sessions.
+*NOTE:* The observe persist support is only available for UDP sessions that
+use TCP/IP (i.e. not AF_UNIX).
 
 When using the libcoap compiled in support, only two functions need to be
 called by the application. *coap_persist_startup*() defines the file names to
@@ -76,10 +77,13 @@ FUNCTIONS
 The *coap_persist_startup*() function is used to enable persist tracking for
 _context_ so when a coap-server is restarted, the persist tracked information
 can be added back in for the server logic.
+
 _dyn_resource_save_file_ is used to save the current list of resources created
 from a request to the unknown resource.
+
 _observe_save_file_ is used to save the current list of active observe
 subscriptions.
+
 _obs_cnt_save_file_ is used to save the current observe counter used when
 sending an observe unsolicited response.  _obs_cnt_save_file_ only gets
 updated every _save_freq_ updates.
@@ -101,7 +105,7 @@ tracking as set up by *coap_persist_startup*() for _context_ and preserve the
 tracking for when the coap-server application restarts.
 
 If using *coap_persist_track_funcs*(), then calling *coap_persist_stop*()
-will stop any 4.04 unsolicited response messages being sent when a
+will stop any 5.03 unsolicited response messages being sent when a
 resource that has an active observe subscription is deleted (as happens
 when *coap_free_context*() is subsequentially called).
 
@@ -213,6 +217,8 @@ typedef int (*coap_dyn_resource_added_t)(coap_session_t *session,
                                          coap_bin_const_t *raw_packet,
                                          void *user_data);
 ----
+
+*NOTE:* Any subsequent changes to the resource are not tracked.
 
 The _resource_deleted_ callback function prototype, called whenever a
 resource is deleted, is defined as:

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -46,6 +46,9 @@
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #endif
+#ifdef _WIN32
+#include <stdio.h>
+#endif /* _WIN32 */
 #ifdef COAP_EPOLL_SUPPORT
 #include <sys/epoll.h>
 #include <sys/timerfd.h>
@@ -395,12 +398,17 @@ coap_socket_close(coap_socket_t *sock) {
                      coap_socket_strerror(), errno);
       }
     }
+#endif /* COAP_EPOLL_SUPPORT */
 #if COAP_SERVER_SUPPORT
 #if COAP_AF_UNIX_SUPPORT
     if (sock->endpoint &&
         sock->endpoint->bind_addr.addr.sa.sa_family == AF_UNIX) {
       /* Clean up Unix endpoint */
+#ifdef _WIN32
+      _unlink(sock->endpoint->bind_addr.addr.cun.sun_path);
+#else /* ! _WIN32 */
       unlink(sock->endpoint->bind_addr.addr.cun.sun_path);
+#endif /* ! _WIN32 */
     }
 #endif /* COAP_AF_UNIX_SUPPORT */
     sock->endpoint = NULL;
@@ -410,12 +418,15 @@ coap_socket_close(coap_socket_t *sock) {
     if (sock->session && sock->session->type == COAP_SESSION_TYPE_CLIENT &&
         sock->session->addr_info.local.addr.sa.sa_family == AF_UNIX) {
       /* Clean up Unix endpoint */
+#ifdef _WIN32
+      _unlink(sock->session->addr_info.local.addr.cun.sun_path);
+#else /* ! _WIN32 */
       unlink(sock->session->addr_info.local.addr.cun.sun_path);
+#endif /* ! _WIN32 */
     }
 #endif /* COAP_AF_UNIX_SUPPORT */
 #endif /* COAP_CLIENT_SUPPORT */
     sock->session = NULL;
-#endif /* COAP_EPOLL_SUPPORT */
     coap_closesocket(sock->fd);
     sock->fd = COAP_INVALID_SOCKET;
   }
@@ -1518,6 +1529,7 @@ release_1:
         if ((s->last_ping_mid = coap_session_send_ping_lkd(s)) == COAP_INVALID_MID) {
           /* Some issue - not safe to continue processing */
           s->last_rx_tx = now;
+          coap_session_failed(s);
           continue;
         }
         if (s->last_ping > 0 && s->last_pong < s->last_ping) {
@@ -1529,6 +1541,22 @@ release_1:
       s_timeout = (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND) - now;
       if (timeout == 0 || s_timeout < timeout)
         timeout = s_timeout;
+    }
+    if (s->type == COAP_SESSION_TYPE_CLIENT &&
+        s->session_failed && ctx->reconnect_time) {
+      if (s->last_rx_tx + ctx->reconnect_time * COAP_TICKS_PER_SECOND <= now) {
+        if (!coap_session_reconnect(s)) {
+          /* server is not back up yet - delay retry a while */
+          s->last_rx_tx = now;
+          s_timeout = ctx->reconnect_time * COAP_TICKS_PER_SECOND;
+          if (timeout == 0 || s_timeout < timeout)
+            timeout = s_timeout;
+        }
+      } else {
+        s_timeout = (s->last_rx_tx + ctx->reconnect_time * COAP_TICKS_PER_SECOND) - now;
+        if (timeout == 0 || s_timeout < timeout)
+          timeout = s_timeout;
+      }
     }
 
 #if !COAP_DISABLE_TCP

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -567,6 +567,17 @@ coap_context_set_session_timeout(coap_context_t *context,
   context->session_timeout = session_timeout;
 }
 
+void
+coap_context_set_session_reconnect_time(coap_context_t *context,
+                                        unsigned int reconnect_time) {
+#if COAP_CLIENT_SUPPORT
+  context->reconnect_time = reconnect_time;
+#else /* ! COAP_CLIENT_SUPPORT */
+  (void)context;
+  (void)reconnect_time;
+#endif /* ! COAP_CLIENT_SUPPORT */
+}
+
 unsigned int
 coap_context_get_session_timeout(const coap_context_t *context) {
   return context->session_timeout;
@@ -576,9 +587,9 @@ void
 coap_context_set_shutdown_no_observe(coap_context_t *context) {
 #if COAP_SERVER_SUPPORT
   context->shutdown_no_send_observe = 1;
-#else /* COAP_SERVER_SUPPORT */
+#else /* ! COAP_SERVER_SUPPORT */
   (void)context;
-#endif /* COAP_SERVER_SUPPORT */
+#endif /* ! COAP_SERVER_SUPPORT */
 }
 
 int
@@ -1438,7 +1449,7 @@ coap_send_lkd(coap_session_t *session, coap_pdu_t *pdu) {
   pdu->session = session;
 #if COAP_CLIENT_SUPPORT
   if (session->type == COAP_SESSION_TYPE_CLIENT &&
-      !coap_netif_available(session)) {
+      !coap_netif_available(session) && !session->session_failed) {
     coap_log_debug("coap_send: Socket closed\n");
     goto error;
   }
@@ -1775,6 +1786,13 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
   (void)request_pdu;
 #endif /* COAP_SERVER_SUPPORT */
   pdu->session = session;
+#if COAP_CLIENT_SUPPORT
+  if (session->session_failed) {
+    coap_session_reconnect(session);
+    if (session->session_failed)
+      goto error;
+  }
+#endif /* COAP_CLIENT_SUPPORT */
   if (pdu->code == COAP_RESPONSE_CODE(508)) {
     /*
      * Need to prepend our IP identifier to the data as per
@@ -1973,6 +1991,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
     return pdu->mid;
   }
   if (bytes_written < 0) {
+    coap_session_disconnected_lkd(session, COAP_NACK_NOT_DELIVERABLE);
     goto error;
   }
 

--- a/src/coap_netif.c
+++ b/src/coap_netif.c
@@ -132,8 +132,8 @@ coap_netif_dgrm_write(coap_session_t *session, const uint8_t *data,
   coap_socket_t *sock = &session->sock;
 #if COAP_SERVER_SUPPORT
   if (sock->flags == COAP_SOCKET_EMPTY) {
-    assert(session->endpoint != NULL);
-    sock = &session->endpoint->sock;
+    if (session->endpoint != NULL)
+      sock = &session->endpoint->sock;
   }
 #endif /* COAP_SERVER_SUPPORT */
 

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -595,6 +595,11 @@ coap_proxy_get_ongoing_session(coap_session_t *session,
                      (void *)proxy_entry,
                      session->context->proxy_list_count);
     }
+  } else if (proxy_entry->ongoing->session_failed) {
+    if (!coap_session_reconnect(proxy_entry->ongoing)) {
+      /* Server is not yet back up */
+      return NULL;
+    }
   }
 
   return proxy_entry;
@@ -650,7 +655,6 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
   coap_uri_t uri;
 
   /* Set up ongoing session (if not already done) */
-
   proxy_entry = coap_proxy_get_ongoing_session(session, request, response,
                                                server_list);
   if (!proxy_entry) {

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -876,7 +876,8 @@ coap_add_observer(coap_resource_t *resource,
                  (void *)s, s->cache_key->key[0], s->cache_key->key[1],
                  s->cache_key->key[2], s->cache_key->key[3]);
 
-  if (session->context->observe_added && session->proto == COAP_PROTO_UDP) {
+  if (session->context->observe_added && session->proto == COAP_PROTO_UDP &&
+      !coap_is_af_unix(&session->addr_info.local)) {
     coap_bin_const_t raw_packet;
     coap_bin_const_t *oscore_info = NULL;
 #if COAP_OSCORE_SUPPORT

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -450,10 +450,17 @@ coap_make_session(coap_proto_t proto, coap_session_type_t type,
     memcpy(&session->addr_hash, addr_hash, sizeof(session->addr_hash));
   else
     memset(&session->addr_hash, 0, sizeof(session->addr_hash));
-  if (local_addr)
+  if (local_addr) {
     coap_address_copy(&session->addr_info.local, local_addr);
-  else
+#if COAP_CLIENT_SUPPORT
+    coap_address_copy(&session->local_reconnect, local_addr);
+#endif /* COAP_CLIENT_SUPPORT */
+  } else {
     coap_address_init(&session->addr_info.local);
+#if COAP_CLIENT_SUPPORT
+    coap_address_init(&session->local_reconnect);
+#endif /* COAP_CLIENT_SUPPORT */
+  }
   if (remote_addr)
     coap_address_copy(&session->addr_info.remote, remote_addr);
   else
@@ -893,6 +900,9 @@ coap_session_connected(coap_session_t *session) {
                    coap_session_str(session));
     if (session->state == COAP_SESSION_STATE_CSM) {
       coap_handle_event_lkd(session->context, COAP_EVENT_SESSION_CONNECTED, session);
+#if COAP_CLIENT_SUPPORT
+      coap_session_reestablished(session);
+#endif /* COAP_CLIENT_SUPPORT */
       if (session->doing_first)
         session->doing_first = 0;
     }
@@ -1023,8 +1033,11 @@ coap_session_disconnected_lkd(coap_session_t *session, coap_nack_reason_t reason
   coap_queue_t *q;
 
   coap_lock_check_locked(session->context);
-  q = session->context->sendqueue;
+#if COAP_CLIENT_SUPPORT
+  coap_session_failed(session);
+#endif /* COAP_CLIENT_SUPPORT */
 
+  q = session->context->sendqueue;
   while (q) {
     if (q->session == session) {
       /* Take the first one */
@@ -1102,10 +1115,12 @@ coap_session_disconnected_lkd(coap_session_t *session, coap_nack_reason_t reason
   }
 
 #if COAP_CLIENT_SUPPORT
-  /* Need to do this before (D)TLS and socket is closed down */
-  LL_FOREACH_SAFE(session->lg_crcv, cq, etmp) {
-    LL_DELETE(session->lg_crcv, cq);
-    coap_block_delete_lg_crcv(session, cq);
+  if (!session->session_failed) {
+    /* Need to do this before (D)TLS and socket is closed down */
+    LL_FOREACH_SAFE(session->lg_crcv, cq, etmp) {
+      LL_DELETE(session->lg_crcv, cq);
+      coap_block_delete_lg_crcv(session, cq);
+    }
   }
 #endif /* COAP_CLIENT_SUPPORT */
   LL_FOREACH_SAFE(session->lg_xmit, lq, ltmp) {
@@ -1127,17 +1142,32 @@ coap_session_disconnected_lkd(coap_session_t *session, coap_nack_reason_t reason
                             state == COAP_SESSION_STATE_CONNECTING ?
                             COAP_EVENT_TCP_FAILED : COAP_EVENT_TCP_CLOSED, session);
     }
-    if (state != COAP_SESSION_STATE_NONE) {
+#if COAP_CLIENT_SUPPORT
+    if (state != COAP_SESSION_STATE_NONE && !session->session_failed) {
       coap_handle_event_lkd(session->context,
                             state == COAP_SESSION_STATE_ESTABLISHED ?
                             COAP_EVENT_SESSION_CLOSED : COAP_EVENT_SESSION_FAILED, session);
     }
+#endif /* COAP_CLIENT_SUPPORT */
     if (session->doing_first)
       session->doing_first = 0;
   }
 #endif /* !COAP_DISABLE_TCP */
-  session->sock.lfunc[COAP_LAYER_SESSION].l_close(session);
+  if (session->sock.lfunc[COAP_LAYER_SESSION].l_close)
+    session->sock.lfunc[COAP_LAYER_SESSION].l_close(session);
 }
+
+#if COAP_CLIENT_SUPPORT
+void
+coap_session_failed(coap_session_t *session) {
+  if (session->context->reconnect_time &&
+      session->state == COAP_SESSION_STATE_ESTABLISHED &&
+      session->type == COAP_SESSION_TYPE_CLIENT) {
+    session->session_failed = 1;
+    coap_ticks(&session->last_rx_tx);
+  }
+}
+#endif /* COAP_CLIENT_SUPPORT */
 
 #if COAP_SERVER_SUPPORT
 static void
@@ -1472,9 +1502,7 @@ coap_session_check_connect(coap_session_t *session) {
   if (COAP_PROTO_RELIABLE(session->proto)) {
     if (session->sock.flags & COAP_SOCKET_WANT_CONNECT) {
       session->state = COAP_SESSION_STATE_CONNECTING;
-      if (session->state != COAP_SESSION_STATE_ESTABLISHED &&
-          session->state != COAP_SESSION_STATE_NONE &&
-          session->type == COAP_SESSION_TYPE_CLIENT) {
+      if (session->type == COAP_SESSION_TYPE_CLIENT) {
         session->doing_first = 1;
       }
     } else {
@@ -1498,6 +1526,91 @@ coap_session_establish(coap_session_t *session) {
 }
 
 #if COAP_CLIENT_SUPPORT
+int
+coap_session_reconnect(coap_session_t *session) {
+  int default_port = COAP_DEFAULT_PORT;
+
+  if (session->sock.lfunc[COAP_LAYER_SESSION].l_close && !session->session_failed)
+    session->sock.lfunc[COAP_LAYER_SESSION].l_close(session);
+
+  switch (session->proto) {
+  case COAP_PROTO_UDP:
+    default_port = COAP_DEFAULT_PORT;
+    break;
+  case COAP_PROTO_DTLS:
+    default_port = COAPS_DEFAULT_PORT;
+    break;
+  case COAP_PROTO_TCP:
+    default_port = COAP_DEFAULT_PORT;
+    break;
+  case COAP_PROTO_TLS:
+    default_port = COAPS_DEFAULT_PORT;
+    break;
+  case COAP_PROTO_WS:
+    default_port = 80;
+    break;
+  case COAP_PROTO_WSS:
+    default_port = 443;
+    break;
+  case COAP_PROTO_NONE:
+  case COAP_PROTO_LAST:
+  default:
+    assert(0);
+    return 0;
+  }
+  session->sock.session = session;
+  coap_log_debug("***%s: trying to reconnect\n", coap_session_str(session));
+  if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
+    session->state = COAP_SESSION_STATE_NONE;
+    if (!coap_netif_dgrm_connect(session, &session->local_reconnect, &session->addr_info.remote,
+                                 default_port)) {
+      goto error;
+    }
+    coap_session_reestablished(session);
+#ifdef WITH_CONTIKI
+    session->sock.context = session->context;
+#endif /* WITH_CONTIKI */
+#if !COAP_DISABLE_TCP
+  } else if (COAP_PROTO_RELIABLE(session->proto)) {
+    if (!coap_netif_strm_connect1(session, &session->local_reconnect, &session->addr_info.remote,
+                                  default_port)) {
+      goto error;
+    }
+#endif /* !COAP_DISABLE_TCP */
+  } else {
+    goto error;
+  }
+#ifdef COAP_EPOLL_SUPPORT
+  coap_epoll_ctl_add(&session->sock,
+                     EPOLLIN |
+                     ((session->sock.flags & COAP_SOCKET_WANT_CONNECT) ?
+                      EPOLLOUT : 0),
+                     __func__);
+#endif /* COAP_EPOLL_SUPPORT */
+
+  session->sock.flags |= COAP_SOCKET_NOT_EMPTY | COAP_SOCKET_WANT_READ;
+  session->sock.flags |= COAP_SOCKET_BOUND;
+  coap_session_check_connect(session);
+  return 1;
+error:
+  return 0;
+}
+
+void
+coap_session_reestablished(coap_session_t *session) {
+  coap_lg_crcv_t *lg_crcv, *etmp;
+
+  if (!session->session_failed)
+    return;
+  coap_log_debug("***%s: session re-established\n",
+                 coap_session_str(session));
+  session->session_failed = 0;
+  LL_FOREACH_SAFE(session->lg_crcv, lg_crcv, etmp) {
+    coap_pdu_reference_lkd(&lg_crcv->pdu);
+    coap_send_internal(session, &lg_crcv->pdu, NULL);
+  }
+}
+
 COAP_API coap_session_t *
 coap_new_client_session(coap_context_t *ctx,
                         const coap_address_t *local_if,

--- a/src/coap_tcp.c
+++ b/src/coap_tcp.c
@@ -16,6 +16,15 @@
 
 #include "coap3/coap_libcoap_build.h"
 
+#if COAP_AF_UNIX_SUPPORT
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif /* HAVE_UNISTD_H */
+#ifdef _WIN32
+#include <stdio.h>
+#endif /* _WIN32 */
+#endif /* COAP_AF_UNIX_SUPPORT */
+
 int
 coap_tcp_is_supported(void) {
   return !COAP_DISABLE_TCP;
@@ -153,6 +162,15 @@ coap_socket_connect_tcp1(coap_socket_t *sock,
   return 1;
 
 error:
+#if COAP_AF_UNIX_SUPPORT
+  if (local_if && local_if->addr.sa.sa_family == AF_UNIX) {
+#ifdef _WIN32
+    _unlink(local_if->addr.cun.sun_path);
+#else /* ! _WIN32 */
+    unlink(local_if->addr.cun.sun_path);
+#endif /* ! _WIN32 */
+  }
+#endif /* COAP_AF_UNIX_SUPPORT */
   coap_socket_close(sock);
   return 0;
 }


### PR DESCRIPTION
Allow re-establishment with upstream server when server restarts.

When upstream server re-connects, re-establish any (D)TLS sessions
and active observe subscriptions.

Supported by a new function coap_context_set_session_reconnect_time().