### PR TITLE
Zephyr: improve POSIX API integration

### DIFF
--- a/include/coap3/libcoap.h
+++ b/include/coap3/libcoap.h
@@ -38,8 +38,6 @@ typedef USHORT in_port_t;
 #define        _IN_PORT_T_DECLARED
 #endif
 #endif /* !defined(__MINGW32__) */
-#elif defined(__ZEPHYR__)
-#include <zephyr/net/socket.h>
 #elif !defined (CONTIKI) && !defined (WITH_LWIP) && !defined (RIOT_VERSION)
 #include <netinet/in.h>
 #include <sys/socket.h>

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -24,10 +24,10 @@
 #include <string.h>
 #include <ctype.h>
 
-#ifndef __ZEPHYR__
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
+#ifndef __ZEPHYR__
 #ifdef HAVE_WS2TCPIP_H
 #include <ws2tcpip.h>
 #endif

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -18,6 +18,9 @@
 #ifdef HAVE_STDIO_H
 #  include <stdio.h>
 #endif
+#ifdef HAVE_UNISTD_H
+# include <unistd.h>
+#endif
 
 #ifndef __ZEPHYR__
 #ifdef HAVE_SYS_SELECT_H
@@ -44,9 +47,6 @@
 #ifdef HAVE_SYS_UIO_H
 # include <sys/uio.h>
 #endif
-#ifdef HAVE_UNISTD_H
-# include <unistd.h>
-#endif
 #ifdef _WIN32
 #include <stdio.h>
 #endif /* _WIN32 */
@@ -58,8 +58,8 @@
 #endif
 #endif /* COAP_EPOLL_SUPPORT */
 #else /* __ZEPHYR__ */
-#include <zephyr/posix/sys/ioctl.h>
-#include <zephyr/posix/sys/select.h>
+#include <sys/ioctl.h>
+#include <sys/select.h>
 #define OPTVAL_T(t)         (const void*)(t)
 #define OPTVAL_GT(t)        (void*)(t)
 


### PR DESCRIPTION
using zephyrs posix api should not require including headers from a zephyr specific location