### PR TITLE
src/coap_net.c: Make CSM Max-Message-Size handling more generic

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -553,6 +553,12 @@ void
 coap_context_set_csm_max_message_size(coap_context_t *context,
                                       uint32_t csm_max_message_size) {
   assert(csm_max_message_size >= 64);
+  if (csm_max_message_size > COAP_DEFAULT_MAX_PDU_RX_SIZE) {
+    csm_max_message_size = COAP_DEFAULT_MAX_PDU_RX_SIZE;
+    coap_log_debug("Restricting CSM Max-Message-Size size to %u\n",
+                   csm_max_message_size);
+  }
+
   context->csm_max_message_size = csm_max_message_size;
 }
 
@@ -4259,9 +4265,9 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
       if (opt_iter.number == COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE) {
         unsigned max_recv = coap_decode_var_bytes(coap_opt_value(option), coap_opt_length(option));
 
-        if (max_recv > context->csm_max_message_size) {
-          max_recv = context->csm_max_message_size;
-          coap_log_debug("*  %s: Setting size to %u\n",
+        if (max_recv > COAP_DEFAULT_MAX_PDU_RX_SIZE) {
+          max_recv = COAP_DEFAULT_MAX_PDU_RX_SIZE;
+          coap_log_debug("*  %s: Restricting CSM Max-Message-Size size to %u\n",
                          coap_session_str(session), max_recv);
         }
         coap_session_set_mtu(session, max_recv);

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -767,10 +767,11 @@ coap_session_max_pdu_size_lkd(const coap_session_t *session) {
 
 void
 coap_session_set_mtu(coap_session_t *session, unsigned mtu) {
-#if defined(WITH_CONTIKI) || defined(WITH_LWIP)
-  if (mtu > COAP_DEFAULT_MAX_PDU_RX_SIZE)
+  if (mtu > COAP_DEFAULT_MAX_PDU_RX_SIZE) {
     mtu = COAP_DEFAULT_MAX_PDU_RX_SIZE;
-#endif
+    coap_log_debug("*  %s: Restricting MTU size to %u\n",
+                   coap_session_str(session), mtu);
+  }
   if (mtu < 64)
     mtu = 64;
   session->mtu = mtu;


### PR DESCRIPTION
Cater for environments like ESP-IDF which use LwIP under the hood.