### PR TITLE
Switch the CMake TinyDTLS build to the native way

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,21 +108,21 @@ set(DTLS_BACKEND
       STRING
       "\
 Name of the dtls backend, only relevant if `ENABLE_DTLS` is ON which is default. \
-Possible values: default, gnutls, openssl, wolfssl, tinydtls and mbedtls. \
+Possible values: default, gnutls, openssl, wolfssl, mbedtls and tinydtls. \
 If specified then this library will be searched and if found also used. \
 If not found then the cmake configuration will stop with an error. \
 If not specified, then cmake will try to use the first one found in the following order: \
-gnutls, openssl, wolfssl, tinydtls, mbedtls \
+gnutls, openssl, wolfssl, mbedtls, tinydtls \
     ")
 set_property(
   CACHE DTLS_BACKEND
   PROPERTY STRINGS
            default
+           gnutls
            openssl
            wolfssl
-           gnutls
-           tinydtls
-           mbedtls)
+           mbedtls
+           tinydtls)
 option(
   USE_VENDORED_TINYDTLS
   "compile with the tinydtls project in the submodule if on, otherwise try to find the compiled lib with find_package"
@@ -460,213 +460,95 @@ set(WITH_TINYDTLS OFF)
 set(WITH_MBEDTLS OFF)
 set(WITH_WOLFSSL OFF)
 
-function(compile_tinydtls)
-  set(TINYDTLS_SOURCES_DIR ${CMAKE_CURRENT_LIST_DIR}/ext/tinydtls)
-  set(TINYDTLS_SOURCES_GENERATED ${TINYDTLS_SOURCES_DIR}/dtls_config.h)
-
-  message(STATUS "compiling the tinydtls lib")
-
-  include(ExternalProject)
-
-  externalproject_add(
-    external_tinydtls
-    SOURCE_DIR "${TINYDTLS_SOURCES_DIR}"
-    BUILD_IN_SOURCE 1
-    DOWNLOAD_COMMAND ""
-    UPDATE_COMMAND ""
-    CONFIGURE_COMMAND
-      ${TINYDTLS_SOURCES_DIR}/configure
-      --disable-manpages
-      --prefix=${CMAKE_BINARY_DIR}
-    BUILD_COMMAND make install
-    INSTALL_COMMAND ""
-    LOG_DOWNLOAD 1
-    LOG_CONFIGURE 1)
-
-  externalproject_add_step(
-    external_tinydtls autoreconf
-    COMMAND ./autogen.sh
-    ALWAYS 1
-    WORKING_DIRECTORY "${TINYDTLS_SOURCES_DIR}"
-    DEPENDERS configure
-    DEPENDEES download)
-
-  # Let cmake know that it needs to execute the external_tinydtls target to generate those files.
-  add_custom_command(
-    OUTPUT ${TINYDTLS_SOURCES_GENERATED}
-    WORKING_DIRECTORY "${TINYDTLS_SOURCES_DIR}"
-    COMMAND "make install"
-    DEPENDS external_tinydtls)
-
-  add_dependencies(${COAP_LIBRARY_NAME} external_tinydtls)
-
-  if(BUILD_SHARED_LIBS)
-    set(LIBTINYDTLS_PATH "${CMAKE_CURRENT_BINARY_DIR}/lib/libtinydtls.so")
-  else()
-    set(LIBTINYDTLS_PATH "${CMAKE_CURRENT_BINARY_DIR}/lib/libtinydtls.a")
-  endif()
-
-  add_library(
-    tinydtls
-    UNKNOWN
-    IMPORTED)
-  set_target_properties(
-    tinydtls
-    PROPERTIES "${CMAKE_CURRENT_BINARY_DIR}/include"
-               INTERFACE_INCLUDE_DIRECTORIES
-               IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-               IMPORTED_LOCATION "${LIBTINYDTLS_PATH}")
-
-endfunction()
-
 if(ENABLE_DTLS)
   message(STATUS "compiling with DTLS support")
   message(STATUS "DTLS_BACKEND: ${DTLS_BACKEND}")
 
-  if(DTLS_BACKEND
-     STREQUAL
-     "default")
+  set(DTLS_FOUND OFF)
+  if(DTLS_BACKEND STREQUAL "default")
     # try to find a crypto lib and use it, use the first one found
+    set(DTLS_REQUIRED "")
+  else()
+    set(DTLS_REQUIRED REQUIRED)
+  endif()
 
+  if((DTLS_BACKEND STREQUAL "gnutls") OR ((DTLS_BACKEND STREQUAL "default") AND (NOT DTLS_FOUND)))
     # libgnutls (e.g. debian libgnutls28-dev)
-    find_package(GnuTLS)
+    find_package(GnuTLS ${DTLS_REQUIRED})
     if(GnuTLS_FOUND)
       set(WITH_GNUTLS ON)
       message(STATUS "compiling with gnutls support")
       set(COAP_WITH_LIBGNUTLS 1)
-    else()
-      # gnutls not found
-      find_package(OpenSSL)
-      if(OpenSSL_FOUND)
-        set(WITH_OPENSSL ON)
-        message(STATUS "compiling with openssl support")
-        set(COAP_WITH_LIBOPENSSL 1)
-      else()
-        # openssl not found
-        # wolfSSL
-        find_package(wolfSSL)
-        if(wolfSSL_FOUND)
-          set(WITH_WOLFSSL ON)
-          message(STATUS "compiling with wolfssl support")
-          set(COAP_WITH_LIBWOLFSSL 1)
-        else()
-          # wolfssl not found
-          # libmbedtls (e.g. debian libmbedtls-dev)
-          find_package(MbedTLS)
-          if(MbedTLS_FOUND)
-            set(WITH_MBEDTLS ON)
-            message(STATUS "compiling with mbedtls support")
-            set(COAP_WITH_LIBMBEDTLS 1)
-          else()
-            # mbedtls not found
-            if(USE_VENDORED_TINYDTLS)
-              compile_tinydtls()
-            else()
-              find_package(TinyDTLS)
-              if(TINYDTLS_FOUND)
-
-              else()
-                # no cryto lib found
-                message(
-                  FATAL_ERROR
-                    "cannot find any cryto lib, either install one or compile without DTLS support"
-                )
-              endif()
-
-            endif()
-
-            set(WITH_TINYDTLS ON)
-            message(STATUS "compiling with tinydtls support")
-            set(COAP_WITH_LIBTINYDTLS 1)
-
-          endif()
-
-        endif()
-
-      endif()
-
+      set(DTLS_FOUND ON)
     endif()
+  endif()
 
-  else()
-    # DTLS_BACKEND variable is not empty, so set all to false and set the only right to true
-    set(WITH_GNUTLS OFF)
-    set(WITH_TINYDTLS OFF)
-    set(WITH_MBEDTLS OFF)
-    set(WITH_OPENSSL OFF)
-    set(WITH_WOLFSSL OFF)
-
-    if(DTLS_BACKEND
-       STREQUAL
-       "gnutls")
-      # libgnutls (e.g. debian libgnutls28-dev)
-      find_package(GnuTLS REQUIRED)
-      set(WITH_GNUTLS ON)
-      message(STATUS "compiling with gnutls support")
-      set(COAP_WITH_LIBGNUTLS 1)
-    endif()
-
-    if(DTLS_BACKEND
-       STREQUAL
-       "openssl")
-      # libssl (e.g. debian libssl1.0-dev)
-      find_package(OpenSSL REQUIRED)
+  if((DTLS_BACKEND STREQUAL "openssl") OR ((DTLS_BACKEND STREQUAL "default") AND (NOT DTLS_FOUND)))
+    # libssl (e.g. debian libssl1.0-dev)
+    find_package(OpenSSL ${DTLS_REQUIRED})
+    if(OpenSSL_FOUND)
       set(WITH_OPENSSL ON)
       message(STATUS "compiling with openssl support")
       set(COAP_WITH_LIBOPENSSL 1)
+      set(DTLS_FOUND ON)
     endif()
+  endif()
 
-    if(DTLS_BACKEND
-        STREQUAL
-        "wolfssl")
-      find_package(wolfSSL REQUIRED)
+  if((DTLS_BACKEND STREQUAL "wolfssl") OR ((DTLS_BACKEND STREQUAL "default") AND (NOT DTLS_FOUND)))
+    # wolfSSL
+    find_package(wolfssl ${DTLS_REQUIRED})
+    if(wolfssl_FOUND)
       set(WITH_WOLFSSL ON)
       message(STATUS "compiling with wolfssl support")
       set(COAP_WITH_LIBWOLFSSL 1)
+      set(DTLS_FOUND ON)
     endif()
+  endif()
 
-    if(DTLS_BACKEND
-       STREQUAL
-       "mbedtls")
-      # libmbedtls (e.g. debian libmbedtls-dev)
-      find_package(MbedTLS REQUIRED)
+  if((DTLS_BACKEND STREQUAL "mbedtls") OR ((DTLS_BACKEND STREQUAL "default") AND (NOT DTLS_FOUND)))
+    # libmbedtls (e.g. debian libmbedtls-dev)
+    find_package(MbedTLS ${DTLS_REQUIRED})
+    if(MbedTLS_FOUND)
       set(WITH_MBEDTLS ON)
       message(STATUS "compiling with mbedtls support")
       set(COAP_WITH_LIBMBEDTLS 1)
+      set(DTLS_FOUND ON)
     endif()
-
-    if(DTLS_BACKEND
-       STREQUAL
-       "tinydtls")
-
-      if(USE_VENDORED_TINYDTLS)
-        compile_tinydtls()
-      else(USE_VENDORED_TINYDTLS)
-        find_package(TinyDTLS REQUIRED)
-      endif(USE_VENDORED_TINYDTLS)
-
-      message(STATUS "compiling with tinydtls support")
-      set(WITH_TINYDTLS ON)
-      set(COAP_WITH_LIBTINYDTLS 1)
-
-    endif()
-
   endif()
 
-endif()
-
-if(WITH_WOLFSSL)
-  if(NOT ZEPHYR_BASE)
-    find_library(WOLFSSL_LIBRARY wolfssl HINTS /usr/local/lib)
-    find_path(WOLFSSL_INCLUDE_DIR wolfssl/wolfcrypt/settings.h HINTS /usr/local/include)
-    if(WOLFSSL_LIBRARY AND WOLFSSL_INCLUDE_DIR)
-      message(STATUS "compiling with wolfssl support")
+  if((DTLS_BACKEND STREQUAL "tinydtls") OR ((DTLS_BACKEND STREQUAL "default") AND (NOT DTLS_FOUND)))
+    if(USE_VENDORED_TINYDTLS)
+      message(STATUS "compiling the tinydtls lib")
+      add_subdirectory("ext/tinydtls")
+      set_target_properties(
+        tinydtls
+        PROPERTIES
+          # for #include <tinydtls/tinydtls.h>; #include "dtls_config.h"; #include "tinydtls.h"
+          INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/ext;${tinydtls_BINARY_DIR};${tinydtls_SOURCE_DIR}"
+          IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+          IMPORTED_LOCATION "${tinydtls_BINARY_DIR}")
+      add_library(TinyDTLS::tinydtls ALIAS tinydtls)
+      set(TinyDTLS_FOUND TRUE)
+      get_target_property(TinyDTLS_VERSION tinydtls VERSION)
     else()
-      message(FATAL_ERROR "WolfSSL not found")
+      find_package(TinyDTLS ${DTLS_REQUIRED})
     endif()
-  else()
-    # Zephyr handles wolfSSL configuration via zephyr/CMakeLists.txt
-    message(STATUS "compiling with wolfssl support (Zephyr)")
+    if(TinyDTLS_FOUND)
+      set(WITH_TINYDTLS ON)
+      message(STATUS "compiling with tinydtls support")
+      set(COAP_WITH_LIBTINYDTLS 1)
+      set(DTLS_FOUND ON)
+    endif()
   endif()
+
+  if((DTLS_BACKEND STREQUAL "default") AND (NOT DTLS_FOUND))
+    # no cryto lib found
+    message(
+      FATAL_ERROR
+      "cannot find any cryto lib, either install one or compile without DTLS support"
+    )
+  endif()
+
 endif()
 
 execute_process(COMMAND git describe --tags --dirty --always
@@ -847,23 +729,16 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include/>
          $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include/>
-         $<INSTALL_INTERFACE:include/>
-         $<BUILD_INTERFACE:$<$<AND:$<BOOL:${COAP_WITH_LIBTINYDTLS}>,$<BOOL:${USE_VENDORED_TINYDTLS}>>:${CMAKE_BINARY_DIR}/include/tinydtls>>
-         $<$<BOOL:${COAP_WITH_LIBGNUTLS}>:${GNUTLS_INCLUDE_DIR}>
-         $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:${MBEDTLS_INCLUDE_DIRS}>
-         $<$<BOOL:${COAP_WITH_LIBWOLFSSL}>:${WOLFSSL_INCLUDE_DIR}>)
+         $<INSTALL_INTERFACE:include/>)
 target_link_libraries(
   ${COAP_LIBRARY_NAME}
   PUBLIC $<$<BOOL:${COAP_WITH_LIBOPENSSL}>:OpenSSL::SSL>
-         $<$<BOOL:${COAP_WITH_LIBOPENSSL}>:OpenSSL::Crypto>
-         $<$<BOOL:${COAP_WITH_LIBGNUTLS}>:${GNUTLS_LIBRARIES}>
-         $<$<BOOL:${COAP_WITH_LIBTINYDTLS}>:tinydtls>
-         $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:${MBEDTLS_LIBRARY}>
-         $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:${MBEDX509_LIBRARY}>
-         $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:${MBEDCRYPTO_LIBRARY}>
-         $<$<BOOL:${COAP_WITH_LIBWOLFSSL}>:${WOLFSSL_LIBRARY}>
-         $<$<BOOL:${MINGW}>:ws2_32>
-         $<$<BOOL:${MINGW}>:iphlpapi>)
+         $<$<BOOL:${COAP_WITH_LIBGNUTLS}>:GnuTLS::GnuTLS>
+         $<$<BOOL:${COAP_WITH_LIBTINYDTLS}>:TinyDTLS::tinydtls>
+         $<$<BOOL:${COAP_WITH_LIBMBEDTLS}>:MbedTLS::mbedtls>
+         $<$<BOOL:${COAP_WITH_LIBWOLFSSL}>:wolfssl::wolfssl>
+         $<$<BOOL:${WIN32}>:ws2_32>
+         $<$<BOOL:${WIN32}>:iphlpapi>)
 
 target_compile_options(
   ${COAP_LIBRARY_NAME}
@@ -912,7 +787,7 @@ if(ENABLE_TESTS)
   # tests require libcunit (e.g. debian libcunit1-dev)
   find_package(CUnit REQUIRED)
   target_link_libraries(testdriver PUBLIC ${PROJECT_NAME}::${COAP_LIBRARY_NAME}
-                                          cunit)
+                                          CUnit::cunit)
   include(CTest)
   add_test(NAME Tests COMMAND testdriver)
 endif()

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,7 @@ EXTRA_DIST = \
   cmake/FindCUnit.cmake \
   cmake/FindMbedTLS.cmake \
   cmake/FindTinyDTLS.cmake \
-  cmake/FindwolfSSL.cmake \
+  cmake/Findwolfssl.cmake \
   coap_config.h.contiki \
   coap_config.h.riot \
   coap_config.h.windows \

--- a/cmake/FindCUnit.cmake
+++ b/cmake/FindCUnit.cmake
@@ -1,14 +1,14 @@
-# FindCUnit.cmake
-# -----------------
+# FindCUnit
+# ---------
 #
 # Find the CUnit library.
 #
 # Imported Targets
 # ^^^^^^^^^^^^^^^^
 #
-# This module defines the following `IMPORTED` targets:
+# This module defines the following :prop_tgt:`IMPORTED` targets:
 #
-# ``cunit``
+# ``CUnit::cunit``
 #   The CUnit library, if found.
 #
 # Result Variables
@@ -18,6 +18,8 @@
 #
 # ``CUnit_FOUND``
 #   System has the CUnit library.
+# ``CUnit_VERSION``
+#   The version of CUnit found.
 # ``CUnit_INCLUDE_DIR``
 #   The CUnit include directory.
 # ``CUnit_LIBRARIES``
@@ -28,53 +30,72 @@
 #
 # Set ``CUnit_ROOT_DIR`` to the root directory of a CUnit installation.
 
-find_path(CUnit_INCLUDE_DIR
+if(CUnit_INCLUDE_DIR AND CUnit_LIBRARIES)
+  # in cache already
+  set(CUnit_FIND_QUIETLY TRUE)
+endif()
+
+if(CUnit_ROOT_DIR)
+  set(_CUnit_EXTRA_FIND_ARGS "NO_CMAKE_FIND_ROOT_PATH")
+endif()
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_CUNIT QUIET cunit)
+endif()
+
+find_path(
+  CUnit_INCLUDE_DIR
   NAMES CUnit/CUnit.h
   PATH_SUFFIXES include
   HINTS ${PROJECT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}
         ${CUnit_ROOT_DIR}
-  )
+		${PC_CUNIT_INCLUDE_DIRS}
+        ${_CUnit_EXTRA_FIND_ARGS})
 
-find_library(CUnit_LIBRARIES
+find_library(
+  CUnit_LIBRARIES
   NAMES cunit
   PATH_SUFFIXES lib
   HINTS ${PROJECT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}
         ${CUnit_ROOT_DIR}
-  )
+		${PC_CUNIT_LIBRARY_DIRS}
+        ${_CUnit_EXTRA_FIND_ARGS})
 
-if(CUnit_LIBRARIES)
-  set(CUnit_FOUND TRUE)
-else()
-  set(CUnit_FOUND FALSE)
-  set(error_message "CUnit not found. Set 'CUnit_ROOT_DIR' to the root directory of a CUnit installation.")
-  if(CUnit_FIND_REQUIRED)
-    message(FATAL_ERROR "${error_message}")
-  elseif(NOT CUDA_FIND_QUIETLY)
-    message(STATUS "${error_message}")
-  endif()
-endif()
-
-if(NOT TARGET cunit)
-  add_library(cunit
-    UNKNOWN
-    IMPORTED
-    )
-  set_target_properties(cunit PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CUnit_INCLUDE_DIR}"
-    IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-    IMPORTED_LOCATION "${CUnit_LIBRARIES}"
-	)
+if(CUnit_INCLUDE_DIR AND EXISTS "${CUnit_INCLUDE_DIR}/CUnit/CUnit.h")
+  file(STRINGS "${CUnit_INCLUDE_DIR}/CUnit/CUnit.h" CUnit_VERSION_STR
+    REGEX "#[\t ]*define[\t ]+CU_VERSION[\t ]+\"[^\"]+\"")
+  string(REGEX REPLACE "^.*CU_VERSION[\t ]+\"([^\"]+)\""
+    "\\1" CUnit_VERSION_STR "${CUnit_VERSION_STR}")
+  set(CUnit_VERSION "${CUnit_VERSION_STR}")
+  unset(CUnit_VERSION_STR)
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CUnit DEFAULT_MSG
-  CUnit_INCLUDE_DIR
-  CUnit_LIBRARIES
-  )
+find_package_handle_standard_args(
+  CUnit
+  FAIL_MESSAGE "Could NOT find CUnit, try to set the path to CUnit root folder in the system variable CUnit_ROOT_DIR"
+  REQUIRED_VARS CUnit_INCLUDE_DIR
+                CUnit_LIBRARIES
+  VERSION_VAR CUnit_VERSION)
+
+if(NOT
+   TARGET
+   CUnit::cunit)
+  add_library(
+    CUnit::cunit
+    UNKNOWN
+    IMPORTED)
+  set_target_properties(
+    CUnit::cunit
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${CUnit_INCLUDE_DIR}"
+               VERSION "${CUnit_VERSION}"
+               IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+               IMPORTED_LOCATION "${CUnit_LIBRARIES}")
+endif()
 
 mark_as_advanced(
   CUnit_INCLUDE_DIR
-  CUnit_LIBRARIES
-  )
+  CUnit_LIBRARIES)

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -1,35 +1,167 @@
-find_path(MBEDTLS_INCLUDE_DIRS mbedtls/ssl.h)
+# FindMbedTLS
+# -----------
+#
+# Find the MbedTLS encryption library.
+#
+# Imported Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following :prop_tgt:`IMPORTED` targets:
+#
+# ``MbedTLS::mbedtls``
+#   The MbedTLS ``mbedtls`` library, if found.
+# ``MbedTLS::mbedx509``
+#   The MbedTLS ``mbedx509`` library, if found.
+# ``MbedTLS::mbedcrypto``
+#   The MbedTLS ``mbedcrypto`` library, if found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project:
+#
+# ``MbedTLS_FOUND``
+#   System has the MbedTLS library.
+# ``MbedTLS_VERSION``
+#   The version of MbedTLS found.
+# ``MBEDTLS_INCLUDE_DIRS``
+#   The MbedTLS include directory.
+# ``MBEDTLS_LIBRARIES``
+#   All MbedTLS libraries.
+#
+# Hints
+# ^^^^^
+#
+# Set ``MBEDTLS_ROOT_DIR`` to the root directory of an MbedTLS installation.
 
-find_library(MBEDTLS_LIBRARY mbedtls)
-find_library(MBEDX509_LIBRARY mbedx509)
-find_library(MBEDCRYPTO_LIBRARY mbedcrypto)
+if(MBEDTLS_INCLUDE_DIRS AND MBEDTLS_LIBRARIES)
+  # in cache already
+  set(MbedTLS_FIND_QUIETLY TRUE)
+endif()
+
+if(MBEDTLS_ROOT_DIR)
+  set(_MBEDTLS_EXTRA_FIND_ARGS "NO_CMAKE_FIND_ROOT_PATH")
+endif()
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_MBEDTLS QUIET tinydtls)
+endif()
+
+find_path(
+  MBEDTLS_INCLUDE_DIRS
+  NAMES mbedtls/ssl.h
+  PATH_SUFFIXES include
+  HINTS ${PROJECT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${MBEDTLS_ROOT_DIR}
+		${PC_MBEDTLS_INCLUDE_DIRS}
+        ${_MBEDTLS_EXTRA_FIND_ARGS})
+
+find_library(
+  MBEDTLS_LIBRARY
+  NAMES mbedtls
+  PATH_SUFFIXES lib
+  HINTS ${PROJECT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${MBEDTLS_ROOT_DIR}
+		${PC_MBEDTLS_LIBRARY_DIRS}
+        ${_MBEDTLS_EXTRA_FIND_ARGS})
+
+find_library(
+  MBEDX509_LIBRARY
+  NAMES mbedx509
+  PATH_SUFFIXES lib
+  HINTS ${PROJECT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${MBEDTLS_ROOT_DIR}
+		${PC_MBEDTLS_LIBRARY_DIRS}
+        ${_EXTRA_FIND_ARGS})
+
+find_library(
+  MBEDCRYPTO_LIBRARY
+  NAMES mbedcrypto
+  PATH_SUFFIXES lib
+  HINTS ${PROJECT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${MBEDTLS_ROOT_DIR}
+		${PC_MBEDTLS_LIBRARY_DIRS}
+        ${_EXTRA_FIND_ARGS})
 
 set(MBEDTLS_LIBRARIES
     "${MBEDTLS_LIBRARY}"
     "${MBEDX509_LIBRARY}"
     "${MBEDCRYPTO_LIBRARY}")
 
-if(MBEDTLS_LIBRARY)
-  set(MbedTLS_FOUND TRUE)
+if(MBEDTLS_INCLUDE_DIRS AND EXISTS "${MBEDTLS_INCLUDE_DIRS}/mbedtls/build_info.h")
+  file(STRINGS "${MBEDTLS_INCLUDE_DIRS}/mbedtls/build_info.h" MbedTLS_VERSION_STR
+    REGEX "#[\t ]*define[\t ]+MBEDTLS_VERSION_STRING[\t ]+\"[^\"]+\"")
+  string(REGEX REPLACE "^.*MBEDTLS_VERSION_STRING[\t ]+\"([^\"]+)\""
+    "\\1" MbedTLS_VERSION_STR "${MbedTLS_VERSION_STR}")
+  set(MbedTLS_VERSION "${MbedTLS_VERSION_STR}")
+  unset(MbedTLS_VERSION_STR)
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  MBEDTLS
-  DEFAULT_MSG
-  MBEDTLS_INCLUDE_DIRS
-  MBEDTLS_LIBRARY
-  MBEDX509_LIBRARY
-  MBEDCRYPTO_LIBRARY)
+  MbedTLS
+  FAIL_MESSAGE "Could NOT find MbedTLS, try to set the path to MbedTLS root folder in the system variable MBEDTLS_ROOT_DIR"
+  REQUIRED_VARS MBEDTLS_INCLUDE_DIRS
+                MBEDTLS_LIBRARY
+                MBEDX509_LIBRARY
+                MBEDCRYPTO_LIBRARY
+  VERSION_VAR MbedTLS_VERSION)
+
+if(NOT
+   TARGET
+   MbedTLS::mbedtls)
+  add_library(
+    MbedTLS::mbedtls
+    UNKNOWN
+    IMPORTED)
+  set_target_properties(
+    MbedTLS::mbedtls
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${MBEDTLS_INCLUDE_DIRS}"
+               VERSION "${MbedTLS_VERSION}"
+               IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+               IMPORTED_LOCATION "${MBEDTLS_LIBRARY}"
+               INTERFACE_LINK_LIBRARIES "MbedTLS::mbedx509")
+endif()
+
+if(NOT
+   TARGET
+   MbedTLS::mbedx509)
+  add_library(
+    MbedTLS::mbedx509
+    UNKNOWN
+    IMPORTED)
+  set_target_properties(
+    MbedTLS::mbedx509
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${MBEDTLS_INCLUDE_DIRS}"
+               VERSION "${MbedTLS_VERSION}"
+               IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+               IMPORTED_LOCATION "${MBEDX509_LIBRARY}"
+               INTERFACE_LINK_LIBRARIES "MbedTLS::mbedcrypto")
+endif()
+
+if(NOT
+   TARGET
+   MbedTLS::mbedcrypto)
+  add_library(
+    MbedTLS::mbedcrypto
+    UNKNOWN
+    IMPORTED)
+  set_target_properties(
+    MbedTLS::mbedcrypto
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${MBEDTLS_INCLUDE_DIRS}"
+               VERSION "${MbedTLS_VERSION}"
+               IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+               IMPORTED_LOCATION "${MBEDCRYPTO_LIBRARY}"
+               INTERFACE_LINK_LIBRARIES "$<$<BOOL:${WIN32}>:bcrypt>")
+endif()
 
 mark_as_advanced(
   MBEDTLS_INCLUDE_DIRS
   MBEDTLS_LIBRARY
   MBEDX509_LIBRARY
   MBEDCRYPTO_LIBRARY)
-
-message(STATUS "MBEDTLS_INCLUDE_DIRS: ${MBEDTLS_INCLUDE_DIRS}")
-message(STATUS "MBEDTLS_LIBRARY: ${MBEDTLS_LIBRARY}")
-message(STATUS "MBEDX509_LIBRARY: ${MBEDX509_LIBRARY}")
-message(STATUS "MBEDCRYPTO_LIBRARY: ${MBEDCRYPTO_LIBRARY}")
-message(STATUS "MBEDTLS_LIBRARIES: ${MBEDTLS_LIBRARIES}")

--- a/cmake/FindTinyDTLS.cmake
+++ b/cmake/FindTinyDTLS.cmake
@@ -1,5 +1,5 @@
 # FindTinyDTLS
-# -----------
+# ------------
 #
 # Find the tinyDTLS encryption library.
 #
@@ -8,7 +8,7 @@
 #
 # This module defines the following :prop_tgt:`IMPORTED` targets:
 #
-# ``tinydtls``
+# ``TinyDTLS::tinydtls``
 #   The tinyDTLS ``tinydtls`` library, if found.
 #
 # Result Variables
@@ -16,8 +16,10 @@
 #
 # This module will set the following variables in your project:
 #
-# ``TINYDTLS_FOUND``
+# ``TinyDTLS_FOUND``
 #   System has the tinyDTLS library.
+# ``TinyDTLS_VERSION``
+#   The version of tinyDTLS found.
 # ``TINYDTLS_INCLUDE_DIR``
 #   The tinyDTLS include directory.
 # ``TINYDTLS_LIBRARIES``
@@ -28,8 +30,18 @@
 #
 # Set ``TINYDTLS_ROOT_DIR`` to the root directory of an tinyDTLS installation.
 
+if(TINYDTLS_INCLUDE_DIR AND TINYDTLS_LIBRARIES)
+  # in cache already
+  set(TinyDTLS_FIND_QUIETLY TRUE)
+endif()
+
 if(TINYDTLS_ROOT_DIR)
-  set(_EXTRA_FIND_ARGS "NO_CMAKE_FIND_ROOT_PATH")
+  set(_TINYDTLS_EXTRA_FIND_ARGS "NO_CMAKE_FIND_ROOT_PATH")
+endif()
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_TINYDTLS QUIET tinydtls)
 endif()
 
 find_path(
@@ -39,7 +51,8 @@ find_path(
   HINTS ${PROJECT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}
         ${TINYDTLS_ROOT_DIR}
-        ${_EXTRA_FIND_ARGS})
+		${PC_TINYDTLS_INCLUDE_DIRS}
+        ${_TINYDTLS_EXTRA_FIND_ARGS})
 
 find_library(
   TINYDTLS_LIBRARIES
@@ -48,41 +61,41 @@ find_library(
   HINTS ${PROJECT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}
         ${TINYDTLS_ROOT_DIR}
-        ${_EXTRA_FIND_ARGS})
+		${PC_TINYDTLS_LIBRARY_DIRS}
+        ${_TINYDTLS_EXTRA_FIND_ARGS})
 
-if(TINYDTLS_LIBRARIES)
-  set(TINYDTLS_FOUND TRUE)
-else()
-  set(TINYDTLS_FOUND FALSE)
-  if(TinyDTLS_FIND_REQUIRED)
-    message(FATAL_ERROR "Tinydtls could not be found")
-  endif()
+if(TINYDTLS_INCLUDE_DIR AND EXISTS "${TINYDTLS_INCLUDE_DIR}/tinydtls/dtls_config.h")
+  file(STRINGS "${TINYDTLS_INCLUDE_DIR}/tinydtls/dtls_config.h" TinyDTLS_VERSION_STR
+    REGEX "#[\t ]*define[\t ]+PACKAGE_VERSION[\t ]+\"[^\"]+\"")
+  string(REGEX REPLACE "^.*PACKAGE_VERSION[\t ]+\"([^\"]+)\""
+    "\\1" TinyDTLS_VERSION_STR "${TinyDTLS_VERSION_STR}")
+  set(TinyDTLS_VERSION "${TinyDTLS_VERSION_STR}")
+  unset(TinyDTLS_VERSION_STR)
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  tinyDTLS
-  FOUND_VAR
-  TINYDTLS_FOUND
-  REQUIRED_VARS
-  TINYDTLS_INCLUDE_DIR
-  TINYDTLS_LIBRARIES
-  VERSION_VAR)
+  TinyDTLS
+  FAIL_MESSAGE "Could NOT find TinyDTLS, try to set the path to TinyDTLS root folder in the system variable TINYDTLS_ROOT_DIR"
+  REQUIRED_VARS TINYDTLS_INCLUDE_DIR
+                TINYDTLS_LIBRARIES
+  VERSION_VAR TinyDTLS_VERSION)
 
 if(NOT
    TARGET
-   tinydtls)
+   TinyDTLS::tinydtls)
   add_library(
-    tinydtls
+    TinyDTLS::tinydtls
     UNKNOWN
     IMPORTED)
   set_target_properties(
-    tinydtls
-    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${TINYDTLS_INCLUDE_DIR}"
+    TinyDTLS::tinydtls
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${TINYDTLS_INCLUDE_DIR};${TINYDTLS_INCLUDE_DIR}/tinydtls"
+               VERSION "${TinyDTLS_VERSION}"
                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
                IMPORTED_LOCATION "${TINYDTLS_LIBRARIES}")
 endif()
 
-message(STATUS "TINYDTLS_INCLUDE_DIR: ${TINYDTLS_INCLUDE_DIR}")
-message(STATUS "TINYDTLS_LIBRARIES: ${TINYDTLS_LIBRARIES}")
-message(STATUS "TINYDTLS_ROOT_DIR: ${TINYDTLS_ROOT_DIR}")
+mark_as_advanced(
+  TINYDTLS_INCLUDE_DIR
+  TINYDTLS_LIBRARIES)

--- a/cmake/Findwolfssl.cmake
+++ b/cmake/Findwolfssl.cmake
@@ -1,5 +1,5 @@
-# FindWolfSSL.cmake
-# -----------------
+# Findwolfssl
+# -----------
 #
 # Find the wolfSSL library.
 #
@@ -8,7 +8,7 @@
 #
 # This module defines the following :prop_tgt:`IMPORTED` targets:
 #
-# ``wolfssl``
+# ``wolfssl::wolfssl``
 #   The wolfSSL library, if found.
 #
 # Result Variables
@@ -16,8 +16,10 @@
 #
 # This module will set the following variables in your project:
 #
-# ``wolfSSL_FOUND``
+# ``wolfssl_FOUND``
 #   System has the wolfSSL library.
+# ``wolfssl_VERSION``
+#   The version of wolfSSL found.
 # ``WOLFSSL_INCLUDE_DIR``
 #   The wolfSSL include directory.
 # ``WOLFSSL_LIBRARIES``
@@ -28,8 +30,18 @@
 #
 # Set ``WOLFSSL_ROOT_DIR`` to the root directory of a wolfSSL installation.
 
+if(WOLFSSL_INCLUDE_DIR AND WOLFSSL_LIBRARIES)
+  # in cache already
+  set(wolfssl_FIND_QUIETLY TRUE)
+endif()
+
 if(WOLFSSL_ROOT_DIR)
   set(_WOLFSSL_EXTRA_FIND_ARGS "NO_CMAKE_FIND_ROOT_PATH")
+endif()
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_WOLFSSL QUIET wolfssl)
 endif()
 
 find_path(
@@ -39,6 +51,7 @@ find_path(
   HINTS ${PROJECT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}
         ${WOLFSSL_ROOT_DIR}
+		${PC_WOLFSSL_INCLUDE_DIRS}
         ${_WOLFSSL_EXTRA_FIND_ARGS})
 
 find_library(
@@ -48,39 +61,41 @@ find_library(
   HINTS ${PROJECT_SOURCE_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}
         ${WOLFSSL_ROOT_DIR}
+		${PC_WOLFSSL_LIBRARY_DIRS}
         ${_WOLFSSL_EXTRA_FIND_ARGS})
 
-if(WOLFSSL_LIBRARIES)
-  set(wolfSSL_FOUND TRUE)
-else()
-  set(wolfSSL_FOUND FALSE)
-  if(wolfSSL_FIND_REQUIRED)
-    message(FATAL_ERROR "wolfSSL could not be found")
-  endif()
+if(WOLFSSL_INCLUDE_DIR AND EXISTS "${WOLFSSL_INCLUDE_DIR}/wolfssl/version.h")
+  file(STRINGS "${WOLFSSL_INCLUDE_DIR}/wolfssl/version.h" WOLFSSL_VERSION_STR
+    REGEX "#[\t ]*define[\t ]+LIBWOLFSSL_VERSION_STRING[\t ]+\"[^\"]+\"")
+  string(REGEX REPLACE "^.*LIBWOLFSSL_VERSION_STRING[\t ]+\"([^\"]+)\""
+    "\\1" WOLFSSL_VERSION_STR "${WOLFSSL_VERSION_STR}")
+  set(wolfssl_VERSION "${WOLFSSL_VERSION_STR}")
+  unset(WOLFSSL_VERSION_STR)
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  wolfSSL
-  FOUND_VAR
-  wolfSSL_FOUND
-  REQUIRED_VARS
-  WOLFSSL_INCLUDE_DIR
-  WOLFSSL_LIBRARIES
-  VERSION_VAR)
+  wolfssl
+  FAIL_MESSAGE "Could NOT find WolfSSL, try to set the path to WolfSSL root folder in the system variable WOLFSSL_ROOT_DIR"
+  REQUIRED_VARS WOLFSSL_INCLUDE_DIR
+                WOLFSSL_LIBRARIES
+  VERSION_VAR wolfssl_VERSION)
 
-if(NOT TARGET wolfssl)
+if(NOT
+   TARGET
+   wolfssl::wolfssl)
   add_library(
-    wolfssl
+    wolfssl::wolfssl
     UNKNOWN
     IMPORTED)
   set_target_properties(
-    wolfssl
+    wolfssl::wolfssl
     PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${WOLFSSL_INCLUDE_DIR}"
+               VERSION "${wolfssl_VERSION}"
                IMPORTED_LINK_INTERFACE_LANGUAGES "C"
                IMPORTED_LOCATION "${WOLFSSL_LIBRARIES}")
 endif()
 
-message(STATUS "WOLFSSL_INCLUDE_DIR: ${WOLFSSL_INCLUDE_DIR}")
-message(STATUS "WOLFSSL_LIBRARIES: ${WOLFSSL_LIBRARIES}")
-message(STATUS "WOLFSSL_ROOT_DIR: ${WOLFSSL_ROOT_DIR}")
+mark_as_advanced(
+  WOLFSSL_INCLUDE_DIR
+  WOLFSSL_LIBRARIES)

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -107,24 +107,21 @@ if(CONFIG_LIBCOAP)
   if(CONFIG_MBEDTLS)
     if(TARGET mbedTLS)
       target_include_directories(mbedTLS INTERFACE ${ZEPHYR_LIBCOAP_MODULE_DIR}/include)
+      add_library(MbedTLS::mbedtls ALIAS mbedTLS)
     else()
       message(WARNING "mbedTLS target not found.")
     endif()
+  endif()
+
+  if(CONFIG_WOLFSSL)
+    target_compile_definitions(wolfSSL INTERFACE WOLFSSL_USER_SETTINGS)
+    add_library(wolfssl::wolfssl ALIAS wolfSSL)
   endif()
 
   add_subdirectory(.. build)
   target_compile_definitions(coap-3 PUBLIC WITH_ZEPHYR)
   target_compile_definitions(coap-3 PUBLIC COAP_MEMORY_TYPE_TRACK=1)
   target_link_libraries(coap-3 PUBLIC zephyr_interface)
-
-  if(CONFIG_MBEDTLS AND TARGET mbedTLS)
-    target_link_libraries(coap-3 PUBLIC mbedTLS)
-  endif()
-
-  if(CONFIG_WOLFSSL)
-    target_compile_definitions(coap-3 PRIVATE WOLFSSL_USER_SETTINGS)
-    target_link_libraries(coap-3 PUBLIC wolfSSL)
-  endif()
 
   set_property(GLOBAL APPEND PROPERTY ZEPHYR_INTERFACE_LIBS coap-3)
 


### PR DESCRIPTION
These changes switch the TinyDTLS library build from Autotools to CMake, as support for CMake has now been added. The use of external libraries has been optimized. PkgConfig support has been added for library detection. The libraries' names were also fixed to use CMake-style naming.

🧐 I would like to note that there are problems compiling TinyDTLS under MSVC due to errors in `ext/tinydtls/dtl_debug.c` and `ext/tinydtls/CMakeLists.txt`. I will try to fix these errors upstream...