### PR TITLE
coap_session.c: Fix GCC array bounds warning for memcpy

### DIFF
--- a/include/coap3/coap_pdu.h
+++ b/include/coap3/coap_pdu.h
@@ -312,8 +312,9 @@ coap_pdu_t *coap_pdu_from_pbuf(struct pbuf *pbuf);
 #endif
 
 /**
-* CoAP protocol types
-*/
+ * CoAP protocol types
+ * Note: coap_layers_coap[] needs updating if extended.
+ */
 typedef enum coap_proto_t {
   COAP_PROTO_NONE = 0,
   COAP_PROTO_UDP,

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -2472,7 +2472,13 @@ coap_new_endpoint_lkd(coap_context_t *context, const coap_address_t *listen_addr
   ep->context = context;
   ep->proto = proto;
   ep->sock.endpoint = ep;
-  memcpy(&ep->sock.lfunc, coap_layers_coap[proto], sizeof(ep->sock.lfunc));
+  if (proto < COAP_PROTO_LAST) {
+    /*
+     * Should be caught above, but come compilers realize that proto
+     * includes COAP_PROTO_LAST, but there is no table entry for that
+     */
+    memcpy(&ep->sock.lfunc, coap_layers_coap[proto], sizeof(ep->sock.lfunc));
+  }
 
   if (COAP_PROTO_NOT_RELIABLE(proto)) {
     if (!coap_netif_dgrm_listen(ep, listen_addr))


### PR DESCRIPTION
Note assert() added from #1209 has now been removed as not needed by #1628, and if NDEBUG is defined then the assert() would have been a noop anyway.