### PR TITLE
Block Transfer: Support constrained memory clients

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -123,6 +123,9 @@ static size_t key_mem_len = 0;
 static size_t ca_mem_len = 0;
 static int verify_peer_cert = 1; /* PKI granularity - by default set */
 
+static FILE *file_block = NULL;
+static size_t file_size = 0;
+
 typedef struct ih_def_t {
   char *hint_match;
   coap_bin_const_t *new_identity;
@@ -269,6 +272,32 @@ track_flush_token(coap_bin_const_t *token, int force) {
   }
 }
 
+static void
+release_file_block(coap_session_t *session COAP_UNUSED, void *app_ptr) {
+  FILE *fp = (FILE *)app_ptr;
+
+  if (fp)
+    fclose(fp);
+  return;
+}
+
+static int
+get_file_block(coap_session_t *session, size_t max, size_t offset,
+               uint8_t *data, size_t *length, void *app_ptr) {
+  FILE *fp = (FILE *)app_ptr;
+
+  (void)session;
+
+  if (!fp)
+    return 0;
+
+  if (fseek(fp, (long)offset, SEEK_SET) != 0) {
+    return 0;
+  }
+  *length = fread(data, 1, max, fp);
+
+  return 1;
+}
 
 static coap_pdu_t *
 coap_new_request(coap_context_t *ctx,
@@ -311,6 +340,10 @@ coap_new_request(coap_context_t *ctx,
     /* Let the underlying libcoap decide how this data should be sent */
     coap_add_data_large_request(session, pdu, length, data,
                                 free_xmit_data, data);
+  } else if (file_size) {
+    coap_add_data_large_request_app(session, pdu, file_size,
+                                    release_file_block, get_file_block,
+                                    file_block);
   }
 
   return pdu;
@@ -546,9 +579,9 @@ usage(const char *program, const char *version) {
           coap_string_tls_version(buffer, sizeof(buffer)));
   fprintf(stderr, "%s\n", coap_string_tls_support(buffer, sizeof(buffer)));
   fprintf(stderr, "\n"
-          "Usage: %s [-a addr] [-b [num,]size] [-e text] [-f file] [-l loss]\n"
-          "\t\t[-m method] [-o file] [-p port] [-q tls_engine_conf_file] [-r]\n"
-          "\t\t[-s duration] [-t type] [-v num] [-w] [-x] [-y rec_secs]\n"
+          "Usage: %s [-a addr] [-b [num,]size] [-e text] [-f file] [-g file]\n"
+          "\t\t[-l loss] [-m method] [-o file] [-p port] [-q tls_engine_conf_file]\n"
+          "\t\t[-r] [-s duration] [-t type] [-v num] [-w] [-x] [-y rec_secs]\n"
           "\t\t[-z] [-A type] [-B seconds]\n"
           "\t\t[-E oscore_conf_file[,seq_file]] [-G count] [-H hoplimit]\n"
           "\t\t[-K interval] [-N] [-O num,text] [-P scheme://address[:port]\n"
@@ -567,6 +600,8 @@ usage(const char *program, const char *version) {
           "\t-e text\t\tInclude text as payload (use percent-encoding for\n"
           "\t       \t\tnon-ASCII characters)\n"
           "\t-f file\t\tFile to send with PUT/POST (use '-' for STDIN)\n"
+          "\t-g file\t\tFile to send with PUT/POST using individual block\n"
+          "\t       \t\trequest call-back\n"
           "\t-l list\t\tFail to send some datagrams specified by a comma\n"
           "\t       \t\tseparated list of numbers or number ranges\n"
           "\t       \t\t(for debugging only)\n"
@@ -623,9 +658,9 @@ usage(const char *program, const char *version) {
           "\t-S     \t\tUse Proxy-Scheme instead of Proxy-Uri option if -P\n"
           "\t       \t\toption used\n"
           "\t-T token\tDefine the initial starting token (up to 24 characters)\n"
-          "\t-U     \t\tNever include Uri-Host or Uri-Port options\n"
           ,program, wait_seconds);
   fprintf(stderr,
+          "\t-U     \t\tNever include Uri-Host or Uri-Port options\n"
           "\t-V num \t\tVerbosity level (default 3, maximum is 7) for (D)TLS\n"
           "\t       \t\tlibrary logging\n"
           "\t-X size\t\tMaximum message size to use for TCP based connections\n"
@@ -1338,6 +1373,32 @@ cmdline_input_from_file(char *filename, coap_string_t *buf) {
   return result;
 }
 
+static int
+cmdline_input_from_file_f(char *filename) {
+  struct stat statbuf;
+
+  if (!filename)
+    return 0;
+
+  /* open specified input file */
+  file_block = fopen(filename, "r");
+  if (!file_block) {
+    perror("cmdline_input_from_file_f: fopen");
+    return 0;
+  }
+
+  if (fstat(fileno(file_block), &statbuf) < 0) {
+    perror("cmdline_input_from_file_f: stat");
+    fclose(file_block);
+    file_block = NULL;
+    return 0;
+  }
+  file_size = statbuf.st_size;
+
+  return 1;
+}
+
+
 static method_t
 cmdline_method(char *arg) {
   static const char *methods[] =
@@ -1879,7 +1940,7 @@ main(int argc, char **argv) {
   coap_startup();
 
   while ((opt = getopt(argc, argv,
-                       "a:b:c:d:e:f:h:j:k:l:m:no:p:q:rs:t:u:v:wx:y:zA:B:C:E:G:H:J:K:L:M:NO:P:R:ST:UV:X:Y23")) != -1) {
+                       "a:b:c:d:e:f:g:h:j:k:l:m:no:p:q:rs:t:u:v:wx:y:zA:B:C:E:G:H:J:K:L:M:NO:P:R:ST:UV:X:Y23")) != -1) {
     switch (opt) {
     case 'a':
       strncpy(node_str, optarg, NI_MAXHOST - 1);
@@ -1914,6 +1975,10 @@ main(int argc, char **argv) {
       break;
     case 'f':
       if (!cmdline_input_from_file(optarg, &payload))
+        payload.length = 0;
+      break;
+    case 'g':
+      if (!cmdline_input_from_file_f(optarg))
         payload.length = 0;
       break;
     case 'j' :

--- a/include/coap3/coap_block.h
+++ b/include/coap3/coap_block.h
@@ -286,7 +286,7 @@ void coap_add_data_blocked_response(const coap_pdu_t *request,
  * coap_add_data_large_*() functions following transmission of the supplied
  * data.
  *
- * @param session The session that this data is associated with
+ * @param session The session that this data is associated with.
  * @param app_ptr The application provided pointer provided to the
  *                coap_add_data_large_* functions.
  */
@@ -328,7 +328,7 @@ typedef void (*coap_release_large_data_t)(coap_session_t *session,
  * @param pdu      The PDU to associate the data with.
  * @param length   The length of data to transmit.
  * @param data     The data to transmit.
- * @param release_func The function to call to de-allocate @p data or @c NULL
+ * @param release_func The function to call to de-allocate @p app_ptr or @c NULL
  *                 if the function is not required.
  * @param app_ptr  A Pointer that the application can provide for when
  *                 release_func() is called.
@@ -341,6 +341,71 @@ COAP_API int coap_add_data_large_request(coap_session_t *session,
                                          const uint8_t *data,
                                          coap_release_large_data_t release_func,
                                          void *app_ptr);
+
+/**
+ * Callback handler for getting the data based on @p app_ptr provided to
+ * coap_add_data_large_request_app() function for then sending the next block
+ * of data.
+ *
+ * @param session The session that this data is associated with.
+ * @param max     The maximum size of the data to be returned.
+ * @param offset  The starting offset of the requested data.
+ * @param data    Where to copy the data into.
+ * @param length  Updated with the provided data length. This cannot be
+ *                larger than @p max. This must be the same as @p max
+ *                apart from the final block.
+ * @param app_ptr The application provided pointer provided to the
+ *                coap_add_data_large_request_app function.
+ *
+ * @return 1 if data provided, else 0.
+ */
+typedef int (*coap_get_large_data_t)(coap_session_t *session, size_t max,
+                                     size_t offset,
+                                     uint8_t *data, size_t *length,
+                                     void *app_ptr);
+/**
+ * Associates given data callback with the @p pdu that is passed as second parameter.
+ *
+ * This function will fail if data has already been added to the @p pdu.
+ *
+ * Used for a client request.
+ *
+ * If the data spans multiple PDUs, then the data will get transmitted using
+ * (Q-)Block1 option with the addition of the Size1 and Request-Tag options.
+ * The underlying library will handle the transmission of the individual blocks.
+ *
+ * Each individual block of data will get requested by the use of a call-back
+ * function @p get_func before transmission.
+ *
+ * There is no need for the application to include the (Q-)Block1 option in the
+ * @p pdu.
+ *
+ * coap_add_data_large_request_app() (or the alternative coap_add_data_large_*()
+ * functions) must be called only once per PDU and must be the last PDU update
+ * before the PDU is transmitted. The (potentially) initial data will get
+ * transmitted when coap_send() is invoked.
+ *
+ * Note: COAP_BLOCK_USE_LIBCOAP must be set by coap_context_set_block_mode()
+ * for libcoap to work correctly when using this function.
+ *
+ * @param session  The session to associate the data with.
+ * @param pdu      The PDU to associate the data with.
+ * @param length   The length of data to transmit.
+ * @param release_func The function to call to de-allocate @p app_ptr or @c NULL
+ *                 if the function is not required.
+ * @param get_func The function to call to get the next block of data
+ *                 for transmission.
+ * @param app_ptr  A Pointer that the application can provide for when
+ *                 @p get_func is called.
+ *
+ * @return @c 1 if addition is successful, else @c 0.
+ */
+COAP_API int coap_add_data_large_request_app(coap_session_t *session,
+                                             coap_pdu_t *pdu,
+                                             size_t length,
+                                             coap_release_large_data_t release_func,
+                                             coap_get_large_data_t get_func,
+                                             void *app_ptr);
 
 /**
  * Associates given data with the @p response pdu that is passed as fourth
@@ -385,7 +450,7 @@ COAP_API int coap_add_data_large_request(coap_session_t *session,
  * @param etag       ETag to use if not 0.
  * @param length     The total length of the data.
  * @param data       The entire data block to transmit.
- * @param release_func The function to call to de-allocate @p data or NULL if
+ * @param release_func The function to call to de-allocate @p app_ptr or NULL if
  *                   the function is not required.
  * @param app_ptr    A Pointer that the application can provide for when
  *                   release_func() is called.

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -153,6 +153,7 @@ typedef struct coap_l_block2_t {
 typedef struct coap_lg_xmit_data_t {
   const uint8_t *data;   /**< large data ptr */
   size_t length;         /**< large data length */
+  coap_get_large_data_t get_func; /**< Where to get data id needed */
   coap_release_large_data_t release_func; /**< large data de-alloc function */
   void *app_ptr;         /**< applicaton provided ptr for de-alloc function */
   uint32_t ref;          /**< Reference count */
@@ -562,7 +563,7 @@ int coap_context_set_max_block_size_lkd(coap_context_t *context, size_t max_bloc
  * @param pdu      The PDU to associate the data with.
  * @param length   The length of data to transmit.
  * @param data     The data to transmit.
- * @param release_func The function to call to de-allocate @p data or @c NULL
+ * @param release_func The function to call to de-allocate @p app_ptr or @c NULL
  *                 if the function is not required.
  * @param app_ptr  A Pointer that the application can provide for when
  *                 release_func() is called.
@@ -575,6 +576,52 @@ int coap_add_data_large_request_lkd(coap_session_t *session,
                                     const uint8_t *data,
                                     coap_release_large_data_t release_func,
                                     void *app_ptr);
+
+/**
+ * Associates given data callback with the @p pdu that is passed as second parameter.
+ *
+ * This function will fail if data has already been added to the @p pdu.
+ *
+ * Used for a client request.
+ *
+ * If the data spans multiple PDUs, then the data will get transmitted using
+ * (Q-)Block1 option with the addition of the Size1 and Request-Tag options.
+ * The underlying library will handle the transmission of the individual blocks.
+ *
+ * Each individual block of data will get requested by the use of a call-back
+ * function @p get_func before transmission.
+ *
+ * There is no need for the application to include the (Q-)Block1 option in the
+ * @p pdu.
+ *
+ * coap_add_data_large_request_app() (or the alternative coap_add_data_large_*()
+ * functions) must be called only once per PDU and must be the last PDU update
+ * before the PDU is transmitted. The (potentially) initial data will get
+ * transmitted when coap_send() is invoked.
+ *
+ * Note: COAP_BLOCK_USE_LIBCOAP must be set by coap_context_set_block_mode()
+ * for libcoap to work correctly when using this function.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param session  The session to associate the data with.
+ * @param pdu      The PDU to associate the data with.
+ * @param length   The length of data to transmit.
+ * @param release_func The function to call to de-allocate @p app_ptr or @c NULL
+ *                 if the function is not required.
+ * @param get_func The function to call to get the next block of data
+ *                 for transmission.
+ * @param app_ptr  A Pointer that the application can provide for when
+ *                 @p get_func is called.
+ *
+ * @return @c 1 if addition is successful, else @c 0.
+ */
+int coap_add_data_large_request_app_lkd(coap_session_t *session,
+                                        coap_pdu_t *pdu,
+                                        size_t length,
+                                        coap_release_large_data_t release_func,
+                                        coap_get_large_data_t get_func,
+                                        void *app_ptr);
 
 /**
  * The function checks if the token needs to be updated before PDU is

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -7,6 +7,7 @@ global:
   coap_add_data_after;
   coap_add_data_blocked_response;
   coap_add_data_large_request;
+  coap_add_data_large_request_app;
   coap_add_data_large_response;
   coap_add_option;
   coap_add_optlist_pdu;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -5,6 +5,7 @@ coap_add_data
 coap_add_data_after
 coap_add_data_blocked_response
 coap_add_data_large_request
+coap_add_data_large_request_app
 coap_add_data_large_response
 coap_add_option
 coap_add_optlist_pdu

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -116,6 +116,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_address.3" > coap_is_bcast.3
 	@echo ".so man3/coap_address.3" > coap_is_mcast.3
 	@echo ".so man3/coap_address.3" > coap_is_af_unix.3
+	@echo ".so man3/coap_block.3" > coap_register_block_data_handler.3
 	@echo ".so man3/coap_cache.3" > coap_cache_get_pdu.3
 	@echo ".so man3/coap_cache.3" > coap_cache_get_app_data.3
 	@echo ".so man3/coap_cache.3" > coap_cache_set_app_data2.3

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -19,7 +19,8 @@ coap-client-notls
 
 SYNOPSIS
 --------
-*coap-client* [*-a* addr] [*-b* [num,]size] [*-e* text] [*-f* file] [*-l* loss]
+*coap-client* [*-a* addr] [*-b* [num,]size] [*-e* text] [*-f* file] [*-g* file]
+              [*-l* loss]
               [*-m* method] [*-o* file] [*-p* port] [*-q* tls_engine_conf_file]
               [*-r*] [*-s duration*] [*-t* type] [*-v* num] [*-w*] [*-x*]
               [*-y* rec_secs] [*-z*] [*-A* type] [*-B* seconds]
@@ -77,6 +78,9 @@ OPTIONS - General
 
 *-f* file::
    File to send with PUT/POST (use '-' for STDIN).
+
+*-g* file::
+   File to send with PUT/POST using individual block request call-back.
 
 *-l* list::
    Fail to send some datagrams specified by a comma separated list of

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -14,6 +14,7 @@ coap_block,
 coap_context_set_block_mode,
 coap_context_set_max_block_size,
 coap_add_data_large_request,
+coap_add_data_large_request_app,
 coap_add_data_large_response,
 coap_get_data_large,
 coap_block_build_body,
@@ -34,6 +35,11 @@ size_t _max_block_size_);*
 *int coap_add_data_large_request(coap_session_t *_session_,
 coap_pdu_t *_pdu_, size_t _length_, const uint8_t *_data_,
 coap_release_large_data_t _release_func_, void *_app_ptr_);*
+
+*int coap_add_data_large_request_app(coap_session_t *_session_,
+coap_pdu_t *_pdu_, size_t _length_,
+coap_release_large_data_t _release_func_, coap_get_large_data_t _get_func_,
+void *_app_ptr_);
 
 *int coap_add_data_large_response(coap_resource_t *_resource_,
 coap_session_t *_session_, const coap_pdu_t *_request_, coap_pdu_t *_response_,
@@ -303,6 +309,33 @@ _release_func_ (if set) is always called.
 *NOTE:* Options cannot be added to the _pdu_ after
 coap_add_data_large_request() is called.
 
+*Function: coap_add_data_large_request_app()*
+
+The *coap_add_data_large_request_app*() function is similar to *coap_add_data*(),
+but supports the transmission of data that has a body size that is potentially
+larger than can be fitted into a single client request PDU. Data of the specified
+overall length _length_ is requested in individual blocks using the call back
+function _get_func_ associated with the _session_ with the
+first block of data added to the PDU _pdu_ along with the appropriate CoAP
+options such as (Q-)Block1, Size1 and Request-Tag if the data does not fit in
+a single PDU.
+
+When the block receipt has been acknowledged by the peer, the library
+will then send the next block of data until all the data has been transmitted.
+
+The _app_ptr_ passed to the function *coap_add_data_large_request_app*() must
+exist until all blocks have been transmitted. The callback function
+_release_func_ can be used to release information associated with _app_ptr_. If not
+NULL, the _release_func_ callback function is called once the final block of data
+has been transmitted. The user-defined parameter _app_ptr_ is the same value that was
+passed to *coap_add_data_large_request_app*(). Even if there is an error return,
+_release_func_ (if set) is always called.
+
+*NOTE:* This function must only be called once per _pdu_.
+
+*NOTE:* Options cannot be added to the _pdu_ after
+coap_add_data_large_request() is called.
+
 *Function: coap_add_data_large_response()*
 
 The *coap_add_data_large_response*() function is responsible for handling
@@ -341,7 +374,7 @@ potentially multiple times, unless if COAP_BLOCK_STLESS_BLOCK2 is set.
 *NOTE:* This function must only be called once per _pdu_.
 
 *NOTE:* Options cannot be added to the _pdu_ after
-coap_add_data_large_request() is called.
+coap_add_data_large_response() is called.
 
 *Function: coap_get_data_large()*
 
@@ -409,8 +442,9 @@ in the updated _body_data_.
 
 RETURN VALUES
 -------------
-*coap_add_data_large_request*(), *coap_add_data_large_response*(), and
-*coap_get_data_large*() return 0 on failure, 1 on success.
+*coap_add_data_large_request*(), *coap_add_data_large_request_app*(),
+*coap_add_data_large_response*(), and *coap_get_data_large*() return 0
+on failure, 1 on success.
 
 *coap_block_build_body*() returns the current state of the body's data
 (which may have some missing gaps) or NULL on error.
@@ -532,6 +566,167 @@ main(int argc, char *argv[]) {
                  "/example/uri", NULL, data, data_length, 0);
 
   /* ... Other code etc. ... */
+
+  coap_cleanup();
+  return 0;
+}
+----
+
+*Setup PDU and Transmit - Constrained devices*
+
+[source, c]
+----
+#include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#define __USE_POSIX
+#include <stdio.h>
+#include <sys/stat.h>
+
+static FILE *file_block = NULL;
+static size_t file_size = 0;
+
+static void
+release_file_block(coap_session_t *session COAP_UNUSED, void *app_ptr) {
+  FILE *fp = (FILE *)app_ptr;
+
+  if (fp)
+    fclose(fp);
+  return;
+}
+
+static int
+get_file_block(coap_session_t *session, size_t max, size_t offset,
+               uint8_t *data, size_t *length, void *app_ptr) {
+  FILE *fp = (FILE *)app_ptr;
+
+  (void)session;
+
+  if (!fp)
+    return 0;
+
+  if (fseek(fp, (long)offset, SEEK_SET) != 0) {
+    return 0;
+  }
+  *length = fread(data, 1, max, fp);
+
+  return 1;
+}
+
+static int
+build_send_pdu(coap_context_t *context, coap_session_t *session,
+               uint8_t msgtype, uint8_t request_code, const char *path,
+               const char *query, int observe) {
+  coap_pdu_t *pdu;
+  uint8_t buf[8];
+  size_t buflen;
+  coap_optlist_t *optlist_chain = NULL;
+  /* Remove (void) definition if variable is used */
+  (void)context;
+
+  /* Create the pdu with the appropriate options */
+  pdu = coap_pdu_init(msgtype, request_code, coap_new_message_id(session),
+                      coap_session_max_pdu_size(session));
+  if (!pdu)
+    return 0;
+
+  /*
+   * Create unique token for this request for handling unsolicited /
+   * delayed responses
+   */
+  coap_session_new_token(session, &buflen, buf);
+  if (!coap_add_token(pdu, buflen, buf)) {
+    coap_log_debug("cannot add token to request\n");
+    goto error;
+  }
+
+  if (path) {
+    /* Add in the Uri-Path options */
+    if (!coap_path_into_optlist((const uint8_t *)path, strlen(path),
+                                COAP_OPTION_URI_PATH, &optlist_chain))
+      goto error;
+  }
+
+  if (query) {
+    /* Add in the Uri-Query options */
+    if (!coap_query_into_optlist((const uint8_t *)query, strlen(query),
+                                 COAP_OPTION_URI_QUERY, &optlist_chain))
+      goto error;
+  }
+
+  if (request_code == COAP_REQUEST_GET && observe) {
+    /* Indicate that we want to observe this resource */
+    if (!coap_insert_optlist(&optlist_chain,
+                             coap_new_optlist(COAP_OPTION_OBSERVE,
+                                              coap_encode_var_safe(buf, sizeof(buf),
+                                                  COAP_OBSERVE_ESTABLISH), buf)
+                            ))
+      goto error;
+  }
+
+  /* ... Other code / options etc. ... */
+
+  /* Add in all the options (after internal sorting) to the pdu */
+  if (!coap_add_optlist_pdu(pdu, &optlist_chain))
+    goto error;
+
+  if (file_size) {
+    coap_add_data_large_request_app(session, pdu, file_size,
+                                    release_file_block, get_file_block,
+                                    file_block);
+  }
+
+  if (coap_send(session, pdu) == COAP_INVALID_MID)
+    goto error;
+  coap_delete_optlist(optlist_chain);
+  return 1;
+
+error:
+
+  if (pdu)
+    coap_delete_pdu(pdu);
+  coap_delete_optlist(optlist_chain);
+  return 0;
+
+}
+
+int
+main(int argc, char *argv[]) {
+  coap_context_t *context = NULL;
+  coap_session_t *session = NULL;
+  struct stat statbuf;
+
+  (void)argc;
+
+  /* Initialize libcoap library */
+  coap_startup();
+
+  /* ... Set up context, session etc. ... */
+
+  /* Set up using libcoap to do the block work */
+  coap_context_set_block_mode(context,
+                              COAP_BLOCK_USE_LIBCOAP | COAP_BLOCK_SINGLE_BODY);
+
+  /* ... Other code etc. ... */
+
+  /* open specified input file */
+
+  file_block = fopen(argv[1], "r");
+  if (!file_block) {
+    perror("fopen");
+    return 1;
+  }
+  if (fstat(fileno(file_block), &statbuf) < 0) {
+    perror("stat");
+    fclose(file_block);
+    file_block = NULL;
+    return 1;
+  }
+  file_size = statbuf.st_size;
+
+  build_send_pdu(context, session, COAP_MESSAGE_CON, COAP_REQUEST_PUT,
+                 "/example/uri", NULL, 0);
+
+  /* ... Other coap_io_process() code etc. ... */
 
   coap_cleanup();
   return 0;

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -778,6 +778,7 @@ coap_add_data_large_internal(coap_session_t *session,
                              size_t length,
                              const uint8_t *data,
                              coap_release_large_data_t release_func,
+                             coap_get_large_data_t get_func,
                              void *app_ptr,
                              int single_request, coap_pdu_code_t request_method) {
 
@@ -1066,12 +1067,17 @@ coap_add_data_large_internal(coap_session_t *session,
       goto fail;
 
     /* Set up for displaying all the data in the pdu */
-    pdu->body_data = data;
-    pdu->body_length = length;
-    coap_log_debug("PDU presented by app.\n");
-    coap_show_pdu(COAP_LOG_DEBUG, pdu);
-    pdu->body_data = NULL;
-    pdu->body_length = 0;
+    if (!get_func) {
+      pdu->body_data = data;
+      pdu->body_length = length;
+      coap_log_debug("PDU presented by app.\n");
+      coap_show_pdu(COAP_LOG_DEBUG, pdu);
+      pdu->body_data = NULL;
+      pdu->body_length = 0;
+    } else {
+      coap_log_debug("PDU presented by app without data.\n");
+      coap_show_pdu(COAP_LOG_DEBUG, pdu);
+    }
 
     coap_log_debug("** %s: lg_xmit %p initialized\n",
                    coap_session_str(session), (void *)lg_xmit);
@@ -1089,6 +1095,7 @@ coap_add_data_large_internal(coap_session_t *session,
     lg_xmit->non_timeout_random_ticks =
         coap_get_non_timeout_random_ticks(session);
 #endif /* COAP_Q_BLOCK_SUPPORT */
+    lg_xmit->data_info->get_func = get_func;
     lg_xmit->data_info->release_func = release_func;
     lg_xmit->data_info->app_ptr = app_ptr;
     pdu->lg_xmit = lg_xmit;
@@ -1210,8 +1217,25 @@ coap_add_data_large_internal(coap_session_t *session,
     rem = block.chunk_size;
     if (rem > lg_xmit->data_info->length - block.num * chunk)
       rem = lg_xmit->data_info->length - block.num * chunk;
-    if (!coap_add_data(pdu, rem, &data[block.num * chunk]))
-      goto fail;
+    if (get_func) {
+#if COAP_CONSTRAINED_STACK
+      /* Protected by global_lock if needed */
+      static uint8_t l_data[1024];
+#else /* ! COAP_CONSTRAINED_STACK */
+      uint8_t l_data[1024];
+#endif /* ! COAP_CONSTRAINED_STACK */
+      size_t l_length;
+
+      assert(rem <= 1024);
+      if (get_func(session, rem, block.num * chunk, l_data, &l_length, lg_xmit->data_info->app_ptr)) {
+        if (!coap_add_data(pdu, l_length, l_data)) {
+          goto fail;
+        }
+      }
+    } else {
+      if (!coap_add_data(pdu, rem, &data[block.num * chunk]))
+        goto fail;
+    }
 
     if (COAP_PDU_IS_REQUEST(pdu))
       lg_xmit->b.b1.bert_size = rem;
@@ -1229,8 +1253,21 @@ coap_add_data_large_internal(coap_session_t *session,
                                               (0 << 4) | (0 << 3) | blk_size), buf);
     }
 add_data:
-    if (!coap_add_data(pdu, length, data))
-      goto fail;
+    if (get_func) {
+      uint8_t *l_data = coap_malloc_type(COAP_STRING, length);
+      size_t l_length;
+
+      if (get_func(session, length, 0, l_data, &l_length, app_ptr)) {
+        if (!coap_add_data(pdu, l_length, l_data)) {
+          coap_free_type(COAP_STRING, l_data);
+          goto fail;
+        }
+        coap_free_type(COAP_STRING, l_data);
+      }
+    } else {
+      if (!coap_add_data(pdu, length, data))
+        goto fail;
+    }
 
     if (release_func) {
       coap_lock_callback(release_func(session, app_ptr));
@@ -1283,7 +1320,42 @@ coap_add_data_large_request_lkd(coap_session_t *session,
     return 0;
   }
   return coap_add_data_large_internal(session, NULL, pdu, NULL, NULL, -1, 0,
-                                      length, data, release_func, app_ptr, 0, 0);
+                                      length, data, release_func, NULL, app_ptr, 0, 0);
+}
+
+COAP_API int
+coap_add_data_large_request_app(coap_session_t *session,
+                                coap_pdu_t *pdu,
+                                size_t length,
+                                coap_release_large_data_t release_func,
+                                coap_get_large_data_t get_func,
+                                void *app_ptr) {
+  int ret;
+
+  coap_lock_lock(return 0);
+  ret = coap_add_data_large_request_app_lkd(session, pdu, length,
+                                            release_func, get_func, app_ptr);
+  coap_lock_unlock();
+  return ret;
+}
+
+int
+coap_add_data_large_request_app_lkd(coap_session_t *session,
+                                    coap_pdu_t *pdu,
+                                    size_t length,
+                                    coap_release_large_data_t release_func,
+                                    coap_get_large_data_t get_func,
+                                    void *app_ptr) {
+  /*
+   * Delay if session->doing_first is set.
+   * E.g. Reliable and CSM not in yet for checking block support
+   */
+  if (coap_client_delay_first(session) == 0) {
+    return 0;
+  }
+  return coap_add_data_large_internal(session, NULL, pdu, NULL, NULL, -1, 0,
+                                      length, NULL, release_func, get_func,
+                                      app_ptr, 0, 0);
 }
 #endif /* ! COAP_CLIENT_SUPPORT */
 
@@ -1300,8 +1372,7 @@ coap_add_data_large_response(coap_resource_t *resource,
                              size_t length,
                              const uint8_t *data,
                              coap_release_large_data_t release_func,
-                             void *app_ptr
-                            ) {
+                             void *app_ptr) {
   int ret;
 
   coap_lock_lock(return 0);
@@ -1409,7 +1480,7 @@ coap_add_data_large_response_lkd(coap_resource_t *resource,
   if (request &&
       !coap_add_data_large_internal(session, request, response, resource,
                                     query, maxage, etag, length, data,
-                                    release_func, app_ptr, single_request,
+                                    release_func, NULL, app_ptr, single_request,
                                     request->code)) {
     response->code = COAP_RESPONSE_CODE(500);
     goto error_released;
@@ -2093,15 +2164,37 @@ coap_send_q_blocks(coap_session_t *session,
       break;
     }
 
-    if (!coap_add_block(block_pdu,
-                        lg_xmit->data_info->length,
-                        lg_xmit->data_info->data,
-                        block.num,
-                        block.szx)) {
-      coap_log_warn("Internal update issue data\n");
-      coap_delete_pdu_lkd(block_pdu);
-      coap_delete_pdu_lkd(t_pdu);
-      break;
+    if (lg_xmit->data_info->get_func) {
+#if COAP_CONSTRAINED_STACK
+      /* Protected by global_lock if needed */
+      static uint8_t l_data[1024];
+#else /* ! COAP_CONSTRAINED_STACK */
+      uint8_t l_data[1024];
+#endif /* ! COAP_CONSTRAINED_STACK */
+      size_t l_length;
+
+      assert(chunk <= 1024);
+      if (lg_xmit->data_info->get_func(session, chunk,
+                                       block.num * chunk, l_data, &l_length,
+                                       lg_xmit->data_info->app_ptr)) {
+        if (!coap_add_data(block_pdu, l_length, l_data)) {
+          coap_log_warn("Internal update issue data (1)\n");
+          coap_delete_pdu_lkd(block_pdu);
+          coap_delete_pdu_lkd(t_pdu);
+          break;
+        }
+      }
+    } else {
+      if (!coap_add_block(block_pdu,
+                          lg_xmit->data_info->length,
+                          lg_xmit->data_info->data,
+                          block.num,
+                          block.szx)) {
+        coap_log_warn("Internal update issue data (2)\n");
+        coap_delete_pdu_lkd(block_pdu);
+        coap_delete_pdu_lkd(t_pdu);
+        break;
+      }
     }
     if (COAP_PDU_IS_RESPONSE(block_pdu)) {
       lg_xmit->last_block = block.num;
@@ -2371,6 +2464,7 @@ coap_block_release_lg_xmit_data(coap_session_t *session,
   if (data_info->release_func) {
     coap_lock_callback(data_info->release_func(session,
                                                data_info->app_ptr));
+    data_info->release_func = NULL;
   }
   coap_free_type(COAP_STRING, data_info);
 }
@@ -3694,11 +3788,30 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *sent,
                                                 block.aszx),
                            buf);
 
-        if (!coap_add_block_b_data(pdu,
-                                   lg_xmit->data_info->length,
-                                   lg_xmit->data_info->data,
-                                   &block))
-          goto fail_body;
+        if (lg_xmit->data_info->get_func) {
+#if COAP_CONSTRAINED_STACK
+          /* Protected by global_lock if needed */
+          static uint8_t l_data[1024];
+#else /* ! COAP_CONSTRAINED_STACK */
+          uint8_t l_data[1024];
+#endif /* ! COAP_CONSTRAINED_STACK */
+          size_t l_length;
+
+          assert(chunk <= 1024);
+          if (lg_xmit->data_info->get_func(session, chunk,
+                                           block.num * chunk, l_data, &l_length,
+                                           lg_xmit->data_info->app_ptr)) {
+            if (!coap_add_data(pdu, l_length, l_data)) {
+              goto fail_body;
+            }
+          }
+        } else {
+          if (!coap_add_block_b_data(pdu,
+                                     lg_xmit->data_info->length,
+                                     lg_xmit->data_info->data,
+                                     &block))
+            goto fail_body;
+        }
         lg_xmit->b.b1.bert_size = block.chunk_size;
         coap_ticks(&lg_xmit->last_sent);
 #if COAP_Q_BLOCK_SUPPORT
@@ -4242,7 +4355,8 @@ reinit:
 
               if (session->block_mode & COAP_BLOCK_STLESS_FETCH && pdu->code == COAP_REQUEST_CODE_FETCH) {
                 (void)coap_get_data(lg_crcv->sent_pdu, &length, &data);
-                coap_add_data_large_internal(session, NULL, pdu, NULL, NULL, -1, 0, length, data, NULL, NULL, 0, 0);
+                coap_add_data_large_internal(session, NULL, pdu, NULL, NULL, -1, 0, length, data, NULL, NULL, NULL,
+                                             0, 0);
               }
               if (coap_send_internal(session, pdu, NULL) == COAP_INVALID_MID)
                 /* Session could now be disconnected, so no lg_crcv */

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4228,6 +4228,9 @@ handle_response(coap_context_t *context, coap_session_t *session,
       if (coap_get_block_b(session, rcvd, COAP_OPTION_Q_BLOCK2, &qblock)) {
         coap_log_debug("Q-Block support available\n");
         set_block_mode_has_q(session->block_mode);
+        if (session->state == COAP_SESSION_STATE_ESTABLISHED)
+          /* Flush out any entries on session->delayqueue */
+          coap_session_connected(session);
       } else {
         coap_log_debug("Q-Block support not available\n");
         set_block_mode_drop_q(session->block_mode);
@@ -4561,7 +4564,8 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
 #endif /* COAP_SERVER_SUPPORT */
 
 #if COAP_Q_BLOCK_SUPPORT
-    if (session->lg_xmit && sent && sent->pdu && sent->pdu->type == COAP_MESSAGE_CON) {
+    if (session->lg_xmit && sent && sent->pdu && sent->pdu->type == COAP_MESSAGE_CON &&
+        !(session->block_mode & COAP_BLOCK_PROBE_Q_BLOCK)) {
       int doing_q_block = 0;
       coap_lg_xmit_t *lg_xmit = NULL;
 


### PR DESCRIPTION
Add in new function coap_add_data_large_request_app() that provides a call-back to get individual blocks rather than having a large buffer held in (contrained) memory.