### PR TITLE
LwIP: Fix TCP traffic timing windows

### DIFF
--- a/examples/lwip/Makefile
+++ b/examples/lwip/Makefile
@@ -124,7 +124,7 @@ CFLAGS += -Ilwip/src/include/ -Ilwip/src/include/ipv4/ \
 LWIP_SRC = def.c init.c tapif.c etharp.c netif.c timeouts.c stats.c udp.c \
 	   tcp.c pbuf.c ip4_addr.c ip4.c inet_chksum.c tcp_in.c tcp_out.c \
 	   icmp.c raw.c ip4_frag.c sys_arch.c ethernet.c ip.c mem.c memp.c \
-	   igmp.c tcpip.c
+	   igmp.c tcpip.c dns.c
 vpath %.c lwip/src/core/ lwip/contrib/ports/unix/proj/minimal/ \
 	  lwip/src/netif/ lwip/src/core/ipv4/ $(USE_LWIP_CONTRIB)/ports/unix/port/ \
 	  $(USE_LWIP_CONTRIB)/ports/unix/port/netif/ lwip/src/api/

--- a/examples/lwip/client.c
+++ b/examples/lwip/client.c
@@ -38,6 +38,7 @@
 
 #include <lwip/init.h>
 #include <lwip/timeouts.h>
+#include <lwip/tcpip.h>
 
 #include <netif/etharp.h>
 #include <netif/tapif.h>
@@ -111,9 +112,17 @@ main(int argc, char **argv) {
   printf("TCP/IP initialized.\n");
 
 #if LWIP_IPV4
-  netif_add(&netif, &ipaddr, &netmask, &gw, NULL, tapif_init, ethernet_input);
+#if NO_SYS
+  netif_add(&netif, &ipaddr, &netmask, &gw, NULL, tapif_init, netif_input);
+#else /* NO_SYS == 0 */
+  netif_add(&netif, &ipaddr, &netmask, &gw, NULL, tapif_init, tcpip_input);
+#endif /* NO_SYS == 0 */
 #else  /* ! LWIP_IPV4 */
-  netif_add(&netif, NULL, tapif_init, ethernet_input);
+#if NO_SYS
+  netif_add(&netif, NULL, tapif_init, netif_init);
+#else /* NO_SYS == 0 */
+  netif_add(&netif, NULL, tapif_init, tcpip_init);
+#endif /* NO_SYS == 0 */
 #endif /* ! LWIP_IPV4 */
   netif.flags |= NETIF_FLAG_ETHARP;
   netif_set_default(&netif);

--- a/examples/lwip/config/lwipopts.h
+++ b/examples/lwip/config/lwipopts.h
@@ -21,8 +21,8 @@
  *  Use lwIP without OS-awareness (no thread, semaphores, mutexes or mboxes).
  */
 #define NO_SYS                     0
-#define LWIP_SOCKET                (NO_SYS==0)
-#define LWIP_NETCONN               (NO_SYS==0)
+#define LWIP_SOCKET                0
+#define LWIP_NETCONN               0
 #define LWIP_NETIF_API             (NO_SYS==0)
 
 #define LWIP_IPV4                       1
@@ -32,8 +32,8 @@
 
 #define LWIP_ICMP6                 (LWIP_IPV6==1)
 
-/* Set to 1 if TCP support is required */
-#define LWIP_TCP                        0
+/* Set to 0 if TCP support is not required */
+#define LWIP_TCP                        1
 
 #if LWIP_IPV4
 /* Set to 1 if Multicast registration support is required for IPv4 */
@@ -43,6 +43,13 @@
 #if LWIP_IPV6
 /* Set to 1 if Multicast registration support is required for IPv6 */
 #define LWIP_IPV6_MLD                   0
+#endif
+
+/*
+ * Set to 1 for DNS resolution support
+ */
+#if 1
+#define LWIP_DNS                        1
 #endif
 
 #ifndef netif_get_index
@@ -96,6 +103,22 @@
 #if 0
 #define LWIP_DEBUG 1
 #define UDP_DEBUG LWIP_DBG_ON
+#endif
+
+/*
+ * Set to 1 for debugging TCP traffic and LWIP_DBG_ON where appropriate
+ */
+#if 0
+#define LWIP_DEBUG 1
+#define TCP_DEBUG            LWIP_DBG_ON
+#define TCP_INPUT_DEBUG      LWIP_DBG_ON
+#define TCP_OUTPUT_DEBUG     LWIP_DBG_ON
+#define TCP_RTO_DEBUG        LWIP_DBG_ON
+#define TCP_CWND_DEBUG       LWIP_DBG_ON
+#define TCP_WND_DEBUG        LWIP_DBG_ON
+#define TCP_FR_DEBUG         LWIP_DBG_ON
+#define TCP_QLEN_DEBUG       LWIP_DBG_ON
+#define TCP_RST_DEBUG        LWIP_DBG_ON
 #endif
 
 #endif /* LWIPOPTS_H_ */

--- a/examples/lwip/config/lwippools.h
+++ b/examples/lwip/config/lwippools.h
@@ -105,7 +105,7 @@ typedef struct l_coap_tiny_context_t {
 #endif
 
 #ifndef MEMP_NUM_COAPSTRING
-#define MEMP_NUM_COAPSTRING 12
+#define MEMP_NUM_COAPSTRING 20
 #endif
 
 #ifndef MEMP_LEN_COAPSTRING

--- a/examples/lwip/server-coap.c
+++ b/examples/lwip/server-coap.c
@@ -26,6 +26,23 @@ static coap_resource_t *time_resource = NULL; /* just for testing */
 # define min(a,b) ((a) < (b) ? (a) : (b))
 #endif
 
+#define INDEX "This is a LwIP test server made with libcoap (see https://libcoap.net)\n" \
+  "Copyright (C) 2010--2025 Olaf Bergmann <bergmann@tzi.org> and others\n\n"
+
+static void
+hnd_get_index(coap_resource_t *resource,
+              coap_session_t *session,
+              const coap_pdu_t *request,
+              const coap_string_t *query COAP_UNUSED,
+              coap_pdu_t *response) {
+
+  (void)resource;
+  (void)session;
+  (void)request;
+  coap_pdu_set_code(response, COAP_RESPONSE_CODE_CONTENT);
+  coap_add_data(response, strlen(INDEX), (const uint8_t *)INDEX);
+}
+
 void
 hnd_get_time(coap_resource_t *resource, coap_session_t  *session,
              const coap_pdu_t *request, const coap_string_t *query,
@@ -76,14 +93,13 @@ hnd_get_time(coap_resource_t *resource, coap_session_t  *session,
 void
 init_coap_resources(coap_context_t *ctx) {
   coap_resource_t *r;
-#if 0
-  r = coap_resource_init(NULL, 0, 0);
+  r = coap_resource_init(NULL, 0);
   coap_register_handler(r, COAP_REQUEST_GET, hnd_get_index);
 
   coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
   coap_add_attr(r, coap_make_str_const("title"), coap_make_str_const("\"General Info\""), 0);
   coap_add_resource(ctx, r);
-#endif
+
   /* store clock base to use in /time */
   my_clock_base = clock_offset;
 

--- a/examples/lwip/server.c
+++ b/examples/lwip/server.c
@@ -44,6 +44,7 @@
 #if LWIP_IPV6_MLD && LWIP_IPV6
 #include <lwip/mld6.h>
 #endif /* LWIP_IPV6_MLD && LWIP_IPV6 */
+#include <lwip/tcpip.h>
 
 #include <netif/etharp.h>
 #include <netif/tapif.h>
@@ -134,7 +135,17 @@ main(int argc, char **argv) {
   printf("TCP/IP initialized.\n");
 
 #if LWIP_IPV4
-  netif_add(&netif, &ipaddr, &netmask, &gw, NULL, tapif_init, ethernet_input);
+#if NO_SYS
+  netif_add(&netif, &ipaddr, &netmask, &gw, NULL, tapif_init, netif_input);
+#else /* NO_SYS == 0 */
+  netif_add(&netif, &ipaddr, &netmask, &gw, NULL, tapif_init, tcpip_input);
+#endif /* NO_SYS == 0 */
+#else  /* ! LWIP_IPV4 */
+#if NO_SYS
+  netif_add(&netif, NULL, tapif_init, netif_init);
+#else /* NO_SYS == 0 */
+  netif_add(&netif, NULL, tapif_init, tcpip_init);
+#endif /* NO_SYS == 0 */
 #endif /* LWIP_IPV4 */
   netif.flags |= NETIF_FLAG_ETHARP;
   netif_set_default(&netif);

--- a/src/coap_address.c
+++ b/src/coap_address.c
@@ -575,7 +575,7 @@ update_coap_addr_port(coap_uri_scheme_t scheme, coap_addr_info_t *info,
   }
 }
 
-#if defined(WITH_LWIP) && !(LWIP_DNS && LWIP_SOCKET && LWIP_COMPAT_SOCKETS)
+#if defined(WITH_LWIP) && !(LWIP_DNS)
 
 coap_addr_info_t *
 coap_resolve_address_info(const coap_str_const_t *address,

--- a/src/coap_dgrm_lwip.c
+++ b/src/coap_dgrm_lwip.c
@@ -484,11 +484,11 @@ coap_lwip_udp_remove(void *ctx) {
 void
 coap_socket_dgrm_close(coap_socket_t *sock) {
   struct udp_pcb *udp_pcb = sock->udp_pcb;
-  err_t err;
 
   sock->udp_pcb = NULL;
   if (udp_pcb) {
 #if NO_SYS == 0
+    err_t err;
     if (coap_lwip_in_call_back_ref == 0) {
       err = tcpip_try_callback(coap_lwip_udp_remove, udp_pcb);
 

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -124,10 +124,16 @@ coap_io_process_lkd(coap_context_t *context, uint32_t timeout_ms) {
   coap_log_info("****** Next wakeup msecs %u (2)\n",
                 timeout);
 #endif /* COAP_DEBUG_WAKEUP_TIMES */
-  if (timeout) {
-    sys_timeout(timeout, coap_io_process_timeout, context);
-    context->timer_configured = 1;
+#if NO_SYS == 0
+  if (!context->input_wait) {
+#endif /* NO_SYS == 0 */
+    if (timeout) {
+      sys_timeout(timeout, coap_io_process_timeout, context);
+      context->timer_configured = 1;
+    }
+#if NO_SYS == 0
   }
+#endif /* NO_SYS == 0 */
 
   UNLOCK_TCPIP_CORE();
 

--- a/src/coap_strm_lwip.c
+++ b/src/coap_strm_lwip.c
@@ -31,6 +31,7 @@ coap_tcp_is_supported(void) {
 #include <lwip/tcp.h>
 
 #if NO_SYS == 0
+extern sys_sem_t coap_io_timeout_sem;
 extern uint32_t coap_lwip_in_call_back_ref;
 #endif /* NO_SYS == 0 */
 
@@ -47,6 +48,9 @@ do_tcp_err(void *arg, err_t err) {
 
   (void)err;
 
+  if (!session)
+    return;
+
   coap_lock_lock(return);
   coap_handle_event_lkd(session->context, COAP_EVENT_TCP_FAILED, session);
   /*
@@ -57,6 +61,9 @@ do_tcp_err(void *arg, err_t err) {
   session->sock.tcp_pcb = NULL;
   coap_session_disconnected_lkd(session, COAP_NACK_NOT_DELIVERABLE);
   coap_lock_unlock();
+#if NO_SYS == 0
+  sys_sem_signal(&coap_io_timeout_sem);
+#endif /* NO_SYS == 0 */
 }
 
 /** Callback from lwIP when a TCP packet is received.
@@ -67,25 +74,35 @@ do_tcp_err(void *arg, err_t err) {
 static err_t
 coap_tcp_recv(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err) {
   coap_session_t *session = (coap_session_t *)arg;
-  coap_socket_t *sock = &session->sock;
+  coap_socket_t *sock = session ? &session->sock : NULL;
   coap_tick_t now;
 
   (void)tpcb;
+  if (!session)
+    return ERR_ARG;
+
   if (p == NULL) {
     /* remote host closed connection */
+    tcp_close(sock->tcp_pcb);
     tcp_arg(sock->tcp_pcb, NULL);
     tcp_recv(sock->tcp_pcb, NULL);
-    tcp_close(sock->tcp_pcb);
     sock->tcp_pcb = NULL;
     coap_lock_lock(return ERR_ARG);
     coap_session_disconnected_lkd(session, COAP_NACK_NOT_DELIVERABLE);
     coap_lock_unlock();
+#if NO_SYS == 0
+    sys_sem_signal(&coap_io_timeout_sem);
+#endif /* NO_SYS == 0 */
     return ERR_OK;
   } else if (err != ERR_OK) {
     /* cleanup, for unknown reason */
     if (p != NULL) {
       pbuf_free(p);
     }
+    tcp_recved(sock->tcp_pcb, p->tot_len);
+#if NO_SYS == 0
+    sys_sem_signal(&coap_io_timeout_sem);
+#endif /* NO_SYS == 0 */
     return err;
   }
 
@@ -100,6 +117,9 @@ coap_tcp_recv(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err) {
   coap_lwip_in_call_back_ref--;
 #endif /* NO_SYS == 0 */
   coap_lock_unlock();
+#if NO_SYS == 0
+  sys_sem_signal(&coap_io_timeout_sem);
+#endif /* NO_SYS == 0 */
   return ERR_OK;
 }
 
@@ -120,6 +140,9 @@ do_tcp_connected(void *arg, struct tcp_pcb *tpcb, err_t err) {
   coap_ticks(&now);
   coap_connect_session(session, now);
   coap_lock_unlock();
+#if NO_SYS == 0
+  sys_sem_signal(&coap_io_timeout_sem);
+#endif /* NO_SYS == 0 */
   return ERR_OK;
 }
 
@@ -212,6 +235,9 @@ do_tcp_accept(void *arg, struct tcp_pcb *newpcb, err_t err) {
     ret_err = ERR_MEM;
   }
   coap_lock_unlock();
+#if NO_SYS == 0
+  sys_sem_signal(&coap_io_timeout_sem);
+#endif /* NO_SYS == 0 */
   return ret_err;
 }
 
@@ -289,6 +315,7 @@ coap_lwip_tcp_write(void *ctx) {
     }
     pbuf_free(cb_ctx->pbuf);
     coap_free_type(COAP_STRING, cb_ctx);
+    sys_sem_signal(&coap_io_timeout_sem);
   }
 }
 #endif /* NO_SYS == 0 */
@@ -361,12 +388,14 @@ coap_socket_read(coap_socket_t *sock, uint8_t *data, size_t data_len) {
       memcpy(data, sock->p->payload, data_len);
       sock->p->payload = &ptr[data_len];
       sock->p->len -= data_len;
+      tcp_recved(sock->tcp_pcb, data_len);
       return data_len;
     } else {
       data_len = sock->p->len;
       memcpy(data, sock->p->payload, sock->p->len);
       pbuf_free(sock->p);
       sock->p = NULL;
+      tcp_recved(sock->tcp_pcb, data_len);
       return data_len;
     }
   }
@@ -379,6 +408,8 @@ coap_lwip_tcp_close(void *ctx) {
   struct tcp_pcb *tcp_pcb = (struct tcp_pcb *)ctx;
 
   if (tcp_pcb) {
+    tcp_err(tcp_pcb, NULL);
+    tcp_arg(tcp_pcb, NULL);
     tcp_recv(tcp_pcb, NULL);
     tcp_close(tcp_pcb);
   }
@@ -398,7 +429,9 @@ coap_lwip_endpoint_tcp_close(void *ctx) {
 void
 coap_socket_strm_close(coap_socket_t *sock) {
   struct tcp_pcb *tcp_pcb = sock->tcp_pcb;
+#if NO_SYS == 0
   err_t err;
+#endif /* NO_SYS == 0 */
 
   sock->tcp_pcb = NULL;
   if (tcp_pcb) {


### PR DESCRIPTION
Use correct input function for netif_add() in examples.

Invoke coap_io_process() as soon as possible following TCP input / error.

Update rcvd window size after receipt of data.

Addresses issues in #1826.