### PR TITLE
Zephyr: Support C++ builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: setup
         run: |
-          sudo apt-get update && sudo apt-get install -y libc6-dev-i386
+          sudo apt-get update && sudo apt-get install -y libc6-dev-i386 lib32stdc++-13-dev
       - name: compile
         run: |
           make -C examples/${{matrix.OS}} EXTRA_CFLAGS=-Werror

--- a/examples/zephyr/.gitignore
+++ b/examples/zephyr/.gitignore
@@ -1,2 +1,4 @@
 # never objects, and not the resulting binary
 coap-client
+coap-cpp-test
+zephyrproject

--- a/examples/zephyr/Makefile
+++ b/examples/zephyr/Makefile
@@ -1,6 +1,6 @@
 ZEPHYR_PROJECT?=zephyrproject
 
-all: $(ZEPHYR_PROJECT) coap-client
+all: $(ZEPHYR_PROJECT) coap-client coap-cpp-test
 
 ${ZEPHYR_PROJECT}:
 	python3 -m venv ${ZEPHYR_PROJECT}/.venv ;\
@@ -34,7 +34,20 @@ coap-client: client-src/src/main.c client-src/* ../../src/*.c ../../include/*/*
 		-DEXTRA_ZEPHYR_MODULES=$${LIBCOAP_DIR} \
 		-DEXTRA_CONF_FILE=$${LIBCOAP_DIR}/zephyr/libcoap-mbedtls.conf)
 	@cp -f $(ZEPHYR_PROJECT)/zephyr/build/zephyr/zephyr.exe coap-client
+	@rm -rf $(ZEPHYR_PROJECT)/zephyr/build
 
+coap-cpp-test: test-cpp-src/src/test.cpp test-cpp-src/* ../../src/*.c ../../include/*/*
+	@LIBCOAP_DIR=`pwd`/../.. ;\
+	(if [ -f $(ZEPHYR_PROJECT)/.venv/bin/activate ]; then \
+	  . $(ZEPHYR_PROJECT)/.venv/bin/activate ;\
+	fi ;\
+	cd $(ZEPHYR_PROJECT)/zephyr ;\
+	west build -p always -b native_sim \
+		$${LIBCOAP_DIR}/examples/zephyr/test-cpp-src -- \
+		-DCONF_FILE=prj.conf \
+		-DEXTRA_ZEPHYR_MODULES=$${LIBCOAP_DIR})
+	@cp -f $(ZEPHYR_PROJECT)/zephyr/build/zephyr/zephyr.exe coap-cpp-test
+	@rm -rf $(ZEPHYR_PROJECT)/zephyr/build
 clean:
 	@rm -rf $(ZEPHYR_PROJECT)/zephyr/build
-	@rm -f coap-client
+	@rm -f coap-client coap-cpp-test

--- a/examples/zephyr/test-cpp-src/CMakeLists.txt
+++ b/examples/zephyr/test-cpp-src/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(coap_client)
+
+target_sources(app PRIVATE src/test.cpp)
+
+include(${ZEPHYR_BASE}/samples/net/common/common.cmake)

--- a/examples/zephyr/test-cpp-src/Kconfig
+++ b/examples/zephyr/test-cpp-src/Kconfig
@@ -1,0 +1,8 @@
+# Private config options for coap-client sample app
+
+# Copyright (c) 2020 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+mainmenu "Test cpp build application"
+
+source "Kconfig.zephyr"

--- a/examples/zephyr/test-cpp-src/prj.conf
+++ b/examples/zephyr/test-cpp-src/prj.conf
@@ -1,0 +1,4 @@
+
+CONFIG_LOG=y
+
+CONFIG_LIBCOAP=y

--- a/examples/zephyr/test-cpp-src/src/test.cpp
+++ b/examples/zephyr/test-cpp-src/src/test.cpp
@@ -1,0 +1,21 @@
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(coap_cpp_test, LOG_LEVEL_DBG);
+
+#include <zephyr/kernel.h>
+#include <errno.h>
+#include "coap3/coap.h"
+#include <stdio.h>
+
+coap_str_const_t *xxx_libcoap_get_version() {
+  coap_str_const_t *ver;
+
+  ver = coap_make_str_const(LIBCOAP_PACKAGE_VERSION);
+  printf("Version: %s\n", ver->s);
+  return ver;
+}
+
+int main()
+{
+  xxx_libcoap_get_version();
+  exit(0);
+}

--- a/include/coap3/coap.h
+++ b/include/coap3/coap.h
@@ -36,10 +36,6 @@
 /* Define the numeric version identifier for libcoap */
 #define LIBCOAP_VERSION (4003005ULL)
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "coap3/libcoap.h"
 
 #include "coap3/coap_forward_decls.h"
@@ -66,9 +62,5 @@ extern "C" {
 #include "coap3/coap_time.h"
 #include "coap3/coap_uri.h"
 #include "coap3/coap_ws.h"
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* COAP_H_ */

--- a/include/coap3/coap_address.h
+++ b/include/coap3/coap_address.h
@@ -25,6 +25,10 @@
 
 #include "coap3/coap_pdu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(WITH_LWIP)
 
 #include <lwip/ip_addr.h>
@@ -338,5 +342,9 @@ coap_is_af_unix(const coap_address_t *a) {
 }
 
 #endif /* WITH_CONTIKI || RIOT_VERSION */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_ADDRESS_H_ */

--- a/include/coap3/coap_asn1_internal.h
+++ b/include/coap3/coap_asn1_internal.h
@@ -19,6 +19,10 @@
 
 #include "coap_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup asn1 ASN.1 Support
@@ -100,5 +104,9 @@ coap_binary_t *get_asn1_tag(coap_asn1_tag_t ltag, const uint8_t *ptr,
 coap_binary_t *get_asn1_spki(const uint8_t *data, size_t size);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_ASN1_INTERNAL_H_ */

--- a/include/coap3/coap_async.h
+++ b/include/coap3/coap_async.h
@@ -19,6 +19,10 @@
 
 #include "coap_net.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup coap_async Asynchronous Messaging
@@ -136,5 +140,9 @@ COAP_API void *coap_async_set_app_data2(coap_async_t *async_entry,
                                         coap_app_data_free_callback_t callback);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_ASYNC_H_ */

--- a/include/coap3/coap_async_internal.h
+++ b/include/coap3/coap_async_internal.h
@@ -20,6 +20,10 @@
 #include "coap_internal.h"
 #include "coap_net.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Note that if COAP_SERVER_SUPPORT is not set, then COAP_ASYNC_SUPPORT undefined */
 #if COAP_ASYNC_SUPPORT
 
@@ -165,5 +169,9 @@ void coap_delete_all_async(coap_context_t *context);
 /** @} */
 
 #endif /* COAP_ASYNC_SUPPORT */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_ASYNC_INTERNAL_H_ */

--- a/include/coap3/coap_block.h
+++ b/include/coap3/coap_block.h
@@ -22,6 +22,10 @@
 #include "coap_option.h"
 #include "coap_pdu.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup block Block Transfer
@@ -438,5 +442,9 @@ COAP_API void coap_context_set_block_mode(coap_context_t *context,
 COAP_API int coap_context_set_max_block_size(coap_context_t *context, size_t max_block_size);
 
 /**@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_BLOCK_H_ */

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -23,6 +23,10 @@
 #include "coap_pdu_internal.h"
 #include "coap_resource.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup block_internal Block Transfer
@@ -582,5 +586,9 @@ void coap_check_update_token(coap_session_t *session, coap_pdu_t *pdu);
 #endif /* ! COAP_CLIENT_SUPPORT */
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_BLOCK_INTERNAL_H_ */

--- a/include/coap3/coap_cache.h
+++ b/include/coap3/coap_cache.h
@@ -18,6 +18,10 @@
 
 #include "coap_forward_decls.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup cache Cache Support
@@ -253,5 +257,9 @@ COAP_API void *coap_cache_set_app_data2(coap_cache_entry_t *cache_entry,
 void *coap_cache_get_app_data(const coap_cache_entry_t *cache_entry);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* COAP_CACHE_H */

--- a/include/coap3/coap_cache_internal.h
+++ b/include/coap3/coap_cache_internal.h
@@ -21,6 +21,10 @@
 #include "coap_io.h"
 #include "coap_uthash_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if COAP_SERVER_SUPPORT
 /**
  * @ingroup internal_api
@@ -215,5 +219,9 @@ int coap_digest_final(coap_digest_ctx_t *digest_ctx,
 /** @} */
 
 #endif /* COAP_SERVER_SUPPORT */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_CACHE_INTERNAL_H_ */

--- a/include/coap3/coap_crypto_internal.h
+++ b/include/coap3/coap_crypto_internal.h
@@ -30,6 +30,10 @@
 
 #include "oscore/oscore_cose.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef COAP_CRYPTO_MAX_KEY_SIZE
 #define COAP_CRYPTO_MAX_KEY_SIZE (32)
 #endif /* COAP_CRYPTO_MAX_KEY_SIZE */
@@ -153,5 +157,9 @@ int coap_crypto_hash(cose_alg_t alg,
                      coap_bin_const_t **hash);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_CRYPTO_INTERNAL_H_ */

--- a/include/coap3/coap_debug.h
+++ b/include/coap3/coap_debug.h
@@ -24,6 +24,12 @@
  * @{
  */
 
+#include "coap_pdu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef COAP_DEBUG_FD
 /**
  * Used for output for @c COAP_LOG_OSCORE to @c COAP_LOG_ERR.
@@ -303,8 +309,6 @@ void coap_print_contiki_prefix(coap_log_t level);
   } while(0)
 #endif
 
-#include "coap_pdu.h"
-
 /**
  * Defines the output mode for the coap_show_pdu() function.
  *
@@ -403,5 +407,9 @@ const char *coap_print_ip_addr(const coap_address_t *address,
  * @return @c 1 If loss level set, @c 0 if there is an error.
  */
 int coap_debug_set_packet_loss(const char *loss_level);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_DEBUG_H_ */

--- a/include/coap3/coap_debug_internal.h
+++ b/include/coap3/coap_debug_internal.h
@@ -14,6 +14,10 @@
  * @brief CoAP Logging support internal information
  */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef COAP_DEBUG_INTERNAL_H_
 #define COAP_DEBUG_INTERNAL_H_
 
@@ -32,5 +36,9 @@ int coap_debug_send_packet(void);
  * Internal function
  */
 void coap_debug_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_DEBUG_INTERNAL_H_ */

--- a/include/coap3/coap_dgrm_internal.h
+++ b/include/coap3/coap_dgrm_internal.h
@@ -20,6 +20,10 @@
 #include "coap_internal.h"
 #include "coap_io.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup dgrm Datagram (UDP) Support
@@ -119,5 +123,9 @@ ssize_t coap_socket_recv(coap_socket_t *sock, coap_packet_t *packet);
 void coap_socket_close(coap_socket_t *sock);
 
 /** @} */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #endif /* COAP_DGRM_INTERNAL_H_ */

--- a/include/coap3/coap_dtls.h
+++ b/include/coap3/coap_dtls.h
@@ -22,6 +22,10 @@
 #include "coap_time.h"
 #include "coap_str.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup dtls DTLS Support
@@ -534,5 +538,9 @@ typedef struct coap_dtls_spsk_t {
 } coap_dtls_spsk_t;
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_DTLS_H */

--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -21,6 +21,10 @@
 
 #include "coap_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup dtls_internal DTLS Support
@@ -503,5 +507,9 @@ int coap_dtls_define_issue(coap_define_issue_key_t type,
 int coap_dtls_set_cid_tuple_change(coap_context_t *context, uint8_t every);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_DTLS_INTERNAL_H */

--- a/include/coap3/coap_encode.h
+++ b/include/coap3/coap_encode.h
@@ -25,6 +25,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef HAVE_FLS
 /* include this only if fls() is not available */
 extern int coap_fls(unsigned int i);
@@ -123,5 +127,9 @@ COAP_STATIC_INLINE COAP_DEPRECATED int
 coap_encode_var_bytes(uint8_t *buf, unsigned int value) {
   return (int)coap_encode_var_safe(buf, sizeof(value), value);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_ENCODE_H_ */

--- a/include/coap3/coap_event.h
+++ b/include/coap3/coap_event.h
@@ -20,6 +20,10 @@
 
 #include "libcoap.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup events Event Handling
@@ -189,5 +193,9 @@ void coap_set_event_handler(coap_context_t *context,
  */
 COAP_DEPRECATED
 void coap_clear_event_handler(coap_context_t *context);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_EVENT_H */

--- a/include/coap3/coap_forward_decls.h
+++ b/include/coap3/coap_forward_decls.h
@@ -18,6 +18,10 @@
 #ifndef COAP_FORWARD_DECLS_H_
 #define COAP_FORWARD_DECLS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Define the forward declations for the structures (even non-opaque)
  * so that applications (using coap.h) as well as libcoap builds
@@ -120,5 +124,9 @@ typedef struct coap_session_t coap_session_t;
  * Observe subscriber information.
  */
 typedef struct coap_subscription_t coap_subscription_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_FORWARD_DECLS_H_ */

--- a/include/coap3/coap_hashkey_internal.h
+++ b/include/coap3/coap_hashkey_internal.h
@@ -21,6 +21,10 @@
 #include "coap_uthash_internal.h"
 #include "coap_str.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef unsigned char coap_key_t[4];
 
 #ifndef coap_hash
@@ -57,5 +61,9 @@ void coap_hash_impl(const unsigned char *s, size_t len, coap_key_t h);
     memset((H), 0, sizeof(coap_key_t));      \
     coap_hash((Str)->s, (Str)->length, (H)); \
   }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_HASHKEY_INTERNAL_H_ */

--- a/include/coap3/coap_io.h
+++ b/include/coap3/coap_io.h
@@ -25,6 +25,10 @@
 #include "net/gnrc.h"
 #endif /* RIOT_VERSION */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef COAP_RXBUFFER_SIZE
 #define COAP_RXBUFFER_SIZE 1472
 #endif /* COAP_RXBUFFER_SIZE */
@@ -70,5 +74,9 @@ typedef enum {
   COAP_NACK_WS_LAYER_FAILED,
   COAP_NACK_WS_FAILED
 } coap_nack_reason_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_IO_H_ */

--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -35,6 +35,10 @@ struct uip_udp_conn;
 #endif /* ! COAP_DISABLE_TCP */
 #endif /* RIOT_VERSION */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct coap_socket_t {
 #if defined(WITH_LWIP)
   struct pbuf *p;
@@ -153,5 +157,9 @@ struct coap_packet_t {
 void coap_start_io_process(void);
 void coap_stop_io_process(void);
 #endif /* WITH_CONTIKI */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_IO_INTERNAL_H_ */

--- a/include/coap3/coap_layers_internal.h
+++ b/include/coap3/coap_layers_internal.h
@@ -19,6 +19,10 @@
 
 #include "coap_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum {
   COAP_LAYER_SESSION,
   COAP_LAYER_WS,
@@ -111,5 +115,9 @@ typedef struct {
 } coap_layer_func_t;
 
 extern coap_layer_func_t coap_layers_coap[COAP_PROTO_LAST][COAP_LAYER_LAST];
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_LAYERS_INTERNAL_H_ */

--- a/include/coap3/coap_mem.h
+++ b/include/coap3/coap_mem.h
@@ -21,6 +21,14 @@
 #include "coap3/coap_proxy.h"
 #include <stdlib.h>
 
+#ifdef WITH_LWIP
+#include <lwip/memp.h>
+#endif /* WITH_LWIP */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef WITH_LWIP
 /**
  * Initializes libcoap's memory management.
@@ -28,6 +36,7 @@
  * constrained devices.
  */
 void coap_memory_init(void);
+
 #endif /* WITH_LWIP */
 
 /**
@@ -137,8 +146,6 @@ coap_free(void *object) {
 
 #ifdef WITH_LWIP
 
-#include <lwip/memp.h>
-
 /* no initialization needed with lwip (or, more precisely: lwip must be
  * completely initialized anyway by the time coap gets active)  */
 COAP_STATIC_INLINE void
@@ -188,5 +195,9 @@ coap_free(void *pointer) {
 #define coap_dump_memory_type_counts(l) coap_lwip_dump_memory_pools(l)
 
 #endif /* WITH_LWIP */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_MEM_H_ */

--- a/include/coap3/coap_mutex_internal.h
+++ b/include/coap3/coap_mutex_internal.h
@@ -19,14 +19,31 @@
 #define COAP_MUTEX_INTERNAL_H_
 
 /*
+ * Do all the #include before the extern "C"
+ */
+#if defined(HAVE_PTHREAD_H) && defined(HAVE_PTHREAD_MUTEX_LOCK)
+#include <pthread.h>
+#elif defined(RIOT_VERSION)
+/* use RIOT's mutex API */
+#include <mutex.h>
+#elif defined(WITH_LWIP) && defined(NO_SYS)
+#include <lwip/sys.h>
+#elif defined(__ZEPHYR__)
+#include <zephyr/sys/mutex.h>
+#endif /* !WITH_CONTIKI && !WITH_LWIP && !RIOT_VERSION && !HAVE_PTHREAD_H && !HAVE_PTHREAD_MUTEX_LOCK */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
  * Mutexes are used for
  * 1) If there is a constrained stack, and large static variables (instead
  *    of the large variable being on the stack) need to be protected.
  * 2) libcoap if built with thread safe support.
  */
-#if defined(HAVE_PTHREAD_H) && defined(HAVE_PTHREAD_MUTEX_LOCK)
-#include <pthread.h>
 
+#if defined(HAVE_PTHREAD_H) && defined(HAVE_PTHREAD_MUTEX_LOCK)
 typedef pthread_mutex_t coap_mutex_t;
 
 #define coap_mutex_init(a)    pthread_mutex_init(a, NULL)
@@ -43,8 +60,6 @@ typedef pthread_mutex_t coap_mutex_t;
 #endif /* !ESPIDF_VERSION */
 
 #elif defined(RIOT_VERSION)
-/* use RIOT's mutex API */
-#include <mutex.h>
 
 typedef mutex_t coap_mutex_t;
 
@@ -119,7 +134,6 @@ typedef int coap_mutex_t;
 #define coap_thread_pid       1
 
 #elif defined(__ZEPHYR__)
-#include <zephyr/sys/mutex.h>
 
 typedef struct sys_mutex coap_mutex_t;
 
@@ -129,7 +143,7 @@ typedef struct sys_mutex coap_mutex_t;
 #define coap_mutex_trylock(a) sys_mutex_lock(a, K_NO_WAIT)
 #define coap_mutex_unlock(a)  sys_mutex_unlock(a)
 
-#else /* !__ZEPYR__ && !WITH_CONTIKI && !WITH_LWIP && !RIOT_VERSION && !HAVE_PTHREAD_H && !HAVE_PTHREAD_MUTEX_LOCK */
+#else /* !__ZEPHYR__ && !WITH_CONTIKI && !WITH_LWIP && !RIOT_VERSION && !HAVE_PTHREAD_H && !HAVE_PTHREAD_MUTEX_LOCK */
 /* define stub mutex functions */
 #if COAP_THREAD_SAFE
 #error Multi-threading not supported (no mutex support)
@@ -157,5 +171,9 @@ extern coap_mutex_t m_log_impl;
 extern coap_mutex_t m_io_threads;
 
 #endif /* COAP_THREAD_SAFE */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_MUTEX_INTERNAL_H_ */

--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -43,6 +43,10 @@
 #include "coap_session.h"
 #include "coap_debug.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup context Context Handling
@@ -1160,5 +1164,9 @@ void coap_lwip_set_input_wait_handler(coap_context_t *context,
 /* Old definitions which may be hanging around in old code - be helpful! */
 #define COAP_RUN_NONBLOCK COAP_RUN_NONBLOCK_deprecated_use_COAP_IO_NO_WAIT
 #define COAP_RUN_BLOCK COAP_RUN_BLOCK_deprecated_use_COAP_IO_WAIT
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_NET_H_ */

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -22,6 +22,10 @@
 #include "coap_subscribe.h"
 #include "coap_threadsafe_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup context_internal Context Handling
@@ -994,5 +998,9 @@ void coap_call_response_handler(coap_session_t *session, coap_pdu_t *sent,
 /**@}*/
 
 extern int coap_started;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_NET_INTERNAL_H_ */

--- a/include/coap3/coap_netif_internal.h
+++ b/include/coap3/coap_netif_internal.h
@@ -19,6 +19,10 @@
 
 #include "coap_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup netif_internal Netif Support
@@ -205,5 +209,9 @@ void coap_netif_close(coap_session_t *session);
 void coap_netif_close_ep(coap_endpoint_t *endpoint);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_NETIF_INTERNAL_H */

--- a/include/coap3/coap_option.h
+++ b/include/coap3/coap_option.h
@@ -17,6 +17,10 @@
 #ifndef COAP_OPTION_H_
 #define COAP_OPTION_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef uint16_t coap_option_num_t;
 
 /**
@@ -431,5 +435,9 @@ COAP_STATIC_INLINE COAP_DEPRECATED int
 coap_option_getb(coap_opt_filter_t *filter, uint16_t type) {
   return coap_option_filter_get(filter, type);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_OPTION_H_ */

--- a/include/coap3/coap_oscore.h
+++ b/include/coap3/coap_oscore.h
@@ -21,6 +21,10 @@
 #ifndef COAP_OSCORE_H_
 #define COAP_OSCORE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup oscore OSCORE Support
@@ -187,5 +191,9 @@ COAP_API int coap_delete_oscore_recipient(coap_context_t *context,
                                           coap_bin_const_t *recipient_id);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_OSCORE_H */

--- a/include/coap3/coap_oscore_internal.h
+++ b/include/coap3/coap_oscore_internal.h
@@ -23,6 +23,10 @@
 
 #include "oscore/oscore_context.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup oscore_internal OSCORE Support
@@ -292,5 +296,9 @@ int coap_new_oscore_recipient_lkd(coap_context_t *context,
                                   coap_bin_const_t *recipient_id);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_OSCORE_INTERNAL_H */

--- a/include/coap3/coap_pdu.h
+++ b/include/coap3/coap_pdu.h
@@ -27,6 +27,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup pdu PDU
@@ -627,5 +631,9 @@ coap_mid_t coap_pdu_get_mid(const coap_pdu_t *pdu);
 void coap_pdu_set_mid(coap_pdu_t *pdu, coap_mid_t mid);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_PDU_H_ */

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -33,6 +33,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup pdu_internal PDU
@@ -472,5 +476,9 @@ coap_pdu_t *coap_pdu_reference_lkd(coap_pdu_t *pdu);
 coap_pdu_t *coap_const_pdu_reference_lkd(const coap_pdu_t *pdu);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_COAP_PDU_INTERNAL_H_ */

--- a/include/coap3/coap_prng.h
+++ b/include/coap3/coap_prng.h
@@ -17,6 +17,10 @@
 #ifndef COAP_PRNG_H_
 #define COAP_PRNG_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup coap_prng Pseudo Random Numbers
@@ -62,5 +66,9 @@ COAP_API void coap_prng_init(unsigned int seed);
 COAP_API int coap_prng(void *buf, size_t len);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_PRNG_H_ */

--- a/include/coap3/coap_prng_internal.h
+++ b/include/coap3/coap_prng_internal.h
@@ -17,6 +17,10 @@
 #ifndef COAP_PRNG_INTERNAL_H_
 #define COAP_PRNG_INTERNAL_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup coap_prng_internal Pseudo Random Numbers
@@ -45,6 +49,10 @@ void coap_prng_init_lkd(unsigned int seed);
  * @return 1 on success, 0 otherwise.
  */
 int coap_prng_lkd(void *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 /** @} */
 

--- a/include/coap3/coap_proxy.h
+++ b/include/coap3/coap_proxy.h
@@ -17,6 +17,10 @@
 #ifndef COAP_PROXY_H_
 #define COAP_PROXY_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup proxy Proxy
@@ -178,5 +182,9 @@ COAP_API coap_session_t *coap_new_client_session_proxy(coap_context_t *context,
                                                        coap_proxy_server_list_t *server_list);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_PROXY_H_ */

--- a/include/coap3/coap_proxy_internal.h
+++ b/include/coap3/coap_proxy_internal.h
@@ -19,6 +19,10 @@
 
 #include "coap_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if COAP_PROXY_SUPPORT
 /**
  * @ingroup internal_api
@@ -255,4 +259,9 @@ void coap_delete_proxy_subscriber(coap_session_t *session, coap_bin_const_t *tok
   }
 
 #endif /* COAP_PROXY_SUPPORT */
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* COAP_PROXY_INTERNAL_H_ */

--- a/include/coap3/coap_resource.h
+++ b/include/coap3/coap_resource.h
@@ -17,6 +17,10 @@
 #ifndef COAP_RESOURCE_H_
 #define COAP_RESOURCE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef COAP_RESOURCE_CHECK_TIME
 /** The interval in seconds to check if resources have changed. */
 #define COAP_RESOURCE_CHECK_TIME 2
@@ -555,5 +559,9 @@ COAP_API coap_print_status_t coap_print_wellknown(coap_context_t *context,
  */
 COAP_DEPRECATED COAP_API int coap_resource_set_dirty(coap_resource_t *r,
                                                      const coap_string_t *query);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_RESOURCE_H_ */

--- a/include/coap3/coap_resource_internal.h
+++ b/include/coap3/coap_resource_internal.h
@@ -20,6 +20,10 @@
 #include "coap_internal.h"
 #include "coap_uthash_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if COAP_SERVER_SUPPORT
 /**
  * @ingroup internal_api
@@ -239,5 +243,9 @@ coap_print_status_t coap_print_wellknown_lkd(coap_context_t *context,
 /** @} */
 
 #endif /* COAP_SERVER_SUPPORT */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_RESOURCE_INTERNAL_H_ */

--- a/include/coap3/coap_riot.h
+++ b/include/coap3/coap_riot.h
@@ -16,6 +16,10 @@
 #ifndef COAP_RIOT_H_
 #define COAP_RIOT_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef LIBCOAP_MSG_QUEUE_SIZE
 /**
  * Size of the queue for passing messages between the network
@@ -35,5 +39,9 @@
  * RIOT-specific initialization.
  */
 void coap_riot_startup(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_RIOT_H_ */

--- a/include/coap3/coap_session.h
+++ b/include/coap3/coap_session.h
@@ -17,6 +17,10 @@
 #ifndef COAP_SESSION_H_
 #define COAP_SESSION_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup session Sessions
@@ -903,5 +907,9 @@ COAP_API coap_mid_t coap_session_send_ping(coap_session_t *session);
  * @param session The CoAP session.
  */
 void coap_session_set_no_observe_cancel(coap_session_t *session);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  /* COAP_SESSION_H */

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -22,6 +22,10 @@
 #include "coap_io_internal.h"
 #include "coap_ws_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define COAP_DEFAULT_SESSION_TIMEOUT 300
 #define COAP_PARTIAL_SESSION_TIMEOUT_TICKS (30 * COAP_TICKS_PER_SECOND)
 #define COAP_DEFAULT_MAX_HANDSHAKE_SESSIONS 100
@@ -881,5 +885,9 @@ void coap_session_reestablished(coap_session_t *session);
 #define SESSIONS_FIND(e, k, res) {                     \
     HASH_FIND(hh, (e), &(k), sizeof(k), (res)); \
   }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_SESSION_INTERNAL_H_ */

--- a/include/coap3/coap_sha1_internal.h
+++ b/include/coap3/coap_sha1_internal.h
@@ -58,6 +58,10 @@
  */
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 /*
  * If you do not have the ISO standard stdint.h header file, then you
  * must typdef the following:
@@ -107,5 +111,9 @@ int SHA1Input(SHA1Context *,
               unsigned int);
 int SHA1Result(SHA1Context *,
                uint8_t Message_Digest[SHA1HashSize]);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_SHA1_INTERNAL_H_ */

--- a/include/coap3/coap_str.h
+++ b/include/coap3/coap_str.h
@@ -19,6 +19,9 @@
 
 #include <string.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @ingroup application_api
@@ -214,5 +217,9 @@ coap_str_const_t *coap_make_str_const(const char *string);
                                                memcmp((binary1)->s, (binary2)->s, (binary1)->length) == 0)))
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_STR_H_ */

--- a/include/coap3/coap_strm_internal.h
+++ b/include/coap3/coap_strm_internal.h
@@ -20,6 +20,10 @@
 #include "coap_internal.h"
 #include "coap_io.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup strm Stream (TCP) Support
@@ -130,5 +134,9 @@ ssize_t coap_socket_read(coap_socket_t *sock, uint8_t *data, size_t data_len);
 #endif /* !COAP_DISABLE_TCP */
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_STRM_INTERNAL_H_ */

--- a/include/coap3/coap_subscribe.h
+++ b/include/coap3/coap_subscribe.h
@@ -18,6 +18,10 @@
 #ifndef COAP_SUBSCRIBE_H_
 #define COAP_SUBSCRIBE_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup observe Resource Observation
@@ -283,5 +287,9 @@ COAP_API int coap_cancel_observe(coap_session_t *session, coap_binary_t *token,
                                  coap_pdu_type_t message_type);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_SUBSCRIBE_H_ */

--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -20,6 +20,10 @@
 
 #include "coap_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup subscribe_internal Observe Subscription
@@ -303,4 +307,9 @@ int coap_cancel_observe_lkd(coap_session_t *session, coap_binary_t *token,
 #endif /* COAP_CLIENT_SUPPORT */
 
 /** @} */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #endif /* COAP_SUBSCRIBE_INTERNAL_H_ */

--- a/include/coap3/coap_supported.h
+++ b/include/coap3/coap_supported.h
@@ -17,6 +17,10 @@
 #ifndef COAP_SUPPORTED_H_
 #define COAP_SUPPORTED_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup supported Optional functionality
@@ -179,5 +183,9 @@ int coap_ws_is_supported(void);
 int coap_wss_is_supported(void);
 
 /**@}*/
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_SUPPORTED_H_ */

--- a/include/coap3/coap_threadsafe_internal.h
+++ b/include/coap3/coap_threadsafe_internal.h
@@ -24,6 +24,10 @@
 #ifndef COAP_THREADSAFE_INTERNAL_H_
 #define COAP_THREADSAFE_INTERNAL_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Support thread safe access into libcoap
  *
@@ -554,5 +558,9 @@ typedef coap_mutex_t coap_lock_t;
 #endif /* ! COAP_THREAD_SAFE */
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_THREADSAFE_INTERNAL_H_ */

--- a/include/coap3/coap_time.h
+++ b/include/coap3/coap_time.h
@@ -28,6 +28,19 @@
 
 #include <stdint.h>
 #include <lwip/sys.h>
+#elif defined(WITH_CONTIKI)
+#include "clock.h"
+#elif defined(RIOT_VERSION)
+#include <xtimer.h>
+#else /* !WITH_LWIP && !WITH_CONTIKI && !RIOT_VERSION */
+#include <stdint.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(WITH_LWIP)
 
 /* lwIP provides ms in sys_now */
 #define COAP_TICKS_PER_SECOND 1000
@@ -59,8 +72,6 @@ coap_ticks_to_rt_us(coap_tick_t t) {
 }
 
 #elif defined(WITH_CONTIKI)
-
-#include "clock.h"
 
 typedef clock_time_t coap_tick_t;
 typedef clock_time_t coap_time_t;
@@ -94,7 +105,6 @@ coap_ticks_to_rt_us(coap_tick_t t) {
 }
 
 #elif defined(RIOT_VERSION)
-#include <xtimer.h>
 
 #ifdef XTIMER_HZ
 #define COAP_TICKS_PER_SECOND (XTIMER_HZ)
@@ -134,7 +144,6 @@ coap_ticks_from_rt_us(uint64_t t) {
 }
 #else /* !WITH_LWIP && !WITH_CONTIKI && !RIOT_VERSION */
 
-#include <stdint.h>
 
 /**
  * This data type represents internal timer ticks with COAP_TICKS_PER_SECOND
@@ -221,5 +230,9 @@ coap_time_le(coap_tick_t a, coap_tick_t b) {
 #define COAP_MAX_DELAY_TICKS (24 * 60 * 60 * COAP_TICKS_PER_SECOND)
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_TIME_H_ */

--- a/include/coap3/coap_uri.h
+++ b/include/coap3/coap_uri.h
@@ -21,6 +21,10 @@
 
 #include "coap_str.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * The scheme specifiers. Secure schemes have an odd numeric value,
  * others are even.
@@ -316,5 +320,9 @@ coap_string_t *coap_get_query(const coap_pdu_t *request);
 coap_string_t *coap_get_uri_path(const coap_pdu_t *request);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_URI_H_ */

--- a/include/coap3/coap_uri_internal.h
+++ b/include/coap3/coap_uri_internal.h
@@ -19,6 +19,10 @@
 
 #include "coap_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup uri URI Support
@@ -44,5 +48,9 @@ extern coap_uri_info_t coap_uri_scheme[COAP_URI_SCHEME_LAST];
 void coap_replace_percents(coap_optlist_t *optlist);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_URI_INTERNAL_H_ */

--- a/include/coap3/coap_uthash_internal.h
+++ b/include/coap3/coap_uthash_internal.h
@@ -29,15 +29,24 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>   /* memcmp, memset, strlen */
 #include <stddef.h>   /* ptrdiff_t */
 #include <stdlib.h>   /* exit */
+#ifdef HASH_DEBUG
+#include <stdio.h>   /* fprintf, stderr */
+#endif
+#if defined(HASH_DEFINE_OWN_STDINT) && HASH_DEFINE_OWN_STDINT
+#elif defined(HASH_NO_STDINT) && HASH_NO_STDINT
+#else
+#include <stdint.h>   /* uint8_t, uint32_t */
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #if defined(HASH_DEFINE_OWN_STDINT) && HASH_DEFINE_OWN_STDINT
 /* This codepath is provided for backward compatibility, but I plan to remove it. */
 #warning "HASH_DEFINE_OWN_STDINT is deprecated; please use HASH_NO_STDINT instead"
 typedef unsigned int uint32_t;
 typedef unsigned char uint8_t;
-#elif defined(HASH_NO_STDINT) && HASH_NO_STDINT
-#else
-#include <stdint.h>   /* uint8_t, uint32_t */
 #endif
 
 /* These macros use decltype or the earlier __typeof GNU extension.
@@ -512,7 +521,6 @@ do {                                                                            
  * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
  */
 #ifdef HASH_DEBUG
-#include <stdio.h>   /* fprintf, stderr */
 #define HASH_OOPS(...) do { fprintf(stderr, __VA_ARGS__); exit(-1); } while (0)
 #define HASH_FSCK(hh,head,where)                                                 \
 do {                                                                             \
@@ -1132,5 +1140,9 @@ typedef struct UT_hash_handle {
    uint32_t keylen;                  /* enclosing struct's key len     */
    uint32_t hashv;                   /* result of hash-fcn(key)        */
 } UT_hash_handle;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* UTHASH_H */

--- a/include/coap3/coap_utlist_internal.h
+++ b/include/coap3/coap_utlist_internal.h
@@ -29,6 +29,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assert.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This file contains macros to manipulate singly and doubly-linked lists.
  *
@@ -1072,4 +1076,9 @@ do {                                                                            
 #endif /* NO_DECLTYPE */
 
 #endif /* UTLIST_H */
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* ! RIOT_VERSION */

--- a/include/coap3/coap_ws.h
+++ b/include/coap3/coap_ws.h
@@ -18,6 +18,10 @@
 #ifndef COAP_WS_H_
 #define COAP_WS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup application_api
  * @defgroup ws WebSockets Support
@@ -33,5 +37,9 @@
 int coap_ws_set_host_request(coap_session_t *session, coap_str_const_t *ws_host);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_WS_H */

--- a/include/coap3/coap_ws_internal.h
+++ b/include/coap3/coap_ws_internal.h
@@ -20,6 +20,10 @@
 
 #include "coap_internal.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup ws_internal WebSockets Support
@@ -151,5 +155,9 @@ void coap_ws_establish(coap_session_t *session);
 void coap_ws_close(coap_session_t *session);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_WS_INTERNAL_H */

--- a/include/coap3/libcoap.h
+++ b/include/coap3/libcoap.h
@@ -43,6 +43,10 @@ typedef USHORT in_port_t;
 #include <sys/socket.h>
 #endif /* ! CONTIKI && ! WITH_LWIP && ! RIOT_VERSION */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef COAP_STATIC_INLINE
 #  if defined(__cplusplus)
 #    define COAP_STATIC_INLINE inline
@@ -88,5 +92,9 @@ typedef USHORT in_port_t;
 void coap_startup(void);
 
 void coap_cleanup(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COAP_LIBCOAP_H_ */

--- a/include/oscore/oscore.h
+++ b/include/oscore/oscore.h
@@ -51,6 +51,10 @@
 #include "oscore_cose.h"
 #include "oscore_context.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @addtogroup oscore_internal
@@ -123,5 +127,9 @@ uint8_t oscore_increment_sender_seq(oscore_ctx_t *ctx);
 void oscore_roll_back_seq(oscore_recipient_ctx_t *ctx);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OSCORE_H */

--- a/include/oscore/oscore_cbor.h
+++ b/include/oscore/oscore_cbor.h
@@ -49,6 +49,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup oscore_cbor_internal OSCORE CBOR Support
@@ -140,5 +144,9 @@ uint8_t oscore_cbor_strip_value(const uint8_t **data, size_t *buf_size,
                                 uint8_t **result, size_t *len);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OSCORE_CBOR_H */

--- a/include/oscore/oscore_context.h
+++ b/include/oscore/oscore_context.h
@@ -52,6 +52,10 @@
 #include "coap3/coap_uthash_internal.h"
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @addtogroup oscore_internal
@@ -277,5 +281,9 @@ int oscore_derive_keystream(oscore_ctx_t *osc_ctx,
                             size_t keystream_size);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OSCORE_CONTEXT_H */

--- a/include/oscore/oscore_cose.h
+++ b/include/oscore/oscore_cose.h
@@ -48,6 +48,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @defgroup oscore_cose_internal OSCORE COSE Support
@@ -266,5 +270,9 @@ int cose_encrypt0_decrypt(cose_encrypt0_t *ptr,
                           size_t plaintext_len);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OSCORE_COSE_H */

--- a/include/oscore/oscore_crypto.h
+++ b/include/oscore/oscore_crypto.h
@@ -50,6 +50,10 @@
 
 #include <coap3/coap_internal.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @ingroup internal_api
  * @addtogroup oscore_internal
@@ -139,5 +143,9 @@ int oscore_hkdf(cose_hkdf_alg_t hkdf_alg,
                 size_t okm_len);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OSCORE_CRYPTO_H */


### PR DESCRIPTION
Some of the Zephyr include files need to be C++, not C based. The 'extern "C"' wrapper in include/coap3/coap.h means that all #include are treated as being C.

Remove 'extern "C"' wrapper from include/coap3/coap.h and add wrapper to include files after #include and before any function / structure definitions.