### PR TITLE
coap_proxy.c: Support enabling multicast forwarding requests

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -673,8 +673,14 @@ static ssize_t user_length = -1;
 
 static size_t proxy_host_name_count = 0;
 static const char **proxy_host_name_list = NULL;
-static coap_proxy_server_list_t forward_proxy = { NULL, 0, 0, COAP_PROXY_FORWARD_STATIC, 0, 300};
-static coap_proxy_server_list_t reverse_proxy = { NULL, 0, 0, COAP_PROXY_REVERSE_STRIP, 0, 10};
+static coap_proxy_server_list_t forward_proxy = { NULL, 0, 0,
+                                                  COAP_PROXY_FWD_STATIC,
+                                                  0, 300
+                                                };
+static coap_proxy_server_list_t reverse_proxy = { NULL, 0, 0,
+                                                  COAP_PROXY_REV | COAP_PROXY_BIT_STRIP,
+                                                  0, 10
+                                                };
 
 static coap_dtls_cpsk_t *
 setup_cpsk(char *client_sni) {
@@ -1493,8 +1499,7 @@ proxy_dtls_setup(coap_context_t *ctx, coap_proxy_server_list_t *proxy_info) {
   for (i = 0; i < proxy_info->entry_count; i++) {
     coap_proxy_server_t *proxy_server = &proxy_info->entry[i];
 
-    if (proxy_info->type == COAP_PROXY_FORWARD_DYNAMIC ||
-        proxy_info->type == COAP_PROXY_FORWARD_DYNAMIC_STRIP) {
+    if ((proxy_info->type & COAP_PROXY_NEW_MASK) == COAP_PROXY_FWD_DYNAMIC) {
       /* This will get filled in by the libcoap proxy logic */
       memset(client_sni, 0, sizeof(client_sni));
     } else {
@@ -1617,7 +1622,7 @@ usage(const char *program, const char *version) {
           "\t-N     \t\tMake \"observe\" responses NON-confirmable. Even if set\n"
           "\t       \t\tevery fifth response will still be sent as a confirmable\n"
           "\t       \t\tresponse (RFC 7641 requirement)\n"
-          "\t-P scheme://address[:port],[name1[,name2[,name3..]]]\n"
+          "\t-P scheme://address[:port] | allow-mcast,[name1[,name2[,name3..]]]\n"
           "\t       \t\tScheme, address, optional port of how to connect to the\n"
           "\t       \t\tnext proxy server and zero or more names (comma\n"
           "\t       \t\tseparated) that this proxy server is known by. The\n"
@@ -1626,6 +1631,7 @@ usage(const char *program, const char *version) {
           "\t       \t\tthese names, then this server is considered to be the\n"
           "\t       \t\tfinal endpoint. If scheme://address[:port] is not\n"
           "\t       \t\tdefined before the leading , (comma) of the first name,\n"
+          "\t       \t\tor is allow-mcast which allows direct mcast requests,\n"
           "\t       \t\tthen the ongoing connection will be a direct connection.\n"
           "\t       \t\tScheme is one of coap, coaps, coap+tcp, coaps+tcp,\n"
           "\t       \t\tcoap+ws, and coaps+ws. http(s) is not currently supported.\n"
@@ -1876,7 +1882,7 @@ cmdline_proxy(char *arg) {
   }
   *host_start = '\000';
 
-  if (host_start != arg) {
+  if (host_start != arg && strcmp("allow-mcast", arg) != 0) {
     /* Next upstream proxy is defined */
     if (coap_split_uri((unsigned char *)arg, strlen(arg), &uri) < 0 ||
         uri.path.length != 0 || uri.query.length != 0) {
@@ -1887,11 +1893,15 @@ cmdline_proxy(char *arg) {
       coap_log_err("Unsupported CoAP Proxy protocol\n");
       return 0;
     }
-    forward_proxy.type = COAP_PROXY_FORWARD_STATIC;
+    forward_proxy.type = COAP_PROXY_FWD_STATIC;
     forward_proxy.idle_timeout_secs = 300;
+  } else if (strcmp("allow-mcast", arg) == 0) {
+    memset(&uri, 0, sizeof(uri));
+    forward_proxy.type = COAP_PROXY_FWD_DYNAMIC | COAP_PROXY_BIT_STRIP | COAP_PROXY_BIT_MCAST;
+    forward_proxy.idle_timeout_secs = 10;
   } else {
     memset(&uri, 0, sizeof(uri));
-    forward_proxy.type = COAP_PROXY_FORWARD_DYNAMIC_STRIP;
+    forward_proxy.type = COAP_PROXY_FWD_DYNAMIC | COAP_PROXY_BIT_STRIP;
     forward_proxy.idle_timeout_secs = 10;
   }
 

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -1000,6 +1000,7 @@ void coap_call_response_handler(coap_session_t *session, coap_pdu_t *sent,
 /**@}*/
 
 extern int coap_started;
+extern uint8_t coap_unique_id[8];
 
 #ifdef __cplusplus
 }

--- a/include/coap3/coap_proxy.h
+++ b/include/coap3/coap_proxy.h
@@ -28,25 +28,62 @@ extern "C" {
  * @{
  */
 
+/**
+ * coap_proxy_type_t Proxy definitions.
+ *
+ * Three types of proxy.
+ *  reverse         Traffic forward to internal set of servers.
+ *  forward-static  Traffic forwarded to defined set of servers.
+ *  forward-dynamic Traffic forwarded to host defined by
+ *                  Proxy-Uri / Proxy-Scheme options.
+ * Operations for each proxy type.
+ *  strip           Remove Proxy-Uri and/or Proxy-Scheme options.
+ *  mcast           Support forward-dynamic traffic to multicast addresses.
+ */
+
 typedef enum {
-  COAP_PROXY_REVERSE,               /**< Act as a reverse proxy */
-  COAP_PROXY_REVERSE_STRIP,         /**< Act as a reverse proxy,
-                                         strip out proxy options */
-  COAP_PROXY_FORWARD_STATIC,        /**< Act as a forward-static proxy */
-  COAP_PROXY_FORWARD_STATIC_STRIP,  /**< Act as a forward-static proxy,
-                                         strip out proxy options */
-  COAP_PROXY_FORWARD_DYNAMIC,       /**< Act as a forward-dynamic proxy
-                                         using the request's Proxy-Uri or
-                                         Proxy-Scheme options to determine
-                                         server */
-  COAP_PROXY_FORWARD_DYNAMIC_STRIP, /**< Act as a forward-dynamic proxy,
-                                         strip out proxy options */
-  /* For backward compatability */
-  COAP_PROXY_FORWARD = COAP_PROXY_FORWARD_STATIC,
-  COAP_PROXY_FORWARD_STRIP = COAP_PROXY_FORWARD_STATIC_STRIP,
-  COAP_PROXY_DIRECT = COAP_PROXY_FORWARD_DYNAMIC,
-  COAP_PROXY_DIRECT_STRIP = COAP_PROXY_FORWARD_DYNAMIC_STRIP,
-} coap_proxy_t;
+  /* Missing initial 'hole' is for the old style proxy mappings */
+  COAP_PROXY_REV = (1 << 3),         /**< reverse proxy. */
+  COAP_PROXY_FWD_STATIC = (2 << 3),  /**< forward-static proxy. */
+  COAP_PROXY_FWD_DYNAMIC = (3 << 3), /**< forward-dynamic proxy. */
+
+  /* Start of bit mask mapping */
+  COAP_PROXY_BIT_STRIP = (1 << 6),
+  /**<
+   * If COAP_PROXY_BIT_STRIP set, then remove any Proxy-Uri or Proxy-Scheme,
+   * else leave them.
+   */
+  COAP_PROXY_BIT_MCAST = (1 << 7),
+  /**<
+   * If COAP_PROXY_BIT_MCAST set, then upstream servers can be multicast,
+   * else only unicast.
+   * [ Ignored if not COAP_PROXY_FWD_DYNAMIC ]
+   */
+} coap_proxy_type_t;
+
+#define COAP_PROXY_OLD_MASK 0x07 /**< Space used in coap_proxy_type_t for old types */
+#define COAP_PROXY_NEW_MASK 0x38 /**< Space used in coap_proxy_type_t for new types */
+
+/**
+ * Old Mappings (4.3.5) that map into the first 3 bits of coap_proxy_type_t
+ */
+typedef enum {
+  COAP_PROXY_REVERSE,       /**< Act as a reverse proxy */
+  COAP_PROXY_REVERSE_STRIP, /**< Act as a reverse proxy,
+                                     strip out proxy options */
+  COAP_PROXY_FORWARD,       /**< Act as a forward-static proxy */
+  COAP_PROXY_FORWARD_STRIP, /**< Act as a forward-static proxy,
+                                     strip out proxy options */
+  COAP_PROXY_DIRECT,        /**< Act as a forward-dynamic proxy */
+  COAP_PROXY_DIRECT_STRIP,  /**< Act as a forward-dynamic proxy,
+                                    strip out proxy options */
+  COAP_PROXY_FORWARD_DYNAMIC = COAP_PROXY_DIRECT,
+  /**< Act as a forward-dynamic proxy */
+  COAP_PROXY_FORWARD_DYNAMIC_STRIP = COAP_PROXY_DIRECT_STRIP,
+  /**< Act as a forward-dynamic proxy, strip out proxy options */
+} coap_proxy_old_t;
+
+typedef coap_proxy_old_t coap_proxy_t;
 
 typedef struct coap_proxy_server_t {
   coap_uri_t uri;         /**< host and port define the server, scheme method */
@@ -59,7 +96,7 @@ typedef struct coap_proxy_server_list_t {
   coap_proxy_server_t *entry; /**< Set of servers to connect to */
   size_t entry_count;         /**< The number of servers in entry list */
   size_t next_entry;          /**< Next server to use (% entry_count) */
-  coap_proxy_t type;          /**< The proxy type */
+  coap_proxy_type_t type;     /**< The proxy type */
   int track_client_session;   /**< If 1, track individual connections to upstream
                                    server, else 0 for all clients to be multiplexed
                                    over the same upstream session */
@@ -74,7 +111,7 @@ typedef struct coap_proxy_server_list_t {
  *
  * @param session CoAP session.
  * @param sent The PDU that was transmitted.
- * @param received The respose PDU that was received, or returned from cache.
+ * @param received The response PDU that was received, or returned from cache.
  * @param cache_key Updated with the cache key pointer provided to
  *                  coap_proxy_forward_request().  The caller should
  *                  delete this cache key (unless the client request set up an
@@ -124,7 +161,9 @@ int coap_verify_proxy_scheme_supported(coap_uri_scheme_t scheme);
  *  Acting as a forward-static proxy - connect to defined upstream server
  *   (possibly round robin load balancing over multiple servers).
  *
- * A request that should go direct to this server is not supported here.
+ * A request that should go direct to this next proxy/server is not
+ * supported using this function - set up a new session using
+ * coap_new_client_session_proxy().
  *
  * @param req_session The client session.
  * @param request The client's request PDU.

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -26,7 +26,7 @@ SYNOPSIS
               [*-y* rec_secs] [*-z* scheme://addr[:port]]
               [*-A* address] [*-E* oscore_conf_file[,seq_file]]
               [*-G* group_if] [*-L* value] [*-N*]
-              [*-P* scheme://addr[:port],[name1[,name2..]]]
+              [*-P* scheme://addr[:port] | allow-mcast,[name1[,name2..]]]
               [*-T* max_token_size] [*-U* type] [*-V* num] [*-X* size]
               [*-3*]
               [[*-h* hint] [*-i* match_identity_file] [*-k* key]
@@ -165,7 +165,8 @@ OPTIONS - General
    if the hostname of the incoming proxy request matches one of these names,
    then this server is considered to be the final endpoint. If
    scheme://address[:port] is not defined before the leading , (comma) of the
-   first name, then the ongoing connection will be a direct connection.
+   first name, or is allow-mcast which allows direct mcast requests, then the
+   ongoing connection will be a direct connection.
    Scheme is one of coap, coaps, coap+tcp, coaps+tcp, coap+ws, and coaps+ws.
    http and https not currently supported.
    This option can be repeated to provide multiple upstream

--- a/man/coap_proxy.txt.in
+++ b/man/coap_proxy.txt.in
@@ -103,6 +103,10 @@ For each upstream server, client sessions can all be multiplexed over a single
 upstream server session, or there can be the same number of upstream server
 sessions as there are client sessions.
 
+Support for doing a multicast request can be enabled or disabled for an upstream
+server when using *forward-dynamic*, providing the ongoing session is UDP and the
+scheme is only coap.
+
 The proxy logic will convert between supported protocals - e.g. coap <> coaps+tcp
 for the incoming and upstream session. Conversions to/from http(s) are not
 currently supported.
@@ -126,20 +130,41 @@ FUNCTIONS
 
 [source, c]
 ----
+/*
+ * coap_proxy_type_t Proxy definitions.
+ *  0x0007  Old 4.3.5 mappings for backward compatability.
+ *  0x0038  New type mappings.
+ *  0xffc0  Bitwise actions.
+ *
+ * Three types of proxy.
+ *  reverse         Traffic forward to internal set of servers.
+ *  forward-static  Traffic forwarded to defined set of servers.
+ *  forward-dynamic Traffic forwarded to host defined by
+ *                  Proxy-Uri / Proxy-Scheme options.
+ * Operations for each proxy type.
+ *  strip           Remove Proxy-Uri and/or Proxy-Scheme options.
+ *  mcast           Support forward-dynamic traffic to multicast addresses.
+ */
+
 typedef enum {
-  COAP_PROXY_REVERSE,               /* Act as a reverse proxy */
-  COAP_PROXY_REVERSE_STRIP,         /* Act as a reverse proxy,
-                                       strip out any proxy options */
-  COAP_PROXY_FORWARD_STATIC,        /* Act as a forward-static proxy */
-  COAP_PROXY_FORWARD_STATIC_STRIP,  /* Act as a forward-static proxy,
-                                       strip out any proxy options */
-  COAP_PROXY_FORWARD_DYNAMIC,       /* Act as a forward-dynamic proxy
-                                       using the request's Proxy-Uri or
-                                       Proxy-Scheme options to determine
-                                       server */
-  COAP_PROXY_FORWARD_DYNAMIC_STRIP, /* Act as a forward-dynamic proxy,
-                                       strip out proxy options */
-} coap_proxy_t;
+  /* Missing initial 'hole' is for the old style proxy mappings */
+  COAP_PROXY_REV = (1 << 3),         /**< reverse proxy. */
+  COAP_PROXY_FWD_STATIC = (2 << 3),  /**< forward-static proxy. */
+  COAP_PROXY_FWD_DYNAMIC = (3 << 3), /**< forward-dynamic proxy. */
+
+  /* Start of bit mask mapping */
+  COAP_PROXY_BIT_STRIP = (1 << 6),
+  /**<
+   * If COAP_PROXY_BIT_STRIP set, then remove any Proxy-Uri or Proxy-Scheme,
+   * else leave them.
+   */
+  COAP_PROXY_BIT_MCAST = (1 << 7),
+  /**<
+   * If COAP_PROXY_BIT_MCAST set, then upstream servers can be multicast,
+   * else only unicast.
+   * [ Ignored if not COAP_PROXY_FWD_DYNAMIC ]
+   */
+} coap_proxy_type_t;
 
 typedef struct coap_proxy_server_t {
   coap_uri_t uri;          /* host and port define the server, scheme method */
@@ -152,7 +177,7 @@ typedef struct coap_proxy_server_list_t {
   coap_proxy_server_t *entry; /* Set of servers to connect to */
   size_t entry_count;         /* The number of servers in entry list */
   size_t next_entry;          /* Next server to use (% entry_count) */
-  coap_proxy_t type;          /* The proxy type */
+  coap_proxy_type_t type;     /* The proxy type - COAP_PROXY_* definitions */
   int track_client_session;   /* If 1, track individual connections to upstream
                                  server, else 0 for all clients to be multiplexed
                                  over the same upstream session */
@@ -216,7 +241,7 @@ and there will be unsolicited responses).
 If _cache_key_ is not defined, but a _cache_key_ was passed into
 *coap_proxy_forward_request*() then it will get deleted.
 
-*NOTE: *coap_proxy_forward_response*() should only be used if
+*NOTE:* *coap_proxy_forward_response*() should only be used if
 *coap_register_proxy_response_handler*() has not been called, and the regular
 response handler is being used (defined by *coap_register_response_handler*(3)).
 
@@ -344,7 +369,7 @@ static coap_proxy_server_list_t reverse_proxy = {
   .entry = redirect_server,
   .entry_count = sizeof(redirect_server)/sizeof(redirect_server[0]),
   .next_entry = 0,
-  .type = COAP_PROXY_REVERSE_STRIP,
+  .type = COAP_PROXY_REV | COAP_PROXY_BIT_STRIP,
   .track_client_session = 0, /* Client sessions multiplexed over upstream session */
   .idle_timeout_secs = 300
 };
@@ -401,7 +426,7 @@ static coap_proxy_server_list_t forward_dynamic_proxy = {
   .entry = NULL, /* Include dummy server with encryption definitions if needed */
   .entry_count = 0, /* if 0 and encryption, client anonymous PKI used */
   .next_entry = 0,
-  .type = COAP_PROXY_FORWARD_DYNAMIC_STRIP,
+  .type = COAP_PROXY_FWD_STATIC | COAP_PROXY_BIT_STRIP,
   .track_client_session = 0,
   .idle_timeout_secs = 10
 };
@@ -476,7 +501,7 @@ static coap_proxy_server_list_t forward_static_proxy = {
   .entry = forward_static_server,
   .entry_count = sizeof(forward_static_server)/sizeof(forward_static_server[0]),
   .next_entry = 0,
-  .type = COAP_PROXY_FORWARD_STATIC,
+  .type = COAP_PROXY_FWD_STATIC,
   .track_client_session = 0,
   .idle_timeout_secs = 300
 };

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -315,6 +315,10 @@ coap_add_data_blocked_response(const coap_pdu_t *request,
     dctx =  coap_digest_setup();
     if (!dctx)
       goto error;
+    if (request && request->session &&
+        coap_is_mcast(&request->session->addr_info.local)) {
+      coap_digest_update(dctx, coap_unique_id, sizeof(coap_unique_id));
+    }
     if (!coap_digest_update(dctx, data, length))
       goto error;
     if (!coap_digest_final(dctx, &digest))
@@ -849,6 +853,9 @@ coap_add_data_large_internal(coap_session_t *session,
         coap_digest_ctx_t *dctx =  coap_digest_setup();
 
         if (dctx) {
+          if (coap_is_mcast(&session->addr_info.local)) {
+            coap_digest_update(dctx, coap_unique_id, sizeof(coap_unique_id));
+          }
           if (coap_digest_update(dctx, data, length)) {
             if (coap_digest_final(dctx, &digest)) {
               memcpy(&etag, digest.key, sizeof(etag));

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -5065,6 +5065,7 @@ coap_check_async(coap_context_t *context, coap_tick_t now, coap_tick_t *tim_rem)
 #endif /* COAP_SERVER_SUPPORT */
 
 int coap_started = 0;
+uint8_t coap_unique_id[8] = { 0 };
 
 #if COAP_THREAD_SAFE
 /*
@@ -5127,6 +5128,7 @@ coap_startup(void) {
   resource_uri_wellknown.uri_path = &well_known;
 #endif /* COAP_SERVER_SUPPORT */
   send_recv_terminate = 0;
+  coap_prng_lkd(&coap_unique_id, sizeof(coap_unique_id));
 }
 
 void

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -317,6 +317,40 @@ coap_verify_proxy_scheme_supported(coap_uri_scheme_t scheme) {
   return 1;
 }
 
+static coap_proxy_type_t
+coap_proxy_map_type(coap_proxy_type_t proxy_type) {
+  if ((proxy_type & COAP_PROXY_NEW_MASK) == 0) {
+    /* Old version - update to bitwise version */
+    switch ((coap_proxy_old_t)proxy_type) {
+    case COAP_PROXY_REVERSE:
+      proxy_type = COAP_PROXY_REV;
+      break;
+    case COAP_PROXY_REVERSE_STRIP:
+      proxy_type = COAP_PROXY_REV | COAP_PROXY_BIT_STRIP;
+      break;
+    case COAP_PROXY_FORWARD:
+      proxy_type = COAP_PROXY_FWD_STATIC;
+      break;
+    case COAP_PROXY_FORWARD_STRIP:
+      proxy_type = COAP_PROXY_FWD_STATIC | COAP_PROXY_BIT_STRIP;
+      break;
+    case COAP_PROXY_DIRECT:
+      /* Mcast was always let through */
+      proxy_type = COAP_PROXY_FWD_DYNAMIC | COAP_PROXY_BIT_MCAST;
+      break;
+    case COAP_PROXY_DIRECT_STRIP:
+      /* Mcast was always let through */
+      proxy_type = COAP_PROXY_FWD_DYNAMIC | COAP_PROXY_BIT_MCAST | COAP_PROXY_BIT_STRIP;
+      break;
+    default:
+      coap_log_warn("Proxy old proxy_type 0x%u unknow\n", proxy_type);
+      proxy_type = COAP_PROXY_FWD_DYNAMIC;
+      break;
+    }
+  }
+  return proxy_type;
+}
+
 static coap_proxy_list_t *
 coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
                        coap_pdu_t *response,
@@ -329,6 +363,7 @@ coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
   coap_opt_iterator_t opt_iter;
   coap_opt_t *proxy_scheme;
   coap_opt_t *proxy_uri;
+  coap_proxy_type_t proxy_type;
 
   *proxy_entry_created = 0;
 
@@ -358,15 +393,9 @@ coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
     memset(server_use, 0, sizeof(*server_use));
   }
 
-  switch (server_list->type) {
-  case COAP_PROXY_REVERSE:
-  case COAP_PROXY_REVERSE_STRIP:
-  case COAP_PROXY_FORWARD_STATIC:
-  case COAP_PROXY_FORWARD_STATIC_STRIP:
-    /* Nothing else needs to be done here */
-    break;
-  case COAP_PROXY_FORWARD_DYNAMIC:
-  case COAP_PROXY_FORWARD_DYNAMIC_STRIP:
+  proxy_type = coap_proxy_map_type(server_list->type);
+
+  if ((proxy_type & COAP_PROXY_NEW_MASK) == COAP_PROXY_FWD_DYNAMIC) {
     /* Need to get actual server from CoAP Proxy-Uri or Proxy-Scheme options */
     /*
      * See if Proxy-Scheme
@@ -400,10 +429,6 @@ coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
       response->code = COAP_RESPONSE_CODE(404);
       return NULL;
     }
-    break;
-  default:
-    assert(0);
-    return NULL;
   }
 
   if (server_use->uri.host.length == 0) {
@@ -567,6 +592,25 @@ coap_proxy_get_ongoing_session(coap_session_t *session,
     proto = info_list->proto;
     memcpy(&dst, &info_list->addr, sizeof(dst));
     coap_free_address_info(info_list);
+    if (coap_is_mcast(&dst)) {
+      coap_proxy_type_t proxy_type = coap_proxy_map_type(server_list->type);
+
+      if ((proxy_type & COAP_PROXY_NEW_MASK) == COAP_PROXY_FWD_DYNAMIC &&
+          (proxy_type & COAP_PROXY_BIT_MCAST) == 0) {
+        response->code = COAP_RESPONSE_CODE(501);
+        coap_proxy_remove_association(session, 0);
+        coap_log_debug("*  %s: mcast proxy forwarding not enabled\n",
+                       coap_session_str(session));
+        return NULL;
+      }
+      if (server_use.uri.scheme != COAP_URI_SCHEME_COAP) {
+        response->code = COAP_RESPONSE_CODE(501);
+        coap_proxy_remove_association(session, 0);
+        coap_log_debug("*  %s: mcast proxy forwarding only supported for 'coap'\n",
+                       coap_session_str(session));
+        return NULL;
+      }
+    }
 
 #if COAP_AF_UNIX_SUPPORT
     coap_address_t bind_addr;
@@ -732,6 +776,10 @@ coap_proxy_call_response_handler(coap_session_t *session, const coap_pdu_t *sent
   if (!resp_pdu)
     return COAP_RESPONSE_FAIL;
 
+  /* Incase change in type of request over the proxy */
+  if (proxy_req && proxy_req->pdu)
+    resp_pdu->type = proxy_req->pdu->type;
+
   if (COAP_PROTO_NOT_RELIABLE(session->proto))
     resp_pdu->max_size = coap_session_max_pdu_size_lkd(session);
 
@@ -869,6 +917,7 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
                                           COAP_OPTION_OBSERVE,
                                           &opt_iter);
   coap_proxy_cache_t *proxy_cache = NULL;
+  coap_proxy_type_t proxy_type;
 
   /* Set up ongoing session (if not already done) */
   proxy_entry = coap_proxy_get_ongoing_session(session, request, response,
@@ -995,10 +1044,8 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
   proxy_req->pdu = coap_const_pdu_reference_lkd(request);
 
   /* Need to create the ongoing request pdu entry */
-  switch (server_list->type) {
-  case COAP_PROXY_REVERSE_STRIP:
-  case COAP_PROXY_FORWARD_STATIC_STRIP:
-  case COAP_PROXY_FORWARD_DYNAMIC_STRIP:
+  proxy_type = coap_proxy_map_type(server_list->type);
+  if (proxy_type & COAP_PROXY_BIT_STRIP) {
     /*
      * Need to replace Proxy-Uri with Uri-Host (and Uri-Port)
      * and strip out Proxy-Scheme.
@@ -1012,6 +1059,10 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
                         coap_session_max_pdu_size_lkd(proxy_entry->ongoing));
     if (!pdu) {
       goto failed;
+    }
+
+    if (coap_is_mcast(&proxy_entry->ongoing->addr_info.remote)) {
+      pdu->type = COAP_MESSAGE_NON;
     }
 
     if (!coap_add_token(pdu, token_len, token)) {
@@ -1059,11 +1110,7 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
     /* Update pdu with options */
     coap_add_optlist_pdu(pdu, &optlist);
     coap_delete_optlist(optlist);
-    break;
-  case COAP_PROXY_REVERSE:
-  case COAP_PROXY_FORWARD_STATIC:
-  case COAP_PROXY_FORWARD_DYNAMIC:
-  default:
+  } else {
     /*
      * Duplicate request PDU for onward transmission (with new token).
      */
@@ -1074,7 +1121,6 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
     }
     if (COAP_PROTO_NOT_RELIABLE(session->proto))
       pdu->max_size = coap_session_max_pdu_size_lkd(proxy_entry->ongoing);
-    break;
   }
 
   if (coap_get_data_large(request, &size, &data, &offset, &total)) {


### PR DESCRIPTION
Now configurable, previously the multicast request was just forwarded.

Following requirements of [draft-ietf-core-groupcomm](https://datatracker.ietf.org/doc/html/draft-ietf-core-groupcomm-bis-15)