### PR TITLE
CI: Fix CI windows-2025 ms-build image build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,7 @@ jobs:
         run: |
           make -C examples/${{matrix.OS}} EXTRA_CFLAGS=-Werror
   ms-build:
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     steps:
       - uses: actions/checkout@v4

--- a/win32/libcoap.props
+++ b/win32/libcoap.props
@@ -9,8 +9,8 @@
     <OpenSSLRootDirDbg>$(OPENSSL_INSTALL_PATH)</OpenSSLRootDirDbg>
     <OpenSSLIncludeDir>$(OpenSSLRootDir)include</OpenSSLIncludeDir>
     <OpenSSLIncludeDirDbg>$(OpenSSLRootDirDbg)include</OpenSSLIncludeDirDbg>
-    <OpenSSLLibDir>$(OpenSSLRootDir)lib</OpenSSLLibDir>
-    <OpenSSLLibDirDbg>$(OpenSSLRootDirDbg)lib</OpenSSLLibDirDbg>
+    <OpenSSLLibDir>$(OpenSSLRootDir)lib\VC\x64\MD</OpenSSLLibDir>
+    <OpenSSLLibDirDbg>$(OpenSSLRootDirDbg)lib\VC\x64\MD</OpenSSLLibDirDbg>
     <CUnitRootDir>$(InstallDir)</CUnitRootDir>
     <CUnitRootDirDbg>$(InstallDirDbg)</CUnitRootDirDbg>
     <CUnitIncludeDir>$(CUnitRootDir)include</CUnitIncludeDir>


### PR DESCRIPTION
Github's windows-latest image is migrating to windows-2025 where the OpenSSL libraries have a different path.