### PR TITLE
Compile time ifdef definitions cleanup

### DIFF
--- a/include/coap3/coap_internal.h
+++ b/include/coap3/coap_internal.h
@@ -57,16 +57,16 @@
 #endif
 
 /* By default without either configured, these need to be set */
-#ifndef COAP_SERVER_SUPPORT
-#ifndef COAP_CLIENT_SUPPORT
+#if ! COAP_SERVER_SUPPORT
+#if ! COAP_CLIENT_SUPPORT
 #define COAP_SERVER_SUPPORT 1
 #define COAP_CLIENT_SUPPORT 1
 #endif /* ! COAP_CLIENT_SUPPORT */
 #endif /* ! COAP_SERVER_SUPPORT */
 
 /* By default without either configured, these need to be set */
-#ifndef COAP_IPV4_SUPPORT
-#ifndef COAP_IPV6_SUPPORT
+#if ! COAP_IPV4_SUPPORT
+#if ! COAP_IPV6_SUPPORT
 #define COAP_IPV4_SUPPORT 1
 #define COAP_IPV6_SUPPORT 1
 #endif /* ! COAP_IPV6_SUPPORT */
@@ -86,7 +86,7 @@
  * Include all the header files that are for internal use only.
  */
 
-#if defined(COAP_OSCORE_SUPPORT) || defined(COAP_WS_SUPPORT)
+#if COAP_OSCORE_SUPPORT
 /* Specific OSCORE general .h files */
 typedef struct oscore_ctx_t oscore_ctx_t;
 #include "oscore/oscore.h"
@@ -94,14 +94,14 @@ typedef struct oscore_ctx_t oscore_ctx_t;
 #include "oscore/oscore_cose.h"
 #include "oscore/oscore_context.h"
 #include "oscore/oscore_crypto.h"
-#endif /* COAP_OSCORE_SUPPORT || COAP_WS_SUPPORT */
+#endif /* COAP_OSCORE_SUPPORT */
 
 /* Specifically defined internal .h files */
 #include "coap_asn1_internal.h"
 #include "coap_async_internal.h"
 #include "coap_block_internal.h"
 #include "coap_cache_internal.h"
-#if defined(COAP_OSCORE_SUPPORT) || defined(COAP_WS_SUPPORT)
+#if COAP_OSCORE_SUPPORT || COAP_WS_SUPPORT
 #include "coap_crypto_internal.h"
 #endif /* COAP_OSCORE_SUPPORT || COAP_WS_SUPPORT */
 #include "coap_debug_internal.h"

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -84,7 +84,7 @@ extern "C" {
 #define COAP_DEFAULT_MAX_PDU_RX_SIZE (UIP_APPDATA_SIZE)
 #elif (UINT_MAX < (8UL*1024*1024+256))
 #define COAP_DEFAULT_MAX_PDU_RX_SIZE (1500UL)
-#elif defined(RIOT_VERSION) && defined(COAP_DISABLE_TCP)
+#elif defined(RIOT_VERSION) && COAP_DISABLE_TCP
 #define COAP_DEFAULT_MAX_PDU_RX_SIZE (1500UL)
 #else
 /* 8 MiB max-message-size plus some space for options */

--- a/src/coap_dgrm_contiki.c
+++ b/src/coap_dgrm_contiki.c
@@ -15,6 +15,9 @@
  */
 
 #include "coap3/coap_libcoap_build.h"
+
+#if defined(WITH_CONTIKI)
+
 #include "contiki-net.h"
 
 extern struct process libcoap_io_process;
@@ -152,3 +155,17 @@ coap_socket_recv(coap_socket_t *sock, coap_packet_t *packet) {
 
   return len;
 }
+
+#else /* ! WITH_CONTIKI */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! WITH_CONTIKI */

--- a/src/coap_dgrm_lwip.c
+++ b/src/coap_dgrm_lwip.c
@@ -15,6 +15,9 @@
  */
 
 #include "coap3/coap_libcoap_build.h"
+
+#if defined(WITH_LWIP)
+
 #include <lwip/udp.h>
 #include <lwip/timeouts.h>
 #include <lwip/tcpip.h>
@@ -439,3 +442,17 @@ coap_socket_dgrm_close(coap_socket_t *sock) {
   }
   return;
 }
+
+#else /* ! WITH_LWIP */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! WITH_LWIP */

--- a/src/coap_dgrm_posix.c
+++ b/src/coap_dgrm_posix.c
@@ -16,6 +16,8 @@
 
 #include "coap3/coap_libcoap_build.h"
 
+#if ! defined(WITH_LWIP) && ! defined(WITH_CONTIKI) && ! defined (RIOT_VERSION)
+
 #ifdef HAVE_STDIO_H
 #  include <stdio.h>
 #endif
@@ -942,3 +944,17 @@ coap_socket_dgrm_close(coap_socket_t *sock) {
   }
   sock->flags = COAP_SOCKET_EMPTY;
 }
+
+#else /* WITH_LWIP || WITH_CONTIKI || RIOT_VERSION */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* WITH_LWIP || WITH_CONTIKI || RIOT_VERSION */

--- a/src/coap_dgrm_riot.c
+++ b/src/coap_dgrm_riot.c
@@ -15,6 +15,8 @@
 
 #include "coap3/coap_libcoap_build.h"
 
+#if defined(RIOT_VERSION)
+
 #include "net/gnrc.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/netreg.h"
@@ -325,3 +327,17 @@ coap_socket_dgrm_close(coap_socket_t *sock) {
   }
   sock->flags = COAP_SOCKET_EMPTY;
 }
+
+#else /* ! RIOT_VERSION */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! RIOT_VERSION */

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -50,7 +50,7 @@
 
 #include "coap3/coap_libcoap_build.h"
 
-#ifdef COAP_WITH_LIBGNUTLS
+#if COAP_WITH_LIBGNUTLS
 
 #define MIN_GNUTLS_VERSION "3.3.0"
 
@@ -3340,7 +3340,7 @@ fail:
 
 #endif /* COAP_OSCORE_SUPPORT */
 
-#else /* !COAP_WITH_LIBGNUTLS */
+#else /* ! COAP_WITH_LIBGNUTLS */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -3352,4 +3352,4 @@ static inline void
 dummy(void) {
 }
 
-#endif /* !COAP_WITH_LIBGNUTLS */
+#endif /* ! COAP_WITH_LIBGNUTLS */

--- a/src/coap_io_contiki.c
+++ b/src/coap_io_contiki.c
@@ -15,6 +15,9 @@
  */
 
 #include "coap3/coap_libcoap_build.h"
+
+#if defined(WITH_CONTIKI)
+
 #include "contiki-net.h"
 
 static void prepare_io(coap_context_t *ctx);
@@ -125,3 +128,17 @@ coap_io_process_lkd(coap_context_t *ctx, uint32_t timeout_ms) {
   coap_ticks(&now);
   return (int)(((now - before) * 1000) / COAP_TICKS_PER_SECOND);
 }
+
+#else /* ! WITH_CONTIKI */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! WITH_CONTIKI */

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -16,6 +16,9 @@
  */
 
 #include "coap3/coap_libcoap_build.h"
+
+#if defined(WITH_LWIP)
+
 #include <lwip/udp.h>
 #include <lwip/timeouts.h>
 #include <lwip/tcpip.h>
@@ -239,3 +242,17 @@ coap_is_af_unix(const coap_address_t *a) {
   (void)a;
   return 0;
 }
+
+#else /* ! WITH_LWIP */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! WITH_LWIP */

--- a/src/coap_io_posix.c
+++ b/src/coap_io_posix.c
@@ -15,6 +15,8 @@
 
 #include "coap3/coap_libcoap_build.h"
 
+#if ! defined(WITH_LWIP) && ! defined(WITH_CONTIKI) && ! defined (RIOT_VERSION)
+
 #ifdef HAVE_STDIO_H
 #  include <stdio.h>
 #endif
@@ -41,7 +43,7 @@
 #ifdef _WIN32
 #include <stdio.h>
 #endif /* _WIN32 */
-#ifdef COAP_EPOLL_SUPPORT
+#if COAP_EPOLL_SUPPORT
 #include <sys/epoll.h>
 #include <sys/timerfd.h>
 #ifdef HAVE_LIMITS_H
@@ -53,7 +55,7 @@
 #include <sys/select.h>
 #endif /* __ZEPHYR__ */
 
-#ifdef COAP_EPOLL_SUPPORT
+#if COAP_EPOLL_SUPPORT
 void
 coap_epoll_ctl_add(coap_socket_t *sock,
                    uint32_t events,
@@ -158,7 +160,7 @@ coap_io_process_with_fds(coap_context_t *ctx, uint32_t timeout_ms,
   return ret;
 }
 
-#if !defined(COAP_EPOLL_SUPPORT) && COAP_THREAD_SAFE
+#if ! COAP_EPOLL_SUPPORT && COAP_THREAD_SAFE
 static unsigned int
 coap_io_prepare_fds(coap_context_t *ctx,
                     int enfds, fd_set *ereadfds, fd_set *ewritefds,
@@ -240,7 +242,7 @@ coap_io_process_with_fds_lkd(coap_context_t *ctx, uint32_t timeout_ms,
   coap_fd_t nfds = 0;
   coap_tick_t before, now;
   unsigned int timeout;
-#ifndef COAP_EPOLL_SUPPORT
+#if ! COAP_EPOLL_SUPPORT
   struct timeval tv;
   int result;
   unsigned int i;
@@ -249,7 +251,7 @@ coap_io_process_with_fds_lkd(coap_context_t *ctx, uint32_t timeout_ms,
   coap_lock_check_locked();
   coap_ticks(&before);
 
-#ifndef COAP_EPOLL_SUPPORT
+#if ! COAP_EPOLL_SUPPORT
 
   timeout = coap_io_prepare_io_lkd(ctx, ctx->sockets,
                                    (sizeof(ctx->sockets) / sizeof(ctx->sockets[0])),
@@ -476,7 +478,7 @@ coap_io_process_with_fds_lkd(coap_context_t *ctx, uint32_t timeout_ms,
   coap_check_async(ctx, now, NULL);
 #endif /* COAP_ASYNC_SUPPORT */
 
-#ifndef COAP_EPOLL_SUPPORT
+#if ! COAP_EPOLL_SUPPORT
 all_over:
 #endif /* COAP_EPOLL_SUPPORT */
   coap_ticks(&now);
@@ -594,3 +596,17 @@ coap_io_process_loop_lkd(coap_context_t *context,
   coap_thread_quit = 0;
   return ret;
 }
+
+#else /* WITH_LWIP || WITH_CONTIKI || RIOT_VERSION */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* WITH_LWIP || WITH_CONTIKI || RIOT_VERSION */

--- a/src/coap_io_riot.c
+++ b/src/coap_io_riot.c
@@ -15,6 +15,8 @@
 
 #include "coap3/coap_libcoap_build.h"
 
+#if defined(RIOT_VERSION)
+
 #include "net/gnrc.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/netreg.h"
@@ -102,3 +104,17 @@ void
 coap_riot_startup(void) {
   msg_init_queue(_msg_q, LIBCOAP_MSG_QUEUE_SIZE);
 }
+
+#else /* ! RIOT_VERSION */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! RIOT_VERSION */

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -34,7 +34,7 @@
 
 #include "coap3/coap_libcoap_build.h"
 
-#ifdef COAP_WITH_LIBMBEDTLS
+#if COAP_WITH_LIBMBEDTLS
 
 /*
  * This code can be conditionally compiled to remove some components if
@@ -3478,7 +3478,7 @@ error:
 
 #endif /* COAP_OSCORE_SUPPORT */
 
-#else /* !COAP_WITH_LIBMBEDTLS */
+#else /* ! COAP_WITH_LIBMBEDTLS */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -3490,4 +3490,4 @@ static inline void
 dummy(void) {
 }
 
-#endif /* COAP_WITH_LIBMBEDTLS */
+#endif /* ! COAP_WITH_LIBMBEDTLS */

--- a/src/coap_mem.c
+++ b/src/coap_mem.c
@@ -276,7 +276,7 @@ static coap_resource_t resource_storage_data[COAP_MAX_RESOURCES];
 static memarray_t resource_storage;
 #endif /* COAP_SERVER_SUPPORT */
 
-#ifdef COAP_WITH_LIBTINYDTLS
+#if COAP_WITH_LIBTINYDTLS
 #undef PACKAGE_BUGREPORT
 #undef PACKAGE_URL
 #include <session.h>
@@ -337,7 +337,7 @@ coap_memory_init(void) {
   INIT_STORAGE(resource, COAP_MAX_RESOURCES);
   INIT_STORAGE(resattr, COAP_MAX_ATTRIBUTES);
 #endif /* COAP_SERVER_SUPPORT */
-#ifdef COAP_WITH_LIBTINYDTLS
+#if COAP_WITH_LIBTINYDTLS
   INIT_STORAGE(dtls, COAP_MAX_DTLS_SESSIONS);
 #endif
   INIT_STORAGE(session, COAP_MAX_SESSIONS);
@@ -384,7 +384,7 @@ get_container(coap_memory_tag_t type) {
   case COAP_RESOURCEATTR:
     return &resattr_storage;
 #endif /* COAP_SERVER_SUPPORT */
-#ifdef COAP_WITH_LIBTINYDTLS
+#if COAP_WITH_LIBTINYDTLS
   case COAP_DTLS_SESSION:
     return &dtls_storage;
 #endif

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -603,7 +603,7 @@ coap_context_set_shutdown_no_observe(coap_context_t *context) {
 
 int
 coap_context_get_coap_fd(const coap_context_t *context) {
-#ifdef COAP_EPOLL_SUPPORT
+#if COAP_EPOLL_SUPPORT
   return context->epfd;
 #else /* ! COAP_EPOLL_SUPPORT */
   (void)context;
@@ -613,7 +613,7 @@ coap_context_get_coap_fd(const coap_context_t *context) {
 
 int
 coap_epoll_is_supported(void) {
-#ifdef COAP_EPOLL_SUPPORT
+#if COAP_EPOLL_SUPPORT
   return 1;
 #else /* ! COAP_EPOLL_SUPPORT */
   return 0;
@@ -622,7 +622,7 @@ coap_epoll_is_supported(void) {
 
 int
 coap_threadsafe_is_supported(void) {
-#ifdef COAP_THREAD_SAFE
+#if COAP_THREAD_SAFE
   return 1;
 #else /* ! COAP_THREAD_SAFE */
   return 0;
@@ -631,7 +631,7 @@ coap_threadsafe_is_supported(void) {
 
 int
 coap_ipv4_is_supported(void) {
-#ifdef COAP_IPV4_SUPPORT
+#if COAP_IPV4_SUPPORT
   return 1;
 #else /* ! COAP_IPV4_SUPPORT */
   return 0;
@@ -640,7 +640,7 @@ coap_ipv4_is_supported(void) {
 
 int
 coap_ipv6_is_supported(void) {
-#ifdef COAP_IPV6_SUPPORT
+#if COAP_IPV6_SUPPORT
   return 1;
 #else /* ! COAP_IPV6_SUPPORT */
   return 0;
@@ -649,7 +649,7 @@ coap_ipv6_is_supported(void) {
 
 int
 coap_client_is_supported(void) {
-#ifdef COAP_CLIENT_SUPPORT
+#if COAP_CLIENT_SUPPORT
   return 1;
 #else /* ! COAP_CLIENT_SUPPORT */
   return 0;
@@ -658,7 +658,7 @@ coap_client_is_supported(void) {
 
 int
 coap_server_is_supported(void) {
-#ifdef COAP_SERVER_SUPPORT
+#if COAP_SERVER_SUPPORT
   return 1;
 #else /* ! COAP_SERVER_SUPPORT */
   return 0;
@@ -667,7 +667,7 @@ coap_server_is_supported(void) {
 
 int
 coap_af_unix_is_supported(void) {
-#ifdef COAP_AF_UNIX_SUPPORT
+#if COAP_AF_UNIX_SUPPORT
   return 1;
 #else /* ! COAP_AF_UNIX_SUPPORT */
   return 0;

--- a/src/coap_notls.c
+++ b/src/coap_notls.c
@@ -17,7 +17,7 @@
 
 #include "coap3/coap_libcoap_build.h"
 
-#if !defined(COAP_WITH_LIBOPENSSL)
+#if ! COAP_WITH_LIBOPENSSL
 int
 coap_tls_engine_configure(coap_str_const_t *conf_mem) {
   (void)conf_mem;
@@ -30,7 +30,7 @@ coap_tls_engine_remove(void) {
 }
 #endif /* ! COAP_WITH_LIBOPENSSL */
 
-#if !defined(COAP_WITH_LIBTINYDTLS) && !defined(COAP_WITH_LIBOPENSSL) && !defined(COAP_WITH_LIBWOLFSSL) && !defined(COAP_WITH_LIBGNUTLS) && !defined(COAP_WITH_LIBMBEDTLS)
+#if ! COAP_WITH_LIBTINYDTLS && ! COAP_WITH_LIBOPENSSL && ! COAP_WITH_LIBWOLFSSL && ! COAP_WITH_LIBGNUTLS && ! COAP_WITH_LIBMBEDTLS
 
 int
 coap_dtls_is_supported(void) {

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -17,7 +17,7 @@
 
 #include "coap3/coap_libcoap_build.h"
 
-#ifdef COAP_WITH_LIBOPENSSL
+#if COAP_WITH_LIBOPENSSL
 
 /*
  * OpenSSL 1.1.0 has support for making decisions during receipt of
@@ -4634,7 +4634,7 @@ coap_crypto_hmac(cose_hmac_alg_t hmac_alg,
 
 #endif /* COAP_OSCORE_SUPPORT */
 
-#else /* !COAP_WITH_LIBOPENSSL */
+#else /* ! COAP_WITH_LIBOPENSSL */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -4646,4 +4646,4 @@ static inline void
 dummy(void) {
 }
 
-#endif /* COAP_WITH_LIBOPENSSL */
+#endif /* ! COAP_WITH_LIBOPENSSL */

--- a/src/coap_sha1.c
+++ b/src/coap_sha1.c
@@ -70,7 +70,7 @@
 
 #include "coap3/coap_libcoap_build.h"
 
-#if COAP_WS_SUPPORT && !defined(COAP_WITH_LIBOPENSSL) && !defined(COAP_WITH_LIBGNUTLS) && !defined(COAP_WITH_LIBMBEDTLS) && !defined(COAP_WITH_LIBWOLFSSL)
+#if COAP_WS_SUPPORT && ! COAP_WITH_LIBOPENSSL && ! COAP_WITH_LIBGNUTLS && ! COAP_WITH_LIBMBEDTLS && ! COAP_WITH_LIBWOLFSSL
 /*
  *  Define the SHA1 circular left shift macro
  */
@@ -396,4 +396,4 @@ SHA1PadMessage(SHA1Context *context) {
 
   SHA1ProcessMessageBlock(context);
 }
-#endif /* COAP_WS_SUPPORT && !defined(COAP_WITH_LIBOPENSSL) && !defined(COAP_WITH_LIBGNUTLS) && !defined(COAP_WITH_LIBMBEDTLS) */
+#endif /* COAP_WS_SUPPORT && ! COAP_WITH_LIBOPENSSL && ! COAP_WITH_LIBGNUTLS && ! COAP_WITH_LIBMBEDTLS */

--- a/src/coap_strm_contiki.c
+++ b/src/coap_strm_contiki.c
@@ -15,6 +15,9 @@
  */
 
 #include "coap3/coap_libcoap_build.h"
+
+#if defined(WITH_CONTIKI)
+
 #include "contiki-net.h"
 
 int
@@ -105,3 +108,17 @@ coap_socket_strm_close(coap_socket_t *sock) {
 }
 
 #endif /* ! COAP_DISABLE_TCP */
+
+#else /* ! WITH_CONTIKI */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! WITH_CONTIKI */

--- a/src/coap_strm_lwip.c
+++ b/src/coap_strm_lwip.c
@@ -15,6 +15,9 @@
  */
 
 #include "coap3/coap_libcoap_build.h"
+
+#if defined(WITH_LWIP)
+
 #include <lwip/timeouts.h>
 #include <lwip/tcpip.h>
 
@@ -331,3 +334,17 @@ coap_socket_strm_close(coap_socket_t *sock) {
   return;
 }
 #endif /* !COAP_DISABLE_TCP */
+
+#else /* ! WITH_LWIP */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! WITH_LWIP */

--- a/src/coap_strm_posix.c
+++ b/src/coap_strm_posix.c
@@ -16,6 +16,8 @@
 
 #include "coap3/coap_libcoap_build.h"
 
+#if ! defined(WITH_LWIP) && ! defined(WITH_CONTIKI) && ! defined (RIOT_VERSION)
+
 #if COAP_AF_UNIX_SUPPORT
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -471,3 +473,17 @@ coap_socket_strm_close(coap_socket_t *sock) {
 }
 
 #endif /* !COAP_DISABLE_TCP */
+
+#else /* WITH_LWIP || WITH_CONTIKI || RIOT_VERSION */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* WITH_LWIP || WITH_CONTIKI || RIOT_VERSION */

--- a/src/coap_strm_riot.c
+++ b/src/coap_strm_riot.c
@@ -15,6 +15,8 @@
 
 #include "coap3/coap_libcoap_build.h"
 
+#if defined(RIOT_VERSION)
+
 #include "net/gnrc.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/netreg.h"
@@ -326,3 +328,17 @@ coap_socket_strm_close(coap_socket_t *sock) {
 }
 
 #endif /* ! COAP_DISABLE_TCP */
+
+#else /* ! RIOT_VERSION */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! RIOT_VERSION */

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -17,7 +17,7 @@
 
 #include "coap3/coap_libcoap_build.h"
 
-#ifdef COAP_WITH_LIBTINYDTLS
+#if COAP_WITH_LIBTINYDTLS
 
 /* We want TinyDTLS versions of these, not libcoap versions */
 #undef PACKAGE_BUGREPORT
@@ -1929,7 +1929,7 @@ coap_crypto_hmac(cose_hmac_alg_t hmac_alg, coap_bin_const_t *key,
 
 #endif /* COAP_OSCORE_SUPPORT */
 
-#else /* !COAP_WITH_LIBTINYDTLS */
+#else /* ! COAP_WITH_LIBTINYDTLS */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -1941,4 +1941,4 @@ static inline void
 dummy(void) {
 }
 
-#endif /* COAP_WITH_LIBTINYDTLS */
+#endif /* ! COAP_WITH_LIBTINYDTLS */

--- a/src/coap_wolfssl.c
+++ b/src/coap_wolfssl.c
@@ -18,7 +18,7 @@
 
 #include "coap3/coap_libcoap_build.h"
 
-#ifdef COAP_WITH_LIBWOLFSSL
+#if COAP_WITH_LIBWOLFSSL
 
 /*
  * Implemented using wolfSSL's OpenSSL compatibility layer based on coap_openssl.c.
@@ -3263,7 +3263,7 @@ coap_crypto_hmac(cose_hmac_alg_t hmac_alg,
 
 #endif /* COAP_OSCORE_SUPPORT */
 
-#else /* !COAP_WITH_LIBWOLFSSL */
+#else /* ! COAP_WITH_LIBWOLFSSL */
 
 #ifdef __clang__
 /* Make compilers happy that do not like empty modules. As this function is
@@ -3275,4 +3275,4 @@ static inline void
 dummy(void) {
 }
 
-#endif /* COAP_WITH_LIBWOLFSSL */
+#endif /* ! COAP_WITH_LIBWOLFSSL */

--- a/src/oscore/oscore.c
+++ b/src/oscore/oscore.c
@@ -46,6 +46,8 @@
 
 #include "coap3/coap_libcoap_build.h"
 
+#if COAP_OSCORE_SUPPORT
+
 /* oscore_cs_params
  * returns cbor array [[param_type], [paramtype, param]]
  */
@@ -455,3 +457,17 @@ oscore_roll_back_seq(oscore_recipient_ctx_t *ctx) {
     ctx->rollback_last_seq = 0;
   }
 }
+
+#else /* ! COAP_OSCORE_SUPPORT */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! COAP_OSCORE_SUPPORT */

--- a/src/oscore/oscore_cbor.c
+++ b/src/oscore/oscore_cbor.c
@@ -45,6 +45,9 @@
  */
 
 #include "coap3/coap_libcoap_build.h"
+
+#if COAP_OSCORE_SUPPORT
+
 #include <string.h>
 
 static void
@@ -427,3 +430,17 @@ oscore_cbor_strip_value(const uint8_t **data, size_t *buf_len, uint8_t **result,
   *len = size;
   return 0;
 }
+
+#else /* ! COAP_OSCORE_SUPPORT */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! COAP_OSCORE_SUPPORT */

--- a/src/oscore/oscore_context.c
+++ b/src/oscore/oscore_context.c
@@ -45,6 +45,8 @@
 
 #include "coap3/coap_libcoap_build.h"
 
+#if COAP_OSCORE_SUPPORT
+
 #include <stdio.h>
 
 static void oscore_enter_context(coap_context_t *c_context,
@@ -778,3 +780,17 @@ oscore_delete_server_associations(coap_session_t *session) {
     session->associations = NULL;
   }
 }
+
+#else /* ! COAP_OSCORE_SUPPORT */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! COAP_OSCORE_SUPPORT */

--- a/src/oscore/oscore_cose.c
+++ b/src/oscore/oscore_cose.c
@@ -44,6 +44,9 @@
  */
 
 #include "coap3/coap_libcoap_build.h"
+
+#if COAP_OSCORE_SUPPORT
+
 #include "stdio.h"
 
 struct cose_curve_desc {
@@ -496,3 +499,17 @@ cose_encrypt0_decrypt(cose_encrypt0_t *ptr,
   ret_len = (int)max_result_len;
   return ret_len;
 }
+
+#else /* ! COAP_OSCORE_SUPPORT */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! COAP_OSCORE_SUPPORT */

--- a/src/oscore/oscore_crypto.c
+++ b/src/oscore/oscore_crypto.c
@@ -45,6 +45,9 @@
  */
 
 #include "coap3/coap_libcoap_build.h"
+
+#if COAP_OSCORE_SUPPORT
+
 #include <string.h>
 
 #include <stdio.h>
@@ -171,3 +174,17 @@ oscore_hkdf(cose_hkdf_alg_t hkdf_alg,
   coap_delete_bin_const(hkdf_extract);
   return ret;
 }
+
+#else /* ! COAP_OSCORE_SUPPORT */
+
+#ifdef __clang__
+/* Make compilers happy that do not like empty modules. As this function is
+ * never used, we ignore -Wunused-function at the end of compiling this file
+ */
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+static inline void
+dummy(void) {
+}
+
+#endif /* ! COAP_OSCORE_SUPPORT */


### PR DESCRIPTION
For the libcoap COAP_ compile time options configured in coap_defines.h or coap_config.h make sure that #ifdef, #ifndef or defined() are not used and replaced with #if as appropriate so that if the COAP_ compile time option is defined as 0, the correct code gets built.

Add #if wrappers to source files that are platform specific or OSCORE.

Fixes #1754 and #1756 
