### PR TITLE
coap_io.c: Correct timeout values when entry has just timed out

### DIFF
--- a/include/coap3/coap_async_internal.h
+++ b/include/coap3/coap_async_internal.h
@@ -74,11 +74,12 @@ coap_async_t *coap_register_async_lkd(coap_session_t *session,
  *
  * @param context The current context.
  * @param now     The current time in ticks.
+ * @param tim_rem Updated with the remaining timeout time if return is @c 1,
+ *                unless set to NULL.
  *
- * @return The tick time before the next Async needs to go, else 0 if
- *         nothing to do.
+ * @return @c 1 if @p tim_rem is set, else @c 0 if there is no timeout.
  */
-coap_tick_t coap_check_async(coap_context_t *context, coap_tick_t now);
+int coap_check_async(coap_context_t *context, coap_tick_t now, coap_tick_t *tim_rem);
 
 /**
  * Retrieves the object identified by @p token from the list of asynchronous

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -258,8 +258,17 @@ coap_mid_t coap_send_q_block1(coap_session_t *session,
                               coap_pdu_t *request,
                               coap_send_pdu_t send_request);
 
-coap_tick_t coap_block_check_q_block1_xmit(coap_session_t *session,
-                                           coap_tick_t now);
+/**
+ * Check if the next Q-Block1 needs to be sent, else get the next timeout value.
+ *
+ * @param session The Session to check.
+ * @param now     The current time in ticks.
+ * @param tim_rem Updated with the remaining timeout time if return is @c 1.
+ *
+ * @return @c 1 if @p tim_rem is set, else @c 0 if there is no timeout.
+ */
+int coap_block_check_q_block1_xmit(coap_session_t *session,
+                                   coap_tick_t now, coap_tick_t *tim_rem);
 
 coap_mid_t coap_block_test_q_block(coap_session_t *session, coap_pdu_t *actual);
 #endif /* COAP_Q_BLOCK_SUPPORT */
@@ -283,8 +292,17 @@ int coap_block_check_lg_srcv_timeouts(coap_session_t *session,
                                       coap_tick_t *tim_rem);
 
 #if COAP_Q_BLOCK_SUPPORT
-coap_tick_t coap_block_check_q_block2_xmit(coap_session_t *session,
-                                           coap_tick_t now);
+/**
+ * Check if the next Q-Block2 needs to be sent, else get the next timeout value.
+ *
+ * @param session The Session to check.
+ * @param now     The current time in ticks.
+ * @param tim_rem Updated with the remaining timeout time if return is @c 1.
+ *
+ * @return @c 1 if @p tim_rem is set, else @c 0 if there is no timeout.
+ */
+int coap_block_check_q_block2_xmit(coap_session_t *session,
+                                   coap_tick_t now, coap_tick_t *tim_rem);
 
 coap_mid_t coap_send_q_block2(coap_session_t *session,
                               coap_resource_t *resource,

--- a/include/coap3/coap_time.h
+++ b/include/coap3/coap_time.h
@@ -217,6 +217,9 @@ coap_time_le(coap_tick_t a, coap_tick_t b) {
   return a == b || coap_time_lt(a,b);
 }
 
+/* Can delay up to 24 hrs before next wakeup (coap_tick_t can be 4 bytes or int64 */
+#define COAP_MAX_DELAY_TICKS (24 * 60 * 60 * COAP_TICKS_PER_SECOND)
+
 /** @} */
 
 #endif /* COAP_TIME_H_ */

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -1345,7 +1345,7 @@ coap_block_check_lg_xmit_timeouts(coap_session_t *session, coap_tick_t now,
   coap_tick_t partial_timeout = COAP_MAX_TRANSMIT_WAIT_TICKS(session);
   int ret = 0;
 
-  *tim_rem = -1;
+  *tim_rem = COAP_MAX_DELAY_TICKS;
 
   LL_FOREACH_SAFE(session->lg_xmit, lg_xmit, q) {
     if (lg_xmit->last_all_sent) {
@@ -1512,7 +1512,7 @@ coap_block_check_lg_crcv_timeouts(coap_session_t *session, coap_tick_t now,
 #endif /* COAP_Q_BLOCK_SUPPORT */
   int ret = 0;
 
-  *tim_rem = -1;
+  *tim_rem = COAP_MAX_DELAY_TICKS;
 #if COAP_Q_BLOCK_SUPPORT
   if (COAP_PROTO_NOT_RELIABLE(session->proto) &&
       session->block_mode & COAP_BLOCK_HAS_Q_BLOCK)
@@ -1715,7 +1715,7 @@ coap_block_check_lg_srcv_timeouts(coap_session_t *session, coap_tick_t now,
 #endif /* COAP_Q_BLOCK_SUPPORT */
   int ret = 0;
 
-  *tim_rem = -1;
+  *tim_rem = COAP_MAX_DELAY_TICKS;
 #if COAP_Q_BLOCK_SUPPORT
   if (COAP_PROTO_NOT_RELIABLE(session->proto) &&
       session->block_mode & COAP_BLOCK_HAS_Q_BLOCK)
@@ -2008,18 +2008,26 @@ coap_send_q_blocks(coap_session_t *session,
 }
 
 #if COAP_CLIENT_SUPPORT
-coap_tick_t
-coap_block_check_q_block1_xmit(coap_session_t *session, coap_tick_t now) {
+/*
+ * Return 1 if there is a future expire time, else 0.
+ * Update tim_rem with remaining value if return is 1.
+ */
+int
+coap_block_check_q_block1_xmit(coap_session_t *session, coap_tick_t now, coap_tick_t *tim_rem) {
   coap_lg_xmit_t *lg_xmit;
   coap_lg_xmit_t *q;
   coap_tick_t timed_out;
-  coap_tick_t tim_rem = (coap_tick_t)-1;
+  int ret = 0;
 
+  *tim_rem = COAP_MAX_DELAY_TICKS;
   LL_FOREACH_SAFE(session->lg_xmit, lg_xmit, q) {
     coap_tick_t non_timeout = lg_xmit->non_timeout_random_ticks;
 
-    if (now < non_timeout)
-      return non_timeout - now;
+    if (now <= non_timeout) {
+      /* Too early in the startup cycle to have an accurate response */
+      *tim_rem = non_timeout - now;
+      return 1;
+    }
     timed_out = now - non_timeout;
 
     if (lg_xmit->last_payload) {
@@ -2033,12 +2041,16 @@ coap_block_check_q_block1_xmit(coap_session_t *session, coap_tick_t now) {
         block.m = lg_xmit->offset + chunk < lg_xmit->length;
         block.szx = lg_xmit->blk_size;
         coap_send_q_blocks(session, lg_xmit, block, &lg_xmit->pdu, COAP_SEND_SKIP_PDU);
-        if (tim_rem > non_timeout)
-          tim_rem = non_timeout;
+        if (*tim_rem > non_timeout) {
+          *tim_rem = non_timeout;
+          ret = 1;
+        }
       } else {
         /* Delay until the next MAX_PAYLOAD needs to be sent off */
-        if (tim_rem > lg_xmit->last_payload - timed_out)
-          tim_rem = lg_xmit->last_payload - timed_out;
+        if (*tim_rem > lg_xmit->last_payload - timed_out) {
+          *tim_rem = lg_xmit->last_payload - timed_out;
+          ret = 1;
+        }
       }
     } else if (lg_xmit->last_all_sent) {
       non_timeout = COAP_NON_TIMEOUT_TICKS(session);
@@ -2048,28 +2060,38 @@ coap_block_check_q_block1_xmit(coap_session_t *session, coap_tick_t now) {
         coap_block_delete_lg_xmit(session, lg_xmit);
       } else {
         /* Delay until the lg_xmit needs to expire */
-        if (tim_rem > lg_xmit->last_all_sent + 4 * non_timeout - now)
-          tim_rem = lg_xmit->last_all_sent + 4 * non_timeout - now;
+        if (*tim_rem > lg_xmit->last_all_sent + 4 * non_timeout - now) {
+          *tim_rem = lg_xmit->last_all_sent + 4 * non_timeout - now;
+          ret = 1;
+        }
       }
     }
   }
-  return tim_rem;
+  return ret;
 }
 #endif /* COAP_CLIENT_SUPPORT */
 
 #if COAP_SERVER_SUPPORT
-coap_tick_t
-coap_block_check_q_block2_xmit(coap_session_t *session, coap_tick_t now) {
+/*
+ * Return 1 if there is a future expire time, else 0.
+ * Update tim_rem with remaining value if return is 1.
+ */
+int
+coap_block_check_q_block2_xmit(coap_session_t *session, coap_tick_t now, coap_tick_t *tim_rem) {
   coap_lg_xmit_t *lg_xmit;
   coap_lg_xmit_t *q;
   coap_tick_t timed_out;
-  coap_tick_t tim_rem = (coap_tick_t)-1;
+  int ret = 0;
 
+  *tim_rem = (coap_tick_t)-1;
   LL_FOREACH_SAFE(session->lg_xmit, lg_xmit, q) {
     coap_tick_t non_timeout = lg_xmit->non_timeout_random_ticks;
 
-    if (now < non_timeout)
-      return non_timeout - now;
+    if (now <= non_timeout) {
+      /* Too early in the startup cycle to have an accurate response */
+      *tim_rem = non_timeout - now;
+      return 1;
+    }
     timed_out = now - non_timeout;
 
     if (lg_xmit->last_payload) {
@@ -2084,12 +2106,16 @@ coap_block_check_q_block2_xmit(coap_session_t *session, coap_tick_t now) {
         block.szx = lg_xmit->blk_size;
         if (block.num == (uint32_t)lg_xmit->last_block)
           coap_send_q_blocks(session, lg_xmit, block, &lg_xmit->pdu, COAP_SEND_SKIP_PDU);
-        if (tim_rem > non_timeout)
-          tim_rem = non_timeout;
+        if (*tim_rem > non_timeout) {
+          *tim_rem = non_timeout;
+          ret = 1;
+        }
       } else {
         /* Delay until the next MAX_PAYLOAD needs to be sent off */
-        if (tim_rem > lg_xmit->last_payload - timed_out)
-          tim_rem = lg_xmit->last_payload - timed_out;
+        if (*tim_rem > lg_xmit->last_payload - timed_out) {
+          *tim_rem = lg_xmit->last_payload - timed_out;
+          ret = 1;
+        }
       }
     } else if (lg_xmit->last_all_sent) {
       non_timeout = COAP_NON_TIMEOUT_TICKS(session);
@@ -2099,12 +2125,14 @@ coap_block_check_q_block2_xmit(coap_session_t *session, coap_tick_t now) {
         coap_block_delete_lg_xmit(session, lg_xmit);
       } else {
         /* Delay until the lg_xmit needs to expire */
-        if (tim_rem > lg_xmit->last_all_sent + 4 * non_timeout - now)
-          tim_rem = lg_xmit->last_all_sent + 4 * non_timeout - now;
+        if (*tim_rem > lg_xmit->last_all_sent + 4 * non_timeout - now) {
+          *tim_rem = lg_xmit->last_all_sent + 4 * non_timeout - now;
+          ret = 1;
+        }
       }
     }
   }
-  return tim_rem;
+  return ret;
 }
 #endif /* COAP_SERVER_SUPPORT */
 #endif /* COAP_Q_BLOCK_SUPPORT */

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1346,7 +1346,7 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
                        coap_tick_t now) {
   coap_queue_t *nextpdu;
   coap_session_t *s, *stmp;
-  coap_tick_t timeout = 0;
+  coap_tick_t timeout = COAP_MAX_DELAY_TICKS;
   coap_tick_t s_timeout;
 #if COAP_SERVER_SUPPORT
   int check_dtls_timeouts = 0;
@@ -1365,7 +1365,10 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
 
 #if COAP_ASYNC_SUPPORT
   /* Check to see if we need to send off any Async requests */
-  timeout = coap_check_async(ctx, now);
+  if (coap_check_async(ctx, now, &s_timeout)) {
+    if (s_timeout < timeout)
+      timeout = s_timeout;
+  }
 #endif /* COAP_ASYNC_SUPPORT */
 #endif /* COAP_SERVER_SUPPORT */
 
@@ -1376,8 +1379,8 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
     coap_retransmit(ctx, coap_pop_next(ctx));
     nextpdu = coap_peek_next(ctx);
   }
-  if (nextpdu && (timeout == 0 ||
-                  nextpdu->t - (now - ctx->sendqueue_basetime) < timeout))
+  if (nextpdu && now >= ctx->sendqueue_basetime &&
+      (nextpdu->t - (now - ctx->sendqueue_basetime) < timeout))
     timeout = nextpdu->t - (now - ctx->sendqueue_basetime);
 
   /* Check for DTLS timeouts */
@@ -1389,7 +1392,7 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
           tls_timeout = now + COAP_TICKS_PER_SECOND / 10;
         coap_log_debug("** DTLS global timeout set to %dms\n",
                        (int)((tls_timeout - now) * 1000 / COAP_TICKS_PER_SECOND));
-        if (timeout == 0 || tls_timeout - now < timeout)
+        if (tls_timeout - now < timeout)
           timeout = tls_timeout - now;
       }
 #if COAP_SERVER_SUPPORT
@@ -1400,7 +1403,7 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
   }
 #if COAP_PROXY_SUPPORT
   if (coap_proxy_check_timeouts(ctx, now, &s_timeout)) {
-    if (timeout == 0 || s_timeout < timeout)
+    if (s_timeout < timeout)
       timeout = s_timeout;
   }
 #endif /* COAP_PROXY_SUPPORT */
@@ -1432,8 +1435,9 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
       } else {
         if (s->type == COAP_SESSION_TYPE_SERVER && s->ref == 0 &&
             s->delayqueue == NULL) {
+          /* Has to be positive based on if() above */
           s_timeout = (s->last_rx_tx + session_timeout) - now;
-          if (timeout == 0 || s_timeout < timeout)
+          if (s_timeout < timeout)
             timeout = s_timeout;
         }
         /* Make sure the session object is not deleted in any callbacks */
@@ -1455,20 +1459,20 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
               timeout = 1;
             }
           }
-          if (tls_timeout > 0 && (timeout == 0 || tls_timeout - now < timeout))
+          if (tls_timeout > 0 && tls_timeout - now < timeout)
             timeout = tls_timeout - now;
         }
         /* Check if any server large receives are missing blocks */
         if (s->lg_srcv) {
           if (coap_block_check_lg_srcv_timeouts(s, now, &s_timeout)) {
-            if (timeout == 0 || s_timeout < timeout)
+            if (s_timeout < timeout)
               timeout = s_timeout;
           }
         }
         /* Check if any server large sending have timed out */
         if (s->lg_xmit) {
           if (coap_block_check_lg_xmit_timeouts(s, now, &s_timeout)) {
-            if (timeout == 0 || s_timeout < timeout)
+            if (s_timeout < timeout)
               timeout = s_timeout;
           }
         }
@@ -1484,9 +1488,10 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
          * restarting
          */
         if (s->lg_xmit) {
-          s_timeout = coap_block_check_q_block2_xmit(s, now);
-          if (timeout == 0 || s_timeout < timeout)
-            timeout = s_timeout;
+          if (coap_block_check_q_block2_xmit(s, now, &s_timeout)) {
+            if (s_timeout < timeout)
+              timeout = s_timeout;
+          }
         }
 #endif /* COAP_Q_BLOCK_SUPPORT */
 release_1:
@@ -1494,16 +1499,19 @@ release_1:
       }
       if (s->type == COAP_SESSION_TYPE_SERVER &&
           s->state == COAP_SESSION_STATE_ESTABLISHED &&
-          s->ref_subscriptions &&
+          s->ref_subscriptions && !s->con_active &&
           ctx->ping_timeout > 0) {
         /* Only do this if this session is observing */
         if (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND <= now) {
           /* Time to send a ping */
-          if ((s->last_ping_mid = coap_session_send_ping_lkd(s)) == COAP_INVALID_MID) {
+          coap_mid_t mid;
+
+          if ((mid = coap_session_send_ping_lkd(s)) == COAP_INVALID_MID) {
             /* Some issue - not safe to continue processing */
             s->last_rx_tx = now;
             continue;
           }
+          s->last_ping_mid = mid;
           if (s->last_ping > 0 && s->last_pong < s->last_ping) {
             coap_session_server_keepalive_failed(s);
             /* check the next session */
@@ -1511,10 +1519,12 @@ release_1:
           }
           s->last_rx_tx = now;
           s->last_ping = now;
+        } else {
+          /* Always positive due to if() above */
+          s_timeout = (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND) - now;
+          if (s_timeout < timeout)
+            timeout = s_timeout;
         }
-        s_timeout = (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND) - now;
-        if (timeout == 0 || s_timeout < timeout)
-          timeout = s_timeout;
       }
     }
   }
@@ -1522,25 +1532,30 @@ release_1:
 #if COAP_CLIENT_SUPPORT
   SESSIONS_ITER_SAFE(ctx->sessions, s, stmp) {
     if (s->type == COAP_SESSION_TYPE_CLIENT &&
-        s->state == COAP_SESSION_STATE_ESTABLISHED &&
+        s->state == COAP_SESSION_STATE_ESTABLISHED && !s->con_active &&
         ctx->ping_timeout > 0) {
-      if (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND <= now && !s->con_active) {
+      if (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND <= now) {
         /* Time to send a ping */
-        if ((s->last_ping_mid = coap_session_send_ping_lkd(s)) == COAP_INVALID_MID) {
+        coap_mid_t mid;
+
+        if ((mid = coap_session_send_ping_lkd(s)) == COAP_INVALID_MID) {
           /* Some issue - not safe to continue processing */
           s->last_rx_tx = now;
           coap_session_failed(s);
           continue;
         }
+        s->last_ping_mid = mid;
         if (s->last_ping > 0 && s->last_pong < s->last_ping) {
           coap_handle_event_lkd(s->context, COAP_EVENT_KEEPALIVE_FAILURE, s);
         }
         s->last_rx_tx = now;
         s->last_ping = now;
+      } else {
+        /* Always positive due to if() above */
+        s_timeout = (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND) - now;
+        if (s_timeout < timeout)
+          timeout = s_timeout;
       }
-      s_timeout = (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND) - now;
-      if (timeout == 0 || s_timeout < timeout)
-        timeout = s_timeout;
     }
     if (s->type == COAP_SESSION_TYPE_CLIENT &&
         s->session_failed && ctx->reconnect_time) {
@@ -1553,8 +1568,9 @@ release_1:
             timeout = s_timeout;
         }
       } else {
+        /* Always positive due to if() above */
         s_timeout = (s->last_rx_tx + ctx->reconnect_time * COAP_TICKS_PER_SECOND) - now;
-        if (timeout == 0 || s_timeout < timeout)
+        if (s_timeout < timeout)
           timeout = s_timeout;
       }
     }
@@ -1566,12 +1582,12 @@ release_1:
         s->csm_tx = now;
         s_timeout = (ctx->csm_timeout_ms * COAP_TICKS_PER_SECOND) / 1000;
       } else if (s->csm_tx + (ctx->csm_timeout_ms * COAP_TICKS_PER_SECOND) / 1000 <= now) {
-        /* timed out */
-        s_timeout = 0;
+        /* timed out - cannot handle 0, so has to be just +ve */
+        s_timeout = 1;
       } else {
         s_timeout = (s->csm_tx + (ctx->csm_timeout_ms * COAP_TICKS_PER_SECOND) / 1000) - now;
       }
-      if ((timeout == 0 || s_timeout < timeout) && s_timeout != 0)
+      if (s_timeout < timeout)
         timeout = s_timeout;
     }
 #endif /* !COAP_DISABLE_TCP */
@@ -1594,21 +1610,21 @@ release_1:
           timeout = 1;
         }
       }
-      if (tls_timeout > 0 && (timeout == 0 || tls_timeout - now < timeout))
+      if (tls_timeout > 0 && tls_timeout - now < timeout)
         timeout = tls_timeout - now;
     }
 
     /* Check if any client large receives are missing blocks */
     if (s->lg_crcv) {
       if (coap_block_check_lg_crcv_timeouts(s, now, &s_timeout)) {
-        if (timeout == 0 || s_timeout < timeout)
+        if (s_timeout < timeout)
           timeout = s_timeout;
       }
     }
     /* Check if any client large sending have timed out */
     if (s->lg_xmit) {
       if (coap_block_check_lg_xmit_timeouts(s, now, &s_timeout)) {
-        if (timeout == 0 || s_timeout < timeout)
+        if (s_timeout < timeout)
           timeout = s_timeout;
       }
     }
@@ -1618,9 +1634,10 @@ release_1:
      * restarting
      */
     if (s->lg_xmit) {
-      s_timeout = coap_block_check_q_block1_xmit(s, now);
-      if (timeout == 0 || s_timeout < timeout)
-        timeout = s_timeout;
+      if (coap_block_check_q_block1_xmit(s, now, &s_timeout)) {
+        if (s_timeout < timeout)
+          timeout = s_timeout;
+      }
     }
 #endif /* COAP_Q_BLOCK_SUPPORT */
 
@@ -2126,7 +2143,7 @@ coap_io_process_with_fds_lkd(coap_context_t *ctx, uint32_t timeout_ms,
   /* Check to see if we need to send off any Async requests as delay might
      have been updated */
   coap_ticks(&now);
-  coap_check_async(ctx, now);
+  coap_check_async(ctx, now, NULL);
 #endif /* COAP_ASYNC_SUPPORT */
 
 #ifndef COAP_EPOLL_SUPPORT

--- a/src/coap_io_riot.c
+++ b/src/coap_io_riot.c
@@ -92,7 +92,7 @@ coap_io_process_lkd(coap_context_t *ctx, uint32_t timeout_ms) {
 #if COAP_ASYNC_SUPPORT
   /* Check to see if we need to send off any Async requests as delay might
      have been updated */
-  coap_check_async(ctx, now);
+  coap_check_async(ctx, now, NULL);
   coap_ticks(&now);
 #endif /* COAP_ASYNC_SUPPORT */
 

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4851,26 +4851,35 @@ coap_can_exit_lkd(coap_context_t *context) {
 }
 #if COAP_SERVER_SUPPORT
 #if COAP_ASYNC_SUPPORT
-coap_tick_t
-coap_check_async(coap_context_t *context, coap_tick_t now) {
-  coap_tick_t next_due = 0;
+/*
+ * Return 1 if there is a future expire time, else 0.
+ * Update tim_rem with remaining value if return is 1.
+ */
+int
+coap_check_async(coap_context_t *context, coap_tick_t now, coap_tick_t *tim_rem) {
+  coap_tick_t next_due = COAP_MAX_DELAY_TICKS;
   coap_async_t *async, *tmp;
+  int ret = 0;
 
   LL_FOREACH_SAFE(context->async_state, async, tmp) {
-    if (async->delay != 0 && async->delay <= now) {
-      /* Send off the request to the application */
-      coap_log_debug("Async PDU presented to app.\n");
-      coap_show_pdu(COAP_LOG_DEBUG, async->pdu);
-      handle_request(context, async->session, async->pdu, NULL);
+    if (async->delay != 0) {
+      if (async->delay <= now) {
+        /* Send off the request to the application */
+        coap_log_debug("Async PDU presented to app.\n");
+        coap_show_pdu(COAP_LOG_DEBUG, async->pdu);
+        handle_request(context, async->session, async->pdu, NULL);
 
-      /* Remove this async entry as it has now fired */
-      coap_free_async_lkd(async->session, async);
-    } else {
-      if (next_due == 0 || next_due > async->delay - now)
+        /* Remove this async entry as it has now fired */
+        coap_free_async_lkd(async->session, async);
+      } else {
         next_due = async->delay - now;
+        ret = 1;
+      }
     }
   }
-  return next_due;
+  if (tim_rem)
+    *tim_rem = next_due;
+  return ret;
 }
 #endif /* COAP_ASYNC_SUPPORT */
 #endif /* COAP_SERVER_SUPPORT */

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -102,8 +102,8 @@ coap_proxy_check_observe(coap_proxy_list_t *proxy_entry) {
 }
 
 /*
- * return 1 if there is a future expire time, else 0.
- * update tim_rem with remaining value if return is 1.
+ * Return 1 if there is a future expire time, else 0.
+ * Update tim_rem with remaining value if return is 1.
  */
 int
 coap_proxy_check_timeouts(coap_context_t *context, coap_tick_t now,
@@ -111,7 +111,7 @@ coap_proxy_check_timeouts(coap_context_t *context, coap_tick_t now,
   size_t i;
   int ret = 0;
 
-  *tim_rem = -1;
+  *tim_rem = COAP_MAX_DELAY_TICKS;
   for (i = 0; i < context->proxy_list_count; i++) {
     coap_proxy_list_t *proxy_entry = &context->proxy_list[i];
 
@@ -126,8 +126,8 @@ coap_proxy_check_timeouts(coap_context_t *context, coap_tick_t now,
       } else {
         if (*tim_rem > proxy_entry->last_used + proxy_entry->idle_timeout_ticks - now) {
           *tim_rem = proxy_entry->last_used + proxy_entry->idle_timeout_ticks - now;
+          ret = 1;
         }
-        ret = 1;
       }
     }
   }


### PR DESCRIPTION
If calculated timeout is 0 in coap_io_prepare_io_lkd(), then do not set overall timeout to 0 so that when passed back to caller it does not get reset to the caller's max defined timeout.

Updated some timeout check functions to update remaining timeout in a new parameter and to return 1 if this parameter was updated, else 0. for simplicity.

It was also unsafe to set the initial max timeout value to -1 as coap_tick_t can be int64_t.