### PR TITLE
coap_block.c: Fix ETag generation for CoAP responses

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -487,11 +487,11 @@ hnd_get_async(coap_resource_t *resource,
   }
   /* no request (observe) or async set up, so this is the delayed request */
 
+  coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTENT);
   /* Send back the appropriate data */
   coap_add_data_large_response(resource, session, request, response,
                                query, COAP_MEDIATYPE_TEXT_PLAIN, -1, 0, 4,
                                (const uint8_t *)"done", NULL, NULL);
-  coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTENT);
 
   /* async is automatically removed by libcoap on return from this handler */
 }

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -834,7 +834,8 @@ coap_add_data_large_internal(coap_session_t *session,
 #endif /* UINT_MAX > MAX_BLK_LEN */
 
 #if COAP_SERVER_SUPPORT
-  if (COAP_PDU_IS_RESPONSE(pdu) && length) {
+  /* Possible response code not yet set, so check if not request */
+  if (!COAP_PDU_IS_REQUEST(pdu) && length) {
     coap_opt_t *etag_opt = coap_check_option(pdu, COAP_OPTION_ETAG, &opt_iter);
 
     if (etag_opt) {


### PR DESCRIPTION
If the response code in the PDU was not set before calling coap_add_data_large_response(), the ETag option was not getting set.