### PR TITLE
fixed memory leak in coap_send

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -1920,10 +1920,12 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
 
         if (pdu->used_size + 1 > pdu->max_size) {
           /* No space */
+          coap_delete_pdu_lkd(pdu);
           return (coap_mid_t)COAP_DROPPED_RESPONSE;
         }
         if (!coap_pdu_resize(pdu, pdu->used_size + 1)) {
           /* Internal error */
+          coap_delete_pdu_lkd(pdu);
           return (coap_mid_t)COAP_DROPPED_RESPONSE;
         }
         data_len = pdu->used_size - (pdu->data - pdu->token);


### PR DESCRIPTION
As the declaration of `coap_send` states, user must not manually release the PDU:
```c
* Sends a CoAP message to given peer. The memory that is
* allocated for the pdu will be released by coap_send().
* The caller must not use or delete the pdu after calling coap_send().
```

This PR fixes a memory leak for some edge cases, where `coap_send_internal` (called by `coap_send_lkd`, called by `coap_send`) returns without any additional memory release.
