### PR TITLE
coap_encode.h: Check BSD is defined before evaluating it

### DIFF
--- a/include/coap3/coap_encode.h
+++ b/include/coap3/coap_encode.h
@@ -17,7 +17,7 @@
 #ifndef COAP_ENCODE_H_
 #define COAP_ENCODE_H_
 
-#if (BSD >= 199103) || defined(_WIN32)
+#if (defined(BSD) && (BSD >= 199103)) || defined(_WIN32)
 # include <string.h>
 #else
 # include <strings.h>


### PR DESCRIPTION
Hello,

The BSD macro is evaluated even if it is not defined, leading to a build error. With this change, it is only evaluated if previously defined.

Best regards,
Tobias