### PR TITLE
coap_net.c: Add Reserved options RFC7252 Table 7 to option check list

### DIFF
--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -144,12 +144,18 @@ void coap_register_pong_handler(coap_context_t *context,
                                 coap_pong_handler_t handler);
 
 /**
- * Registers the option type @p type with the given context object @p ctx.
+ * Registers the option number @p number with the given context object @p context.
  *
- * @param ctx  The context to use.
- * @param type The option type to register.
+ * A registered option should only be for options that libcoap library does not
+ * know about (not defined in the CoAP RFCs). On receipt or sending of a PDU,
+ * this registered option will get ignored when checking for unknown critical
+ * options, duplicate options or the options defined as Reserved in RFC 7252 Table 7.
+ *
+ * @param context The context to use.
+ * @param number  The option number to register.
  */
-COAP_API void coap_register_option(coap_context_t *ctx, uint16_t type);
+COAP_API void coap_register_option(coap_context_t *context,
+                                   coap_option_num_t number);
 
 /**
  * Creates a new coap_context_t object that will hold the CoAP stack status.

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -374,33 +374,19 @@ void coap_dispatch(coap_context_t *context, coap_session_t *session,
                    coap_pdu_t *pdu);
 
 /**
- * Verifies that @p pdu contains no unknown critical options. Options must be
- * registered at @p ctx, using the function coap_register_option(). A basic set
- * of options is registered automatically by coap_new_context(). This function
- * returns @c 1 if @p pdu is ok, @c 0 otherwise. The given filter object @p
- * unknown will be updated with the unknown options. As only @c COAP_MAX_OPT
- * options can be signalled this way, remaining options must be examined
- * manually.
+ * Verifies that @p pdu contains no unknown critical options, duplicate options
+ * or the options defined as Reserved in RFC 7252 Table 7.
  *
- * @code
-  coap_opt_filter_t f = COAP_OPT_NONE;
-  coap_opt_iterator_t opt_iter;
-
-  if (coap_option_check_critical(session, pdu, f) == 0) {
-    coap_option_iterator_init(pdu, &opt_iter, f);
-
-    while (coap_option_next(&opt_iter)) {
-      if (opt_iter.type & 0x01) {
-        ... handle unknown critical option in opt_iter ...
-      }
-    }
-  }
-   @endcode
+ * Options registered using coap_register_option() are not tested.
+ *
+ * The given filter object @p unknown will be updated with the unknown options.
+ * The maximum number of unknown options is limited by what can be put into a
+ * coap_opt_filter_t.
  *
  * @param session  The current session.
  * @param pdu      The PDU to check.
  * @param unknown  The output filter that will be updated to indicate the
- *                 unknown critical options found in @p pdu.
+ *                 unknown critical/duplicated/reserved options found in @p pdu.
  *
  * @return         @c 1 if everything was ok, @c 0 otherwise.
  */
@@ -558,14 +544,19 @@ int coap_join_mcast_group_intf_lkd(coap_context_t *ctx, const char *groupname,
                                    const char *ifname);
 
 /**
- * Registers the option type @p type with the given context object @p ctx.
+ * Registers the option number @p number with the given context object @p context.
  *
  * Note: This function must be called in the locked state.
  *
- * @param ctx  The context to use.
- * @param type The option type to register.
+ * A registered option should only be for options that libcoap library does not
+ * know about (not defined in the CoAP RFCs). On receipt or sending of a PDU,
+ * this registered option will get ignored when checking for unknown critical
+ * options, duplicate options or the options defined as Reserved in RFC 7252 Table 7.
+ *
+ * @param context The context to use.
+ * @param number  The option number to register.
  */
-void coap_register_option_lkd(coap_context_t *ctx, uint16_t type);
+void coap_register_option_lkd(coap_context_t *context, coap_option_num_t number);
 
 /**
  * Set the context's default PKI information for a server.

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -128,6 +128,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_context.3" > coap_context_set_cid_tuple_change.3
 	@echo ".so man3/coap_context.3" > coap_context_set_shutdown_no_observe.3
 	@echo ".so man3/coap_context.3" > coap_context_set_session_reconnect_time.3
+	@echo ".so man3/coap_context.3" > coap_register_option.3
 	@echo ".so man3/coap_deprecated.3" > coap_set_app_data.3
 	@echo ".so man3/coap_deprecated.3" > coap_get_app_data.3
 	@echo ".so man3/coap_deprecated.3" > coap_option_setb.3

--- a/man/coap_context.txt.in
+++ b/man/coap_context.txt.in
@@ -26,7 +26,8 @@ coap_context_set_app_data2,
 coap_context_get_app_data,
 coap_context_set_cid_tuple_change,
 coap_context_set_shutdown_no_observe,
-coap_context_set_session_reconnect_time
+coap_context_set_session_reconnect_time,
+coap_register_option
 - Work with CoAP contexts
 
 SYNOPSIS
@@ -74,6 +75,8 @@ coap_app_data_free_callback_t _app_cb_);*
 
 *void coap_context_set_session_reconnect_time(coap_context_t *_context_,
 unsigned int _reconnect_time_);*
+
+*void coap_register_option(coap_context_t *_context_, coap_option_num_t _number_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -238,6 +241,15 @@ However, if the session failure was caused by a server restart, a restart
 observe subscription attempt for a previously dynamically created resource
 will not cause the resource to be recreated.  This can be done by using
 *coap_persist*(3) in the server.
+
+*Function: coap_register_option()*
+
+The *coap_register_option*() function is used to register option _number_ in
+the _context_. A registered option should only be for options that libcoap
+library does not know about (not defined in the CoAP RFCs). On receipt or
+sending of a PDU, this registered option will get ignored when checking
+for unknown critical options, duplicate options or the options defined as
+Reserved in RFC 7252 Table 7.
 
 RETURN VALUES
 -------------

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -923,6 +923,29 @@ coap_option_check_critical(coap_session_t *session,
   coap_option_iterator_init(pdu, &opt_iter, COAP_OPT_ALL);
 
   while (coap_option_next(&opt_iter)) {
+    /* Check for explicitely reserved option RFC 5272 12.2 Table 7 */
+    /* Need to check reserved options */
+    switch (opt_iter.number) {
+    case 0:
+    case 128:
+    case 132:
+    case 136:
+    case 140:
+      if (coap_option_filter_get(&ctx->known_options, opt_iter.number) <= 0) {
+        coap_log_debug("unknown reserved option %d\n", opt_iter.number);
+        ok = 0;
+
+        /* When opt_iter.number cannot be set in unknown, all of the appropriate
+         * slots have been used up and no more options can be tracked.
+         * Safe to break out of this loop as ok is already set. */
+        if (coap_option_filter_set(unknown, opt_iter.number) == 0) {
+          goto overflow;
+        }
+      }
+      break;
+    default:
+      break;
+    }
     if (opt_iter.number & 0x01) {
       /* first check the known built-in critical options */
       switch (opt_iter.number) {
@@ -933,7 +956,12 @@ coap_option_check_critical(coap_session_t *session,
           coap_log_debug("disabled support for critical option %u\n",
                          opt_iter.number);
           ok = 0;
-          coap_option_filter_set(unknown, opt_iter.number);
+          /* When opt_iter.number cannot be set in unknown, all of the appropriate
+           * slots have been used up and no more options can be tracked.
+           * Safe to break out of this loop as ok is already set. */
+          if (coap_option_filter_set(unknown, opt_iter.number) == 0) {
+            goto overflow;
+          }
         }
         break;
 #endif /* COAP_Q_BLOCK_SUPPORT */
@@ -980,7 +1008,7 @@ coap_option_check_critical(coap_session_t *session,
            * slots have been used up and no more options can be tracked.
            * Safe to break out of this loop as ok is already set. */
           if (coap_option_filter_set(unknown, opt_iter.number) == 0) {
-            break;
+            goto overflow;
           }
         }
       }
@@ -988,9 +1016,11 @@ coap_option_check_critical(coap_session_t *session,
     if (last_number == opt_iter.number) {
       /* Check for duplicated option RFC 5272 5.4.5 */
       if (!coap_option_check_repeatable(opt_iter.number)) {
-        ok = 0;
-        if (coap_option_filter_set(unknown, opt_iter.number) == 0) {
-          break;
+        if (coap_option_filter_get(&ctx->known_options, opt_iter.number) <= 0) {
+          ok = 0;
+          if (coap_option_filter_set(unknown, opt_iter.number) == 0) {
+            goto overflow;
+          }
         }
       }
     } else if (opt_iter.number == COAP_OPTION_BLOCK2 &&
@@ -1022,7 +1052,7 @@ coap_option_check_critical(coap_session_t *session,
     }
     last_number = opt_iter.number;
   }
-
+overflow:
   return ok;
 }
 
@@ -3015,27 +3045,14 @@ coap_new_error_response(const coap_pdu_t *request, coap_pdu_code_t code,
                         coap_opt_filter_t *opts) {
   coap_opt_iterator_t opt_iter;
   coap_pdu_t *response;
-  size_t size = request->e_token_length;
   unsigned char type;
-  coap_opt_t *option;
-  coap_option_num_t opt_num = 0;        /* used for calculating delta-storage */
 
 #if COAP_ERROR_PHRASE_LENGTH > 0
   const char *phrase;
   if (code != COAP_RESPONSE_CODE(508)) {
     phrase = coap_response_phrase(code);
-
-    /* Need some more space for the error phrase and payload start marker */
-    if (phrase)
-      size += strlen(phrase) + 1;
   } else {
-    /*
-     * Need space for IP for 5.08 response which is filled in in
-     * coap_send_internal()
-     * https://rfc-editor.org/rfc/rfc8768.html#section-4
-     */
     phrase = NULL;
-    size += INET6_ADDRSTRLEN;
   }
 #endif
 
@@ -3045,53 +3062,10 @@ coap_new_error_response(const coap_pdu_t *request, coap_pdu_code_t code,
   type = request->type == COAP_MESSAGE_CON ?
          COAP_MESSAGE_ACK : COAP_MESSAGE_NON;
 
-  /* Estimate how much space we need for options to copy from
-   * request. We always need the Token, for 4.02 the unknown critical
-   * options must be included as well. */
-
-  /* we do not want these */
-  coap_option_filter_unset(opts, COAP_OPTION_CONTENT_FORMAT);
-  coap_option_filter_unset(opts, COAP_OPTION_HOP_LIMIT);
-  /* Unsafe to send this back */
-  coap_option_filter_unset(opts, COAP_OPTION_OSCORE);
-
-  coap_option_iterator_init(request, &opt_iter, opts);
-
-  /* Add size of each unknown critical option. As known critical
-     options as well as elective options are not copied, the delta
-     value might grow.
-   */
-  while ((option = coap_option_next(&opt_iter))) {
-    uint16_t delta = opt_iter.number - opt_num;
-    /* calculate space required to encode (opt_iter.number - opt_num) */
-    if (delta < 13) {
-      size++;
-    } else if (delta < 269) {
-      size += 2;
-    } else {
-      size += 3;
-    }
-
-    /* add coap_opt_length(option) and the number of additional bytes
-     * required to encode the option length */
-
-    size += coap_opt_length(option);
-    switch (*option & 0x0f) {
-    case 0x0e:
-      size++;
-    /* fall through */
-    case 0x0d:
-      size++;
-      break;
-    default:
-      ;
-    }
-
-    opt_num = opt_iter.number;
-  }
-
   /* Now create the response and fill with options and payload data. */
-  response = coap_pdu_init(type, code, request->mid, size);
+  response = coap_pdu_init(type, code, request->mid,
+                           request->session ?
+                           coap_session_max_pdu_size_lkd(request->session) : 512);
   if (response) {
     /* copy token */
     if (!coap_add_token(response, request->actual_token.length,
@@ -3100,20 +3074,31 @@ coap_new_error_response(const coap_pdu_t *request, coap_pdu_code_t code,
       coap_delete_pdu_lkd(response);
       return NULL;
     }
-
-    /* copy all options */
-    coap_option_iterator_init(request, &opt_iter, opts);
-    while ((option = coap_option_next(&opt_iter))) {
-      coap_add_option_internal(response, opt_iter.number,
-                               coap_opt_length(option),
-                               coap_opt_value(option));
-    }
+    if (response->code == COAP_RESPONSE_CODE(402)) {
+      char buf[128];
+      int first = 1;
 
 #if COAP_ERROR_PHRASE_LENGTH > 0
-    /* note that diagnostic messages do not need a Content-Format option. */
-    if (phrase)
-      coap_add_data(response, (size_t)strlen(phrase), (const uint8_t *)phrase);
+      snprintf(buf, sizeof(buf), "%s", phrase ? phrase : "");
+#else
+      buf[0] = '\000';
 #endif
+      /* copy all options into diagnostic message */
+      coap_option_iterator_init(request, &opt_iter, opts);
+      while (coap_option_next(&opt_iter)) {
+        size_t len = strlen(buf);
+
+        snprintf(&buf[len], sizeof(buf) - len, "%s%d", first ? " " : ",", opt_iter.number);
+        first = 0;
+      }
+      coap_add_data(response, (size_t)strlen(buf), (const uint8_t *)buf);
+#if COAP_ERROR_PHRASE_LENGTH > 0
+    } else {
+      /* note that diagnostic messages do not need a Content-Format option. */
+      if (phrase)
+        coap_add_data(response, (size_t)strlen(phrase), (const uint8_t *)phrase);
+#endif
+    }
   }
 
   return response;


### PR DESCRIPTION
The checking can be overriden by using coap_register_option().

Updated the diagnostic payload for 4.02 responses to be inline with RFC 7252, and not include the actual errant options in the response.