### PR TITLE
Observe: Make sending observe failed messages optional

### DIFF
--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -310,6 +310,16 @@ void coap_context_set_session_timeout(coap_context_t *context,
  */
 unsigned int coap_context_get_session_timeout(const coap_context_t *context);
 
+/*
+ * Stop sending out observe subscriptons when calling coap_free_context().
+ *
+ * If this is not called, then 5.03 messages are sent out for every observe
+ * subscription when the context is freed off.
+ *
+ * @param context The coap_context_t object.
+ */
+void coap_context_set_shutdown_no_observe(coap_context_t *context);
+
 /**
  * Set the CSM timeout value. The number of seconds to wait for a (TCP) CSM
  * negotiation response from the peer.

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -193,6 +193,9 @@ struct coap_context_t {
                                         resource */
   uint8_t mcast_per_resource;      /**< Mcast controlled on a per resource
                                         basis */
+  uint8_t shutdown_no_send_observe; /**< Do not send out unsolicited observe when
+                                         coap_free_context() is called. Otherwise
+                                         5.03 will get sent */
 #endif /* COAP_SERVER_SUPPORT */
 #if COAP_PROXY_SUPPORT
   coap_proxy_list_t *proxy_list;   /**< Set of active proxy sessions */

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -72,6 +72,7 @@ global:
   coap_context_set_psk2;
   coap_context_set_psk;
   coap_context_set_session_timeout;
+  coap_context_set_shutdown_no_observe;
   coap_debug_set_packet_loss;
   coap_decode_var_bytes8;
   coap_decode_var_bytes;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -70,6 +70,7 @@ coap_context_set_pki_root_cas
 coap_context_set_psk
 coap_context_set_psk2
 coap_context_set_session_timeout
+coap_context_set_shutdown_no_observe
 coap_debug_set_packet_loss
 coap_decode_var_bytes
 coap_decode_var_bytes8

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -126,6 +126,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_set_app_data2.3
 	@echo ".so man3/coap_context.3" > coap_context_get_app_data.3
 	@echo ".so man3/coap_context.3" > coap_context_set_cid_tuple_change.3
+	@echo ".so man3/coap_context.3" > coap_context_set_shutdown_no_observe.3
 	@echo ".so man3/coap_deprecated.3" > coap_set_app_data.3
 	@echo ".so man3/coap_deprecated.3" > coap_get_app_data.3
 	@echo ".so man3/coap_deprecated.3" > coap_option_setb.3

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -24,7 +24,8 @@ coap_context_get_csm_timeout_ms,
 coap_context_set_max_token_size,
 coap_context_set_app_data2,
 coap_context_get_app_data,
-coap_context_set_cid_tuple_change
+coap_context_set_cid_tuple_change,
+coap_context_set_shutdown_no_observe
 - Work with CoAP contexts
 
 SYNOPSIS
@@ -67,6 +68,8 @@ coap_app_data_free_callback_t _app_cb_);*
 *void *coap_context_get_app_data(const coap_context_t *_context_);*
 
 *int coap_context_set_cid_tuple_change(coap_context_t *_context_context, uint8_t _every_);*
+
+*void coap_context_set_shutdown_no_observe(coap_context_t *_context_);
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -209,6 +212,14 @@ The *coap_context_set_cid_tuple_change*() function is used to define to a client
 to force the client's port to change _every_ packets sent, providing the ability
 to test a CID (RFC9146) enabled server. Only supported by DTLS libraries that
 support CID.
+
+*Function: coap_context_set_shutdown_no_observe()*
+
+The *coap_context_set_shutdown_no_observe*() function is used to set the logic
+so that no unsolicited observe responses are sent out by the server when
+*coap_free_context*() is called. If *coap_context_set_shutdown_no_observe*()
+is not called, then 5.03 responses are sent out indicating that the observed
+resource is temporarily unavailable.
 
 RETURN VALUES
 -------------

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -572,6 +572,15 @@ coap_context_get_session_timeout(const coap_context_t *context) {
   return context->session_timeout;
 }
 
+void
+coap_context_set_shutdown_no_observe(coap_context_t *context) {
+#if COAP_SERVER_SUPPORT
+  context->shutdown_no_send_observe = 1;
+#else /* COAP_SERVER_SUPPORT */
+  (void)context;
+#endif /* COAP_SERVER_SUPPORT */
+}
+
 int
 coap_context_get_coap_fd(const coap_context_t *context) {
 #ifdef COAP_EPOLL_SUPPORT
@@ -803,6 +812,8 @@ coap_free_context_lkd(coap_context_t *context) {
   coap_lock_check_locked(context);
 #if COAP_SERVER_SUPPORT
   /* Removing a resource may cause a NON unsolicited observe to be sent */
+  if (context->shutdown_no_send_observe)
+    context->observe_no_clear = 1;
   coap_delete_all_resources(context);
 #endif /* COAP_SERVER_SUPPORT */
 

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -476,14 +476,15 @@ coap_delete_attr(coap_attr_t *attr) {
 
 typedef enum coap_deleting_resource_t {
   COAP_DELETING_RESOURCE,
-  COAP_NOT_DELETING_RESOURCE
+  COAP_NOT_DELETING_RESOURCE,
+  COAP_DELETING_RESOURCE_ON_EXIT
 } coap_deleting_resource_t;
 
 static void coap_notify_observers(coap_context_t *context, coap_resource_t *r,
                                   coap_deleting_resource_t deleting);
 
 static void
-coap_free_resource(coap_resource_t *resource) {
+coap_free_resource(coap_resource_t *resource, coap_deleting_resource_t deleting) {
   coap_attr_t *attr, *tmp;
   coap_subscription_t *obs, *otmp;
 
@@ -491,7 +492,7 @@ coap_free_resource(coap_resource_t *resource) {
 
   if (!resource->context->observe_no_clear) {
     coap_resource_notify_observers_lkd(resource, NULL);
-    coap_notify_observers(resource->context, resource, COAP_DELETING_RESOURCE);
+    coap_notify_observers(resource->context, resource, deleting);
   }
 
   if (resource->context->resource_deleted)
@@ -536,11 +537,11 @@ coap_add_resource_lkd(coap_context_t *context, coap_resource_t *resource) {
   coap_lock_check_locked(context);
   if (resource->is_unknown) {
     if (context->unknown_resource)
-      coap_free_resource(context->unknown_resource);
+      coap_free_resource(context->unknown_resource, COAP_DELETING_RESOURCE);
     context->unknown_resource = resource;
   } else if (resource->is_proxy_uri) {
     if (context->proxy_uri_resource)
-      coap_free_resource(context->proxy_uri_resource);
+      coap_free_resource(context->proxy_uri_resource, COAP_DELETING_RESOURCE);
     context->proxy_uri_resource = resource;
   } else {
     coap_resource_t *r = coap_get_resource_from_uri_path_lkd(context,
@@ -616,7 +617,7 @@ coap_delete_resource_lkd(coap_context_t *context, coap_resource_t *resource) {
   }
 
   /* and free its allocated memory */
-  coap_free_resource(resource);
+  coap_free_resource(resource, COAP_DELETING_RESOURCE);
 
   return 1;
 }
@@ -631,17 +632,17 @@ coap_delete_all_resources(coap_context_t *context) {
 
   HASH_ITER(hh, context->resources, res, rtmp) {
     HASH_DELETE(hh, context->resources, res);
-    coap_free_resource(res);
+    coap_free_resource(res, COAP_DELETING_RESOURCE_ON_EXIT);
   }
 
   context->resources = NULL;
 
   if (context->unknown_resource) {
-    coap_free_resource(context->unknown_resource);
+    coap_free_resource(context->unknown_resource, COAP_DELETING_RESOURCE_ON_EXIT);
     context->unknown_resource = NULL;
   }
   if (context->proxy_uri_resource) {
-    coap_free_resource(context->proxy_uri_resource);
+    coap_free_resource(context->proxy_uri_resource, COAP_DELETING_RESOURCE_ON_EXIT);
     context->proxy_uri_resource = NULL;
   }
 }
@@ -1232,6 +1233,15 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
           coap_delete_observer(r, obs->session, &obs->pdu->actual_token);
           obs = NULL;
         }
+        break;
+      case COAP_DELETING_RESOURCE_ON_EXIT:
+        /* Don't worry if it does not get there */
+        response->type = COAP_MESSAGE_NON;
+        response->code = COAP_RESPONSE_CODE(503);
+        coap_add_option_internal(response, COAP_OPTION_MAXAGE,
+                                 coap_encode_var_safe(buf, sizeof(buf),
+                                                      30),
+                                 buf);
         break;
       case COAP_DELETING_RESOURCE:
       default:


### PR DESCRIPTION
When a server cleanly closes down (calls coap_free_context()), when a resource gets deleted, a 4.04 message is sent out (not when using coap_persist(3)) for any active observe subscriptions. If a server knows it is going to be restarted, then there is no need to send out a observe failed message.

When deleting a resource when normally running, it is correct to send out a 4.04 Not Found response as the resource has genuinely gone away.  However, when the server is cleaning shutting down, it is better to use 5.03 Service Unavailable to indicate the situation may be temporary.