### PR TITLE
Update the lg_crcv for each block to prevent premature release during long transfers.

### DIFF
--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -4160,6 +4160,9 @@ reinit:
         if (updated_block) {
           void *body_free;
 
+          /* Update last_used to prevent premature timeout during long transfers */
+          coap_ticks(&lg_crcv->last_used);
+
           if ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) || block.bert) {
             if (size2 < saved_offset + length) {
               size2 = saved_offset + length;


### PR DESCRIPTION
# Issue
When downloading larger images when `COAP_BLOCK_USE_LIBCOAP` is set, the lg_crcv is released to early, before all blocks have been received. By updating this variable during each block, this issue ceases to exist. 

# Test config:
```
libcoap$ ./configure --with-mbedtls --disable-doxygen --disable-manpages --disable-tests
make

libcoap/examples$ ./coap-client
coap-client v4.3.5 -- a small CoAP implementation
Copyright (C) 2010-2024 Olaf Bergmann <bergmann@tzi.org> and others

Build: v4.3.5
TLS Library: Mbed TLS - runtime 3.6.4, libcoap built for 3.6.4
(DTLS and TLS support; PSK, PKI, no PKCS11, no RPK and CID support)
(Have OSCORE)
(Have WebSockets)
```

# Test case:
Downloading 1MB blob from a coaps server.

# Result w/o the fix - download stops due to premature `lg_crcv` release:
```
Uri-Path:bda61, Block2:781/_/1024, Request-Tag:0x198f017e ]
Dec 03 11:33:18.123  1 DEBG ** 172.27.9.144:52596 <-> 130.213.182.58:5684 DTLS: mid=0x76e1: added to retransmit queue (2375ms)
Dec 03 11:33:18.127  1 DEBG ** 172.27.9.144:52596 <-> 130.213.182.58:5684 DTLS: lg_crcv 0x55f2aef88820 released
Dec 03 11:33:18.241  1 DEBG *  172.27.9.144:52596 <-> 130.213.182.58:5684 DTLS: netif: recv 1082 bytes
Dec 03 11:33:18.241  1 DEBG *  172.27.9.144:52596 <-> 130.213.182.58:5684 DTLS: dtls:  recv 1045 bytes
v:1 t:ACK c:2.05 i:76e1 {30e00000000001} [ Content-Format:application/octet-stream, Block2:781/M/1024, Size2:1042352 ] :: binary data length 1024
<< . . . >>
Dec 03 11:33:18.241  1 DEBG ** 172.27.9.144:52596 <-> 130.213.182.58:5684 DTLS: mid=0x76e1: removed (1)
Dec 03 11:33:18.241  1 DEBG ** process incoming 2.05 response:
Dec 03 11:33:34.217  1 DEBG *  172.27.9.144:52596 <-> 130.213.182.58:5684 DTLS: netif: recv   39 bytes
Dec 03 11:33:34.217  1 ERR  cannot send CoAP pdu
Dec 03 11:33:34.217  1 DEBG ***172.27.9.144:52596 <-> 130.213.182.58:5684 DTLS: session disconnected (COAP_NACK_TLS_FAILED)
Dec 03 11:33:34.218  1 DEBG *  172.27.9.144:52596 <-> 130.213.182.58:5684 DTLS: netif: sent   39 bytes
Dec 03 11:33:34.218  1 DEBG ***EVENT: COAP_EVENT_DTLS_CLOSED
Dec 03 11:33:34.218  1 INFO coap_send_recv: No response received within the timeout
Dec 03 11:33:34.218  1 DEBG ***172.27.9.144:52596 <-> 130.213.182.58:5684 DTLS: session 0x55f2aef7af80: closed
```

# Result after the fix - since `lg_crcv->last_used` is updated during each block, premature release won't happen anymore:
```
Uri-Path:bda61, Block2:1017/_/1024, Request-Tag:0x74fd2e24 ]
Dec 03 11:38:24.885  1 DEBG ** 172.27.9.144:58865 <-> 130.213.182.58:5684 DTLS: mid=0xcd56: added to retransmit queue (2719ms)
Dec 03 11:38:25.009  1 DEBG *  172.27.9.144:58865 <-> 130.213.182.58:5684 DTLS: netif: recv 1002 bytes
Dec 03 11:38:25.009  1 DEBG *  172.27.9.144:58865 <-> 130.213.182.58:5684 DTLS: dtls:  recv  965 bytes
v:1 t:ACK c:2.05 i:cd56 {3fa00000000001} [ Content-Format:application/octet-stream, Block2:1017/_/1024, Size2:1042352 ] :: binary data length 944
<<...>>
Dec 03 11:38:25.009  1 DEBG ** 172.27.9.144:58865 <-> 130.213.182.58:5684 DTLS: mid=0xcd56: removed (1)
Dec 03 11:38:25.009  1 DEBG found Block option, block size is 1024, block nr. 1017
Dec 03 11:38:25.009  1 DEBG Client app version of updated PDU (3)
v:1 t:ACK c:2.05 i:cd56 {} [ Content-Format:application/octet-stream, Size2:1042352 ] :: binary data length 1042352
<<...>>
Dec 03 11:38:25.073  1 DEBG ** 172.27.9.144:58865 <-> 130.213.182.58:5684 DTLS: lg_crcv 0x55ace91de820 released
Dec 03 11:38:25.073  1 DEBG ** process incoming 2.05 response:
Dec 03 11:38:25.074  1 DEBG *  172.27.9.144:58865 <-> 130.213.182.58:5684 DTLS: netif: sent   39 bytes
Dec 03 11:38:25.074  1 DEBG ***EVENT: COAP_EVENT_DTLS_CLOSED
Dec 03 11:38:25.075  1 DEBG ***172.27.9.144:58865 <-> 130.213.182.58:5684 DTLS: session 0x55ace91d0f80: closed
```