### PR TITLE
RIOT: Fix examples client issue

### DIFF
--- a/examples/riot/README
+++ b/examples/riot/README
@@ -12,7 +12,7 @@ This will
   and examples/libcoap-server taken from pkg_libcoap/, examples_client/
   and examples_server respectively/.
   (updates RIOT's libcoap code to the latest commited version in your
-   environment).
+   environment, along with any modified files).
 * build the client application
 * build the server application
 
@@ -22,6 +22,7 @@ To run (and/or rebuild) the server application
 * make RIOT_CI_BUILD=1
 * make term
 * (at the shell prompt) coaps start
+* (or at the shell prompt) coaps stop
 
 The server creates a resource for 'time' with a query 'ticks'.  This is
 reported for `.well-known/core`. The work flow for adding more resources does
@@ -32,10 +33,11 @@ To run (and/or rebuild) the client application
 * cd RIOT/examples-libcoap-client
 * make RIOT_CI_BUILD=1
 * make term
-* (at the shell prompt) coapc
+* (at the shell prompt) coapc coap://[ip-6-address]/some/path
 
 The client will try to connect to the URI defined in app.config named
-CONFIG_LIBCOAP_CLIENT_URI (unless overridden by running 'make menuconfig').
+CONFIG_LIBCOAP_CLIENT_URI (unless overridden by running 'make menuconfig'),
+or as specified in the parameter after the coapc.
 
 Note to developers
 ==================

--- a/examples/riot/examples_libcoap_client/client-coap.c
+++ b/examples/riot/examples_libcoap_client/client-coap.c
@@ -219,7 +219,7 @@ client_coap_init(int argc, char **argv)
     }
 
     res = coap_uri_into_optlist(&uri, &dst, &optlist, 1);
-    if (res) {
+    if (res != 1) {
         coap_log_warn("Failed to create options\n");
         goto fail;
     }

--- a/examples/riot/pkg_libcoap/Makefile
+++ b/examples/riot/pkg_libcoap/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=libcoap
 PKG_URL=https://github.com/obgm/libcoap
-PKG_VERSION=0d240530b4beba90cc86c488e17bd0090437a0dd
+PKG_VERSION=cd06a72916bd234fd5dfdaea4def50f178440614
 PKG_LICENSE=BSD-2-Clause
 
 LIBCOAP_BUILD_DIR=$(BINDIR)/pkg/$(PKG_NAME)


### PR DESCRIPTION
Bring the code up to the latest libcoap spec.