### PR TITLE
Add CUnit autodetection to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,8 +909,11 @@ if(ENABLE_TESTS)
     ${CMAKE_CURRENT_LIST_DIR}/tests/test_wellknown.c
     ${CMAKE_CURRENT_LIST_DIR}/tests/test_wellknown.h)
   # tests require libcunit (e.g. debian libcunit1-dev)
+  find_package(CUnit REQUIRED)
   target_link_libraries(testdriver PUBLIC ${PROJECT_NAME}::${COAP_LIBRARY_NAME}
-                                          -lcunit)
+                                          cunit)
+  include(CTest)
+  add_test(NAME Tests COMMAND testdriver)
 endif()
 
 #

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ EXTRA_DIST = \
   cmake_coap_config.h.in \
   cmake_coap_defines.h.in \
   cmake/Config.cmake.in \
+  cmake/FindCUnit.cmake \
   cmake/FindMbedTLS.cmake \
   cmake/FindTinyDTLS.cmake \
   cmake/FindwolfSSL.cmake \

--- a/cmake/FindCUnit.cmake
+++ b/cmake/FindCUnit.cmake
@@ -1,0 +1,80 @@
+# FindCUnit.cmake
+# -----------------
+#
+# Find the CUnit library.
+#
+# Imported Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following `IMPORTED` targets:
+#
+# ``cunit``
+#   The CUnit library, if found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project:
+#
+# ``CUnit_FOUND``
+#   System has the CUnit library.
+# ``CUnit_INCLUDE_DIR``
+#   The CUnit include directory.
+# ``CUnit_LIBRARIES``
+#   All CUnit libraries.
+#
+# Hints
+# ^^^^^
+#
+# Set ``CUnit_ROOT_DIR`` to the root directory of a CUnit installation.
+
+find_path(CUnit_INCLUDE_DIR
+  NAMES CUnit/CUnit.h
+  PATH_SUFFIXES include
+  HINTS ${PROJECT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CUnit_ROOT_DIR}
+  )
+
+find_library(CUnit_LIBRARIES
+  NAMES cunit
+  PATH_SUFFIXES lib
+  HINTS ${PROJECT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CUnit_ROOT_DIR}
+  )
+
+if(CUnit_LIBRARIES)
+  set(CUnit_FOUND TRUE)
+else()
+  set(CUnit_FOUND FALSE)
+  set(error_message "CUnit not found. Set 'CUnit_ROOT_DIR' to the root directory of a CUnit installation.")
+  if(CUnit_FIND_REQUIRED)
+    message(FATAL_ERROR "${error_message}")
+  elseif(NOT CUDA_FIND_QUIETLY)
+    message(STATUS "${error_message}")
+  endif()
+endif()
+
+if(NOT TARGET cunit)
+  add_library(cunit
+    UNKNOWN
+    IMPORTED
+    )
+  set_target_properties(cunit PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CUnit_INCLUDE_DIR}"
+    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+    IMPORTED_LOCATION "${CUnit_LIBRARIES}"
+	)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CUnit DEFAULT_MSG
+  CUnit_INCLUDE_DIR
+  CUnit_LIBRARIES
+  )
+
+mark_as_advanced(
+  CUnit_INCLUDE_DIR
+  CUnit_LIBRARIES
+  )


### PR DESCRIPTION
Added a rules file for automatic detection of the [CUnit](https://cunit.sourceforge.net/) library, as well as support for running tests directly from CMake.

The CUnit tests run perfectly on both Windows and Debian.
