### PR TITLE
coap_session.c: Remove need for waiting for CSM for TCP call-home

### DIFF
--- a/src/coap_dtls.c
+++ b/src/coap_dtls.c
@@ -266,11 +266,11 @@ void
 coap_dtls_establish(coap_session_t *session) {
   session->state = COAP_SESSION_STATE_HANDSHAKE;
 #if COAP_CLIENT_SUPPORT
-  if (session->type == COAP_SESSION_TYPE_CLIENT)
+  if (session->type == COAP_SESSION_TYPE_CLIENT || session->client_initiated)
     session->tls = coap_dtls_new_client_session(session);
+  else
 #endif /* COAP_CLIENT_SUPPORT */
 #if COAP_SERVER_SUPPORT
-  if (session->type != COAP_SESSION_TYPE_CLIENT)
     session->tls = coap_dtls_new_server_session(session);
 #endif /* COAP_SERVER_SUPPORT */
 
@@ -295,11 +295,11 @@ void
 coap_tls_establish(coap_session_t *session) {
   session->state = COAP_SESSION_STATE_HANDSHAKE;
 #if COAP_CLIENT_SUPPORT
-  if (session->type == COAP_SESSION_TYPE_CLIENT)
+  if (session->type == COAP_SESSION_TYPE_CLIENT || session->client_initiated)
     session->tls = coap_tls_new_client_session(session);
+  else
 #endif /* COAP_CLIENT_SUPPORT */
 #if COAP_SERVER_SUPPORT
-  if (session->type != COAP_SESSION_TYPE_CLIENT)
     session->tls = coap_tls_new_server_session(session);
 #endif /* COAP_SERVER_SUPPORT */
 

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -2321,27 +2321,27 @@ coap_session_set_type_server_lkd(coap_session_t *session) {
       LL_PREPEND(session->context->endpoint, ep);
     }
     /* Need to use coap_send_lkd() here to get traffic flowing */
-    if (COAP_PROTO_NOT_RELIABLE(session->proto)) {
-      ping = coap_new_pdu_lkd(COAP_MESSAGE_CON, COAP_EMPTY_CODE, session);
-    }
-#if !COAP_DISABLE_TCP
-    else {
-      ping = coap_new_pdu_lkd(COAP_MESSAGE_CON, COAP_SIGNALING_CODE_PING, session);
-    }
-#endif /* !COAP_DISABLE_TCP */
-    if (!ping) {
-      session->type = COAP_SESSION_TYPE_SERVER;
-      return 0;
-    }
-    mid = coap_send_lkd(session, ping);
-    if (mid != COAP_INVALID_MID) {
-      coap_tick_t now;
+    if (session->proto == COAP_PROTO_UDP) {
+      ping = coap_pdu_init(COAP_MESSAGE_CON, COAP_EMPTY_CODE,
+                           coap_new_message_id_lkd(session), 0);
+      if (!ping) {
+        session->type = COAP_SESSION_TYPE_SERVER;
+        return 0;
+      }
+      mid = coap_send_lkd(session, ping);
+      if (mid != COAP_INVALID_MID) {
+        coap_tick_t now;
 
-      coap_ticks(&now);
-      session->last_ping_mid = mid;
-      session->last_rx_tx = now;
-      session->last_ping = now;
+        coap_ticks(&now);
+        session->last_ping_mid = mid;
+        session->last_rx_tx = now;
+        session->last_ping = now;
+      }
     }
+    /*
+     * (D)TLS will initiate traffic with handshake.
+     * Reliable protocols will be sending a CSM, so no nead for Ping.
+     */
     if (session->context) {
       if (session->context->sessions) {
         SESSIONS_DELETE(session->context->sessions, session);


### PR DESCRIPTION
Fixes (D)TLS startup direction as well.