### PR TITLE
coap_session_mfree: Check for lg_crcv all cleared out if failure

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -543,6 +543,9 @@ coap_session_mfree(coap_session_t *session) {
         }
       }
     }
+    /* In case coap_cancel_observe_lkd() failure, which could clear down lg_crcv */
+    if (!session->lg_crcv)
+      break;
     LL_DELETE(session->lg_crcv, lg_crcv);
     coap_block_delete_lg_crcv(session, lg_crcv);
   }


### PR DESCRIPTION
Call to coap_cancel_observe_lkd() may cause session->lg_crcv to be cleared out if transmission failure.