### PR TITLE
Fix compiler warnings

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1715,7 +1715,7 @@ do_call_home(coap_context_t *ctx) {
   coap_str_const_t server;
   uint16_t port;
   coap_addr_info_t *info_list = NULL;
-  coap_session_t *session;
+  coap_session_t *session = NULL;
 
   server = call_home_uri.host;
   port = call_home_uri.port;

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -2503,6 +2503,7 @@ tls_verify_call_back(int preverify_ok, X509_STORE_CTX *ctx) {
     if (base_buf) {
       /* base_buf2 gets moved to the end */
       assert(i2d_X509(x509, &base_buf2) > 0);
+      (void)base_buf2;
       coap_lock_callback_ret(ret,
                              setup_data->validate_cn_call_back(cn, base_buf, length, session,
                                                                depth, preverify_ok,


### PR DESCRIPTION
Fixed warnings of unused variable (for Release build) and possible use of initialized variable (for not so smart compilers).
