### PR TITLE
coap_io.c: Support MinGW build with _WIN32_WINNT == 0x0a00

### DIFF
--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -95,9 +95,9 @@ coap_mfree_endpoint(coap_endpoint_t *ep) {
 #define CMSG_NXTHDR WSA_CMSG_NXTHDR
 #define CMSG_LEN WSA_CMSG_LEN
 #define CMSG_SPACE WSA_CMSG_SPACE
-#if(_WIN32_WINNT < 0x0603)
+#if(_WIN32_WINNT < 0x0603 || _WIN32_WINNT == 0x0a00)
 #define cmsghdr _WSACMSGHDR
-#endif /* (_WIN32_WINNT<0x0603) */
+#endif /* (_WIN32_WINNT<0x0603 || _WIN32_WINNT == 0x0a00) */
 #endif /* (_WIN32_WINNT>=0x0600) */
 #endif /* defined(__MINGW32__) */
 


### PR DESCRIPTION
Fixes #1692