### PR TITLE
add COAP_BLOCK_FORCE_Q_BLOCK

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -593,7 +593,7 @@ usage(const char *program, const char *version) {
           "\t-K interval\tSend a ping after interval seconds of inactivity\n"
           "\t-L value\tSum of one or more COAP_BLOCK_* flag valuess for block\n"
           "\t       \t\thandling methods. Default is 1 (COAP_BLOCK_USE_LIBCOAP)\n"
-          "\t       \t\t(Sum of one or more of 1,2,4,8,16 and 32)\n"
+          "\t       \t\t(Sum of one or more of 1,2,4,8,16,32 and 512)\n"
           "\t-N     \t\tSend NON-confirmable message\n"
           "\t-O num,text\tAdd option num with contents text to request. If the\n"
           "\t       \t\ttext begins with 0x, then the hex text (two [0-9a-f] per\n"

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1585,7 +1585,7 @@ usage(const char *program, const char *version) {
           "\t       \t\tif the -A option is used\n"
           "\t-L value\tSum of one or more COAP_BLOCK_* flag valuess for block\n"
           "\t       \t\thandling methods. Default is 1 (COAP_BLOCK_USE_LIBCOAP)\n"
-          "\t       \t\t(Sum of one or more of 1,2,4 64, 128 and 256)\n"
+          "\t       \t\t(Sum of one or more of 1,2,4 64, 128, 256 and 512)\n"
           , program);
   fprintf(stderr,
           "\t-N     \t\tMake \"observe\" responses NON-confirmable. Even if set\n"

--- a/include/coap3/coap_block.h
+++ b/include/coap3/coap_block.h
@@ -72,6 +72,7 @@ typedef struct {
 #define COAP_BLOCK_NOT_RANDOM_BLOCK1 0x80 /* (svr)Disable server handling random order
                                              block1 */
 #define COAP_BLOCK_CACHE_RESPONSE 0x100 /* (svr)Cache CON request's response */
+#define COAP_BLOCK_FORCE_Q_BLOCK  0x200 /* force Q-Block method without support check */
 /* WARNING: Added defined values must not encroach into 0xff000000 which are defined elsewhere */
 
 /**

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -49,7 +49,8 @@ extern "C" {
                              COAP_BLOCK_STLESS_FETCH | \
                              COAP_BLOCK_STLESS_BLOCK2 | \
                              COAP_BLOCK_NOT_RANDOM_BLOCK1 | \
-                             COAP_BLOCK_CACHE_RESPONSE)
+                             COAP_BLOCK_CACHE_RESPONSE | \
+                             COAP_BLOCK_FORCE_Q_BLOCK)
 #else /* ! COAP_Q_BLOCK_SUPPORT */
 #define COAP_BLOCK_SET_MASK (COAP_BLOCK_USE_LIBCOAP | \
                              COAP_BLOCK_SINGLE_BODY | \
@@ -87,7 +88,8 @@ extern "C" {
     block_mode &= ~(COAP_BLOCK_TRY_Q_BLOCK |\
                     COAP_BLOCK_PROBE_Q_BLOCK |\
                     COAP_BLOCK_HAS_Q_BLOCK | \
-                    COAP_BLOCK_USE_M_Q_BLOCK); \
+                    COAP_BLOCK_USE_M_Q_BLOCK | \
+                    COAP_BLOCK_FORCE_Q_BLOCK); \
   } while (0)
 
 #define COAP_SINGLE_BLOCK_OR_Q (COAP_BLOCK_SINGLE_BODY|COAP_BLOCK_HAS_Q_BLOCK)

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -180,6 +180,7 @@ OPTIONS - General
      COAP_BLOCK_USE_M_Q_BLOCK       8
      COAP_BLOCK_NO_PREEMPTIVE_RTAG 16
      COAP_BLOCK_STLESS_FETCH       32
+     COAP_BLOCK_FORCE_Q_BLOCK     512
 
 *-N* ::
    Send NON-confirmable message. If option *-N* is not specified, a

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -149,6 +149,7 @@ OPTIONS - General
      COAP_BLOCK_STLESS_BLOCK2      64
      COAP_BLOCK_NOT_RANDOM_BLOCK1 128
      COAP_BLOCK_CACHE_RESPONSE    256
+     COAP_BLOCK_FORCE_Q_BLOCK     512
 
 *-N* ::
    Send NON-confirmable message for "observe" responses. If option *-N* is

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -160,6 +160,7 @@ session _block_mode_.
 #define COAP_BLOCK_STLESS_BLOCK2 0x40 /* (Server) Server is stateless for Block2 transfers */
 #define COAP_BLOCK_NOT_RANDOM_BLOCK1 0x80 /* (Server) Disable server handling random order block1 */
 #define COAP_BLOCK_CACHE_RESPONSE 0x100 /* (Server) Cache CON request's response */
+#define COAP_BLOCK_FORCE_Q_BLOCK  0x200 /* force Q-Block method without support check */
 ----
 _block_mode_ is an or'd set of zero or more COAP_BLOCK_* definitions.
 
@@ -229,6 +230,12 @@ If *COAP_BLOCK_CACHE_RESPONSE* is set, then the server will cache the response
 for the latest unreliable CON request so that if the CON request is repeated,
 the cached response gets re-transmitted. If it is not set, then the response is
 sent as a separate response (empty ACK sent first) using CON.
+
+If *COAP_BLOCK_FORCE_Q_BLOCK* is set, libcoap will not initiate a probe request
+to check if the peer does support Q-Block method as it does if
+*COAP_BLOCK_TRY_Q_BLOCK* is set and will assume the peer supports Q-Block
+method. If unsure or minimum latency is not required, use
+*COAP_BLOCK_TRY_Q_BLOCK* instead of *COAP_BLOCK_FORCE_Q_BLOCK*.
 
 *Function: coap_context_set_max_block_size()*
 

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -422,7 +422,7 @@ coap_context_set_block_mode_lkd(coap_context_t *context,
   context->block_mode &= ~COAP_BLOCK_SET_MASK;
   context->block_mode |= block_mode & COAP_BLOCK_SET_MASK;
 #if ! COAP_Q_BLOCK_SUPPORT
-  if (block_mode & (COAP_BLOCK_TRY_Q_BLOCK|COAP_BLOCK_USE_M_Q_BLOCK))
+  if (block_mode & (COAP_BLOCK_TRY_Q_BLOCK|COAP_BLOCK_USE_M_Q_BLOCK|COAP_BLOCK_FORCE_Q_BLOCK))
     coap_log_debug("Q-Block support not compiled in - ignored\n");
 #endif /* ! COAP_Q_BLOCK_SUPPORT */
 }

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -475,6 +475,11 @@ coap_make_session(coap_proto_t proto, coap_session_type_t type,
 #endif /* COAP_SERVER_SUPPORT */
     coap_session_set_mtu(session, COAP_DEFAULT_MTU);
   session->block_mode = context->block_mode;
+#if COAP_Q_BLOCK_SUPPORT
+  if (session->block_mode & COAP_BLOCK_FORCE_Q_BLOCK) {
+    set_block_mode_has_q(session->block_mode);
+  }
+#endif
   if (proto == COAP_PROTO_DTLS) {
     session->tls_overhead = 29;
     if (session->tls_overhead >= session->mtu) {


### PR DESCRIPTION
As discussed in #1778, this adds a flag to force Q-Block method without checking for compatibility of the peer. This avoids an initial request of .well-known/core in environments where all peers are known to support the Q-Block method.