### PR TITLE
coap_dgrm_internal.h, coap_subscribe_internal.h: Fix extern C guards

### DIFF
--- a/include/coap3/coap_dgrm_internal.h
+++ b/include/coap3/coap_dgrm_internal.h
@@ -126,7 +126,7 @@ void coap_socket_dgrm_close(coap_socket_t *sock);
 /** @} */
 
 #ifdef __cplusplus
-extern "C" {
+}
 #endif
 
 #endif /* COAP_DGRM_INTERNAL_H_ */

--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -309,7 +309,7 @@ int coap_cancel_observe_lkd(coap_session_t *session, coap_binary_t *token,
 /** @} */
 
 #ifdef __cplusplus
-extern "C" {
+}
 #endif
 
 #endif /* COAP_SUBSCRIBE_INTERNAL_H_ */


### PR DESCRIPTION
Hello everyone,

Compiling and linking this project for C++ failed for me because these two files open extern C guards which are not closed properly. This PR fixes the way the guards are fixed.
Best regards,
Tobias