### PR TITLE
Locking: Remove context from a subset of the lock function macros (2 of 3)

### DIFF
--- a/include/coap3/coap_threadsafe_internal.h
+++ b/include/coap3/coap_threadsafe_internal.h
@@ -181,7 +181,7 @@ int coap_lock_lock_func(const char *file, int line);
  *
  */
 #define coap_lock_callback(func) do { \
-    coap_lock_check_locked(c); \
+    coap_lock_check_locked(); \
     global_lock.in_callback++; \
     global_lock.callback_file = __FILE__; \
     global_lock.callback_line = __LINE__; \
@@ -201,7 +201,7 @@ int coap_lock_lock_func(const char *file, int line);
  *
  */
 #define coap_lock_callback_ret(r,func) do { \
-    coap_lock_check_locked(c); \
+    coap_lock_check_locked(); \
     global_lock.in_callback++; \
     global_lock.callback_file = __FILE__; \
     global_lock.callback_line = __LINE__; \
@@ -220,7 +220,7 @@ int coap_lock_lock_func(const char *file, int line);
  *
  */
 #define coap_lock_callback_release(func,failed) do { \
-    coap_lock_check_locked(c); \
+    coap_lock_check_locked(); \
     coap_lock_unlock(c); \
     func; \
     coap_lock_lock(c,failed); \
@@ -239,7 +239,7 @@ int coap_lock_lock_func(const char *file, int line);
  *
  */
 #define coap_lock_callback_ret_release(r,func,failed) do { \
-    coap_lock_check_locked(c); \
+    coap_lock_check_locked(); \
     coap_lock_unlock(c); \
     (r) = func; \
     coap_lock_lock(c,failed); \
@@ -327,7 +327,7 @@ int coap_lock_lock_func(void);
  *
  */
 #define coap_lock_callback(func) do { \
-    coap_lock_check_locked(c); \
+    coap_lock_check_locked(); \
     global_lock.in_callback++; \
     func; \
     global_lock.in_callback--; \
@@ -345,7 +345,7 @@ int coap_lock_lock_func(void);
  *
  */
 #define coap_lock_callback_ret(r,func) do { \
-    coap_lock_check_locked(c); \
+    coap_lock_check_locked(); \
     global_lock.in_callback++; \
     global_lock.in_callback++; \
     (r) = func; \
@@ -363,7 +363,7 @@ int coap_lock_lock_func(void);
  *
  */
 #define coap_lock_callback_release(func,failed) do { \
-    coap_lock_check_locked(c); \
+    coap_lock_check_locked(); \
     coap_lock_unlock(c); \
     func; \
     coap_lock_lock(c,failed); \
@@ -382,7 +382,7 @@ int coap_lock_lock_func(void);
  *
  */
 #define coap_lock_callback_ret_release(r,func,failed) do { \
-    coap_lock_check_locked(c); \
+    coap_lock_check_locked(); \
     coap_lock_unlock(c); \
     (r) = func; \
     coap_lock_lock(c,failed); \
@@ -401,7 +401,7 @@ int coap_lock_lock_func(void);
 /**
  * libcoap library code. Check that global_lock is locked.
  */
-#define coap_lock_check_locked(c) do { \
+#define coap_lock_check_locked() do { \
     assert(coap_thread_pid == global_lock.pid); \
   } while (0)
 
@@ -418,7 +418,7 @@ int coap_lock_lock_func(void);
  *
  */
 #define coap_lock_invert(alt_lock,failed) do { \
-    coap_lock_check_locked(c); \
+    coap_lock_check_locked(); \
     coap_lock_unlock(c); \
     alt_lock; \
     coap_lock_lock(c,failed); \
@@ -477,7 +477,7 @@ typedef coap_mutex_t coap_lock_t;
  *
  * libcoap library code. Check that global_lock is locked.
  */
-#define coap_lock_check_locked(c) {}
+#define coap_lock_check_locked() {}
 
 /**
  * Dummy for no thread-safe code

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -53,7 +53,7 @@ coap_register_async_lkd(coap_session_t *session,
   size_t len;
   const uint8_t *data;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   if (!COAP_PDU_IS_REQUEST(request))
     return NULL;
 
@@ -118,7 +118,7 @@ coap_async_trigger(coap_async_t *async) {
 void
 coap_async_trigger_lkd(coap_async_t *async) {
   assert(async != NULL);
-  coap_lock_check_locked(async->session->context);
+  coap_lock_check_locked();
   coap_ticks(&async->delay);
 
   coap_log_debug("   %s: Async request triggered\n",
@@ -137,7 +137,7 @@ void
 coap_async_set_delay_lkd(coap_async_t *async, coap_tick_t delay) {
   coap_tick_t now;
 
-  coap_lock_check_locked(async->session->context);
+  coap_lock_check_locked();
   assert(async != NULL);
   coap_ticks(&now);
 
@@ -170,7 +170,7 @@ coap_async_t *
 coap_find_async_lkd(coap_session_t *session, coap_bin_const_t token) {
   coap_async_t *tmp;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   SEARCH_PAIR(session->context->async_state, tmp,
               session, session,
               pdu->actual_token.length, token.length,

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -416,7 +416,7 @@ coap_context_set_block_mode(coap_context_t *context,
 void
 coap_context_set_block_mode_lkd(coap_context_t *context,
                                 uint32_t block_mode) {
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   if (!(block_mode & COAP_BLOCK_USE_LIBCOAP))
     block_mode = 0;
   context->block_mode &= ~COAP_BLOCK_SET_MASK;
@@ -455,7 +455,7 @@ coap_context_set_max_block_size_lkd(coap_context_t *context, size_t max_block_si
                   max_block_size);
     return 0;
   }
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   max_block_size = (coap_fls((uint32_t)max_block_size >> 4) - 1) & 0x07;
   context->block_mode &= ~COAP_BLOCK_MAX_SIZE_MASK;
   context->block_mode |= COAP_BLOCK_MAX_SIZE_SET((uint32_t)max_block_size);
@@ -555,7 +555,7 @@ coap_cancel_observe_lkd(coap_session_t *session, coap_binary_t *token,
   if (!session)
     return 0;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   if (!(session->block_mode & COAP_BLOCK_USE_LIBCOAP)) {
     coap_log_debug("** %s: coap_cancel_observe: COAP_BLOCK_USE_LIBCOAP not enabled\n",
                    coap_session_str(session));
@@ -3902,7 +3902,7 @@ coap_handle_response_get_block(coap_context_t *context,
   size_t offset;
   int ack_rst_sent = 0;
 
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   memset(&block, 0, sizeof(block));
 #if COAP_Q_BLOCK_SUPPORT
   memset(&qblock, 0, sizeof(qblock));

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -60,7 +60,7 @@ int
 coap_cache_ignore_options_lkd(coap_context_t *ctx,
                               const uint16_t *options,
                               size_t count) {
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   if (ctx->cache_ignore_options) {
     coap_free_type(COAP_STRING, ctx->cache_ignore_options);
   }
@@ -182,7 +182,7 @@ coap_new_cache_entry_lkd(coap_session_t *session, const coap_pdu_t *pdu,
                          unsigned int idle_timeout) {
   coap_cache_entry_t *entry;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   entry = coap_malloc_type(COAP_CACHE_ENTRY,
                            sizeof(coap_cache_entry_t));
   if (!entry) {
@@ -235,7 +235,7 @@ coap_cache_entry_t *
 coap_cache_get_by_key_lkd(coap_context_t *ctx, const coap_cache_key_t *cache_key) {
   coap_cache_entry_t *cache_entry = NULL;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   assert(cache_key);
   if (cache_key) {
     HASH_FIND(hh, ctx->cache, cache_key, sizeof(coap_cache_key_t), cache_entry);
@@ -269,7 +269,7 @@ coap_cache_get_by_pdu_lkd(coap_session_t *session,
   if (!cache_key)
     return NULL;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   cache_entry = coap_cache_get_by_key_lkd(session->context, cache_key);
   coap_delete_cache_key(cache_key);
   if (cache_entry && cache_entry->idle_timeout > 0) {

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1282,7 +1282,7 @@ coap_io_prepare_epoll_lkd(coap_context_t *ctx, coap_tick_t now) {
   unsigned int num_sockets;
   unsigned int timeout;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   /* Use the common logic */
   timeout = coap_io_prepare_io_lkd(ctx, sockets, max_sockets, &num_sockets, now);
   /* Save when the next expected I/O is to take place */
@@ -1356,7 +1356,7 @@ coap_io_prepare_io_lkd(coap_context_t *ctx,
   (void)max_sockets;
 #endif /* COAP_EPOLL_SUPPORT || WITH_LWIP || RIOT_VERSION*/
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   *num_sockets = 0;
 
 #if COAP_SERVER_SUPPORT
@@ -1916,7 +1916,7 @@ coap_io_process_with_fds_lkd(coap_context_t *ctx, uint32_t timeout_ms,
   unsigned int i;
 #endif /* ! COAP_EPOLL_SUPPORT */
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   coap_ticks(&before);
 
 #ifndef COAP_EPOLL_SUPPORT
@@ -2290,7 +2290,7 @@ coap_io_pending_lkd(coap_context_t *context) {
 
   if (!context)
     return 0;
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   if (coap_io_process_lkd(context, COAP_IO_NO_WAIT) < 0)
     return 0;
 

--- a/src/coap_io_contiki.c
+++ b/src/coap_io_contiki.c
@@ -245,7 +245,7 @@ int
 coap_io_process_lkd(coap_context_t *ctx, uint32_t timeout_ms) {
   coap_tick_t before, now;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   if (timeout_ms != COAP_IO_NO_WAIT) {
     coap_log_err("coap_io_process_lkd() must be called with COAP_IO_NO_WAIT\n");
     return -1;

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -95,7 +95,7 @@ coap_io_process_lkd(coap_context_t *context, uint32_t timeout_ms) {
   unsigned int num_sockets;
   unsigned int timeout;
 
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   coap_ticks(&before);
   timeout = coap_io_prepare_io_lkd(context, NULL, 0, &num_sockets, before);
   if (timeout == 0 || (timeout_ms != COAP_IO_WAIT && timeout_ms < timeout))

--- a/src/coap_io_riot.c
+++ b/src/coap_io_riot.c
@@ -48,7 +48,7 @@ coap_io_process_lkd(coap_context_t *ctx, uint32_t timeout_ms) {
   ztimer64_t timeout_timer;
   thread_flags_t tflags;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
 
   coap_ticks(&before);
   /* Use the common logic */

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -365,7 +365,7 @@ coap_context_set_psk_lkd(coap_context_t *ctx,
                          size_t key_len) {
   coap_dtls_spsk_t setup_data;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   memset(&setup_data, 0, sizeof(setup_data));
   if (hint) {
     setup_data.psk_info.hint.s = (const uint8_t *)hint;
@@ -395,7 +395,7 @@ coap_context_set_psk2_lkd(coap_context_t *ctx, coap_dtls_spsk_t *setup_data) {
   if (!setup_data)
     return 0;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   ctx->spsk_setup_data = *setup_data;
 
   if (coap_dtls_is_supported() || coap_tls_is_supported()) {
@@ -418,7 +418,7 @@ coap_context_set_pki(coap_context_t *ctx,
 int
 coap_context_set_pki_lkd(coap_context_t *ctx,
                          const coap_dtls_pki_t *setup_data) {
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   if (!setup_data)
     return 0;
   if (setup_data->version != COAP_DTLS_PKI_SETUP_VERSION) {
@@ -820,7 +820,7 @@ coap_free_context_lkd(coap_context_t *context) {
   if (!context)
     return;
 
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
 #if COAP_SERVER_SUPPORT
   /* Removing a resource may cause a NON unsolicited observe to be sent */
   if (context->shutdown_no_send_observe)
@@ -1086,7 +1086,7 @@ coap_send_ack_lkd(coap_session_t *session, const coap_pdu_t *request) {
   coap_pdu_t *response;
   coap_mid_t result = COAP_INVALID_MID;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   if (request && request->type == COAP_MESSAGE_CON &&
       COAP_PROTO_NOT_RELIABLE(session->proto)) {
     response = coap_pdu_init(COAP_MESSAGE_ACK, 0, request->mid, 0);
@@ -1196,7 +1196,7 @@ coap_send_message_type_lkd(coap_session_t *session, const coap_pdu_t *request,
   coap_pdu_t *response;
   coap_mid_t result = COAP_INVALID_MID;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   if (request && COAP_PROTO_NOT_RELIABLE(session->proto)) {
     response = coap_pdu_init(type, 0, request->mid, 0);
     if (response)
@@ -1468,7 +1468,7 @@ coap_send_lkd(coap_session_t *session, coap_pdu_t *pdu) {
 
   assert(pdu);
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
 
   /* Check validity of sending code */
   if (!coap_check_code_class(session, pdu)) {
@@ -2113,7 +2113,7 @@ coap_send_recv_lkd(coap_session_t *session, coap_pdu_t *request_pdu,
   coap_ticks(&start);
   assert(request_pdu);
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
 
   session->resp_pdu = NULL;
   session->req_token = coap_new_bin_const(request_pdu->actual_token.s,
@@ -2673,7 +2673,7 @@ coap_io_do_io_lkd(coap_context_t *ctx, coap_tick_t now) {
 #else /* ! COAP_EPOLL_SUPPORT */
   coap_session_t *s, *rtmp;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
 #if COAP_SERVER_SUPPORT
   coap_endpoint_t *ep, *tmp;
   LL_FOREACH_SAFE(ctx->endpoint, ep, tmp) {
@@ -2740,7 +2740,7 @@ coap_io_do_epoll_lkd(coap_context_t *ctx, struct epoll_event *events, size_t nev
   coap_tick_t now;
   size_t j;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   coap_ticks(&now);
   for (j = 0; j < nevents; j++) {
     coap_socket_t *sock = (coap_socket_t *)events[j].data.ptr;
@@ -4869,7 +4869,7 @@ coap_can_exit_lkd(coap_context_t *context) {
   coap_session_t *s, *rtmp;
   if (!context)
     return 1;
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   if (context->sendqueue)
     return 0;
 #if COAP_SERVER_SUPPORT

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -120,7 +120,7 @@ coap_new_client_session_oscore_psk_lkd(coap_context_t *ctx,
                                        coap_oscore_conf_t *oscore_conf) {
   coap_session_t *session;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   session = coap_new_client_session_psk2_lkd(ctx, local_if, server, proto, psk_data);
 
   if (!session)
@@ -158,7 +158,7 @@ coap_new_client_session_oscore_pki_lkd(coap_context_t *ctx,
                                        coap_oscore_conf_t *oscore_conf) {
   coap_session_t *session;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   session = coap_new_client_session_pki_lkd(ctx, local_if, server, proto, pki_data);
 
   if (!session)
@@ -189,7 +189,7 @@ coap_context_oscore_server_lkd(coap_context_t *context,
                                coap_oscore_conf_t *oscore_conf) {
   oscore_ctx_t *osc_ctx;
 
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   osc_ctx = coap_oscore_init(context, oscore_conf);
   /* osc_ctx already added to context->osc_ctx */
   if (osc_ctx)
@@ -2160,7 +2160,7 @@ coap_new_oscore_recipient(coap_context_t *context,
 int
 coap_new_oscore_recipient_lkd(coap_context_t *context,
                               coap_bin_const_t *recipient_id) {
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   if (context->p_osc_ctx == NULL)
     return 0;
   if (oscore_add_recipient(context->p_osc_ctx, recipient_id, 0) == NULL)
@@ -2184,7 +2184,7 @@ coap_delete_oscore_recipient(coap_context_t *context,
 int
 coap_delete_oscore_recipient_lkd(coap_context_t *context,
                                  coap_bin_const_t *recipient_id) {
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   if (context->p_osc_ctx == NULL)
     return 0;
   return oscore_delete_recipient(context->p_osc_ctx, recipient_id);

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -171,7 +171,7 @@ coap_new_pdu_lkd(coap_pdu_type_t type, coap_pdu_code_t code,
                  coap_session_t *session) {
   coap_pdu_t *pdu;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   pdu = coap_pdu_init(type, code, coap_new_message_id_lkd(session),
                       coap_session_max_pdu_size_lkd(session));
   if (!pdu)
@@ -235,7 +235,7 @@ coap_pdu_duplicate_lkd(const coap_pdu_t *old_pdu,
   uint8_t doing_first = session->doing_first;
   coap_pdu_t *pdu;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   /*
    * Need to make sure that coap_session_max_pdu_size_lkd() immediately
    * returns, rather than wait for the first CSM response from remote

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -1370,7 +1370,7 @@ coap_new_client_session_proxy_lkd(coap_context_t *ctx,
   coap_addr_info_t *info_list = NULL;
   coap_str_const_t remote;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
 
 #if COAP_IPV6_SUPPORT
   remote.s = (const uint8_t *)"::1";

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -144,7 +144,7 @@ coap_print_wellknown_lkd(coap_context_t *context, unsigned char *buf,
   };
 #endif /* WITHOUT_QUERY_FILTER */
 
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
 #ifndef WITHOUT_QUERY_FILTER
   /* split query filter, if any */
   if (query_filter) {
@@ -534,7 +534,7 @@ coap_add_resource(coap_context_t *context, coap_resource_t *resource) {
 
 void
 coap_add_resource_lkd(coap_context_t *context, coap_resource_t *resource) {
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   if (resource->is_unknown) {
     if (context->unknown_resource)
       coap_free_resource(context->unknown_resource, COAP_DELETING_RESOURCE);
@@ -600,7 +600,7 @@ coap_delete_resource_lkd(coap_context_t *context, coap_resource_t *resource) {
 
   context = resource->context;
   if (context) {
-    coap_lock_check_locked(context);
+    coap_lock_check_locked();
   }
 
   if (resource->is_unknown) {
@@ -663,7 +663,7 @@ coap_get_resource_from_uri_path_lkd(coap_context_t *context,
                                     coap_str_const_t *uri_path) {
   coap_resource_t *result;
 
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
 
   RESOURCES_FIND(context->resources, uri_path, result);
 
@@ -1112,7 +1112,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
   coap_block_b_t block;
   coap_tick_t now;
 
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
 
   if (r->observable && (r->dirty || r->partiallydirty)) {
     if (r->list_being_traversed)
@@ -1364,7 +1364,7 @@ coap_resource_notify_observers(coap_resource_t *r,
 int
 coap_resource_notify_observers_lkd(coap_resource_t *r,
                                    const coap_string_t *query COAP_UNUSED) {
-  coap_lock_check_locked(r->context);
+  coap_lock_check_locked();
   if (!r->observable)
     return 0;
   if (!r->subscribers)
@@ -1440,7 +1440,7 @@ coap_check_notify(coap_context_t *context) {
 void
 coap_check_notify_lkd(coap_context_t *context) {
 
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   if (context->observe_pending) {
     context->observe_pending = 0;
     RESOURCES_ITER(context->resources, r) {

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -375,7 +375,7 @@ coap_session_release(coap_session_t *session) {
 void
 coap_session_release_lkd(coap_session_t *session) {
   if (session) {
-    coap_lock_check_locked(session->context);
+    coap_lock_check_locked();
 #ifndef __COVERITY__
     assert(session->ref > 0);
     if (session->ref > 0)
@@ -598,7 +598,7 @@ void
 coap_session_free(coap_session_t *session) {
   if (!session)
     return;
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   assert(session->ref == 0);
   if (session->ref)
     return;
@@ -734,7 +734,7 @@ size_t
 coap_session_max_pdu_size_lkd(const coap_session_t *session) {
   size_t max_with_header;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
 #if COAP_CLIENT_SUPPORT
   /*
    * Delay if session->doing_first is set.
@@ -876,7 +876,7 @@ coap_mid_t
 coap_session_send_ping_lkd(coap_session_t *session) {
   coap_pdu_t *ping = NULL;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   if (session->state != COAP_SESSION_STATE_ESTABLISHED ||
       session->con_active)
     return COAP_INVALID_MID;
@@ -1037,7 +1037,7 @@ coap_session_disconnected_lkd(coap_session_t *session, coap_nack_reason_t reason
   int sent_nack = 0;
   coap_queue_t *q;
 
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
 #if COAP_CLIENT_SUPPORT
   coap_session_failed(session);
 #endif /* COAP_CLIENT_SUPPORT */
@@ -1639,7 +1639,7 @@ coap_new_client_session_lkd(coap_context_t *ctx,
                             coap_proto_t proto) {
   coap_session_t *session;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   session = coap_session_create_client(ctx, local_if, server,
                                        proto);
   if (session) {
@@ -1672,7 +1672,7 @@ coap_new_client_session_psk_lkd(coap_context_t *ctx,
                                 const uint8_t *key, unsigned key_len) {
   coap_dtls_cpsk_t setup_data;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   memset(&setup_data, 0, sizeof(setup_data));
   setup_data.version = COAP_DTLS_CPSK_SETUP_VERSION;
 
@@ -1827,7 +1827,7 @@ coap_new_client_session_psk2_lkd(coap_context_t *ctx,
                                  coap_dtls_cpsk_t *setup_data) {
   coap_session_t *session;
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   session = coap_session_create_client(ctx, local_if, server, proto);
 
   if (!session || !setup_data)
@@ -2023,7 +2023,7 @@ coap_new_client_session_pki_lkd(coap_context_t *ctx,
     return NULL;
   }
 
-  coap_lock_check_locked(ctx);
+  coap_lock_check_locked();
   l_setup_data = *setup_data;
   coap_sanitize_client_sni(&l_setup_data.client_sni);
 
@@ -2128,7 +2128,7 @@ coap_new_message_id(coap_session_t *session) {
 
 uint16_t
 coap_new_message_id_lkd(coap_session_t *session) {
-  coap_lock_check_locked(session->context);
+  coap_lock_check_locked();
   if (COAP_PROTO_NOT_RELIABLE(session->proto))
     return ++session->tx_mid;
   /* TCP/TLS have no notion of mid */
@@ -2273,7 +2273,7 @@ coap_new_endpoint_lkd(coap_context_t *context, const coap_address_t *listen_addr
     return NULL;
   }
 
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
 
   switch (proto) {
   case COAP_PROTO_UDP:
@@ -2406,7 +2406,7 @@ coap_free_endpoint_lkd(coap_endpoint_t *ep) {
 
     if (ep->context) {
       /* If fully allocated and inserted */
-      coap_lock_check_locked(ep->context);
+      coap_lock_check_locked();
       SESSIONS_ITER_SAFE(ep->sessions, session, rtmp) {
         assert(session->ref == 0);
         if (session->ref == 0) {

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -101,7 +101,7 @@ coap_persist_observe_add_lkd(coap_context_t *context,
   coap_subscription_t *s;
   coap_endpoint_t *ep;
 
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   if (e_listen_addr == NULL || s_addr_info == NULL || raw_packet == NULL)
     return NULL;
 
@@ -1172,7 +1172,7 @@ coap_persist_startup_lkd(coap_context_t *context,
                          const char *observe_save_file,
                          const char *obs_cnt_save_file,
                          uint32_t save_freq) {
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   if (dyn_resource_save_file) {
     context->dyn_resource_save_file =
         coap_new_bin_const((const uint8_t *)dyn_resource_save_file,
@@ -1234,7 +1234,7 @@ void
 coap_persist_stop_lkd(coap_context_t *context) {
   if (context == NULL)
     return;
-  coap_lock_check_locked(context);
+  coap_lock_check_locked();
   context->observe_no_clear = 1;
   coap_persist_cleanup(context);
 }


### PR DESCRIPTION
Makes reading the code simpler.

Context is no longer used as global_lock is used in the coap_lock_lock() and coap_lock_unlock() functions.

Part 2 of 3.

Update coap_lock_check_locked() and all users.