### PR TITLE
make async release after application callback conditional to enable multiple async triggers

### DIFF
--- a/man/coap_async.txt.in
+++ b/man/coap_async.txt.in
@@ -209,7 +209,10 @@ hnd_get_with_delay(coap_session_t *session,
                                (const uint8_t *)"done", NULL, NULL);
   coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTENT);
 
-  /* async is automatically removed by libcoap on return from this handler */
+  /*
+   * async is automatically removed by libcoap on return from this handler unless
+   * coap_async_set_delay() is called.
+   */
 }
 ----
 

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -3957,7 +3957,21 @@ skip_handler:
       goto drop_it_no_debug;
     }
   }
-  respond = no_response(pdu, response, session, resource);
+#if COAP_ASYNC_SUPPORT
+  if (async) {
+    coap_tick_t now;
+
+    coap_ticks(&now);
+
+    if (async->delay == 0 || async->delay > now) {
+      respond = RESPONSE_DROP;
+    } else {
+#endif /* COAP_ASYNC_SUPPORT */
+      respond = no_response(pdu, response, session, resource);
+#if COAP_ASYNC_SUPPORT
+    }
+  }
+#endif /* COAP_ASYNC_SUPPORT */
   if (respond != RESPONSE_DROP) {
 #if (COAP_MAX_LOGGING_LEVEL >= _COAP_LOG_DEBUG)
     coap_mid_t mid = pdu->mid;
@@ -4988,8 +5002,10 @@ coap_check_async(coap_context_t *context, coap_tick_t now, coap_tick_t *tim_rem)
         coap_show_pdu(COAP_LOG_DEBUG, async->pdu);
         handle_request(context, async->session, async->pdu, NULL);
 
-        /* Remove this async entry as it has now fired */
-        coap_free_async_lkd(async->session, async);
+        if (async->delay != 0 && async->delay <= now) {
+          /* Remove this async entry as it has now fired */
+          coap_free_async_lkd(async->session, async);
+        }
       } else {
         next_due = async->delay - now;
         ret = 1;


### PR DESCRIPTION
As discussed in #1696, this commit enables triggering an async object multiple times. I am not really happy with the commit message but I had no better idea so far.

In the example at the end of https://libcoap.net/doc/reference/develop/man_coap_async.html, it is noted that the async object is freed after the callback. Should I add a note there that this can be avoided by a `coap_async_set_delay` call?

Thank you!