### PR TITLE
LwIP: Add in support for disabling IPv4 or IPv6

### DIFF
--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -30,13 +30,9 @@ LDLIBS := $(shell if [ -f $(libcoap_dir)/config.log ] ; then \
 all: lwip \
      check-version \
      check-tinydtls \
-     lib-server \
      server \
-     lib-client \
      client \
-     lib-server-dtls \
      server-dtls \
-     lib-client-dtls \
      client-dtls
 
 lwip:
@@ -223,18 +219,18 @@ SD_OBJS = ${SD_APP_OBJ} ${SD_LWIP_OBJ} ${SD_COAP_OBJ} ${SD_DTLS_OBJ}
 
 ${SN_OBJS} ${SD_OBJS}: server-coap.h
 
-server: ${SN_OBJS}
+server: lib-server ${SN_OBJS}
 	$(CC) $(CFLAGS) ${SN_OBJS} -o server ${LDLIBS}
 
-server-dtls: ${SD_OBJS}
+server-dtls: lib-server-dtls ${SD_OBJS}
 	$(CC) $(CFLAGS) ${SD_OBJS} -o server-dtls ${LDLIBS}
 
 ${CN_OBJS} ${CD_OBJS}: client-coap.h
 
-client: ${CN_OBJS}
+client: lib-client ${CN_OBJS}
 	$(CC) $(CFLAGS) ${CN_OBJS} -o client ${LDLIBS}
 
-client-dtls: ${CD_OBJS}
+client-dtls:  lib-client-dtls ${CD_OBJS}
 	$(CC) $(CFLAGS) ${CD_OBJS} -o client-dtls ${LDLIBS}
 
 lib-server:

--- a/examples/lwip/README
+++ b/examples/lwip/README
@@ -77,3 +77,7 @@ The client supports an optional parameter which is the CoAP URI to connect to
 is "coap://libcoap.net/" for client and client-dtls.
 Using "coaps://libcoap.net" will establish a DTLS session if there is
 DTLS support compiled in (client-dtls).
+
+Note: PRECONFIGURED_TAPIF=tap0 environment variable may need to be set if building for IPv6 only.
+
+Note: Use of TinyDTLS requires both IPv4 and IPv6 to be set.

--- a/examples/lwip/client.c
+++ b/examples/lwip/client.c
@@ -112,14 +112,16 @@ main(int argc, char **argv) {
 
 #if LWIP_IPV4
   netif_add(&netif, &ipaddr, &netmask, &gw, NULL, tapif_init, ethernet_input);
-#endif /* LWIP_IPV4 */
+#else  /* ! LWIP_IPV4 */
+  netif_add(&netif, NULL, tapif_init, ethernet_input);
+#endif /* ! LWIP_IPV4 */
   netif.flags |= NETIF_FLAG_ETHARP;
   netif_set_default(&netif);
-  netif_set_up(&netif);
 #if LWIP_IPV6
   netif_create_ip6_linklocal_address(&netif, 1);
   netif_ip6_addr_set_state(&netif, 0, IP6_ADDR_PREFERRED);
 #endif
+  netif_set_up(&netif);
 
   /* start applications here */
 

--- a/examples/lwip/server.c
+++ b/examples/lwip/server.c
@@ -152,7 +152,7 @@ main(int argc, char **argv) {
 #if LWIP_IPV4
   printf("IP6 [%s]\n", ip6addr_ntoa(&netif.ip6_addr[0].u_addr.ip6));
 #else /* ! LWIP_IPV4 */
-  printf("IP6 [%s]\n", ip6addr_ntoa(&netif.ip6_addr[0].addr));
+  printf("IP6 [%s]\n", ip6addr_ntoa(&netif.ip6_addr[0]));
 #endif /* ! LWIP_IPV4 */
 #if LWIP_IPV6_MLD
   if (mld6_joingroup_netif(&netif, &v6group) == ERR_OK) {

--- a/src/coap_dgrm_lwip.c
+++ b/src/coap_dgrm_lwip.c
@@ -311,10 +311,10 @@ coap_socket_send(coap_socket_t *sock, coap_session_t *session,
     pbuf_free(pbuf);
     if (err < 0) {
       if (err == ERR_RTE) {
-        coap_log_warn("** %s: udp_send: Packet not routable\n",
+        coap_log_warn("** %s: udp_sendto: Packet not routable\n",
                       coap_session_str(session));
       } else {
-        coap_log_warn("** %s: udp_send: error %d\n",
+        coap_log_warn("** %s: udp_sendto: error %d\n",
                       coap_session_str(session), err);
       }
       return -1;

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -178,9 +178,9 @@ static uint32_t b_ipv4[COAP_BCST_CNT];
 
 int
 coap_is_bcast(const coap_address_t *a) {
+#if COAP_IPV4_SUPPORT
   int i;
   coap_tick_t now;
-#if COAP_IPV4_SUPPORT
   const ip4_addr_t *ipv4;
 #endif /* COAP_IPV4_SUPPORT */
 


### PR DESCRIPTION
Note that TinyDTLS needs both IPv4 and IPv6 if DTLS is going to be used.

PRECONFIGURED_TAPIF=tap0 environment variable may need to be set if IPv6 only.