### PR TITLE
cmake: fix COAP_THREAD_* flag handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,7 @@ check_function_exists(if_nametoindex HAVE_IF_NAMETOINDEX)
 # check for symbols
 if(WIN32)
   set(HAVE_STRUCT_CMSGHDR 1)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
   message(STATUS "setting HAVE_STRUCT_CMSGHDR")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL QNX)
   set(HAVE_STRUCT_CMSGHDR 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,22 +428,22 @@ else()
 endif()
 
 if(${ENABLE_THREAD_SAFE})
-  set(COAP_THREAD_SAFE "${ENABLE_THREAD_SAFE}")
+  set(COAP_THREAD_SAFE "1")
   message(STATUS "compiling with thread safe support")
 endif()
 
 if(${ENABLE_THREAD_RECURSIVE_LOCK_CHECK})
-  set(COAP_THREAD_RECURSIVE_CHECK "${ENABLE_THREAD_RECURSIVE_LOCK_CHECK}")
+  set(COAP_THREAD_RECURSIVE_CHECK "1")
   message(STATUS "compiling with thread recursive lock detection support")
 endif()
 
 if(${ENABLE_THREAD_NUM_LOGGING})
-  set(COAP_THREAD_NUM_LOGGING "${ENABLE_THREAD_NUM_LOGGING}")
+  set(COAP_THREAD_NUM_LOGGING "1")
   message(STATUS "compiling with thread number logging support")
 endif()
 
 if(${ENABLE_SMALL_STACK})
-  set(COAP_CONSTRAINED_STACK "${ENABLE_SMALL_STACK}")
+  set(COAP_CONSTRAINED_STACK "1")
   message(STATUS "compiling with small stack support")
 endif()
 

--- a/cmake_coap_config.h.in
+++ b/cmake_coap_config.h.in
@@ -85,6 +85,9 @@
 /* Define to 1 if you have the `select' function. */
 #cmakedefine HAVE_SELECT @HAVE_SELECT@
 
+/* Define to 1 if you have the <signal.h> header file. */
+#cmakedefine HAVE_SIGNAL_H @HAVE_SIGNAL_H@
+
 /* Define to 1 if you have the `socket' function. */
 #cmakedefine HAVE_SOCKET @HAVE_SOCKET@
 


### PR DESCRIPTION
Hello,

while investigating #1817, I noticed that, despite 8c1e09a25dabbd2d47cddff42807784af3c11a24, I still do not see the thread numbers and that no COAP_THREAD_* flag is in effect when building with cmake. They are set to "ON" and `#if COAP_THREAD_SAFE` results in `false` in this case. This PR sets them to "1" and adds the then missing `HAVE_SIGNAL_H` flag.