### PR TITLE
Add functions to get endpoint from a session and store/load userdata with/from endpoint

### DIFF
--- a/include/coap3/coap_session.h
+++ b/include/coap3/coap_session.h
@@ -204,6 +204,15 @@ coap_session_type_t coap_session_get_type(const coap_session_t *session);
 coap_session_state_t coap_session_get_state(const coap_session_t *session);
 
 /**
+ * Get the endpoint of a session
+ *
+ * @param session The CoAP session.
+ *
+ * @return The session's endpoint, or @c NULL on error.
+ */
+coap_endpoint_t *coap_session_get_endpoint(const coap_session_t *session);
+
+/**
  * Get the session if index
  *
  * @param session The CoAP session.
@@ -454,6 +463,36 @@ void coap_endpoint_set_default_mtu(coap_endpoint_t *endpoint, unsigned mtu);
  * @param endpoint The endpoint to release.
  */
 COAP_API void coap_free_endpoint(coap_endpoint_t *endpoint);
+
+/**
+ * Returns any application-specific data that has been stored with @p
+ * endpoint using the function coap_endpoint_set_app_data(). This function
+ * will return @c NULL if no data has been stored.
+ *
+ * @param endpoint The CoAP endpoint.
+ *
+ * @return Pointer to the stored data or @c NULL.
+ */
+void *coap_endpoint_get_app_data(const coap_endpoint_t *endpoint);
+
+/**
+ * Stores @p data with the given endpoint, returning the previously stored
+ * value or NULL. The data @p callback can be defined if the data is to be
+ * released when the endpoint is deleted.
+ *
+ * Note: It is the responsibility of the caller to free off (if appropriate) any
+ * returned data.
+ *
+ * @param endpoint The CoAP endpoint.
+ * @param data The pointer to the data to store or NULL to just clear out the
+ *             previous data.
+ * @param callback The optional release call-back for data on endpoint
+ *                 removal or NULL.
+ *
+ * @return The previous data (if any) stored in the endpoint.
+ */
+COAP_API void *coap_endpoint_set_app_data(coap_endpoint_t *endpoint, void *data,
+                                          coap_app_data_free_callback_t callback);
 
 /**
  * Get the session associated with the specified @p remote_addr and @p index.

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -255,6 +255,9 @@ struct coap_endpoint_t {
                                        any */
   coap_address_t bind_addr;       /**< local interface address */
   coap_session_t *sessions;       /**< hash table or list of active sessions */
+
+  void *app_data;                       /**< application-specific data */
+  coap_app_data_free_callback_t app_cb; /**< call-back to release app_data */
 };
 #endif /* COAP_SERVER_SUPPORT */
 
@@ -649,6 +652,27 @@ void coap_session_server_keepalive_failed(coap_session_t *session);
  * @return The previous data (if any) stored in the session.
  */
 void *coap_session_set_app_data2_lkd(coap_session_t *session, void *data,
+                                     coap_app_data_free_callback_t callback);
+
+/**
+ * Stores @p data with the given endpoint, returning the previously stored
+ * value or NULL. The data @p callback can be defined if the data is to be
+ * released when the endpoint is deleted.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * Note: It is the responsibility of the caller to free off (if appropriate) any
+ * returned data.
+ *
+ * @param endpoint The CoAP endpoint.
+ * @param data The pointer to the data to store or NULL to just clear out the
+ *             previous data.
+ * @param callback The optional release call-back for data on endpoint
+ *                 removal or NULL.
+ *
+ * @return The previous data (if any) stored in the endpoint.
+ */
+void *coap_endpoint_set_app_data_lkd(coap_endpoint_t *endpoint, void *data,
                                      coap_app_data_free_callback_t callback);
 
 void coap_session_free(coap_session_t *session);

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -101,6 +101,8 @@ global:
   coap_enable_pdu_data_output;
   coap_encode_var_safe8;
   coap_encode_var_safe;
+  coap_endpoint_get_app_data;
+  coap_endpoint_set_app_data;
   coap_endpoint_set_default_mtu;
   coap_endpoint_str;
   coap_epoll_is_supported;
@@ -266,6 +268,7 @@ global:
   coap_session_get_by_peer;
   coap_session_get_context;
   coap_session_get_default_leisure;
+  coap_session_get_endpoint;
   coap_session_get_ifindex;
   coap_session_get_max_payloads;
   coap_session_get_max_retransmit;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -99,6 +99,8 @@ coap_dump_memory_type_counts
 coap_enable_pdu_data_output
 coap_encode_var_safe
 coap_encode_var_safe8
+coap_endpoint_get_app_data
+coap_endpoint_set_app_data
 coap_endpoint_set_default_mtu
 coap_endpoint_str
 coap_epoll_is_supported
@@ -264,6 +266,7 @@ coap_session_get_app_data
 coap_session_get_by_peer
 coap_session_get_context
 coap_session_get_default_leisure
+coap_session_get_endpoint
 coap_session_get_ifindex
 coap_session_get_max_payloads
 coap_session_get_max_retransmit

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -216,8 +216,11 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_resource.3" > coap_resource_get_uri_path.3
 	@echo ".so man3/coap_resource.3" > coap_get_resource_from_uri_path.3
 	@echo ".so man3/coap_resource.3" > coap_print_wellknown.3
+	@echo ".so man3/coap_session.3" > coap_endpoint_get_app_data.3
+	@echo ".so man3/coap_session.3" > coap_endpoint_set_app_data.3
 	@echo ".so man3/coap_session.3" > coap_session_get_addr_remote.3
 	@echo ".so man3/coap_session.3" > coap_session_get_context.3
+	@echo ".so man3/coap_session.3" > coap_session_get_endpoint.3
 	@echo ".so man3/coap_session.3" > coap_session_get_ifindex.3
 	@echo ".so man3/coap_session.3" > coap_session_get_proto.3
 	@echo ".so man3/coap_session.3" > coap_session_get_psk_hint.3

--- a/man/coap_session.txt.in
+++ b/man/coap_session.txt.in
@@ -21,13 +21,16 @@ coap_session_get_addr_local,
 coap_session_get_addr_mcast,
 coap_session_get_addr_remote,
 coap_session_get_context,
+coap_session_get_endpoint,
 coap_session_get_ifindex,
 coap_session_get_proto,
 coap_session_get_state,
 coap_session_get_tls,
 coap_session_get_type,
 coap_session_get_psk_hint,
-coap_session_get_psk_key
+coap_session_get_psk_key,
+coap_endpoint_set_app_data,
+coap_endpoint_get_app_data
 - Work with CoAP sessions
 
 SYNOPSIS
@@ -58,6 +61,8 @@ const coap_session_t *_session_);*
 
 *coap_context_t *coap_session_get_context(const coap_session_t *_session_);*
 
+*coap_endpoint_t *coap_session_get_endpoint(const coap_session_t *_session_);*
+
 *int coap_session_get_ifindex(const coap_session_t *_session_);*
 
 *coap_proto_t coap_session_get_proto(const coap_session_t *_session_);*
@@ -74,6 +79,11 @@ const coap_session_t *_session_);*
 
 *const coap_bin_const_t *coap_session_get_psk_key(
 const coap_session_t *_session_);*
+
+*void *coap_endpoint_set_app_data(coap_endpoint_t *_endpoint_, void *_app_data_,
+                                  coap_app_data_free_callback_t _app_cb_);*
+
+*void *coap_endpoint_get_app_data(const coap_endpoint_t *_endpoint_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -190,6 +200,20 @@ associated with the _session_.
 The  *coap_session_get_ifindex*() function is used to get the network interface
 index that the traffic came in over from the _session_.
 
+*Function: coap_endpoint_set_app_data()*
+
+The *coap_endpoint_set_app_data*() function is used to define a _app_data_ pointer
+for the _endpoint_ which can then be retrieved at a later date. There is an
+additional callback _app_cb_ (if set) to be used if the data is to be released
+when the _endpoint_ is deleted. If this is a subsequent call for the _endpoint_,
+then the existing data is returned, and it is the responsibility of the caller to
+release this previous data.  On the first call, NULL is returned.
+
+*Function: coap_endpoint_get_app_data()*
+
+The *coap_session_get_app_data*() function is used to retrieve the data
+pointer previously defined by *coap_endpoint_set_app_data*() in _endpoint_.
+
 [source, c]
 ----
 COAP_PROTO_UDP
@@ -264,6 +288,9 @@ address / port or NULL on error or this is not a multicast session.
 *coap_session_get_context*() returns a pointer to the current CoAP Context or
 NULL on error.
 
+*coap_session_get_endpoint*() returns the endpoint over which this session was
+created, or NULL on error.
+
 *coap_session_get_ifindex*() returns the network interface the traffic last
 came in over, or -1 on error.
 
@@ -282,6 +309,10 @@ pre-shared-key identity hint, or NULL if not defined.
 
 *coap_session_get_psk_key*() returns the current session's pre-shared-key
 key information, or NULL if not defined.
+
+*coap_endpoint_set_app_data*() returns a previously defined pointer or NULL.
+
+*coap_endpoint_get_app_data*() returns a previously defined pointer.
 
 SEE ALSO
 --------

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -2214,6 +2214,17 @@ coap_session_get_state(const coap_session_t *session) {
   return 0;
 }
 
+coap_endpoint_t *
+coap_session_get_endpoint(const coap_session_t *session) {
+#if COAP_SERVER_SUPPORT
+  if (session)
+    return session->endpoint;
+#else /* ! COAP_SERVER_SUPPORT */
+  (void)session;
+#endif /* ! COAP_SERVER_SUPPORT */
+  return 0;
+}
+
 int
 coap_session_get_ifindex(const coap_session_t *session) {
   if (session)
@@ -2439,6 +2450,34 @@ coap_free_endpoint_lkd(coap_endpoint_t *ep) {
     coap_mfree_endpoint(ep);
   }
 }
+
+void *
+coap_endpoint_get_app_data(const coap_endpoint_t *endpoint) {
+  assert(endpoint);
+  return endpoint->app_data;
+}
+
+COAP_API void *
+coap_endpoint_set_app_data(coap_endpoint_t *endpoint, void *app_data,
+                           coap_app_data_free_callback_t callback) {
+  void *old_data;
+
+  coap_lock_lock(endpoint->context, return NULL);
+  old_data = coap_endpoint_set_app_data_lkd(endpoint, app_data, callback);
+  coap_lock_unlock(endpoint->context);
+  return old_data;
+}
+
+void *
+coap_endpoint_set_app_data_lkd(coap_endpoint_t *endpoint, void *app_data,
+                               coap_app_data_free_callback_t callback) {
+  void *old_data = endpoint->app_data;
+
+  endpoint->app_data = app_data;
+  endpoint->app_cb = app_data ? callback : NULL;
+  return old_data;
+}
+
 #endif /* COAP_SERVER_SUPPORT */
 
 coap_session_t *


### PR DESCRIPTION
Hello,

in my application I would like to add information to my "userdata" session struct based on the local endpoint of this session. For example, I would like to assign a session to a default user, if the session is started over a (non-DTLS) localhost/unix domain socket, so I can keep my ACLs in place. I could probably try to get the local address of a session and find the corresponding endpoint myself but as there is already a pointer to the endpoint in the session struct, it would be easier if an application could just access this pointer.

The first commit adds a function `coap_session_get_endpoint` to achieve this. The second commit adds two functions `coap_endpoint_set_app_data2` and `coap_endpoint_get_app_data` to store "userdata" with an endpoint. This way it is also easier to access my own endpoint structure.

I added the latter two function to the coap_session files. Maybe "coap_context" would be a better fit?

Thank you!