### PR TITLE
coap_mbedtls.c: Fix SNI hostname definition if not provided

### DIFF
--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -1435,9 +1435,7 @@ setup_client_ssl_session(coap_session_t *c_session,
       }
     }
 #endif /* MBEDTLS_SSL_SRV_C && MBEDTLS_SSL_ALPN */
-    if (m_context->setup_data.client_sni) {
-      mbedtls_ssl_set_hostname(&m_env->ssl, m_context->setup_data.client_sni);
-    }
+    mbedtls_ssl_set_hostname(&m_env->ssl, m_context->setup_data.client_sni);
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
 #if MBEDTLS_VERSION_NUMBER >= 0x02100100
     mbedtls_ssl_set_mtu(&m_env->ssl, (uint16_t)c_session->mtu);


### PR DESCRIPTION
MbedTLS based PKI clients may report

SSL - Attempt to verify a certificate without an expected hostname. This is usually insecure.  In TLS clients, when a client authenticates a server through its certificate, the client normally checks three things: ....

The application provided client_sni may have been removed as per [RFC 6066 Section 3 Server Name Indication](https://datatracker.ietf.org/doc/html/rfc6066#section-3)
````
   Literal IPv4 and IPv6 addresses are not permitted in "HostName".
````

and so MbedTLS is now explicitly told that therw is no hostname.