### PR TITLE
coap_net.c: Set remote CSM Max Message Size to local max if bigger

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4257,8 +4257,14 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
     }
     while ((option = coap_option_next(&opt_iter))) {
       if (opt_iter.number == COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE) {
-        coap_session_set_mtu(session, coap_decode_var_bytes(coap_opt_value(option),
-                                                            coap_opt_length(option)));
+        unsigned max_recv = coap_decode_var_bytes(coap_opt_value(option), coap_opt_length(option));
+
+        if (max_recv > context->csm_max_message_size) {
+          max_recv = context->csm_max_message_size;
+          coap_log_debug("*  %s: Setting size to %u\n",
+                         coap_session_str(session), max_recv);
+        }
+        coap_session_set_mtu(session, max_recv);
         set_mtu = 1;
       } else if (opt_iter.number == COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER) {
         session->csm_block_supported = 1;

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -175,7 +175,8 @@ coap_new_pdu_lkd(coap_pdu_type_t type, coap_pdu_code_t code,
   pdu = coap_pdu_init(type, code, coap_new_message_id_lkd(session),
                       coap_session_max_pdu_size_lkd(session));
   if (!pdu)
-    coap_log_crit("coap_new_pdu: cannot allocate memory for new PDU\n");
+    coap_log_crit("coap_new_pdu: cannot allocate memory for new PDU (size = %zu)\n",
+                  coap_session_max_pdu_size_lkd(session));
   return pdu;
 }
 


### PR DESCRIPTION
Prevent remote endpoint from setting Max Message Size to be larger than the local endpoint can handle.