### PR TITLE
Fix Doxygen under Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -973,7 +973,7 @@ if(ENABLE_DOCS)
     # application
     add_custom_target(
       doc_doxygen ALL
-      COMMAND ${DOXYGEN_EXECUTABLE} -u > /dev/null 2>&1
+      COMMAND ${DOXYGEN_EXECUTABLE} -u > $<IF:$<PLATFORM_ID:Windows>,NUL,/dev/null> 2>&1
       COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       COMMENT "Generating API documentation with Doxygen"


### PR DESCRIPTION
The CMakeLists.txt file calls Doxygen and redirects its output to `/dev/null` to suppress it. However, for Windows, you need to redirect it to `NUL:` otherwise, a build error will occur.
