### PR TITLE
coap_io.c: Cleanup MinGW builds

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -181,8 +181,8 @@ on a Windows host.
 
 Remove any old copy of MSYS2 using Windows program remove.
 
-Download https://repo.msys2.org/distrib/x86_64/msys2-x86_64-20230318.exe and
-run the executable, accepting the defaults.
+Download https://repo.msys2.org/distrib/x86_64/msys2-x86_64-20230318.exe or
+later and run the executable, accepting the defaults.
 
 In a UCRT64 window, add in the following packages
 
@@ -199,6 +199,22 @@ Alternatively, in a MINGW64 window, add in the following packages
  pacman -S mingw-w64-x86_64-cmake
  pacman -S mingw-w64-x86_64-gcc
  pacman -S mingw-w64-x86_64-openssl
+
+Alternatively, in a MINGW32 window, add in the following packages
+
+ pacman -S git
+ pacman -S vim
+ pacman -S mingw-w64-i686-cmake
+ pacman -S mingw-w64-i686-gcc
+ pacman -S mingw-w64-i686-openssl
+
+Alternatively, in a CLANG64 window, add in the following packages
+
+ pacman -S git
+ pacman -S vim
+ pacman -S mingw-w64-clang-x86_64-cmake
+ pacman -S mingw-w64-clang-x86_64-gcc
+ pacman -S mingw-w64-clang-x86_64-openssl
 
 Then clone a copy of the github libcoap repository in a UCRT64 or MINGW64 window
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,8 @@ endif() # ! ZEPHYR_BASE
 if(MINGW)
 add_compile_options(
   $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wno-format>
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wno-format-security>)
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wno-format-security>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wno-c23-extensions>)
 endif()
 
 if(${WARNING_TO_ERROR})

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2700,7 +2700,7 @@ main(int argc, char **argv) {
   if (coap_fd != -1) {
     /* if coap_fd is -1, then epoll is not supported within libcoap */
     FD_ZERO(&m_readfds);
-    FD_SET(coap_fd, &m_readfds);
+    FD_SET((coap_fd_t)coap_fd, &m_readfds);
     nfds = coap_fd + 1;
   }
 

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -89,18 +89,6 @@ coap_mfree_endpoint(coap_endpoint_t *ep) {
 }
 #endif /* COAP_SERVER_SUPPORT */
 
-#if defined(__MINGW32__)
-#if(_WIN32_WINNT >= 0x0600)
-#define CMSG_FIRSTHDR WSA_CMSG_FIRSTHDR
-#define CMSG_NXTHDR WSA_CMSG_NXTHDR
-#define CMSG_LEN WSA_CMSG_LEN
-#define CMSG_SPACE WSA_CMSG_SPACE
-#if(_WIN32_WINNT < 0x0603 || _WIN32_WINNT == 0x0a00)
-#define cmsghdr _WSACMSGHDR
-#endif /* (_WIN32_WINNT<0x0603 || _WIN32_WINNT == 0x0a00) */
-#endif /* (_WIN32_WINNT>=0x0600) */
-#endif /* defined(__MINGW32__) */
-
 #if !defined(WITH_CONTIKI) && !defined(WITH_LWIP) && !defined(RIOT_VERSION)
 
 #if COAP_SERVER_SUPPORT
@@ -747,7 +735,7 @@ struct in_pktinfo {
   struct in_addr ipi_spec_dst;
   struct in_addr ipi_addr;
 };
-#endif /* ! __MINGW32__ */
+#endif /* ! __MINGW32__ && ! RIOT_VERSION */
 #endif
 #endif /* ! WITH_LWIP */
 
@@ -765,6 +753,15 @@ struct in_pktinfo {
 #include <mswsock.h>
 #if defined(__MINGW32__)
 static __thread LPFN_WSARECVMSG lpWSARecvMsg = NULL;
+#if(_WIN32_WINNT >= 0x0600)
+#define CMSG_FIRSTHDR WSA_CMSG_FIRSTHDR
+#define CMSG_NXTHDR WSA_CMSG_NXTHDR
+#define CMSG_LEN WSA_CMSG_LEN
+#define CMSG_SPACE WSA_CMSG_SPACE
+#if(_WIN32_WINNT < 0x0603 || _WIN32_WINNT == 0x0a00)
+#define cmsghdr _WSACMSGHDR
+#endif /* (_WIN32_WINNT<0x0603 || _WIN32_WINNT == 0x0a00) */
+#endif /* (_WIN32_WINNT>=0x0600) */
 #else /* ! __MINGW32__ */
 static __declspec(thread) LPFN_WSARECVMSG lpWSARecvMsg = NULL;
 #endif /* ! __MINGW32__ */
@@ -860,7 +857,7 @@ coap_socket_send(coap_socket_t *sock, coap_session_t *session,
 #if defined(_WIN32)
     DWORD dwNumberOfBytesSent = 0;
     int r;
-#endif /* _WIN32 && !__MINGW32__ */
+#endif /* _WIN32 */
 #ifdef HAVE_STRUCT_CMSGHDR
     /* a buffer large enough to hold all packet info types, ipv6 is the largest */
     char buf[CMSG_SPACE(sizeof(struct in6_pktinfo))];
@@ -1007,7 +1004,7 @@ coap_socket_send(coap_socket_t *sock, coap_session_t *session,
       bytes_written = -1;
       coap_win_error_to_errno();
     }
-#else /* !_WIN32 || __MINGW32__ */
+#else /* !_WIN32 */
 #ifdef HAVE_STRUCT_CMSGHDR
     bytes_written = sendmsg(sock->fd, &mhdr, 0);
 #else /* ! HAVE_STRUCT_CMSGHDR */
@@ -1015,7 +1012,7 @@ coap_socket_send(coap_socket_t *sock, coap_session_t *session,
                            &session->addr_info.remote.addr.sa,
                            session->addr_info.remote.size);
 #endif /* ! HAVE_STRUCT_CMSGHDR */
-#endif /* !_WIN32 || __MINGW32__ */
+#endif /* !_WIN32 */
   }
 
   if (bytes_written < 0)
@@ -1086,7 +1083,7 @@ coap_socket_recv(coap_socket_t *sock, coap_packet_t *packet) {
 #if defined(_WIN32)
     DWORD dwNumberOfBytesRecvd = 0;
     int r;
-#endif /* _WIN32 && !__MINGW32__ */
+#endif /* _WIN32 */
 #ifdef HAVE_STRUCT_CMSGHDR
     /* a buffer large enough to hold all packet info types, ipv6 is the largest */
     char buf[CMSG_SPACE(sizeof(struct in6_pktinfo))];
@@ -1096,7 +1093,7 @@ coap_socket_recv(coap_socket_t *sock, coap_packet_t *packet) {
 
 #if defined(__MINGW32__)
     iov[0].iov_base = (char *) packet->payload;
-#else
+#else /* ! __MINGW32__ */
     iov[0].iov_base = packet->payload;
 #endif /* defined(__MINGW32__) */
     iov[0].iov_len = (iov_len_t)COAP_RXBUFFER_SIZE;

--- a/src/coap_time.c
+++ b/src/coap_time.c
@@ -30,12 +30,12 @@
 
 static coap_tick_t coap_clock_offset = 0;
 
-#if _POSIX_TIMERS && !defined(__APPLE__)
+#if _POSIX_TIMERS && !defined(__APPLE__) && !defined(__MINGW32__)
 /* _POSIX_TIMERS is > 0 when clock_gettime() is available */
 
 /* Use real-time clock for correct timestamps in coap_log(). */
 #define COAP_CLOCK CLOCK_REALTIME
-#endif
+#endif /* _POSIX_TIMERS && ! __APPLE__ && ! __MINGW32__ */
 
 #if defined(HAVE_WINSOCK2_H) && !defined(__MINGW32__)
 static int


### PR DESCRIPTION
Move the MinGW #if tests to after where mswsock.h is included.

Tidy up documentation.

Tested against MSYS2 UCRT64, CLANG64, MINGW32 and MINGW64 on Windows 11.
Fixed a couple of minor build issues found.
