### PR TITLE
coap_session.c: fix free callback for endpoint app data

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -2446,6 +2446,11 @@ coap_free_endpoint_lkd(coap_endpoint_t *ep) {
         LL_DELETE(ep->context->endpoint, ep);
       }
     }
+
+    if (ep->app_cb) {
+      ep->app_cb(ep->app_data);
+    }
+
     coap_mfree_endpoint(ep);
   }
 }


### PR DESCRIPTION
Sorry, I forgot to test this with #1665 yesterday.