### PR TITLE
Locking: Remove context from a subset of the lock function macros (1 of 3)

### DIFF
--- a/include/coap3/coap_threadsafe_internal.h
+++ b/include/coap3/coap_threadsafe_internal.h
@@ -45,8 +45,7 @@
  * not like the solution.
  *
  * So the initial support for thread safe is done at global lock level
- * using global_lock. However, context is provided as a parameter should
- * context level locking be subsequently used.
+ * using global_lock.
  *
  * Any public API call needs to potentially lock global_lock.
  *
@@ -178,11 +177,10 @@ int coap_lock_lock_func(const char *file, int line);
  * Called when
  *   Locked
  *
- * @param c Context.
  * @param func app call-back function to invoke.
  *
  */
-#define coap_lock_callback(c,func) do { \
+#define coap_lock_callback(func) do { \
     coap_lock_check_locked(c); \
     global_lock.in_callback++; \
     global_lock.callback_file = __FILE__; \
@@ -199,11 +197,10 @@ int coap_lock_lock_func(const char *file, int line);
  *   Locked
  *
  * @param r Return value from @p func.
- * @param c Context.
  * @param func app call-back function to invoke.
  *
  */
-#define coap_lock_callback_ret(r,c,func) do { \
+#define coap_lock_callback_ret(r,func) do { \
     coap_lock_check_locked(c); \
     global_lock.in_callback++; \
     global_lock.callback_file = __FILE__; \
@@ -218,12 +215,11 @@ int coap_lock_lock_func(const char *file, int line);
  * Called when
  *   Locked
  *
- * @param c Context.
  * @param func app call-back function to invoke.
  * @param failed Code to execute on (re-)lock failure.
  *
  */
-#define coap_lock_callback_release(c,func,failed) do { \
+#define coap_lock_callback_release(func,failed) do { \
     coap_lock_check_locked(c); \
     coap_lock_unlock(c); \
     func; \
@@ -238,12 +234,11 @@ int coap_lock_lock_func(const char *file, int line);
  *   Locked (need to unlock over app call-back)
  *
  * @param r Return value from @p func.
- * @param c Context to unlock.
  * @param func app call-back function to invoke.
  * @param failed Code to execute on lock failure
  *
  */
-#define coap_lock_callback_ret_release(r,c,func,failed) do { \
+#define coap_lock_callback_ret_release(r,func,failed) do { \
     coap_lock_check_locked(c); \
     coap_lock_unlock(c); \
     (r) = func; \
@@ -328,11 +323,10 @@ int coap_lock_lock_func(void);
  * Called when
  *   Locked
  *
- * @param c Context.
  * @param func app call-back function to invoke.
  *
  */
-#define coap_lock_callback(c,func) do { \
+#define coap_lock_callback(func) do { \
     coap_lock_check_locked(c); \
     global_lock.in_callback++; \
     func; \
@@ -347,11 +341,10 @@ int coap_lock_lock_func(void);
  *   Locked
  *
  * @param r Return value from @p func.
- * @param c Context.
  * @param func app call-back function to invoke.
  *
  */
-#define coap_lock_callback_ret(r,c,func) do { \
+#define coap_lock_callback_ret(r,func) do { \
     coap_lock_check_locked(c); \
     global_lock.in_callback++; \
     global_lock.in_callback++; \
@@ -365,12 +358,11 @@ int coap_lock_lock_func(void);
  * Called when
  *   Locked (need to unlock over app call-back)
  *
- * @param c Context.
  * @param func app call-back function to invoke.
  * @param failed Code to execute on (re-)lock failure.
  *
  */
-#define coap_lock_callback_release(c,func,failed) do { \
+#define coap_lock_callback_release(func,failed) do { \
     coap_lock_check_locked(c); \
     coap_lock_unlock(c); \
     func; \
@@ -385,12 +377,11 @@ int coap_lock_lock_func(void);
  *   Locked (need to unlock over app call-back)
  *
  * @param r Return value from @p func.
- * @param c Context.
  * @param func app call-back function to invoke.
  * @param failed Code to execute on lock failure.
  *
  */
-#define coap_lock_callback_ret_release(r,c,func,failed) do { \
+#define coap_lock_callback_ret_release(r,func,failed) do { \
     coap_lock_check_locked(c); \
     coap_lock_unlock(c); \
     (r) = func; \
@@ -422,12 +413,11 @@ int coap_lock_lock_func(void);
  * Called when
  *   Locked (need to unlock over locking of alternative lock)
  *
- * @param c Context.
  * @param alt_lock Alternative lock locking code.
  * @param failed Code to execute on lock failure.
  *
  */
-#define coap_lock_invert(c,alt_lock,failed) do { \
+#define coap_lock_invert(alt_lock,failed) do { \
     coap_lock_check_locked(c); \
     coap_lock_unlock(c); \
     alt_lock; \
@@ -497,11 +487,10 @@ typedef coap_mutex_t coap_lock_t;
  * Called when
  *   Locked
  *
- * @param c Context.
  * @param func app call-back function to invoke.
  *
  */
-#define coap_lock_callback(c,func) func
+#define coap_lock_callback(func) func
 
 /**
  * Dummy for no thread-safe code
@@ -513,11 +502,10 @@ typedef coap_mutex_t coap_lock_t;
  *   Locked
  *
  * @param r Return value from @p func.
- * @param c Context.
  * @param func app call-back function to invoke.
  *
  */
-#define coap_lock_callback_ret(r,c,func) (r) = func
+#define coap_lock_callback_ret(r,func) (r) = func
 
 /**
  * Dummy for no thread-safe code
@@ -527,12 +515,11 @@ typedef coap_mutex_t coap_lock_t;
  * Called when
  *   Locked
  *
- * @param c Context.
  * @param func app call-back function to invoke.
  * @param failed Code to execute on (re-)lock failure.
  *
  */
-#define coap_lock_callback_release(c,func,failed) func
+#define coap_lock_callback_release(func,failed) func
 
 /**
  * Dummy for no thread-safe code
@@ -545,12 +532,11 @@ typedef coap_mutex_t coap_lock_t;
  *   Unlocked by thread free'ing off context
  *
  * @param r Return value from @p func.
- * @param c Context to unlock.
  * @param func app call-back function to invoke.
  * @param failed Code to execute on lock failure
  *
  */
-#define coap_lock_callback_ret_release(r,c,func,failed) (r) = func
+#define coap_lock_callback_ret_release(r,func,failed) (r) = func
 
 /**
  * Dummy for no thread-safe code
@@ -562,12 +548,11 @@ typedef coap_mutex_t coap_lock_t;
  * Called when
  *   Locked (need to unlock over locking of alternative lock)
  *
- * @param c Context.
  * @param alt_lock Alternative lock locking code.
  * @param failed Code to execute on lock failure.
  *
  */
-#define coap_lock_invert(c,alt_lock,failed) alt_lock
+#define coap_lock_invert(alt_lock,failed) alt_lock
 
 #endif /* ! COAP_THREAD_SAFE */
 

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -190,7 +190,7 @@ coap_free_async_sub(coap_context_t *context, coap_async_t *s) {
       s->pdu = NULL;
     }
     if (s->app_cb && s->app_data) {
-      coap_lock_callback(context, s->app_cb(s->app_data));
+      coap_lock_callback(s->app_cb(s->app_data));
     }
     coap_free_type(COAP_STRING, s);
   }

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -804,7 +804,7 @@ coap_add_data_large_internal(coap_session_t *session,
   if (pdu->data) {
     coap_log_warn("coap_add_data_large: PDU already contains data\n");
     if (release_func) {
-      coap_lock_callback(session->context, release_func(session, app_ptr));
+      coap_lock_callback(release_func(session, app_ptr));
     }
     return 0;
   }
@@ -1047,7 +1047,7 @@ coap_add_data_large_internal(coap_session_t *session,
         goto fail;
     }
     if (release_func) {
-      coap_lock_callback(session->context, release_func(session, app_ptr));
+      coap_lock_callback(release_func(session, app_ptr));
     }
   } else if ((have_block_defined && length > chunk) || (ssize_t)length > avail) {
     /* Only add in lg_xmit if more than one block needs to be handled */
@@ -1225,7 +1225,7 @@ add_data:
       goto fail;
 
     if (release_func) {
-      coap_lock_callback(session->context, release_func(session, app_ptr));
+      coap_lock_callback(release_func(session, app_ptr));
     }
   }
   return 1;
@@ -1234,7 +1234,7 @@ fail:
   if (lg_xmit) {
     coap_block_delete_lg_xmit(session, lg_xmit);
   } else if (release_func) {
-    coap_lock_callback(session->context, release_func(session, app_ptr));
+    coap_lock_callback(release_func(session, app_ptr));
   }
   return 0;
 }
@@ -1270,7 +1270,7 @@ coap_add_data_large_request_lkd(coap_session_t *session,
    */
   if (coap_client_delay_first(session) == 0) {
     if (release_func) {
-      coap_lock_callback(session->context, release_func(session, app_ptr));
+      coap_lock_callback(release_func(session, app_ptr));
     }
     return 0;
   }
@@ -1411,7 +1411,7 @@ coap_add_data_large_response_lkd(coap_resource_t *resource,
 
 error:
   if (release_func) {
-    coap_lock_callback(session->context, release_func(session, app_ptr));
+    coap_lock_callback(release_func(session, app_ptr));
   }
 error_released:
 #if COAP_ERROR_PHRASE_LENGTH > 0
@@ -2356,8 +2356,7 @@ coap_block_release_lg_xmit_data(coap_session_t *session,
     return;
   }
   if (data_info->release_func) {
-    coap_lock_callback(session->context,
-                       data_info->release_func(session,
+    coap_lock_callback(data_info->release_func(session,
                                                data_info->app_ptr));
   }
   coap_free_type(COAP_STRING, data_info);

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -292,7 +292,7 @@ coap_delete_cache_entry(coap_context_t *ctx, coap_cache_entry_t *cache_entry) {
   }
   coap_delete_cache_key(cache_entry->cache_key);
   if (cache_entry->app_cb && cache_entry->app_data) {
-    coap_lock_callback(ctx, cache_entry->app_cb(cache_entry->app_data));
+    coap_lock_callback(cache_entry->app_cb(cache_entry->app_data));
   }
   coap_free_type(COAP_CACHE_ENTRY, cache_entry);
 }

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -648,7 +648,7 @@ psk_client_callback(gnutls_session_t g_session,
 
     lhint.length = temp.length;
     lhint.s = temp.s;
-    coap_lock_callback_ret(cpsk_info, c_session->context,
+    coap_lock_callback_ret(cpsk_info,
                            setup_data->validate_ih_call_back(&lhint,
                                                              c_session,
                                                              setup_data->ih_call_back_arg));
@@ -808,7 +808,7 @@ check_rpk_cert(coap_gnutls_context_t *g_context,
     G_CHECK(gnutls_pubkey_export(pcert.pubkey, GNUTLS_X509_FMT_DER, der, &size),
             "gnutls_pubkey_export");
     gnutls_pcert_deinit(&pcert);
-    coap_lock_callback_ret(ret, c_session->context,
+    coap_lock_callback_ret(ret,
                            g_context->setup_data.validate_cn_call_back(COAP_DTLS_RPK_CERT_CN,
                                der,
                                size,
@@ -969,7 +969,7 @@ cert_verify_gnutls(gnutls_session_t g_session) {
     G_CHECK(gnutls_x509_crt_export(cert, GNUTLS_X509_FMT_DER, der, &size),
             "gnutls_x509_crt_export");
     gnutls_x509_crt_deinit(cert);
-    coap_lock_callback_ret(ret, c_session->context,
+    coap_lock_callback_ret(ret,
                            g_context->setup_data.validate_cn_call_back(OUTPUT_CERT_NAME,
                                der,
                                size,
@@ -1599,7 +1599,7 @@ post_client_hello_gnutls_psk(gnutls_session_t g_session) {
        */
       const coap_dtls_spsk_info_t *new_entry;
 
-      coap_lock_callback_ret(new_entry, c_session->context,
+      coap_lock_callback_ret(new_entry,
                              c_session->context->spsk_setup_data.validate_sni_call_back(name,
                                  c_session,
                                  c_session->context->spsk_setup_data.sni_call_back_arg));
@@ -1715,7 +1715,7 @@ post_client_hello_gnutls_pki(gnutls_session_t g_session) {
        */
       coap_dtls_key_t *new_entry;
 
-      coap_lock_callback_ret(new_entry, c_session->context,
+      coap_lock_callback_ret(new_entry,
                              g_context->setup_data.validate_sni_call_back(name,
                                  g_context->setup_data.sni_call_back_arg));
       if (!new_entry) {

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -2203,7 +2203,7 @@ coap_io_process_loop_lkd(coap_context_t *context,
        * main_loop_codecode should not be blocking for any time, and not calling
        * coap_io_process().
        */
-      coap_lock_callback_release(context, main_loop_code(main_loop_code_arg),
+      coap_lock_callback_release(main_loop_code(main_loop_code_arg),
                                  /* On re-lock failure */
                                  ret = 0; break);
       /*

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -104,8 +104,7 @@ coap_io_process_lkd(coap_context_t *context, uint32_t timeout_ms) {
   if (timeout_ms == COAP_IO_NO_WAIT)
     timeout = 1;
 
-  coap_lock_invert(context,
-                   LOCK_TCPIP_CORE(),
+  coap_lock_invert(LOCK_TCPIP_CORE(),
                    UNLOCK_TCPIP_CORE(); return 0);
 
   if (context->timer_configured) {
@@ -124,19 +123,16 @@ coap_io_process_lkd(coap_context_t *context, uint32_t timeout_ms) {
   UNLOCK_TCPIP_CORE();
 
   if (context->input_wait) {
-    coap_lock_callback_release(context,
-                               context->input_wait(context->input_arg, timeout),
+    coap_lock_callback_release(context->input_wait(context->input_arg, timeout),
                                return 0);
 #if NO_SYS == 0
   } else {
-    coap_lock_callback_release(context,
-                               sys_arch_sem_wait(&coap_io_timeout_sem, timeout),
+    coap_lock_callback_release(sys_arch_sem_wait(&coap_io_timeout_sem, timeout),
                                return 0);
 #endif /* NO_SYS == 0 */
   }
 
-  coap_lock_invert(context,
-                   LOCK_TCPIP_CORE(),
+  coap_lock_invert(LOCK_TCPIP_CORE(),
                    UNLOCK_TCPIP_CORE(); return 0);
 
   sys_check_timeouts();
@@ -415,8 +411,7 @@ coap_socket_send(coap_socket_t *sock, coap_session_t *session,
       return -1;
     memcpy(pbuf->payload, data, data_len);
 
-    coap_lock_invert(session->context,
-                     LOCK_TCPIP_CORE(),
+    coap_lock_invert(LOCK_TCPIP_CORE(),
                      UNLOCK_TCPIP_CORE(); return -1);
 
     err = udp_sendto(sock->udp_pcb, pbuf, &session->addr_info.remote.addr,
@@ -483,8 +478,7 @@ coap_socket_connect_udp(coap_socket_t *sock,
   if (connect_addr.port == 0)
     connect_addr.port = default_port;
 
-  coap_lock_invert(sock->session->context,
-                   LOCK_TCPIP_CORE(),
+  coap_lock_invert(LOCK_TCPIP_CORE(),
                    goto err_unlock);
 
   pcb = udp_new();
@@ -782,8 +776,7 @@ coap_socket_write(coap_socket_t *sock, const uint8_t *data, size_t data_len) {
     return -1;
   memcpy(pbuf->payload, data, data_len);
 
-  coap_lock_invert(context,
-                   LOCK_TCPIP_CORE(),
+  coap_lock_invert(LOCK_TCPIP_CORE(),
                    UNLOCK_TCPIP_CORE(); return 0);
 
   err = tcp_write(sock->tcp_pcb, pbuf->payload, pbuf->len, 1);
@@ -828,8 +821,7 @@ void
 coap_socket_close(coap_socket_t *sock) {
   if (sock->udp_pcb) {
     if (sock->session) {
-      coap_lock_invert(sock->session->context,
-                       LOCK_TCPIP_CORE(),
+      coap_lock_invert(LOCK_TCPIP_CORE(),
                        UNLOCK_TCPIP_CORE(); return);
     } else {
       LOCK_TCPIP_CORE();
@@ -846,8 +838,7 @@ coap_socket_close(coap_socket_t *sock) {
 #endif /* COAP_SERVER_SUPPORT */
       tcp_recv(sock->tcp_pcb, NULL);
     if (sock->session) {
-      coap_lock_invert(sock->session->context,
-                       LOCK_TCPIP_CORE(),
+      coap_lock_invert(LOCK_TCPIP_CORE(),
                        UNLOCK_TCPIP_CORE(); return);
     } else {
       LOCK_TCPIP_CORE();

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -484,7 +484,7 @@ cert_verify_callback_mbedtls(void *data, mbedtls_x509_crt *crt,
   if (setup_data->validate_cn_call_back) {
     int ret;
 
-    coap_lock_callback_ret(ret, c_session->context,
+    coap_lock_callback_ret(ret,
                            setup_data->validate_cn_call_back(cn,
                                                              crt->raw.p,
                                                              crt->raw.len,
@@ -942,7 +942,7 @@ pki_sni_callback(void *p_info, mbedtls_ssl_context *ssl,
     coap_dtls_key_t *new_entry;
     pki_sni_entry *pki_sni_entry_list;
 
-    coap_lock_callback_ret(new_entry, c_session->context,
+    coap_lock_callback_ret(new_entry,
                            m_context->setup_data.validate_sni_call_back(name,
                                m_context->setup_data.sni_call_back_arg));
     if (!new_entry) {
@@ -1020,7 +1020,7 @@ psk_sni_callback(void *p_info, mbedtls_ssl_context *ssl,
     const coap_dtls_spsk_info_t *new_entry;
     psk_sni_entry *psk_sni_entry_list;
 
-    coap_lock_callback_ret(new_entry, c_session->context,
+    coap_lock_callback_ret(new_entry,
                            c_session->context->spsk_setup_data.validate_sni_call_back(name,
                                c_session,
                                c_session->context->spsk_setup_data.sni_call_back_arg));

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -3875,8 +3875,7 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
     coap_log_debug("call custom handler for resource '%*.*s' (3)\n",
                    (int)resource->uri_path->length, (int)resource->uri_path->length,
                    resource->uri_path->s);
-    coap_lock_callback_release(context,
-                               h(resource, session, pdu, query, response),
+    coap_lock_callback_release(h(resource, session, pdu, query, response),
                                /* context is being freed off */
                                coap_delete_string(query); goto finish);
   }
@@ -4078,7 +4077,7 @@ coap_call_response_handler(coap_session_t *session,
     session->last_con_handler_res = COAP_RESPONSE_OK;
     return;
   } else if (context->response_handler) {
-    coap_lock_callback_ret_release(ret, context,
+    coap_lock_callback_ret_release(ret,
                                    context->response_handler(session,
                                                              sent,
                                                              rcvd,
@@ -4241,8 +4240,7 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
   } else if (pdu->code == COAP_SIGNALING_CODE_PING) {
     coap_pdu_t *pong = coap_pdu_init(COAP_MESSAGE_CON, COAP_SIGNALING_CODE_PONG, 0, 1);
     if (context->ping_handler) {
-      coap_lock_callback(context,
-                         context->ping_handler(session, pdu, pdu->mid));
+      coap_lock_callback(context->ping_handler(session, pdu, pdu->mid));
     }
     if (pong) {
       coap_add_option_internal(pong, COAP_SIGNALING_OPTION_CUSTODY, 0, NULL);
@@ -4251,8 +4249,7 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
   } else if (pdu->code == COAP_SIGNALING_CODE_PONG) {
     session->last_pong = session->last_rx_tx;
     if (context->pong_handler) {
-      coap_lock_callback(context,
-                         context->pong_handler(session, pdu, pdu->mid));
+      coap_lock_callback(context->pong_handler(session, pdu, pdu->mid));
     }
   } else if (pdu->code == COAP_SIGNALING_CODE_RELEASE
              || pdu->code == COAP_SIGNALING_CODE_ABORT) {
@@ -4599,8 +4596,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
         }
       } else if (is_ping_rst) {
         if (context->pong_handler) {
-          coap_lock_callback(context,
-                             context->pong_handler(session, pdu, pdu->mid));
+          coap_lock_callback(context->pong_handler(session, pdu, pdu->mid));
         }
         session->last_pong = session->last_rx_tx;
         session->last_ping_mid = COAP_INVALID_MID;
@@ -4692,8 +4688,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
       {
         if (COAP_PDU_IS_EMPTY(pdu)) {
           if (context->ping_handler) {
-            coap_lock_callback(context,
-                               context->ping_handler(session, pdu, pdu->mid));
+            coap_lock_callback(context->ping_handler(session, pdu, pdu->mid));
           }
         } else {
           packet_is_bad = 1;
@@ -4815,7 +4810,7 @@ coap_handle_event_lkd(coap_context_t *context, coap_event_t event,
   coap_log_debug("***EVENT: %s\n", coap_event_name(event));
 
   if (context->handle_event) {
-    coap_lock_callback_ret(ret, context, context->handle_event(session, event));
+    coap_lock_callback_ret(ret, context->handle_event(session, event));
 #if COAP_PROXY_SUPPORT
     if (event == COAP_EVENT_SERVER_SESSION_DEL)
       coap_proxy_remove_association(session, 0);

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -784,7 +784,7 @@ coap_dtls_psk_client_callback(SSL *ssl,
 
     lhint.s = temp.s;
     lhint.length = temp.length;
-    coap_lock_callback_ret(cpsk_info, c_session->context,
+    coap_lock_callback_ret(cpsk_info,
                            setup_data->validate_ih_call_back(&lhint,
                                                              c_session,
                                                              setup_data->ih_call_back_arg));
@@ -2468,7 +2468,7 @@ tls_verify_call_back(int preverify_ok, X509_STORE_CTX *ctx) {
 
     /* base_buf2 gets moved to the end */
     i2d_X509(x509, &base_buf2);
-    coap_lock_callback_ret(ret, session->context,
+    coap_lock_callback_ret(ret,
                            setup_data->validate_cn_call_back(cn, base_buf, length, session,
                                                              depth, preverify_ok,
                                                              setup_data->cn_call_back_arg));
@@ -2623,7 +2623,7 @@ tls_server_name_call_back(SSL *ssl,
       coap_dtls_pki_t sni_setup_data;
       coap_dtls_key_t *new_entry;
 
-      coap_lock_callback_ret(new_entry, session->context,
+      coap_lock_callback_ret(new_entry,
                              setup_data->validate_sni_call_back(sni,
                                                                 setup_data->sni_call_back_arg));
       if (!new_entry) {
@@ -2723,7 +2723,7 @@ psk_tls_server_name_call_back(SSL *ssl,
       SSL_CTX *ctx;
       const coap_dtls_spsk_info_t *new_entry;
 
-      coap_lock_callback_ret(new_entry, c_session->context,
+      coap_lock_callback_ret(new_entry,
                              setup_data->validate_sni_call_back(sni,
                                                                 c_session,
                                                                 setup_data->sni_call_back_arg));
@@ -2944,7 +2944,7 @@ is_x509:
        */
       coap_dtls_key_t *new_entry;
 
-      coap_lock_callback_ret(new_entry, session->context,
+      coap_lock_callback_ret(new_entry,
                              setup_data->validate_sni_call_back(sni,
                                                                 setup_data->sni_call_back_arg));
       if (!new_entry) {
@@ -3073,7 +3073,7 @@ psk_tls_client_hello_call_back(SSL *ssl,
        */
       const coap_dtls_spsk_info_t *new_entry;
 
-      coap_lock_callback_ret(new_entry, c_session->context,
+      coap_lock_callback_ret(new_entry,
                              setup_data->validate_sni_call_back(
                                  sni,
                                  c_session,

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -720,7 +720,7 @@ coap_proxy_call_response_handler(coap_session_t *session, const coap_pdu_t *sent
       goto failed;
     }
   }
-  coap_lock_callback_ret_release(fwd_pdu, session->context,
+  coap_lock_callback_ret_release(fwd_pdu,
                                  session->context->proxy_response_handler(session,
                                      sent,
                                      resp_pdu,

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -500,7 +500,7 @@ coap_free_resource(coap_resource_t *resource, coap_deleting_resource_t deleting)
                                         resource->context->observe_user_data);
 
   if (resource->context->release_userdata && resource->user_data) {
-    coap_lock_callback(resource->context, resource->context->release_userdata(resource->user_data));
+    coap_lock_callback(resource->context->release_userdata(resource->user_data));
   }
 
   /* delete registered attributes */
@@ -1227,8 +1227,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
                        r->uri_path->s);
 
         /* obs may get deleted during callback (potentially by another thread) */
-        coap_lock_callback_release(obs->session->context,
-                                   h(r, obs->session, obs->pdu, query, response),
+        coap_lock_callback_release(h(r, obs->session, obs->pdu, query, response),
                                    /* context is being freed off */
                                    coap_delete_string(query);
                                    coap_delete_pdu_lkd(response);

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1003,8 +1003,7 @@ coap_handle_nack(coap_session_t *session,
       coap_check_update_token(session, sent);
       token = sent->actual_token;
     }
-    coap_lock_callback(session->context,
-                       session->context->nack_handler(session, sent, reason, mid));
+    coap_lock_callback(session->context->nack_handler(session, sent, reason, mid));
     if (sent) {
       coap_update_token(sent, token.length, token.s);
     }

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -975,10 +975,9 @@ coap_op_dyn_resource_load_disk(coap_context_t *ctx) {
         goto fail;
       query = coap_get_query(request);
       /* Call the application handler to set up this dynamic resource */
-      coap_lock_callback_release(ctx,
-                                 ctx->unknown_resource->handler[request->code-1](ctx->unknown_resource,
-                                     session, request,
-                                     query, response),
+      coap_lock_callback_release(ctx->unknown_resource->handler[request->code-1](ctx->unknown_resource,
+                                 session, request,
+                                 query, response),
                                  /* context is being freed off */
                                  goto fail);
       coap_delete_string(query);

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -496,7 +496,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
 
       lhint.length = id_len;
       lhint.s = id;
-      coap_lock_callback_ret(cpsk_info, coap_session->context,
+      coap_lock_callback_ret(cpsk_info,
                              setup_cdata->validate_ih_call_back(&lhint,
                                                                 coap_session,
                                                                 setup_cdata->ih_call_back_arg));
@@ -700,7 +700,7 @@ verify_ecdsa_key(struct dtls_context_t *dtls_context COAP_UNUSED,
                                          &remote_addr, dtls_session->ifindex);
     if (!c_session)
       return -3;
-    coap_lock_callback_ret(ret, t_context->coap_context,
+    coap_lock_callback_ret(ret,
                            t_context->setup_data.validate_cn_call_back(COAP_DTLS_RPK_CERT_CN,
                                buf, p-buf, c_session, 0, 1, t_context->setup_data.cn_call_back_arg));
     if (!ret) {

--- a/src/coap_wolfssl.c
+++ b/src/coap_wolfssl.c
@@ -608,7 +608,7 @@ coap_dtls_psk_client_callback(WOLFSSL *ssl,
 
     lhint.s = temp.s;
     lhint.length = temp.length;
-    coap_lock_callback_ret(cpsk_info, c_session->context,
+    coap_lock_callback_ret(cpsk_info,
                            setup_data->validate_ih_call_back(&lhint,
                                                              c_session,
                                                              setup_data->ih_call_back_arg));
@@ -1577,7 +1577,7 @@ tls_verify_call_back(int preverify_ok, WOLFSSL_X509_STORE_CTX *ctx) {
 
       /* base_buf2 gets moved to the end */
       wolfSSL_i2d_X509(x509, &base_buf2);
-      coap_lock_callback_ret(ret, session->context,
+      coap_lock_callback_ret(ret,
                              setup_data->validate_cn_call_back(cn, base_buf, length, session,
                                                                depth, preverify_ok,
                                                                setup_data->cn_call_back_arg));
@@ -1628,7 +1628,7 @@ tls_server_name_call_back(WOLFSSL *ssl,
     if (!sni || !sni[0]) {
       sni = "";
     }
-    coap_lock_callback_ret(new_entry, session->context,
+    coap_lock_callback_ret(new_entry,
                            setup_data->validate_sni_call_back(sni,
                                                               setup_data->sni_call_back_arg));
     if (!new_entry) {
@@ -1675,7 +1675,7 @@ psk_tls_server_name_call_back(WOLFSSL *ssl,
     if (!sni || !sni[0]) {
       sni = "";
     }
-    coap_lock_callback_ret(new_entry, c_session->context,
+    coap_lock_callback_ret(new_entry,
                            setup_data->validate_sni_call_back(sni,
                                                               c_session,
                                                               setup_data->sni_call_back_arg));


### PR DESCRIPTION
Makes reading the code simpler.

Context is no longer used as global_lock is used in the coap_lock_lock() and coap_lock_unlock() functions.

Part 1 of 3.

Update coap_lock_callback(), coap_lock_callback_ret(), coap_lock_callback_release(), coap_lock_callback_ret_release() and coap_lock_invert() macros and all users.