### PR TITLE
Locking: Remove context from a subset of the lock function macros (3 of 3)

### DIFF
--- a/include/coap3/coap_threadsafe_internal.h
+++ b/include/coap3/coap_threadsafe_internal.h
@@ -152,7 +152,7 @@ int coap_lock_lock_func(const char *file, int line);
  * @param failed Code to execute on lock failure.
  *
  */
-#define coap_lock_lock(c,failed) do { \
+#define coap_lock_lock(failed) do { \
     if (!coap_lock_lock_func(__FILE__, __LINE__)) { \
       failed; \
     } \
@@ -167,7 +167,7 @@ int coap_lock_lock_func(const char *file, int line);
  *
  * @param c Context.
  */
-#define coap_lock_unlock(c) do { \
+#define coap_lock_unlock() do { \
     coap_lock_unlock_func(__FILE__, __LINE__); \
   } while (0)
 
@@ -221,9 +221,9 @@ int coap_lock_lock_func(const char *file, int line);
  */
 #define coap_lock_callback_release(func,failed) do { \
     coap_lock_check_locked(); \
-    coap_lock_unlock(c); \
+    coap_lock_unlock(); \
     func; \
-    coap_lock_lock(c,failed); \
+    coap_lock_lock(failed); \
   } while (0)
 
 /**
@@ -240,9 +240,9 @@ int coap_lock_lock_func(const char *file, int line);
  */
 #define coap_lock_callback_ret_release(r,func,failed) do { \
     coap_lock_check_locked(); \
-    coap_lock_unlock(c); \
+    coap_lock_unlock(); \
     (r) = func; \
-    coap_lock_lock(c,failed); \
+    coap_lock_lock(failed); \
   } while (0)
 
 extern coap_lock_t global_lock;
@@ -298,7 +298,7 @@ int coap_lock_lock_func(void);
  * @param failed Code to execute on lock failure
  *
  */
-#define coap_lock_lock(c,failed) do { \
+#define coap_lock_lock(failed) do { \
     if (!coap_lock_lock_func()) { \
       failed; \
     } \
@@ -313,7 +313,7 @@ int coap_lock_lock_func(void);
  *
  * @param c Context.
  */
-#define coap_lock_unlock(c) do { \
+#define coap_lock_unlock() do { \
     coap_lock_unlock_func(); \
   } while (0)
 
@@ -364,9 +364,9 @@ int coap_lock_lock_func(void);
  */
 #define coap_lock_callback_release(func,failed) do { \
     coap_lock_check_locked(); \
-    coap_lock_unlock(c); \
+    coap_lock_unlock(); \
     func; \
-    coap_lock_lock(c,failed); \
+    coap_lock_lock(failed); \
   } while (0)
 
 /**
@@ -383,9 +383,9 @@ int coap_lock_lock_func(void);
  */
 #define coap_lock_callback_ret_release(r,func,failed) do { \
     coap_lock_check_locked(); \
-    coap_lock_unlock(c); \
+    coap_lock_unlock(); \
     (r) = func; \
-    coap_lock_lock(c,failed); \
+    coap_lock_lock(failed); \
   } while (0)
 
 # endif /* ! COAP_THREAD_RECURSIVE_CHECK */
@@ -419,9 +419,9 @@ int coap_lock_lock_func(void);
  */
 #define coap_lock_invert(alt_lock,failed) do { \
     coap_lock_check_locked(); \
-    coap_lock_unlock(c); \
+    coap_lock_unlock(); \
     alt_lock; \
-    coap_lock_lock(c,failed); \
+    coap_lock_lock(failed); \
   } while (0)
 
 extern coap_lock_t global_lock;
@@ -447,11 +447,10 @@ typedef coap_mutex_t coap_lock_t;
  *   global_lock not locked if libcoap not started and @p failed is executed. @p failed must
  *   be code that skips doing the lock protected code.
  *
- * @param c Context.
  * @param failed Code to execute on lock failure.
  *
  */
-#define coap_lock_lock(c,failed)
+#define coap_lock_lock(failed)
 
 /**
  * Dummy for no thread-safe code
@@ -460,10 +459,8 @@ typedef coap_mutex_t coap_lock_t;
  *
  * Unlocked when
  *   Same thread locked context
- *
- * @param c Context.
  */
-#define coap_lock_unlock(c)
+#define coap_lock_unlock()
 
 /**
  * Dummy for no thread-safe code

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -40,9 +40,9 @@ coap_register_async(coap_session_t *session,
                     const coap_pdu_t *request, coap_tick_t delay) {
   coap_async_t *async;
 
-  coap_lock_lock(session->context, return NULL);
+  coap_lock_lock(return NULL);
   async = coap_register_async_lkd(session, request, delay);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return async;
 }
 
@@ -110,9 +110,9 @@ coap_register_async_lkd(coap_session_t *session,
 
 COAP_API void
 coap_async_trigger(coap_async_t *async) {
-  coap_lock_lock(async->session->context, return);
+  coap_lock_lock(return);
   coap_async_trigger_lkd(async);
-  coap_lock_unlock(async->session->context);
+  coap_lock_unlock();
 }
 
 void
@@ -128,9 +128,9 @@ coap_async_trigger_lkd(coap_async_t *async) {
 
 COAP_API void
 coap_async_set_delay(coap_async_t *async, coap_tick_t delay) {
-  coap_lock_lock(async->session->context, return);
+  coap_lock_lock(return);
   coap_async_set_delay_lkd(async, delay);
-  coap_lock_unlock(async->session->context);
+  coap_lock_unlock();
 }
 
 void
@@ -160,9 +160,9 @@ COAP_API coap_async_t *
 coap_find_async(coap_session_t *session, coap_bin_const_t token) {
   coap_async_t *tmp;
 
-  coap_lock_lock(session->context, return NULL);
+  coap_lock_lock(return NULL);
   tmp = coap_find_async_lkd(session, token);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return tmp;
 }
 
@@ -198,9 +198,9 @@ coap_free_async_sub(coap_context_t *context, coap_async_t *s) {
 
 COAP_API void
 coap_free_async(coap_session_t *session, coap_async_t *async) {
-  coap_lock_lock(session->context, return);
+  coap_lock_lock(return);
   coap_free_async_lkd(session, async);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
 }
 
 void
@@ -220,9 +220,9 @@ coap_delete_all_async(coap_context_t *context) {
 
 COAP_API void
 coap_async_set_app_data(coap_async_t *async_entry, void *app_data) {
-  coap_lock_lock(NULL, return);
+  coap_lock_lock(return);
   coap_async_set_app_data2_lkd(async_entry, app_data, NULL);
-  coap_lock_unlock(NULL);
+  coap_lock_unlock();
 }
 
 COAP_API void *
@@ -230,9 +230,9 @@ coap_async_set_app_data2(coap_async_t *async_entry, void *app_data,
                          coap_app_data_free_callback_t callback) {
   void *old_data;
 
-  coap_lock_lock(NULL, return NULL);
+  coap_lock_lock(return NULL);
   old_data = coap_async_set_app_data2_lkd(async_entry, app_data, callback);
-  coap_lock_unlock(NULL);
+  coap_lock_unlock();
   return old_data;
 }
 

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -408,9 +408,9 @@ error:
 COAP_API void
 coap_context_set_block_mode(coap_context_t *context,
                             uint32_t block_mode) {
-  coap_lock_lock(context, return);
+  coap_lock_lock(return);
   coap_context_set_block_mode_lkd(context, block_mode);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
 }
 
 void
@@ -432,9 +432,9 @@ coap_context_set_max_block_size(coap_context_t *context,
                                 size_t max_block_size) {
   int ret;
 
-  coap_lock_lock(context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_context_set_max_block_size_lkd(context, max_block_size);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -540,9 +540,9 @@ coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
                     coap_pdu_type_t type) {
   int ret;
 
-  coap_lock_lock(session->context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_cancel_observe_lkd(session, token, type);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1250,10 +1250,10 @@ coap_add_data_large_request(coap_session_t *session,
                            ) {
   int ret;
 
-  coap_lock_lock(session->context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_add_data_large_request_lkd(session, pdu, length, data,
                                         release_func, app_ptr);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1296,11 +1296,11 @@ coap_add_data_large_response(coap_resource_t *resource,
                             ) {
   int ret;
 
-  coap_lock_lock(session->context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_add_data_large_response_lkd(resource, session, request,
                                          response, query, media_type, maxage, etag,
                                          length, data, release_func, app_ptr);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return ret;
 }
 

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -50,9 +50,9 @@ coap_cache_ignore_options(coap_context_t *ctx,
                           size_t count) {
   int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_cache_ignore_options_lkd(ctx, options, count);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -168,10 +168,10 @@ coap_new_cache_entry(coap_session_t *session, const coap_pdu_t *pdu,
                      unsigned int idle_timeout) {
   coap_cache_entry_t *cache;
 
-  coap_lock_lock(session->context, return NULL);
+  coap_lock_lock(return NULL);
   cache = coap_new_cache_entry_lkd(session, pdu, record_pdu, session_based,
                                    idle_timeout);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return cache;
 }
 
@@ -225,9 +225,9 @@ COAP_API coap_cache_entry_t *
 coap_cache_get_by_key(coap_context_t *ctx, const coap_cache_key_t *cache_key) {
   coap_cache_entry_t *cache;
 
-  coap_lock_lock(ctx, return NULL);
+  coap_lock_lock(return NULL);
   cache = coap_cache_get_by_key_lkd(ctx, cache_key);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return cache;
 }
 
@@ -253,9 +253,9 @@ coap_cache_get_by_pdu(coap_session_t *session,
                       coap_cache_session_based_t session_based) {
   coap_cache_entry_t *entry;
 
-  coap_lock_lock(session->context, return NULL);
+  coap_lock_lock(return NULL);
   entry = coap_cache_get_by_pdu_lkd(session, request, session_based);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return entry;
 }
 
@@ -306,9 +306,9 @@ COAP_API void
 coap_cache_set_app_data(coap_cache_entry_t *cache_entry,
                         void *data,
                         coap_app_data_free_callback_t callback) {
-  coap_lock_lock(NULL, return);
+  coap_lock_lock(return);
   coap_cache_set_app_data2_lkd(cache_entry, data, callback);
-  coap_lock_unlock(NULL);
+  coap_lock_unlock();
 }
 
 COAP_API void *
@@ -316,9 +316,9 @@ coap_cache_set_app_data2(coap_cache_entry_t *cache_entry, void *app_data,
                          coap_app_data_free_callback_t callback) {
   void *old_data;
 
-  coap_lock_lock(NULL, return NULL);
+  coap_lock_lock(return NULL);
   old_data = coap_cache_set_app_data2_lkd(cache_entry, app_data, callback);
-  coap_lock_unlock(NULL);
+  coap_lock_unlock();
   return old_data;
 }
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -1263,9 +1263,9 @@ COAP_API unsigned int
 coap_io_prepare_epoll(coap_context_t *ctx, coap_tick_t now) {
   unsigned int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_io_prepare_epoll_lkd(ctx, now);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1328,9 +1328,9 @@ coap_io_prepare_io(coap_context_t *ctx,
                    coap_tick_t now) {
   unsigned int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_io_prepare_io_lkd(ctx, sockets, max_sockets, num_sockets, now);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1673,10 +1673,10 @@ coap_io_get_fds(coap_context_t *ctx,
                 unsigned int *rem_timeout_ms) {
   unsigned int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_io_get_fds_lkd(ctx, read_fds, have_read_fds, max_read_fds, write_fds,
                             have_write_fds, max_write_fds, rem_timeout_ms);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1804,9 +1804,9 @@ COAP_API int
 coap_io_process(coap_context_t *ctx, uint32_t timeout_ms) {
   int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_io_process_lkd(ctx, timeout_ms);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1821,10 +1821,10 @@ coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
                          fd_set *eexceptfds) {
   int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_io_process_with_fds_lkd(ctx, timeout_ms, enfds, ereadfds, ewritefds,
                                      eexceptfds);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1977,12 +1977,12 @@ coap_io_process_with_fds_lkd(coap_context_t *ctx, uint32_t timeout_ms,
   /* on Windows select will return an error if called without FDs */
   if (nfds > 0) {
     /* Unlock so that other threads can lock/update ctx */
-    coap_lock_unlock(ctx);
+    coap_lock_unlock();
 
     result = select((int)nfds, &ctx->readfds, &ctx->writefds, &ctx->exceptfds,
                     timeout > 0 ? &tv : NULL);
 
-    coap_lock_lock(ctx, return -1);
+    coap_lock_lock(return -1);
   } else {
     goto all_over;
   }
@@ -2098,7 +2098,7 @@ coap_io_process_with_fds_lkd(coap_context_t *ctx, uint32_t timeout_ms,
     }
 
     /* Unlock so that other threads can lock/update ctx */
-    coap_lock_unlock(ctx);
+    coap_lock_unlock();
 
     nfds = epoll_wait(ctx->epfd, events, COAP_MAX_EPOLL_EVENTS, etimeout);
     if (nfds < 0) {
@@ -2106,11 +2106,11 @@ coap_io_process_with_fds_lkd(coap_context_t *ctx, uint32_t timeout_ms,
         coap_log_err("epoll_wait: unexpected error: %s (%d)\n",
                      coap_socket_strerror(), nfds);
       }
-      coap_lock_lock(ctx, return -1);
+      coap_lock_lock(return -1);
       break;
     }
 
-    coap_lock_lock(ctx, return -1);
+    coap_lock_lock(return -1);
 #if COAP_THREAD_SAFE
     /* Need to refresh what is available to read / write etc. */
     nfds = epoll_wait(ctx->epfd, events, COAP_MAX_EPOLL_EVENTS, 0);
@@ -2170,11 +2170,11 @@ coap_io_process_loop(coap_context_t *context,
 
   if (!context)
     return 0;
-  coap_lock_lock(context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_io_process_loop_lkd(context, main_loop_code,
                                  main_loop_code_arg, timeout_ms,
                                  thread_count);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -2271,9 +2271,9 @@ COAP_API int
 coap_io_pending(coap_context_t *context) {
   int ret;
 
-  coap_lock_lock(context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_io_pending_lkd(context);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return ret;
 }
 

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -82,9 +82,9 @@ int
 coap_io_process(coap_context_t *ctx, uint32_t timeout_ms) {
   int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_io_process_lkd(ctx, timeout_ms);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -220,9 +220,9 @@ coap_recvc(void *arg, struct udp_pcb *upcb, struct pbuf *p,
         goto error;
       }
     }
-    coap_lock_lock(session->context, return);
+    coap_lock_lock(return);
     coap_dispatch(session->context, session, pdu);
-    coap_lock_unlock(session->context);
+    coap_lock_unlock();
   }
 #if NO_SYS == 0
   sys_sem_signal(&coap_io_timeout_sem);
@@ -292,7 +292,7 @@ coap_udp_recvs(void *arg, struct udp_pcb *upcb, struct pbuf *p,
 
   coap_ticks(&now);
 
-  coap_lock_lock(ep->context, goto error_free_pbuf);
+  coap_lock_lock(goto error_free_pbuf);
   session = coap_endpoint_get_session(ep, packet, now);
   if (!session)
     goto error_free_pbuf;
@@ -340,7 +340,7 @@ coap_udp_recvs(void *arg, struct udp_pcb *upcb, struct pbuf *p,
 
   coap_delete_pdu_lkd(pdu);
   coap_free_packet(packet);
-  coap_lock_unlock(ep->context);
+  coap_lock_unlock();
 #if NO_SYS == 0
   sys_sem_signal(&coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
@@ -359,7 +359,7 @@ error:
 cleanup:
   coap_delete_pdu_lkd(pdu);
   coap_free_packet(packet);
-  coap_lock_unlock(ep->context);
+  coap_lock_unlock();
 #if NO_SYS == 0
   sys_sem_signal(&coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */

--- a/src/coap_io_riot.c
+++ b/src/coap_io_riot.c
@@ -32,9 +32,9 @@ int
 coap_io_process(coap_context_t *ctx, uint32_t timeout_ms) {
   int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_io_process_lkd(ctx, timeout_ms);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -68,12 +68,12 @@ coap_io_process_lkd(coap_context_t *ctx, uint32_t timeout_ms) {
     ctx->selecting_thread = thread_get_active();
 
     /* Unlock so that other threads can lock/update ctx */
-    coap_lock_unlock(ctx);
+    coap_lock_unlock();
 
     tflags = thread_flags_wait_any(COAP_SELECT_THREAD_FLAG |
                                    THREAD_FLAG_TIMEOUT);
     /* Take control of ctx again */
-    coap_lock_lock(ctx, return -1);
+    coap_lock_lock(return -1);
 
     if (tflags & THREAD_FLAG_TIMEOUT) {
       errno = EINTR;

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -217,9 +217,9 @@ coap_delete_node(coap_queue_t *node) {
   context = node->session->context;
   (void)context;
 #endif /* COAP_THREAD_SAFE */
-  coap_lock_lock(context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_delete_node_lkd(node);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -352,9 +352,9 @@ coap_context_set_psk(coap_context_t *ctx,
                      size_t key_len) {
   int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_context_set_psk_lkd(ctx, hint, key, key_len);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -384,9 +384,9 @@ COAP_API int
 coap_context_set_psk2(coap_context_t *ctx, coap_dtls_spsk_t *setup_data) {
   int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_context_set_psk2_lkd(ctx, setup_data);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -409,9 +409,9 @@ coap_context_set_pki(coap_context_t *ctx,
                      const coap_dtls_pki_t *setup_data) {
   int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_context_set_pki_lkd(ctx, setup_data);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -438,9 +438,9 @@ coap_context_set_pki_root_cas(coap_context_t *ctx,
                               const char *ca_dir) {
   int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_context_set_pki_root_cas_lkd(ctx, ca_file, ca_dir);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -458,9 +458,9 @@ COAP_API int
 coap_context_load_pki_trust_store(coap_context_t *ctx) {
   int ret;
 
-  coap_lock_lock(ctx, return 0);
+  coap_lock_lock(return 0);
   ret = coap_context_load_pki_trust_store_lkd(ctx);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -668,9 +668,9 @@ coap_af_unix_is_supported(void) {
 COAP_API void
 coap_context_set_app_data(coap_context_t *context, void *app_data) {
   assert(context);
-  coap_lock_lock(context, return);
+  coap_lock_lock(return);
   coap_context_set_app_data2_lkd(context, app_data, NULL);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
 }
 
 void *
@@ -684,9 +684,9 @@ coap_context_set_app_data2(coap_context_t *context, void *app_data,
                            coap_app_data_free_callback_t callback) {
   void *old_data;
 
-  coap_lock_lock(context, return NULL);
+  coap_lock_lock(return NULL);
   old_data = coap_context_set_app_data2_lkd(context, app_data, callback);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return old_data;
 }
 
@@ -721,7 +721,7 @@ coap_new_context(const coap_address_t *listen_addr) {
   }
   memset(c, 0, sizeof(coap_context_t));
 
-  coap_lock_lock(c, coap_free_type(COAP_CONTEXT, c); return NULL);
+  coap_lock_lock(coap_free_type(COAP_CONTEXT, c); return NULL);
 #ifdef COAP_EPOLL_SUPPORT
   c->epfd = epoll_create1(0);
   if (c->epfd == -1) {
@@ -782,7 +782,7 @@ coap_new_context(const coap_address_t *listen_addr) {
 
   c->max_token_size = COAP_TOKEN_DEFAULT_MAX; /* RFC8974 */
 
-  coap_lock_unlock(c);
+  coap_lock_unlock();
   return c;
 
 #if defined(COAP_EPOLL_SUPPORT) || COAP_SERVER_SUPPORT
@@ -795,9 +795,9 @@ onerror:
 COAP_API void
 coap_set_app_data(coap_context_t *context, void *app_data) {
   assert(context);
-  coap_lock_lock(context, return);
+  coap_lock_lock(return);
   coap_context_set_app_data2_lkd(context, app_data, NULL);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
 }
 
 void *
@@ -810,9 +810,9 @@ COAP_API void
 coap_free_context(coap_context_t *context) {
   if (!context)
     return;
-  coap_lock_lock(context, return);
+  coap_lock_lock(return);
   coap_free_context_lkd(context);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
 }
 
 void
@@ -1060,9 +1060,9 @@ COAP_API coap_mid_t
 coap_send_rst(coap_session_t *session, const coap_pdu_t *request) {
   coap_mid_t mid;
 
-  coap_lock_lock(session->context, return COAP_INVALID_MID);
+  coap_lock_lock(return COAP_INVALID_MID);
   mid = coap_send_rst_lkd(session, request);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return mid;
 }
 
@@ -1075,9 +1075,9 @@ COAP_API coap_mid_t
 coap_send_ack(coap_session_t *session, const coap_pdu_t *request) {
   coap_mid_t mid;
 
-  coap_lock_lock(session->context, return COAP_INVALID_MID);
+  coap_lock_lock(return COAP_INVALID_MID);
   mid = coap_send_ack_lkd(session, request);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return mid;
 }
 
@@ -1155,9 +1155,9 @@ coap_send_error(coap_session_t *session,
                 coap_opt_filter_t *opts) {
   coap_mid_t mid;
 
-  coap_lock_lock(session->context, return COAP_INVALID_MID);
+  coap_lock_lock(return COAP_INVALID_MID);
   mid = coap_send_error_lkd(session, request, code, opts);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return mid;
 }
 
@@ -1184,9 +1184,9 @@ coap_send_message_type(coap_session_t *session, const coap_pdu_t *request,
                        coap_pdu_type_t type) {
   coap_mid_t mid;
 
-  coap_lock_lock(session->context, return COAP_INVALID_MID);
+  coap_lock_lock(return COAP_INVALID_MID);
   mid = coap_send_message_type_lkd(session, request, type);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return mid;
 }
 
@@ -1448,9 +1448,9 @@ COAP_API coap_mid_t
 coap_send(coap_session_t *session, coap_pdu_t *pdu) {
   coap_mid_t mid;
 
-  coap_lock_lock(session->context, return COAP_INVALID_MID);
+  coap_lock_lock(return COAP_INVALID_MID);
   mid = coap_send_lkd(session, pdu);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return mid;
 }
 
@@ -2081,9 +2081,9 @@ coap_send_recv(coap_session_t *session, coap_pdu_t *request_pdu,
                coap_pdu_t **response_pdu, uint32_t timeout_ms) {
   int ret;
 
-  coap_lock_lock(session->context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_send_recv_lkd(session, request_pdu, response_pdu, timeout_ms);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -2659,9 +2659,9 @@ coap_accept_endpoint(coap_context_t *ctx, coap_endpoint_t *endpoint,
 
 COAP_API void
 coap_io_do_io(coap_context_t *ctx, coap_tick_t now) {
-  coap_lock_lock(ctx, return);
+  coap_lock_lock(return);
   coap_io_do_io_lkd(ctx, now);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
 }
 
 void
@@ -2720,9 +2720,9 @@ coap_io_do_io_lkd(coap_context_t *ctx, coap_tick_t now) {
 
 COAP_API void
 coap_io_do_epoll(coap_context_t *ctx, struct epoll_event *events, size_t nevents) {
-  coap_lock_lock(ctx, return);
+  coap_lock_lock(return);
   coap_io_do_epoll_lkd(ctx, events, nevents);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
 }
 
 /*
@@ -4796,9 +4796,9 @@ coap_handle_event(coap_context_t *context, coap_event_t event,
                   coap_session_t *session) {
   int ret;
 
-  coap_lock_lock(context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_handle_event_lkd(context, event, session);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -4858,9 +4858,9 @@ COAP_API int
 coap_can_exit(coap_context_t *context) {
   int ret;
 
-  coap_lock_lock(context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_can_exit_lkd(context);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -5059,9 +5059,9 @@ coap_register_pong_handler(coap_context_t *context,
 
 COAP_API void
 coap_register_option(coap_context_t *ctx, uint16_t type) {
-  coap_lock_lock(ctx, return);
+  coap_lock_lock(return);
   coap_register_option_lkd(ctx, type);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
 }
 
 void
@@ -5076,9 +5076,9 @@ coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
                            const char *ifname) {
   int ret;
 
-  coap_lock_lock(ctx, return -1);
+  coap_lock_lock(return -1);
   ret = coap_join_mcast_group_intf_lkd(ctx, group_name, ifname);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return ret;
 }
 

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -70,9 +70,9 @@ coap_new_client_session_oscore(coap_context_t *ctx,
                                coap_oscore_conf_t *oscore_conf) {
   coap_session_t *session;
 
-  coap_lock_lock(ctx, return NULL);
+  coap_lock_lock(return NULL);
   session = coap_new_client_session_oscore_lkd(ctx, local_if, server, proto, oscore_conf);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return session;
 }
 
@@ -104,10 +104,10 @@ coap_new_client_session_oscore_psk(coap_context_t *ctx,
                                    coap_oscore_conf_t *oscore_conf) {
   coap_session_t *session;
 
-  coap_lock_lock(ctx, return NULL);
+  coap_lock_lock(return NULL);
   session = coap_new_client_session_oscore_psk_lkd(ctx, local_if, server, proto, psk_data,
                                                    oscore_conf);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return session;
 }
 
@@ -142,10 +142,10 @@ coap_new_client_session_oscore_pki(coap_context_t *ctx,
                                    coap_oscore_conf_t *oscore_conf) {
   coap_session_t *session;
 
-  coap_lock_lock(ctx, return NULL);
+  coap_lock_lock(return NULL);
   session = coap_new_client_session_oscore_pki_lkd(ctx, local_if, server, proto, pki_data,
                                                    oscore_conf);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return session;
 }
 
@@ -178,9 +178,9 @@ coap_context_oscore_server(coap_context_t *context,
                            coap_oscore_conf_t *oscore_conf) {
   int ret;
 
-  coap_lock_lock(context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_context_oscore_server_lkd(context, oscore_conf);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -300,9 +300,9 @@ coap_oscore_new_pdu_encrypted(coap_session_t *session,
                               oscore_partial_iv_t send_partial_iv) {
   coap_pdu_t *ret_pdu;
 
-  coap_lock_lock(session->context, return NULL);
+  coap_lock_lock(return NULL);
   ret_pdu = coap_oscore_new_pdu_encrypted_lkd(session, pdu, kid_context, send_partial_iv);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
 
   return ret_pdu;
 }
@@ -2151,9 +2151,9 @@ coap_new_oscore_recipient(coap_context_t *context,
                           coap_bin_const_t *recipient_id) {
   int ret;
 
-  coap_lock_lock(context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_new_oscore_recipient_lkd(context, recipient_id);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -2175,9 +2175,9 @@ coap_delete_oscore_recipient(coap_context_t *context,
 
   if (!context || !recipient_id)
     return 0;
-  coap_lock_lock(context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_delete_oscore_recipient_lkd(context, recipient_id);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return ret;
 }
 

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -160,9 +160,9 @@ coap_new_pdu(coap_pdu_type_t type, coap_pdu_code_t code,
              coap_session_t *session) {
   coap_pdu_t *pdu;
 
-  coap_lock_lock(session->context, return NULL);
+  coap_lock_lock(return NULL);
   pdu = coap_new_pdu_lkd(type, code, session);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return pdu;
 }
 
@@ -181,9 +181,9 @@ coap_new_pdu_lkd(coap_pdu_type_t type, coap_pdu_code_t code,
 
 COAP_API void
 coap_delete_pdu(coap_pdu_t *pdu) {
-  coap_lock_lock(NULL, return);
+  coap_lock_lock(return);
   coap_delete_pdu_lkd(pdu);
-  coap_lock_unlock(NULL);
+  coap_lock_unlock();
 }
 
 void
@@ -212,13 +212,13 @@ coap_pdu_duplicate(const coap_pdu_t *old_pdu,
                    coap_opt_filter_t *drop_options) {
   coap_pdu_t *new_pdu;
 
-  coap_lock_lock(session->context, return NULL);
+  coap_lock_lock(return NULL);
   new_pdu = coap_pdu_duplicate_lkd(old_pdu,
                                    session,
                                    token_length,
                                    token,
                                    drop_options);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return new_pdu;
 }
 

--- a/src/coap_prng.c
+++ b/src/coap_prng.c
@@ -57,18 +57,18 @@ coap_prng_impl(unsigned char *buf, size_t len) {
 
 COAP_API void
 coap_prng_init(unsigned int seed) {
-  coap_lock_lock(NULL, return);
+  coap_lock_lock(return);
   coap_prng_init_lkd(seed);
-  coap_lock_unlock(NULL);
+  coap_lock_unlock();
 }
 
 COAP_API int
 coap_prng(void *buf, size_t len) {
   int ret;
 
-  coap_lock_lock(NULL, return 0);
+  coap_lock_lock(return 0);
   ret = coap_prng_lkd(buf, len);
-  coap_lock_unlock(NULL);
+  coap_lock_unlock();
   return ret;
 }
 

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -754,14 +754,14 @@ coap_proxy_forward_request(coap_session_t *session,
                            coap_proxy_server_list_t *server_list) {
   int ret;
 
-  coap_lock_lock(session->context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_proxy_forward_request_lkd(session,
                                        request,
                                        response,
                                        resource,
                                        cache_key,
                                        server_list);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1069,11 +1069,11 @@ coap_proxy_forward_response(coap_session_t *session,
                             coap_cache_key_t **cache_key) {
   int ret;
 
-  coap_lock_lock(session->context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_proxy_forward_response_lkd(session,
                                         received,
                                         cache_key);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1357,9 +1357,9 @@ coap_new_client_session_proxy(coap_context_t *ctx,
                               coap_proxy_server_list_t *server_list) {
   coap_session_t *session;
 
-  coap_lock_lock(ctx, return NULL);
+  coap_lock_lock(return NULL);
   session = coap_new_client_session_proxy_lkd(ctx, server_list);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return session;
 }
 

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -106,9 +106,9 @@ coap_print_wellknown(coap_context_t *context, unsigned char *buf,
                      size_t *buflen, size_t offset,
                      const coap_string_t *query_filter) {
   coap_print_status_t result;
-  coap_lock_lock(context, return COAP_PRINT_STATUS_ERROR);
+  coap_lock_lock(return COAP_PRINT_STATUS_ERROR);
   result = coap_print_wellknown_lkd(context, buf, buflen, offset, query_filter);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return result;
 }
 
@@ -527,9 +527,9 @@ coap_free_resource(coap_resource_t *resource, coap_deleting_resource_t deleting)
 
 COAP_API void
 coap_add_resource(coap_context_t *context, coap_resource_t *resource) {
-  coap_lock_lock(context, return);
+  coap_lock_lock(return);
   coap_add_resource_lkd(context, resource);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
 }
 
 void
@@ -581,9 +581,9 @@ coap_delete_resource(coap_context_t *context, coap_resource_t *resource) {
 
   context = resource->context;
   if (context) {
-    coap_lock_lock(context, return 0);
+    coap_lock_lock(return 0);
     ret = coap_delete_resource_lkd(context, resource);
-    coap_lock_unlock(context);
+    coap_lock_unlock();
   } else {
     ret = coap_delete_resource_lkd(context, resource);
   }
@@ -651,9 +651,9 @@ COAP_API coap_resource_t *
 coap_get_resource_from_uri_path(coap_context_t *context, coap_str_const_t *uri_path) {
   coap_resource_t *result;
 
-  coap_lock_lock(context, return NULL);
+  coap_lock_lock(return NULL);
   result = coap_get_resource_from_uri_path_lkd(context, uri_path);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
 
   return result;
 }
@@ -1344,9 +1344,9 @@ COAP_API int
 coap_resource_set_dirty(coap_resource_t *r, const coap_string_t *query) {
   int ret;
 
-  coap_lock_lock(r->context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_resource_notify_observers_lkd(r, query);
-  coap_lock_unlock(r->context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1355,9 +1355,9 @@ coap_resource_notify_observers(coap_resource_t *r,
                                const coap_string_t *query) {
   int ret;
 
-  coap_lock_lock(r->context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_resource_notify_observers_lkd(r, query);
-  coap_lock_unlock(r->context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1432,9 +1432,9 @@ coap_resource_get_uri_path(coap_resource_t *resource) {
 
 COAP_API void
 coap_check_notify(coap_context_t *context) {
-  coap_lock_lock(context, return);
+  coap_lock_lock(return);
   coap_check_notify_lkd(context);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
 }
 
 void

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -346,9 +346,9 @@ coap_session_get_non_receive_timeout(const coap_session_t *session) {
 
 COAP_API coap_session_t *
 coap_session_reference(coap_session_t *session) {
-  coap_lock_lock(session->context, return NULL);
+  coap_lock_lock(return NULL);
   coap_session_reference_lkd(session);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return session;
 }
 
@@ -366,9 +366,9 @@ coap_session_release(coap_session_t *session) {
     (void)context;
 #endif /* COAP_THREAD_SAFE */
 
-    coap_lock_lock(context, return);
+    coap_lock_lock(return);
     coap_session_release_lkd(session);
-    coap_lock_unlock(context);
+    coap_lock_unlock();
   }
 }
 
@@ -398,9 +398,9 @@ coap_session_release_lkd(coap_session_t *session) {
 COAP_API void
 coap_session_set_app_data(coap_session_t *session, void *app_data) {
   assert(session);
-  coap_lock_lock(session->context, return);
+  coap_lock_lock(return);
   coap_session_set_app_data2_lkd(session, app_data, NULL);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
 }
 
 void *
@@ -414,9 +414,9 @@ coap_session_set_app_data2(coap_session_t *session, void *app_data,
                            coap_app_data_free_callback_t callback) {
   void *old_data;
 
-  coap_lock_lock(session->context, return NULL);
+  coap_lock_lock(return NULL);
   old_data = coap_session_set_app_data2_lkd(session, app_data, callback);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return old_data;
 }
 
@@ -724,9 +724,9 @@ coap_session_max_pdu_size(const coap_session_t *session) {
    * but need to maintain source code backward compatibility
    */
   memcpy(&session_rw, &session, sizeof(session_rw));
-  coap_lock_lock(session_rw->context, return 0);
+  coap_lock_lock(return 0);
   size = coap_session_max_pdu_size_lkd(session_rw);
-  coap_lock_unlock(session_rw->context);
+  coap_lock_unlock();
   return size;
 }
 
@@ -866,9 +866,9 @@ COAP_API coap_mid_t
 coap_session_send_ping(coap_session_t *session) {
   coap_mid_t mid;
 
-  coap_lock_lock(session->context, return COAP_INVALID_MID);
+  coap_lock_lock(return COAP_INVALID_MID);
   mid = coap_session_send_ping_lkd(session);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return mid;
 }
 
@@ -1017,9 +1017,9 @@ coap_handle_nack(coap_session_t *session,
 
 COAP_API void
 coap_session_disconnected(coap_session_t *session, coap_nack_reason_t reason) {
-  coap_lock_lock(session->context, return);
+  coap_lock_lock(return);
   coap_session_disconnected_lkd(session, reason);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
 }
 
 void
@@ -1626,9 +1626,9 @@ coap_new_client_session(coap_context_t *ctx,
                         coap_proto_t proto) {
   coap_session_t *session;
 
-  coap_lock_lock(ctx, return NULL);
+  coap_lock_lock(return NULL);
   session = coap_new_client_session_lkd(ctx, local_if, server, proto);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return session;
 }
 
@@ -1658,9 +1658,9 @@ coap_new_client_session_psk(coap_context_t *ctx,
                             const uint8_t *key, unsigned key_len) {
   coap_session_t *session;
 
-  coap_lock_lock(ctx, return NULL);
+  coap_lock_lock(return NULL);
   session = coap_new_client_session_psk_lkd(ctx, local_if, server, proto, identity, key, key_len);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return session;
 }
 
@@ -1813,9 +1813,9 @@ coap_new_client_session_psk2(coap_context_t *ctx,
                              coap_dtls_cpsk_t *setup_data) {
   coap_session_t *session;
 
-  coap_lock_lock(ctx, return NULL);
+  coap_lock_lock(return NULL);
   session = coap_new_client_session_psk2_lkd(ctx, local_if, server, proto, setup_data);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return session;
 }
 
@@ -2001,9 +2001,9 @@ coap_new_client_session_pki(coap_context_t *ctx,
                             coap_dtls_pki_t *setup_data) {
   coap_session_t *session;
 
-  coap_lock_lock(ctx, return NULL);
+  coap_lock_lock(return NULL);
   session = coap_new_client_session_pki_lkd(ctx, local_if, server, proto, setup_data);
-  coap_lock_unlock(ctx);
+  coap_lock_unlock();
   return session;
 }
 
@@ -2120,9 +2120,9 @@ COAP_API uint16_t
 coap_new_message_id(coap_session_t *session) {
   uint16_t mid;
 
-  coap_lock_lock(session->context, return 0);
+  coap_lock_lock(return 0);
   mid = coap_new_message_id_lkd(session);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return mid;
 }
 
@@ -2186,9 +2186,9 @@ COAP_API int
 coap_session_set_type_client(coap_session_t *session) {
   int ret;
 
-  coap_lock_lock(session->context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_session_set_type_client_lkd(session);
-  coap_lock_unlock(session->context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -2257,9 +2257,9 @@ COAP_API coap_endpoint_t *
 coap_new_endpoint(coap_context_t *context, const coap_address_t *listen_addr, coap_proto_t proto) {
   coap_endpoint_t *endpoint;
 
-  coap_lock_lock(context, return NULL);
+  coap_lock_lock(return NULL);
   endpoint = coap_new_endpoint_lkd(context, listen_addr, proto);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return endpoint;
 }
 
@@ -2390,11 +2390,11 @@ coap_free_endpoint(coap_endpoint_t *ep) {
   if (ep) {
     coap_context_t *context = ep->context;
     if (context) {
-      coap_lock_lock(context, return);
+      coap_lock_lock(return);
     }
     coap_free_endpoint_lkd(ep);
     if (context) {
-      coap_lock_unlock(context);
+      coap_lock_unlock();
     }
   }
 }

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -63,14 +63,14 @@ coap_persist_observe_add(coap_context_t *context,
                          const coap_bin_const_t *oscore_info) {
   coap_subscription_t *subs;
 
-  coap_lock_lock(context, return NULL);
+  coap_lock_lock(return NULL);
   subs = coap_persist_observe_add_lkd(context,
                                       e_proto,
                                       e_listen_addr,
                                       s_addr_info,
                                       raw_packet,
                                       oscore_info);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return subs;
 }
 
@@ -1156,13 +1156,13 @@ coap_persist_startup(coap_context_t *context,
                      uint32_t save_freq) {
   int ret;
 
-  coap_lock_lock(context, return 0);
+  coap_lock_lock(return 0);
   ret = coap_persist_startup_lkd(context,
                                  dyn_resource_save_file,
                                  observe_save_file,
                                  obs_cnt_save_file,
                                  save_freq);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   return ret;
 }
 
@@ -1225,9 +1225,9 @@ COAP_API void
 coap_persist_stop(coap_context_t *context) {
   if (!context)
     return;
-  coap_lock_lock(context, return);
+  coap_lock_lock(return);
   coap_persist_stop_lkd(context);
-  coap_lock_unlock(context);
+  coap_lock_unlock();
 }
 
 void

--- a/src/coap_threadsafe.c
+++ b/src/coap_threadsafe.c
@@ -127,9 +127,9 @@ coap_io_process_worker_thread(void *arg) {
   while (!coap_thread_quit) {
     int result;
 
-    coap_lock_lock(context, return 0);
+    coap_lock_lock(return 0);
     result = coap_io_process_lkd(context, COAP_IO_WAIT);
-    coap_lock_unlock(context);
+    coap_lock_unlock();
     if (result < 0)
       break;
   }
@@ -180,7 +180,7 @@ coap_io_process_remove_threads(coap_context_t *context) {
 
   (void)context;
 
-  coap_lock_unlock(context);
+  coap_lock_unlock();
   coap_mutex_lock(&m_io_threads);
 
   for (i = 0; i < thread_id_count ; i++) {
@@ -201,7 +201,7 @@ coap_io_process_remove_threads(coap_context_t *context) {
   thread_id_count = 0;
 
   coap_mutex_unlock(&m_io_threads);
-  coap_lock_lock(context, return);
+  coap_lock_lock(return);
 }
 #endif /* !WITH_LWIP */
 


### PR DESCRIPTION
Makes reading the code simpler.

Context is no longer used as global_lock is used in the coap_lock_lock() and coap_lock_unlock() functions.

Part 3 of 3.

Update coap_lock_lock() and coap_lock_unlock() macros and all users.