### PR TITLE
add coap_context_register_payload_transmit_callback

### DIFF
--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -1093,6 +1093,12 @@ COAP_API coap_socket_flags_t coap_socket_get_flags(coap_socket_t *socket);
  */
 COAP_API void coap_socket_set_flags(coap_socket_t *socket, coap_socket_flags_t flags);
 
+
+typedef int (*coap_payload_transmit_callback_t)(coap_context_t *ctx, coap_session_t *session, coap_pdu_t *pdu, void *payload, size_t index, size_t size, void *app_data);
+
+void coap_context_register_payload_transmit_callback(coap_context_t *ctx, coap_payload_transmit_callback_t callback, void *app_data);
+
+
 /**@}*/
 
 #if defined(WITH_LWIP) || defined(WITH_LWIP_MAN_CHECK) || defined(__DOXYGEN__)

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -224,6 +224,8 @@ struct coap_context_t {
   coap_resource_dynamic_create_t dyn_create_handler; /**< Dynamc resource create handler */
   uint32_t dynamic_cur;            /* Current number of dynamic resources */
   uint32_t dynamic_max;            /* Max number of dynamic resources or 0 is unlimited */
+  void *payload_transmit_cb_app_data;                  /**< application-specific data */
+  coap_payload_transmit_callback_t payload_transmit_cb; /**< call-back to retrieve required blocks of the transmit payload */
 };
 
 /**

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -1065,6 +1065,7 @@ coap_add_data_large_internal(coap_session_t *session,
     coap_show_pdu(COAP_LOG_DEBUG, pdu);
     pdu->body_data = NULL;
     pdu->body_length = 0;
+    pdu->session = session;
 
     coap_log_debug("** %s: lg_xmit %p initialized\n",
                    coap_session_str(session), (void *)lg_xmit);
@@ -2086,6 +2087,7 @@ coap_send_q_blocks(coap_session_t *session,
       break;
     }
 
+    block_pdu->session = session;
     if (!coap_add_block(block_pdu,
                         lg_xmit->data_info->length,
                         lg_xmit->data_info->data,
@@ -3687,6 +3689,7 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *sent,
                                                 block.aszx),
                            buf);
 
+        pdu->session = session;
         if (!coap_add_block_b_data(pdu,
                                    lg_xmit->data_info->length,
                                    lg_xmit->data_info->data,

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -5214,6 +5214,13 @@ coap_register_option_lkd(coap_context_t *ctx, uint16_t type) {
   coap_option_filter_set(&ctx->known_options, type);
 }
 
+void
+coap_context_register_payload_transmit_callback(coap_context_t *ctx, coap_payload_transmit_callback_t callback, void *app_data) {
+  ctx->payload_transmit_cb = callback;
+  ctx->payload_transmit_cb_app_data = app_data;
+}
+
+
 #if ! defined WITH_CONTIKI && ! defined WITH_LWIP && ! defined RIOT_VERSION && !defined(__ZEPHYR__)
 #if COAP_SERVER_SUPPORT
 COAP_API int

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -850,8 +850,16 @@ coap_add_data(coap_pdu_t *pdu, size_t len, const uint8_t *data) {
     return 1;
   } else {
     uint8_t *payload = coap_add_data_after(pdu, len);
-    if (payload != NULL)
-      memcpy(payload, data, len);
+    if (payload != NULL) {
+      coap_context_t *ctx;
+      
+      ctx = coap_session_get_context(pdu->session);
+      if (ctx->payload_transmit_cb) {
+        return ctx->payload_transmit_cb(ctx, pdu->session, pdu, payload, (data - pdu->lg_xmit->data_info->data), len, ctx->payload_transmit_cb_app_data);
+      } else {
+        memcpy(payload, data, len);
+      }
+    }
     return payload != NULL;
   }
 }


### PR DESCRIPTION
This is a proof-of-concept patch for the introduction of an application callback that provides the data for the next block during a transmission in order to avoid keeping the complete payload in the RAM during the whole transfer. See also #1810.