### PR TITLE
Q-Block: Support client with seeing every Q-Block instead of complete body

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -485,6 +485,25 @@ response_handler(coap_session_t *session COAP_UNUSED,
       }
       return COAP_RESPONSE_OK;
     }
+    /* Check if Q-Block2 option is set */
+    block_opt = coap_check_option(received, COAP_OPTION_Q_BLOCK2, &opt_iter);
+    if (!single_block_requested && block_opt) { /* handle Q-Block2 */
+
+      /* TODO: check if we are looking at the correct block number */
+      if (coap_opt_block_num(block_opt) == 0) {
+        /* See if observe is set in first response */
+        ready = doing_observe ? coap_check_option(received,
+                                                  COAP_OPTION_OBSERVE, &opt_iter) == NULL : 1;
+      }
+      if (COAP_OPT_BLOCK_MORE(block_opt)) {
+        doing_getting_block = 1;
+      } else {
+        doing_getting_block = 0;
+        if (!is_mcast)
+          track_flush_token(&token, 0);
+      }
+      return COAP_RESPONSE_OK;
+    }
   } else {      /* no 2.05 */
     /* check if an error was signaled and output payload if so */
     if (COAP_RESPONSE_CLASS(rcv_code) >= 4) {
@@ -538,7 +557,7 @@ usage(const char *program, const char *version) {
           "\t\t[-K interval] [-N] [-O num,text] [-P scheme://address[:port]\n"
           "\t\t[-S] [-T token] [-U] [-V num] [-X size]\n"
           "\t\t[[-d count]]\n"
-          "\t\t[[h match_hint_file] [-k key] [-u user] [-2]]\n"
+          "\t\t[[h match_hint_file] [-k key] [-u user] [-2] [-3]]\n"
           "\t\t[[-c certfile] [-j keyfile] [-n] [-C cafile]\n"
           "\t\t[-J pkcs11_pin] [-M raw_pk] [-R trust_casfile] [-Y]] URI\n"
           "\tURI can be an absolute URI or a URI prefixed with scheme and host\n\n"
@@ -593,7 +612,7 @@ usage(const char *program, const char *version) {
           "\t-K interval\tSend a ping after interval seconds of inactivity\n"
           "\t-L value\tSum of one or more COAP_BLOCK_* flag valuess for block\n"
           "\t       \t\thandling methods. Default is 1 (COAP_BLOCK_USE_LIBCOAP)\n"
-          "\t       \t\t(Sum of one or more of 1,2,4,8,16 and 32)\n"
+          "\t       \t\t(Sum of one or more of 1,2,4,8,16,32, and 512)\n"
           "\t-N     \t\tSend NON-confirmable message\n"
           "\t-O num,text\tAdd option num with contents text to request. If the\n"
           "\t       \t\ttext begins with 0x, then the hex text (two [0-9a-f] per\n"
@@ -636,6 +655,7 @@ usage(const char *program, const char *version) {
           "\t       \t\tbyte) is converted to binary data\n"
           "\t-u user\t\tUser identity to send for pre-shared key mode\n"
           "\t-2     \t\tUse EC-JPAKE negotiation (if supported)\n"
+          "\t-3     \t\tUse coap_send() instead of coap_send_recv()\n"
           "PKI Options (if supported by underlying (D)TLS library)\n"
           "\tNote: If any one of '-c certfile', '-j keyfile' or '-C cafile' is in\n"
           "\tPKCS11 URI naming format (pkcs11: prefix), then any remaining non\n"
@@ -1844,7 +1864,7 @@ main(int argc, char **argv) {
   size_t data_len = 0;
   coap_addr_info_t *info_list = NULL;
   uint8_t cid_every = 0;
-  coap_pdu_t *resp_pdu;
+  int use_coap_send = 0;
 #ifndef _WIN32
   struct sigaction sa;
 #endif
@@ -1860,7 +1880,7 @@ main(int argc, char **argv) {
   coap_startup();
 
   while ((opt = getopt(argc, argv,
-                       "a:b:c:d:e:f:h:j:k:l:m:no:p:q:rs:t:u:v:wx:y:zA:B:C:E:G:H:J:K:L:M:NO:P:R:ST:UV:X:Y2")) != -1) {
+                       "a:b:c:d:e:f:h:j:k:l:m:no:p:q:rs:t:u:v:wx:y:zA:B:C:E:G:H:J:K:L:M:NO:P:R:ST:UV:X:Y23")) != -1) {
     switch (opt) {
     case 'a':
       strncpy(node_str, optarg, NI_MAXHOST - 1);
@@ -2040,6 +2060,9 @@ main(int argc, char **argv) {
     case '2':
       ec_jpake = 1;
       break;
+    case '3':
+      use_coap_send = 1;
+      break;
     default:
       usage(argv[0], LIBCOAP_PACKAGE_VERSION);
       goto failed;
@@ -2211,53 +2234,62 @@ main(int argc, char **argv) {
   if (coap_get_log_level() < COAP_LOG_DEBUG)
     coap_show_pdu(COAP_LOG_INFO, pdu);
 
-  resp_pdu = NULL;
-  result = coap_send_recv(session, pdu, &resp_pdu, wait_ms);
-  if (result >= 0) {
-    if (response_handler(session, pdu, resp_pdu, coap_pdu_get_mid(resp_pdu))
-        != COAP_RESPONSE_OK) {
-      coap_log_err("Response PDU issue\n");
-    }
-    if (result < (int)wait_ms) {
-      wait_ms -= result;
-    } else {
-      wait_ms = 0;
+  if (use_coap_send) {
+    if (coap_send(session, pdu) == COAP_INVALID_MID) {
+      coap_log_err("cannot send CoAP pdu\n");
       quit = 1;
     }
   } else {
-    switch (result) {
-    case -1:
-      coap_log_info("coap_send_recv: Invalid timeout value %u\n", wait_ms);
-      break;
-    case -2:
-      coap_log_info("coap_send_recv: Failed to transmit PDU\n");
-      break;
-    case -3:
-      /* Nack / Event handler already reported issue */
-      break;
-    case -4:
-      coap_log_info("coap_send_recv: Internal coap_io_process() failed\n");
-      break;
-    case -5:
-      coap_log_info("coap_send_recv: No response received within the timeout\n");
-      break;
-    case -6:
-      coap_log_info("coap_send_recv: Terminated by user\n");
-      break;
-    case -7:
-      coap_log_info("coap_send_recv: Client Mode code not enabled\n");
-      break;
-    default:
-      coap_log_info("coap_send_recv: Invalid return value %d\n", result);
-      break;
-    }
-    quit = 1;
-  }
-  coap_delete_pdu(pdu);
-  coap_delete_pdu(resp_pdu);
+    coap_pdu_t *resp_pdu;
 
-  if (!is_mcast && !doing_observe && repeat_count == 1) {
-    quit = 1;
+    resp_pdu = NULL;
+    result = coap_send_recv(session, pdu, &resp_pdu, wait_ms);
+    if (result >= 0) {
+      if (response_handler(session, pdu, resp_pdu, coap_pdu_get_mid(resp_pdu))
+          != COAP_RESPONSE_OK) {
+        coap_log_err("Response PDU issue\n");
+      }
+      if (result < (int)wait_ms) {
+        wait_ms -= result;
+      } else {
+        wait_ms = 0;
+        quit = 1;
+      }
+    } else {
+      switch (result) {
+      case -1:
+        coap_log_info("coap_send_recv: Invalid timeout value %u\n", wait_ms);
+        break;
+      case -2:
+        coap_log_info("coap_send_recv: Failed to transmit PDU\n");
+        break;
+      case -3:
+        /* Nack / Event handler already reported issue */
+        break;
+      case -4:
+        coap_log_info("coap_send_recv: Internal coap_io_process() failed\n");
+        break;
+      case -5:
+        coap_log_info("coap_send_recv: No response received within the timeout\n");
+        break;
+      case -6:
+        coap_log_info("coap_send_recv: Terminated by user\n");
+        break;
+      case -7:
+        coap_log_info("coap_send_recv: Client Mode code not enabled\n");
+        break;
+      default:
+        coap_log_info("coap_send_recv: Invalid return value %d\n", result);
+        break;
+      }
+      quit = 1;
+    }
+    coap_delete_pdu(pdu);
+    coap_delete_pdu(resp_pdu);
+
+    if (!is_mcast && !doing_observe && repeat_count == 1) {
+      quit = 1;
+    }
   }
   repeat_count--;
 

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1584,7 +1584,7 @@ usage(const char *program, const char *version) {
           "\t       \t\tif the -A option is used\n"
           "\t-L value\tSum of one or more COAP_BLOCK_* flag valuess for block\n"
           "\t       \t\thandling methods. Default is 1 (COAP_BLOCK_USE_LIBCOAP)\n"
-          "\t       \t\t(Sum of one or more of 1,2,4 64, 128 and 256)\n"
+          "\t       \t\t(Sum of one or more of 1,2,4,64,128 and 256)\n"
           , program);
   fprintf(stderr,
           "\t-N     \t\tMake \"observe\" responses NON-confirmable. Even if set\n"

--- a/include/coap3/coap_block.h
+++ b/include/coap3/coap_block.h
@@ -72,6 +72,7 @@ typedef struct {
 #define COAP_BLOCK_NOT_RANDOM_BLOCK1 0x80 /* (svr)Disable server handling random order
                                              block1 */
 #define COAP_BLOCK_CACHE_RESPONSE 0x100 /* (svr)Cache CON request's response */
+#define COAP_BLOCK_Q_BLOCK_EVERY 0x200 /* (cl) Pass every Q-Block PDU to response handler */
 /* WARNING: Added defined values must not encroach into 0xff000000 which are defined elsewhere */
 
 /**

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -49,7 +49,8 @@ extern "C" {
                              COAP_BLOCK_STLESS_FETCH | \
                              COAP_BLOCK_STLESS_BLOCK2 | \
                              COAP_BLOCK_NOT_RANDOM_BLOCK1 | \
-                             COAP_BLOCK_CACHE_RESPONSE)
+                             COAP_BLOCK_CACHE_RESPONSE | \
+                             COAP_BLOCK_Q_BLOCK_EVERY)
 #else /* ! COAP_Q_BLOCK_SUPPORT */
 #define COAP_BLOCK_SET_MASK (COAP_BLOCK_USE_LIBCOAP | \
                              COAP_BLOCK_SINGLE_BODY | \

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -28,7 +28,7 @@ SYNOPSIS
               [*-P* scheme://addr[:port]] [*-S*] [*-T* token] [*-U*] [*-V* num]
               [*-X* size]
               [[*-d* value]]
-              [[*-h* match_hint_file] [*-k* key] [*-u* user] [*-2*]]
+              [[*-h* match_hint_file] [*-k* key] [*-u* user] [*-2*] [*-3*]]
               [[*-c* certfile] [*-j* keyfile] [*-n*] [*-C* cafile]
               [*-J* pkcs11_pin] [*-M* rpk_file] [*-R* trust_casfile] [*-Y*]] URI
 
@@ -171,15 +171,16 @@ OPTIONS - General
 
 *-L* value::
    Sum of one or more COAP_BLOCK_* flag values for different block handling
-   methods. Default is 1 (COAP_BLOCK_USE_LIBCOAP). This vlue can be set as a
+   methods. Default is 1 (COAP_BLOCK_USE_LIBCOAP). This value can be set as a
    hex value - e.g. 0x13.
 
-     COAP_BLOCK_USE_LIBCOAP         1
-     COAP_BLOCK_SINGLE_BODY         2
-     COAP_BLOCK_TRY_Q_BLOCK         4
-     COAP_BLOCK_USE_M_Q_BLOCK       8
-     COAP_BLOCK_NO_PREEMPTIVE_RTAG 16
-     COAP_BLOCK_STLESS_FETCH       32
+     COAP_BLOCK_USE_LIBCOAP         1       0x001
+     COAP_BLOCK_SINGLE_BODY         2       0x003
+     COAP_BLOCK_TRY_Q_BLOCK         4       0x004
+     COAP_BLOCK_USE_M_Q_BLOCK       8       0x008
+     COAP_BLOCK_NO_PREEMPTIVE_RTAG 16       0x010
+     COAP_BLOCK_STLESS_FETCH       32       0x020
+     COAP_BLOCK_Q_BLOCK_EVERY     512       0x200
 
 *-N* ::
    Send NON-confirmable message. If option *-N* is not specified, a
@@ -245,6 +246,9 @@ OPTIONS - PSK
 
 *-2* ::
    Use EC-JPAKE negotiation (if supported).
+
+*-3* ::
+   Use coap_send() instead of coap_send_recv() for testing.
 
 OPTIONS - PKI
 -------------

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -143,12 +143,12 @@ OPTIONS - General
    methods. Default is 1 (COAP_BLOCK_USE_LIBCOAP). This vlue can be set as a
    hex value - e.g. 0x103.
 
-     COAP_BLOCK_USE_LIBCOAP         1
-     COAP_BLOCK_SINGLE_BODY         2
-     COAP_BLOCK_TRY_Q_BLOCK         4
-     COAP_BLOCK_STLESS_BLOCK2      64
-     COAP_BLOCK_NOT_RANDOM_BLOCK1 128
-     COAP_BLOCK_CACHE_RESPONSE    256
+     COAP_BLOCK_USE_LIBCOAP         1       0x001
+     COAP_BLOCK_SINGLE_BODY         2       0x002
+     COAP_BLOCK_TRY_Q_BLOCK         4       0x004
+     COAP_BLOCK_STLESS_BLOCK2      64       0x040
+     COAP_BLOCK_NOT_RANDOM_BLOCK1 128       0x080
+     COAP_BLOCK_CACHE_RESPONSE    256       0x100
 
 *-N* ::
    Send NON-confirmable message for "observe" responses. If option *-N* is

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -160,6 +160,7 @@ session _block_mode_.
 #define COAP_BLOCK_STLESS_BLOCK2 0x40 /* (Server) Server is stateless for Block2 transfers */
 #define COAP_BLOCK_NOT_RANDOM_BLOCK1 0x80 /* (Server) Disable server handling random order block1 */
 #define COAP_BLOCK_CACHE_RESPONSE 0x100 /* (Server) Cache CON request's response */
+#define COAP_BLOCK_Q_BLOCK_EVERY 0x200 /* (Client) Pass every Q-Block PDU to response handler */
 ----
 _block_mode_ is an or'd set of zero or more COAP_BLOCK_* definitions.
 
@@ -185,7 +186,10 @@ is not for the final block, otherwise a COAP_RESPONSE_CODE_CREATED 2.01
 
 To indicate support for Q-Block-1 and Q-Block2, *COAP_BLOCK_TRY_Q_BLOCK* needs
 to be set on both the client and server.  *COAP_BLOCK_SINGLE_BODY* is assumed to
-be set if using Q-Block as the data will always be presented as a single body.
+be set if using Q-Block in the server as the data will always be presented as a
+single body. For the client, *COAP_BLOCK_Q_BLOCK_EVERY* needs to be explicitely
+set to receive the data for each packet, otherwise *COAP_BLOCK_SINGLE_BODY*
+is assumed to be set.
 If *COAP_BLOCK_USE_M_Q_BLOCK* is defined, then the 'M' bit version of recovery
 will be used if possible.
 
@@ -229,6 +233,10 @@ If *COAP_BLOCK_CACHE_RESPONSE* is set, then the server will cache the response
 for the latest unreliable CON request so that if the CON request is repeated,
 the cached response gets re-transmitted. If it is not set, then the response is
 sent as a separate response (empty ACK sent first) using CON.
+
+If *COAP_BLOCK_Q_BLOCK_EVERY* is set, Q-Block is in use and *COAP_BLOCK_SINGLE_BODY*
+is not set, then the client response handler will receive each Q-Block PDU
+instead of a single body with all the data.
 
 *Function: coap_context_set_max_block_size()*
 

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -1492,6 +1492,7 @@ coap_build_missing_pdu(coap_session_t *session, coap_lg_crcv_t *lg_crcv) {
   size_t len = coap_encode_var_safe8(buf, sizeof(token), token);
 
   memset(&drop_options, 0, sizeof(coap_opt_filter_t));
+  coap_option_filter_set(&drop_options, COAP_OPTION_Q_BLOCK1);
   coap_option_filter_set(&drop_options, COAP_OPTION_Q_BLOCK2);
   coap_option_filter_set(&drop_options, COAP_OPTION_OBSERVE);
   pdu = coap_pdu_duplicate_lkd(lg_crcv->sent_pdu, session, len, buf,
@@ -4117,7 +4118,8 @@ reinit:
         if (updated_block) {
           void *body_free;
 
-          if ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) || block.bert) {
+          if (!(session->block_mode & COAP_BLOCK_Q_BLOCK_EVERY) &&
+              ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) || block.bert)) {
             if (size2 < saved_offset + length) {
               size2 = saved_offset + length;
             }
@@ -4151,17 +4153,23 @@ reinit:
                                                         &lg_crcv->rec_blocks)) {
                     /* Need to ask for them individually */
                     coap_request_missing_q_block2(session, lg_crcv);
+                    if (session->block_mode & COAP_BLOCK_Q_BLOCK_EVERY)
+                      goto give_pdu_to_app;
                     goto skip_app_handler;
                   }
                 } else {
                   /* The remote end will be sending the next one unless this
                      is a MAX_PAYLOADS and all previous have been received */
+                  if (session->block_mode & COAP_BLOCK_Q_BLOCK_EVERY)
+                    goto give_pdu_to_app;
                   goto skip_app_handler;
                 }
                 if (COAP_PROTO_RELIABLE(session->proto) ||
-                    rcvd->type != COAP_MESSAGE_NON)
+                    rcvd->type != COAP_MESSAGE_NON) {
+                  if (session->block_mode & COAP_BLOCK_Q_BLOCK_EVERY)
+                    goto give_pdu_to_app;
                   goto skip_app_handler;
-
+                }
               } else
 #endif /* COAP_Q_BLOCK_SUPPORT */
                 block.m = 0;
@@ -4195,7 +4203,8 @@ reinit:
                 /* Session could now be disconnected, so no lg_crcv */
                 goto skip_app_handler;
             }
-            if ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) || block.bert)
+            if (!(session->block_mode & COAP_BLOCK_Q_BLOCK_EVERY) &&
+                ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) || block.bert))
               goto skip_app_handler;
 
             /* need to put back original token into rcvd */
@@ -4222,7 +4231,8 @@ reinit:
 #if COAP_Q_BLOCK_SUPPORT
 give_to_app:
 #endif /* COAP_Q_BLOCK_SUPPORT */
-          if ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) || block.bert) {
+          if (!(session->block_mode & COAP_BLOCK_Q_BLOCK_EVERY) &&
+              ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) || block.bert)) {
             /* Pretend that there is no block */
             coap_remove_option(rcvd, block_opt);
             if (lg_crcv->observe_set) {
@@ -4418,6 +4428,25 @@ skip_app_handler:
   if (!ack_rst_sent)
     coap_send_ack_lkd(session, rcvd);
   return 1;
+
+#if COAP_Q_BLOCK_SUPPORT
+give_pdu_to_app:
+  /* need to put back original token into rcvd */
+  if (!coap_binary_equal(&rcvd->actual_token, lg_crcv->app_token)) {
+    coap_update_token(rcvd, lg_crcv->app_token->length, lg_crcv->app_token->s);
+    coap_log_debug("Client app version of updated PDU (6)\n");
+    coap_show_pdu(COAP_LOG_DEBUG, rcvd);
+  }
+
+  if (sent) {
+    /* need to put back original token into sent */
+    if (lg_crcv->app_token)
+      coap_update_token(sent, lg_crcv->app_token->length,
+                        lg_crcv->app_token->s);
+  }
+  coap_call_response_handler(session, sent, rcvd, NULL);
+  return 1;
+#endif /* COAP_Q_BLOCK_SUPPORT */
 }
 #endif /* COAP_CLIENT_SUPPORT */
 

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4009,7 +4009,7 @@ skip_handler:
       /* No delays to response */
 #if COAP_Q_BLOCK_SUPPORT
       if (session->block_mode & COAP_BLOCK_USE_LIBCOAP &&
-          !lg_xmit_ctrl && response->code == COAP_RESPONSE_CODE(205) &&
+          !lg_xmit_ctrl && COAP_RESPONSE_CLASS(response->code) == 2 &&
           coap_get_block_b(session, response, COAP_OPTION_Q_BLOCK2, &block) &&
           block.m) {
         if (coap_send_q_block2(session, resource, query, pdu->code, block,


### PR DESCRIPTION
Addresses #1758.  This supports clients processing every Q-Block packet which is done by setting COAP_BLOCK_Q_BLOCK_EVERY  in the block_mode which overrides the implicit setting of COAP_BLOCK_SINGLE_BODY.

Note that using coap_send_recv() as opposed to coap_send() in the client, this separately implicitly sets COAP_BLOCK_SINGLE_BODY, which will override COAP_BLOCK_Q_BLOCK_EVERY.

