### PR TITLE
fixes use after free CVE-2025-50518

### DIFF
--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -411,11 +411,11 @@ coap_pdu_t *coap_new_pdu_lkd(coap_pdu_type_t type, coap_pdu_code_t code,
  *
  * @param pdu The PDU for free off.
  */
-void coap_delete_pdu_lkd(coap_pdu_t *pdu);
+void coap_delete_pdu_lkd(coap_pdu_t **pdu);
 
 COAP_STATIC_INLINE void
 coap_pdu_release_lkd(coap_pdu_t *pdu) {
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
 }
 
 /**

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -187,8 +187,7 @@ coap_free_async_sub(coap_context_t *context, coap_async_t *async) {
       async->session = NULL;
     }
     if (async->pdu) {
-      coap_delete_pdu_lkd(async->pdu);
-      async->pdu = NULL;
+      coap_delete_pdu_lkd(&async->pdu);
     }
     if (async->app_cb && async->app_data) {
       coap_lock_callback(async->app_cb(async->app_data));

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -2033,7 +2033,7 @@ coap_send_q_blocks(coap_session_t *session,
   if (send_pdu == COAP_SEND_INC_PDU &&
       (mid = coap_send_internal(session, pdu, NULL)) == COAP_INVALID_MID) {
     /* Not expected, underlying issue somewhere */
-    coap_delete_pdu_lkd(block_pdu);
+    coap_delete_pdu_lkd(&block_pdu);
     return COAP_INVALID_MID;
   }
 
@@ -2076,8 +2076,8 @@ coap_send_q_blocks(coap_session_t *session,
                                                  block.szx),
                             buf)) {
       coap_log_warn("Internal update issue option\n");
-      coap_delete_pdu_lkd(block_pdu);
-      coap_delete_pdu_lkd(t_pdu);
+      coap_delete_pdu_lkd(&block_pdu);
+      coap_delete_pdu_lkd(&t_pdu);
       break;
     }
 
@@ -2087,8 +2087,8 @@ coap_send_q_blocks(coap_session_t *session,
                         block.num,
                         block.szx)) {
       coap_log_warn("Internal update issue data\n");
-      coap_delete_pdu_lkd(block_pdu);
-      coap_delete_pdu_lkd(t_pdu);
+      coap_delete_pdu_lkd(&block_pdu);
+      coap_delete_pdu_lkd(&t_pdu);
       break;
     }
     if (COAP_PDU_IS_RESPONSE(block_pdu)) {
@@ -2097,7 +2097,7 @@ coap_send_q_blocks(coap_session_t *session,
     mid = coap_send_internal(session, block_pdu, NULL);
     if (mid == COAP_INVALID_MID) {
       /* Not expected, underlying issue somewhere */
-      coap_delete_pdu_lkd(t_pdu);
+      coap_delete_pdu_lkd(&t_pdu);
       return COAP_INVALID_MID;
     }
     block_pdu = t_pdu;
@@ -2523,7 +2523,7 @@ coap_block_delete_lg_crcv(coap_session_t *session,
     coap_delete_bin_const(lg_crcv->obs_token[i]);
   }
   coap_free_type(COAP_STRING, lg_crcv->obs_token);
-  coap_delete_pdu_lkd(lg_crcv->sent_pdu);
+  coap_delete_pdu_lkd(&lg_crcv->sent_pdu);
   coap_free_type(COAP_LG_CRCV, lg_crcv);
 }
 #endif /* COAP_CLIENT_SUPPORT */
@@ -2558,7 +2558,7 @@ coap_block_delete_lg_xmit(coap_session_t *session,
     coap_delete_binary(lg_xmit->b.b1.app_token);
   else
     coap_delete_string(lg_xmit->b.b2.query);
-  coap_delete_pdu_lkd(lg_xmit->sent_pdu);
+  coap_delete_pdu_lkd(&lg_xmit->sent_pdu);
 
   coap_log_debug("** %s: lg_xmit %p released\n",
                  coap_session_str(session), (void *)lg_xmit);

--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -195,7 +195,7 @@ coap_new_cache_entry_lkd(coap_session_t *session, const coap_pdu_t *pdu,
     entry->pdu = coap_pdu_init(pdu->type, pdu->code, pdu->mid, pdu->alloc_size);
     if (entry->pdu) {
       if (!coap_pdu_resize(entry->pdu, pdu->alloc_size)) {
-        coap_delete_pdu_lkd(entry->pdu);
+        coap_delete_pdu_lkd(&entry->pdu);
         coap_free_type(COAP_CACHE_ENTRY, entry);
         return NULL;
       }
@@ -288,7 +288,7 @@ coap_delete_cache_entry(coap_context_t *ctx, coap_cache_entry_t *cache_entry) {
     HASH_DELETE(hh, ctx->cache, cache_entry);
   }
   if (cache_entry->pdu) {
-    coap_delete_pdu_lkd(cache_entry->pdu);
+    coap_delete_pdu_lkd(&cache_entry->pdu);
   }
   coap_delete_cache_key(cache_entry->cache_key);
   if (cache_entry->app_cb && cache_entry->app_data) {

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -212,7 +212,7 @@ coap_recvc(void *arg, struct udp_pcb *upcb, struct pbuf *p,
           if (coap_send_internal(session, response, NULL) == COAP_INVALID_MID)
             coap_log_warn("coap_handle_dgram: error sending response\n");
         }
-        coap_delete_pdu_lkd(pdu);
+        coap_delete_pdu_lkd(&pdu);
         coap_lock_unlock();
 #if NO_SYS == 0
         sys_sem_signal(&coap_io_timeout_sem);
@@ -227,7 +227,7 @@ coap_recvc(void *arg, struct udp_pcb *upcb, struct pbuf *p,
 #if NO_SYS == 0
   sys_sem_signal(&coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   coap_lock_unlock();
   return;
 
@@ -238,7 +238,7 @@ error:
    */
   if (session)
     coap_send_rst_lkd(session, pdu);
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   coap_lock_unlock();
 #if NO_SYS == 0
   sys_sem_signal(&coap_io_timeout_sem);
@@ -340,7 +340,7 @@ coap_udp_recvs(void *arg, struct udp_pcb *upcb, struct pbuf *p,
     coap_dispatch(ep->context, session, pdu);
   }
 
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   coap_free_packet(packet);
   coap_lock_unlock();
 #if NO_SYS == 0
@@ -359,7 +359,7 @@ error:
   if (session && pdu)
     coap_send_rst_lkd(session, pdu);
 cleanup:
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   coap_free_packet(packet);
   coap_lock_unlock();
 #if NO_SYS == 0

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -231,7 +231,7 @@ coap_delete_node_lkd(coap_queue_t *node) {
   if (!node)
     return 0;
 
-  coap_delete_pdu_lkd(node->pdu);
+  coap_delete_pdu_lkd(&node->pdu);
   if (node->session) {
     /*
      * Need to remove out of context->sendqueue as added in by coap_wait_ack()
@@ -1312,7 +1312,7 @@ coap_send_test_extended_token(coap_session_t *session) {
 
   token = coap_new_binary(session->max_token_size);
   if (token == NULL) {
-    coap_delete_pdu_lkd(pdu);
+    coap_delete_pdu_lkd(&pdu);
     return COAP_INVALID_MID;
   }
   for (i = 0; i < session->max_token_size; i++) {
@@ -1630,7 +1630,7 @@ coap_send_lkd(coap_session_t *session, coap_pdu_t *pdu) {
       ret = coap_cancel_observe_lkd(session, &tmp, pdu->type);
       if (ret == 1) {
         /* Observe Cancel successfully sent */
-        coap_delete_pdu_lkd(pdu);
+        coap_delete_pdu_lkd(&pdu);
         return ret;
       }
       /* Some mismatch somewhere - continue to send original packet */
@@ -1806,7 +1806,7 @@ coap_send_lkd(coap_session_t *session, coap_pdu_t *pdu) {
   return mid;
 
 error:
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   return COAP_INVALID_MID;
 }
 
@@ -1906,13 +1906,13 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
         if (hop_limit == 1) {
           coap_log_warn("Proxy loop detected '%s'\n",
                         (char *)pdu->data);
-          coap_delete_pdu_lkd(pdu);
+          coap_delete_pdu_lkd(&pdu);
           return (coap_mid_t)COAP_DROPPED_RESPONSE;
         } else if (hop_limit < 1 || hop_limit > 255) {
           /* Something is bad - need to drop this pdu (TODO or delete option) */
           coap_log_warn("Proxy return has bad hop limit count '%zu'\n",
                         hop_limit);
-          coap_delete_pdu_lkd(pdu);
+          coap_delete_pdu_lkd(&pdu);
           return (coap_mid_t)COAP_DROPPED_RESPONSE;
         }
         hop_limit--;
@@ -1942,7 +1942,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
              a_match[len] == ' ')) {
           coap_log_warn("Proxy loop detected '%s'\n",
                         (char *)pdu->data);
-          coap_delete_pdu_lkd(pdu);
+          coap_delete_pdu_lkd(&pdu);
           return (coap_mid_t)COAP_DROPPED_RESPONSE;
         }
       }
@@ -2037,7 +2037,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
       goto error;
     }
     bytes_written = coap_send_pdu(session, osc_pdu, NULL);
-    coap_delete_pdu_lkd(pdu);
+    coap_delete_pdu_lkd(&pdu);
     pdu = osc_pdu;
   } else
 #endif /* COAP_OSCORE_SUPPORT */
@@ -2049,7 +2049,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
       request_pdu && COAP_PROTO_NOT_RELIABLE(session->proto) &&
       COAP_PDU_IS_REQUEST(request_pdu) &&
       COAP_PDU_IS_RESPONSE(pdu) && pdu->type == COAP_MESSAGE_ACK) {
-    coap_delete_pdu_lkd(session->cached_pdu);
+    coap_delete_pdu_lkd(&session->cached_pdu);
     session->cached_pdu = pdu;
     coap_pdu_reference_lkd(session->cached_pdu);
     coap_pdu_cksum(request_pdu, &session->cached_pdu_cksum);
@@ -2081,7 +2081,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
   if (pdu->type != COAP_MESSAGE_CON
       || COAP_PROTO_RELIABLE(session->proto)) {
     coap_mid_t id = pdu->mid;
-    coap_delete_pdu_lkd(pdu);
+    coap_delete_pdu_lkd(&pdu);
     return id;
   }
 
@@ -2098,7 +2098,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
   node->timeout = coap_calc_timeout(session, r);
   return coap_wait_ack(session->context, session, node);
 error:
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   return COAP_INVALID_MID;
 }
 
@@ -2230,7 +2230,7 @@ fail:
   session->block_mode = block_mode;
   session->doing_send_recv = 0;
   /* delete referenced copy */
-  coap_delete_pdu_lkd(session->resp_pdu);
+  coap_delete_pdu_lkd(&session->resp_pdu);
   session->resp_pdu = NULL;
   coap_delete_bin_const(session->req_token);
   session->req_token = NULL;
@@ -2507,12 +2507,12 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
       if (!coap_pdu_parse(session->proto, packet->payload, bytes_read, pdu)) {
         coap_handle_event_lkd(session->context, COAP_EVENT_BAD_PACKET, session);
         coap_log_warn("discard malformed PDU\n");
-        coap_delete_pdu_lkd(pdu);
+        coap_delete_pdu_lkd(&pdu);
         return;
       }
 
       coap_dispatch(ctx, session, pdu);
-      coap_delete_pdu_lkd(pdu);
+      coap_delete_pdu_lkd(&pdu);
       return;
     }
   } else {
@@ -2561,7 +2561,7 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
                   coap_log_warn("coap_read_session: error sending response\n");
               }
             }
-            coap_delete_pdu_lkd(pdu);
+            coap_delete_pdu_lkd(&pdu);
           } else {
             session->partial_read += n;
           }
@@ -2610,7 +2610,7 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
               if (coap_pdu_parse_header(pdu, session->proto)) {
                 coap_dispatch(ctx, session, pdu);
               }
-              coap_delete_pdu_lkd(pdu);
+              coap_delete_pdu_lkd(&pdu);
             }
           } else {
             /* More of the header to go */
@@ -2917,7 +2917,7 @@ coap_handle_dgram(coap_context_t *ctx, coap_session_t *session,
         if (coap_send_internal(session, response, NULL) == COAP_INVALID_MID)
           coap_log_warn("coap_handle_dgram: error sending response\n");
       }
-      coap_delete_pdu_lkd(pdu);
+      coap_delete_pdu_lkd(&pdu);
       return -1;
     } else {
       goto error;
@@ -2925,7 +2925,7 @@ coap_handle_dgram(coap_context_t *ctx, coap_session_t *session,
   }
 
   coap_dispatch(ctx, session, pdu);
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   return 0;
 
 error:
@@ -2934,7 +2934,7 @@ error:
    * https://rfc-editor.org/rfc/rfc7252#section-4.3 MAY send RST
    */
   coap_send_rst_lkd(session, pdu);
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   return -1;
 }
 
@@ -3145,7 +3145,7 @@ coap_new_error_response(const coap_pdu_t *request, coap_pdu_code_t code,
     if (!coap_add_token(response, request->actual_token.length,
                         request->actual_token.s)) {
       coap_log_debug("cannot add token to error response\n");
-      coap_delete_pdu_lkd(response);
+      coap_delete_pdu_lkd(&response);
       return NULL;
     }
     if (response->code == COAP_RESPONSE_CODE(402)) {
@@ -4077,7 +4077,7 @@ skip_handler:
                    response->mid);
     coap_show_pdu(COAP_LOG_DEBUG, response);
 drop_it_no_debug:
-    coap_delete_pdu_lkd(response);
+    coap_delete_pdu_lkd(&response);
   }
   if (query)
     coap_delete_string(query);
@@ -4104,7 +4104,7 @@ finish:
   return;
 
 fail_response:
-  coap_delete_pdu_lkd(response);
+  coap_delete_pdu_lkd(&response);
   response =
       coap_new_error_response(pdu, COAP_RESPONSE_CODE(resp),
                               &opt_filter);
@@ -4520,7 +4520,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
           coap_log_warn("OSCORE: PDU could not be decrypted\n");
         }
         coap_delete_node_lkd(sent);
-        coap_delete_pdu_lkd(orig_pdu);
+        coap_delete_pdu_lkd(&orig_pdu);
         return;
       } else {
         session->oscore_encryption = 1;
@@ -4825,10 +4825,10 @@ cleanup:
       coap_handle_event_lkd(context, COAP_EVENT_BAD_PACKET, session);
     }
   }
-  coap_delete_pdu_lkd(orig_pdu);
+  coap_delete_pdu_lkd(&orig_pdu);
   coap_delete_node_lkd(sent);
 #if COAP_OSCORE_SUPPORT
-  coap_delete_pdu_lkd(dec_pdu);
+  coap_delete_pdu_lkd(&dec_pdu);
 #endif /* COAP_OSCORE_SUPPORT */
 }
 

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -660,8 +660,7 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
   coap_free_type(COAP_OSCORE_BUF, ciphertext_buffer);
   ciphertext_buffer = NULL;
 
-  coap_delete_pdu_lkd(plain_pdu);
-  plain_pdu = NULL;
+  coap_delete_pdu_lkd(&plain_pdu);
 
   if (association && association->is_observe == 0)
     oscore_delete_association(session, association);
@@ -720,7 +719,7 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
       if (association->partial_iv == NULL)
         goto error;
       association->recipient_ctx = rcp_ctx;
-      coap_delete_pdu_lkd(association->sent_pdu);
+      coap_delete_pdu_lkd(&association->sent_pdu);
       if (session->b_2_step != COAP_OSCORE_B_2_NONE || association->just_set_up) {
         size_t size;
 
@@ -752,8 +751,8 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
 error:
   if (ciphertext_buffer)
     coap_free_type(COAP_OSCORE_BUF, ciphertext_buffer);
-  coap_delete_pdu_lkd(osc_pdu);
-  coap_delete_pdu_lkd(plain_pdu);
+  coap_delete_pdu_lkd(&osc_pdu);
+  coap_delete_pdu_lkd(&plain_pdu);
   return NULL;
 }
 
@@ -802,15 +801,14 @@ build_and_send_error_pdu(coap_session_t *session,
       goto fail_resp;
     session->oscore_encryption = 0;
     coap_send_internal(session, osc_pdu, NULL);
-    coap_delete_pdu_lkd(err_pdu);
-    err_pdu = NULL;
+    coap_delete_pdu_lkd(&err_pdu);
   } else {
     coap_send_internal(session, err_pdu, NULL);
     err_pdu = NULL;
   }
 fail_resp:
   session->oscore_encryption = oscore_encryption;
-  coap_delete_pdu_lkd(err_pdu);
+  coap_delete_pdu_lkd(&err_pdu);
   return;
 }
 
@@ -1604,8 +1602,7 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
       goto error;
     }
   }
-  coap_delete_pdu_lkd(plain_pdu);
-  plain_pdu = NULL;
+  coap_delete_pdu_lkd(&plain_pdu);
 
   /* Make sure headers are correctly set up */
   if (!coap_pdu_encode_header(decrypt_pdu, session->proto)) {
@@ -1666,8 +1663,8 @@ error:
 error_no_ack:
   if (association && association->is_observe == 0)
     oscore_delete_association(session, association);
-  coap_delete_pdu_lkd(decrypt_pdu);
-  coap_delete_pdu_lkd(plain_pdu);
+  coap_delete_pdu_lkd(&decrypt_pdu);
+  coap_delete_pdu_lkd(&plain_pdu);
   return NULL;
 }
 

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -186,17 +186,21 @@ coap_new_pdu_lkd(coap_pdu_type_t type, coap_pdu_code_t code,
 COAP_API void
 coap_delete_pdu(coap_pdu_t *pdu) {
   coap_lock_lock(return);
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   coap_lock_unlock();
 }
 
 void
-coap_delete_pdu_lkd(coap_pdu_t *pdu) {
-  if (pdu != NULL) {
+coap_delete_pdu_lkd(coap_pdu_t **pdu_ptr) {
+  if (pdu_ptr != NULL && *pdu_ptr != NULL) {
+    coap_pdu_t *pdu = *pdu_ptr;
+    
     if (pdu->ref) {
       pdu->ref--;
+      /* Don't set to NULL if still referenced */
       return;
     }
+    
 #ifdef WITH_LWIP
     pbuf_free(pdu->pbuf);
 #else
@@ -205,6 +209,9 @@ coap_delete_pdu_lkd(coap_pdu_t *pdu) {
 #endif
     coap_delete_binary(pdu->data_free);
     coap_free_type(COAP_PDU, pdu);
+    
+    /* Set caller's pointer to NULL to prevent use-after-free */
+    *pdu_ptr = NULL;
   }
 }
 
@@ -289,7 +296,7 @@ coap_pdu_duplicate_lkd(const coap_pdu_t *old_pdu,
   return pdu;
 
 fail:
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   return NULL;
 }
 

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -79,7 +79,7 @@ void
 coap_proxy_del_req(coap_proxy_list_t *proxy_entry, coap_proxy_req_t *proxy_req) {
   coap_proxy_log_entry(proxy_req->incoming, proxy_req->pdu,  proxy_req->token_used, "del");
 
-  coap_delete_pdu_lkd(proxy_req->pdu);
+  coap_delete_pdu_lkd(&proxy_req->pdu);
   coap_delete_bin_const(proxy_req->token_used);
   coap_delete_cache_key(proxy_req->cache_key);
   if (proxy_req->proxy_cache) {
@@ -97,8 +97,8 @@ coap_proxy_del_req(coap_proxy_list_t *proxy_entry, coap_proxy_req_t *proxy_req) 
     proxy_req->proxy_cache->ref--;
     if (proxy_req->proxy_cache->ref == 0) {
       PROXY_CACHE_DELETE(proxy_entry->rsp_cache, proxy_req->proxy_cache);
-      coap_delete_pdu_lkd(proxy_req->proxy_cache->req_pdu);
-      coap_delete_pdu_lkd(proxy_req->proxy_cache->rsp_pdu);
+      coap_delete_pdu_lkd(&proxy_req->proxy_cache->req_pdu);
+      coap_delete_pdu_lkd(&proxy_req->proxy_cache->rsp_pdu);
       coap_free_type(COAP_STRING, proxy_req->proxy_cache);
       proxy_req->proxy_cache = NULL;
     }
@@ -798,12 +798,12 @@ coap_proxy_call_response_handler(coap_session_t *session, const coap_pdu_t *sent
     }
     if (fwd_pdu != resp_pdu) {
       /* Application created a new PDU */
-      coap_delete_pdu_lkd(resp_pdu);
+      coap_delete_pdu_lkd(&resp_pdu);
     }
   } else {
 failed:
     ret = COAP_RESPONSE_FAIL;
-    coap_delete_pdu_lkd(resp_pdu);
+    coap_delete_pdu_lkd(&resp_pdu);
   }
   coap_delete_string(l_query);
   return ret;
@@ -1022,7 +1022,7 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
                                  &uri) < 0) {
           /* Need to return a 5.05 RFC7252 Section 5.7.2 */
           coap_log_warn("Proxy URI not decodable\n");
-          coap_delete_pdu_lkd(pdu);
+          coap_delete_pdu_lkd(&pdu);
           return 0;
         }
         if (!coap_uri_into_optlist(&uri, NULL, &optlist, 0)) {
@@ -1107,7 +1107,7 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
 
 failed:
   response->code = COAP_RESPONSE_CODE(500);
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   return 0;
 
 return_cached_info:
@@ -1353,7 +1353,7 @@ coap_proxy_process_incoming(coap_session_t *session,
 
     /* Need to cache the response */
     if (proxy_req->proxy_cache) {
-      coap_delete_pdu_lkd(proxy_req->proxy_cache->rsp_pdu);
+      coap_delete_pdu_lkd(&proxy_req->proxy_cache->rsp_pdu);
       proxy_cache = proxy_req->proxy_cache;
     } else {
       proxy_cache = coap_malloc_type(COAP_STRING, sizeof(coap_proxy_cache_t));
@@ -1485,8 +1485,8 @@ coap_proxy_local_write(coap_session_t *session, coap_pdu_t *pdu) {
     mid = COAP_INVALID_MID;
   }
 fail:
-  coap_delete_pdu_lkd(response);
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&response);
+  coap_delete_pdu_lkd(&pdu);
   return mid;
 }
 

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -875,7 +875,7 @@ coap_add_observer(coap_resource_t *resource,
                                                cache_ignore_options,
                                                sizeof(cache_ignore_options)/sizeof(cache_ignore_options[0]));
     if (cache_key == NULL) {
-      coap_delete_pdu_lkd(s->pdu);
+      coap_delete_pdu_lkd(&s->pdu);
       coap_delete_cache_key(cache_key);
       coap_free_type(COAP_SUBSCRIPTION, s);
       return NULL;
@@ -1045,7 +1045,7 @@ coap_delete_observer_internal(coap_resource_t *resource, coap_session_t *session
     assert(session->ref_subscriptions > 0);
     session->ref_subscriptions--;
     coap_session_release_lkd(session);
-    coap_delete_pdu_lkd(s->pdu);
+    coap_delete_pdu_lkd(&s->pdu);
     coap_delete_cache_key(s->cache_key);
     coap_free_type(COAP_SUBSCRIPTION, s);
   }
@@ -1109,7 +1109,7 @@ coap_delete_observers(coap_context_t *context, coap_session_t *session) {
         assert(resource->subscribers);
         LL_DELETE(resource->subscribers, s);
         coap_session_release_lkd(session);
-        coap_delete_pdu_lkd(s->pdu);
+        coap_delete_pdu_lkd(&s->pdu);
         coap_delete_cache_key(s->cache_key);
         coap_free_type(COAP_SUBSCRIPTION, s);
       }
@@ -1190,7 +1190,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
                           obs->pdu->actual_token.s)) {
         coap_log_debug("coap_check_notify: cannot add token, resource stays "
                        "partially dirty\n");
-        coap_delete_pdu_lkd(response);
+        coap_delete_pdu_lkd(&response);
         goto next_one_fail_no_pending;
       }
 
@@ -1248,7 +1248,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
         coap_lock_callback_release(h(r, obs->session, obs->pdu, query, response),
                                    /* context is being freed off */
                                    coap_delete_string(query);
-                                   coap_delete_pdu_lkd(response);
+                                   coap_delete_pdu_lkd(&response);
                                    coap_session_release_lkd(obs_session);
                                    coap_pdu_release_lkd(obs_pdu);
                                    r->list_being_traversed = 0;
@@ -1261,7 +1261,7 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
                         COAP_RESPONSE_CLASS(response->code),
                         response->code & 0x1f);
           coap_delete_string(query);
-          coap_delete_pdu_lkd(response);
+          coap_delete_pdu_lkd(&response);
           coap_session_release_lkd(obs_session);
           coap_pdu_release_lkd(obs_pdu);
           r->list_being_traversed = 0;

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -561,7 +561,7 @@ coap_session_mfree(coap_session_t *session) {
     coap_delete_node_lkd(q);
   }
   if (session->partial_pdu)
-    coap_delete_pdu_lkd(session->partial_pdu);
+    coap_delete_pdu_lkd(&session->partial_pdu);
   if (session->sock.lfunc[COAP_LAYER_SESSION].l_close)
     session->sock.lfunc[COAP_LAYER_SESSION].l_close(session);
   if (session->psk_identity)
@@ -629,7 +629,7 @@ coap_session_free(coap_session_t *session) {
   coap_delete_bin_const(session->last_token);
   coap_delete_bin_const(session->echo);
 #if COAP_SERVER_SUPPORT
-  coap_delete_pdu_lkd(session->cached_pdu);
+  coap_delete_pdu_lkd(&session->cached_pdu);
 #endif /* COAP_SERVER_SUPPORT */
 
   if (session->app_cb) {
@@ -866,7 +866,7 @@ coap_session_send_csm(coap_session_t *session) {
     }
   }
   if (pdu)
-    coap_delete_pdu_lkd(pdu);
+    coap_delete_pdu_lkd(&pdu);
 }
 #endif /* !COAP_DISABLE_TCP */
 
@@ -1118,8 +1118,7 @@ coap_session_disconnected_lkd(coap_session_t *session, coap_nack_reason_t reason
   session->con_active = 0;
 
   if (session->partial_pdu) {
-    coap_delete_pdu_lkd(session->partial_pdu);
-    session->partial_pdu = NULL;
+    coap_delete_pdu_lkd(&session->partial_pdu);
   }
   session->partial_read = 0;
 

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -317,14 +317,14 @@ oscore_fail:
 #else /* ! COAP_OSCORE_SUPPORT */
   (void)oscore_info;
 #endif /* ! COAP_OSCORE_SUPPORT */
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   return s;
 
 malformed:
   coap_log_warn("coap_persist_observe_add: discard malformed PDU\n");
 fail:
   coap_delete_string(uri_path);
-  coap_delete_pdu_lkd(pdu);
+  coap_delete_pdu_lkd(&pdu);
   return NULL;
 }
 
@@ -996,10 +996,10 @@ coap_op_dyn_resource_load_disk(coap_context_t *ctx) {
                                  goto fail);
       coap_delete_string(query);
       query = NULL;
-      coap_delete_pdu_lkd(response);
+      coap_delete_pdu_lkd(&response);
       response = NULL;
 next:
-      coap_delete_pdu_lkd(request);
+      coap_delete_pdu_lkd(&request);
       request = NULL;
     }
     coap_delete_string(name);
@@ -1009,8 +1009,8 @@ fail:
   coap_delete_string(name);
   coap_delete_binary(raw_packet);
   coap_delete_string(query);
-  coap_delete_pdu_lkd(request);
-  coap_delete_pdu_lkd(response);
+  coap_delete_pdu_lkd(&request);
+  coap_delete_pdu_lkd(&response);
   fclose(fp_orig);
   coap_free_type(COAP_SESSION, session);
 }

--- a/src/oscore/oscore_context.c
+++ b/src/oscore/oscore_context.c
@@ -673,7 +673,7 @@ oscore_delete_recipient(oscore_ctx_t *osc_ctx, coap_bin_const_t *rid) {
 void
 oscore_free_association(oscore_association_t *association) {
   if (association) {
-    coap_delete_pdu_lkd(association->sent_pdu);
+    coap_delete_pdu_lkd(&association->sent_pdu);
     coap_delete_bin_const(association->token);
     coap_delete_bin_const(association->aad);
     coap_delete_bin_const(association->nonce);


### PR DESCRIPTION
This PR sets the `pdu` to be NULL when calling `coap_delete_pdu_lkd()/coap_delete_pdu()` so that on a subsequent delete request there is no freed memory reference.

See https://github.com/obgm/libcoap/issues/1724

This fix is for a reported vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2025-50518