### PR TITLE
size_t %zu format: Support compilers that do not support printf %zu

### DIFF
--- a/include/coap3/coap_internal.h
+++ b/include/coap3/coap_internal.h
@@ -51,6 +51,16 @@
 #define PRIu64 "lu"
 #endif /* ! PRIu64 */
 #endif /* ! HAVE_INTTYPES_H */
+/*
+ * To handle compilers / libraries that cannot handle %zu/%zd formats.
+ * Define these separately to whatver the complier / library can work with.
+ */
+#ifndef PRIuS
+#define PRIuS "zu"
+#endif /* PRIuS */
+#ifndef PRIdS
+#define PRIdS "zd"
+#endif /* PRIdS */
 
 #if defined(HAVE_ERRNO_H)
 # include <errno.h>

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -19,6 +19,14 @@
 #include <dirent.h>
 #include <errno.h>
 #include <string.h>
+#include <inttypes.h>
+#ifndef PRIuS
+#define PRIuS "zu"
+#endif /* PRIuS */
+#ifndef PRIdS
+#define PRIdS "zd"
+#endif /* PRIdS */
+
 
 #ifdef _WIN32
 #define GCC_OPTIONS "-I../include"
@@ -460,7 +468,7 @@ main(int argc, char *argv[]) {
         man_cnt++;
       }
       if (man_cnt == sizeof(man_list) / sizeof(name_list[0])) {
-        fprintf(stderr, "man_list[] too small (%zd) for entries from %s\n",
+        fprintf(stderr, "man_list[] too small (%" PRIdS ") for entries from %s\n",
                 sizeof(man_list) / sizeof(name_list[0]), argv[2]);
         exit(1);
       }
@@ -630,7 +638,7 @@ main(int argc, char *argv[]) {
           if (i != name_cnt)
             continue;
           if (i >= (int)(sizeof(name_list)/sizeof(name_list[0]))) {
-            fprintf(stderr, "NAME: %s insufficient space (%zu >= %u)\n", buffer,
+            fprintf(stderr, "NAME: %s insufficient space (%" PRIuS " >= %u)\n", buffer,
                     i, (int)(sizeof(name_list)/sizeof(name_list[0])));
             continue;
           }

--- a/src/coap_address.c
+++ b/src/coap_address.c
@@ -682,7 +682,7 @@ coap_resolve_address_info(const coap_str_const_t *address,
   memset(addrstr, 0, sizeof(addrstr));
   if (address && address->length) {
     if (address->length >= sizeof(addrstr)) {
-      coap_log_warn("Host name too long (%zu > 255)\n", address->length);
+      coap_log_warn("Host name too long (%" PRIuS " > 255)\n", address->length);
       return NULL;
     }
     memcpy(addrstr, address->s, address->length);

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -86,7 +86,7 @@ coap_get_block_b(const coap_session_t *session, const coap_pdu_t *pdu,
       block->bert = 1;
       if (coap_get_data(pdu, &length, &data)) {
         if (block->m && (length % 1024) != 0) {
-          coap_log_debug("block: Oversized packet - reduced to %zu from %zu\n",
+          coap_log_debug("block: Oversized packet - reduced to %" PRIuS " from %" PRIuS "\n",
                          length - (length % 1024), length);
           length -= length % 1024;
         }
@@ -159,7 +159,7 @@ setup_block_b(coap_session_t *session, coap_pdu_t *pdu, coap_block_b_t *block,
         return 0;
       }
       new_blk_size = coap_flsll((long long)avail) - 5;
-      coap_log_debug("decrease block size for %zu to %d\n", avail, new_blk_size);
+      coap_log_debug("decrease block size for %" PRIuS " to %d\n", avail, new_blk_size);
       szx = block->szx;
       block->szx = new_blk_size;
       block->num <<= szx - block->szx;
@@ -299,7 +299,7 @@ coap_add_data_blocked_response(const coap_pdu_t *request,
     if (coap_get_block(request, COAP_OPTION_BLOCK2, &block2)) {
       block2_requested = 1;
       if (block2.num != 0 && length <= (block2.num << (block2.szx + 4))) {
-        coap_log_debug("Illegal block requested (%d > last = %zu)\n",
+        coap_log_debug("Illegal block requested (%d > last = %" PRIuS ")\n",
                        block2.num,
                        length >> (block2.szx + 4));
         response->code = COAP_RESPONSE_CODE(400);
@@ -455,7 +455,7 @@ coap_context_set_max_block_size_lkd(coap_context_t *context, size_t max_block_si
   case 1024:
     break;
   default:
-    coap_log_info("coap_context_set_max_block_size: Invalid max block size (%zu)\n",
+    coap_log_info("coap_context_set_max_block_size: Invalid max block size (%" PRIuS ")\n",
                   max_block_size);
     return 0;
   }
@@ -1417,7 +1417,7 @@ coap_add_data_large_response_lkd(coap_resource_t *resource,
     if (coap_get_block_b(session, request, COAP_OPTION_BLOCK2, &block)) {
       block_requested = 1;
       if (block.num != 0 && length <= (block.num << (block.szx + 4))) {
-        coap_log_debug("Illegal block requested (%d > last = %zu)\n",
+        coap_log_debug("Illegal block requested (%d > last = %" PRIuS ")\n",
                        block.num,
                        length >> (block.szx + 4));
         response->code = COAP_RESPONSE_CODE(400);
@@ -1428,7 +1428,7 @@ coap_add_data_large_response_lkd(coap_resource_t *resource,
     else if (coap_get_block_b(session, request, COAP_OPTION_Q_BLOCK2, &block)) {
       block_requested = 1;
       if (block.num != 0 && length <= (block.num << (block.szx + 4))) {
-        coap_log_debug("Illegal block requested (%d > last = %zu)\n",
+        coap_log_debug("Illegal block requested (%d > last = %" PRIuS ")\n",
                        block.num,
                        length >> (block.szx + 4));
         response->code = COAP_RESPONSE_CODE(400);
@@ -2828,7 +2828,7 @@ coap_handle_request_send_block(coap_session_t *session,
         } else {
           coap_log_debug("ignoring request to increase Block size, "
                          "next block is not aligned on requested block size "
-                         "boundary. (%zu x %u mod %u = %zu (which is not 0)\n",
+                         "boundary. (%" PRIuS " x %u mod %u = %" PRIuS " (which is not 0)\n",
                          lg_xmit->offset/chunk + 1, (1 << (lg_xmit->blk_size + 4)),
                          (1 << (block.szx + 4)),
                          (lg_xmit->offset + chunk) % ((size_t)1 << (block.szx + 4)));
@@ -3178,11 +3178,11 @@ coap_handle_request_put_block(coap_context_t *context,
   rtag = rtag_opt ? coap_opt_value(rtag_opt) : NULL;
 
   if (length > block.chunk_size) {
-    coap_log_debug("block: Oversized packet - reduced to %"PRIu32" from %zu\n",
+    coap_log_debug("block: Oversized packet - reduced to %"PRIu32" from %" PRIuS "\n",
                    block.chunk_size, length);
     length = block.chunk_size;
   } else if (!block.bert && block.m && length != block.chunk_size) {
-    coap_log_info("block: Undersized packet chunk %"PRIu32" got %zu\n",
+    coap_log_info("block: Undersized packet chunk %"PRIu32" got %" PRIuS "\n",
                   block.chunk_size, length);
     response->code = COAP_RESPONSE_CODE(400);
     goto skip_app_handler;
@@ -3683,7 +3683,7 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *sent,
         coap_get_block_b(session, rcvd, lg_xmit->option, &block)) {
 
       if (block.bert) {
-        coap_log_debug("found Block option, block is BERT, block nr. %u (%zu)\n",
+        coap_log_debug("found Block option, block is BERT, block nr. %u (%" PRIuS ")\n",
                        block.num, lg_xmit->b.b1.bert_size);
       } else {
         coap_log_debug("found Block option, block size is %u, block nr. %u\n",
@@ -3710,7 +3710,7 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *sent,
         } else {
           coap_log_debug("ignoring request to increase Block size, "
                          "next block is not aligned on requested block size boundary. "
-                         "(%zu x %u mod %u = %zu != 0)\n",
+                         "(%" PRIuS " x %u mod %u = %" PRIuS " != 0)\n",
                          lg_xmit->offset/chunk + 1, (1 << (lg_xmit->blk_size + 4)),
                          (1 << (block.szx + 4)),
                          (lg_xmit->offset + chunk) % ((size_t)1 << (block.szx + 4)));
@@ -4117,12 +4117,12 @@ coap_handle_response_get_block(coap_context_t *context,
         int updated_block;
 
         if (length > block.chunk_size) {
-          coap_log_debug("block: Oversized packet - reduced to %"PRIu32" from %zu\n",
+          coap_log_debug("block: Oversized packet - reduced to %"PRIu32" from %" PRIuS "\n",
                          block.chunk_size, length);
           length = block.chunk_size;
         }
         if (block.m && length != block.chunk_size) {
-          coap_log_warn("block: Undersized packet - expected %"PRIu32", got %zu\n",
+          coap_log_warn("block: Undersized packet - expected %"PRIu32", got %" PRIuS "\n",
                         block.chunk_size, length);
           /* Unclear how to properly handle this */
           rcvd->code = COAP_RESPONSE_CODE(402);

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -920,7 +920,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
          * letter M if set, the _ otherwise */
         if (COAP_OPT_BLOCK_SZX(option) == 7) {
           if (coap_get_data(pdu, &data_len, &data))
-            buf_len = snprintf((char *)buf, sizeof(buf), "%u/%c/BERT(%zu)",
+            buf_len = snprintf((char *)buf, sizeof(buf), "%u/%c/BERT(%" PRIuS ")",
                                coap_opt_block_num(option), /* block number */
                                COAP_OPT_BLOCK_MORE(option) ? 'M' : '_', /* M bit */
                                data_len);
@@ -1065,7 +1065,7 @@ no_more:
       snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,  " :: ");
       outbuflen = strlen(outbuf);
       snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
-               "data length %zu (data suppressed)\n", data_len);
+               "data length %"PRIuS " (data suppressed)\n", data_len);
       COAP_DO_SHOW_OUTPUT_LINE;
 #if COAP_THREAD_SAFE
       coap_mutex_unlock(&m_show_pdu);
@@ -1082,7 +1082,7 @@ no_more:
 
       outbuflen = strlen(outbuf);
       snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
-               "binary data length %zu\n", data_len);
+               "binary data length %"PRIuS "\n", data_len);
       COAP_DO_SHOW_OUTPUT_LINE;
       /*
        * Output hex dump of binary data as a continuous entry

--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -2052,7 +2052,7 @@ coap_dgram_write(gnutls_transport_ptr_t context, const void *send_buffer,
     if (result != (int)send_buffer_length) {
       int keep_errno = errno;
 
-      coap_log_warn("coap_netif_dgrm_write failed (%zd != %zu)\n",
+      coap_log_warn("coap_netif_dgrm_write failed (%" PRIdS " != %" PRIuS ")\n",
                     result, send_buffer_length);
       errno = keep_errno;
       if (result < 0) {
@@ -2742,7 +2742,7 @@ coap_sock_write(gnutls_transport_ptr_t context, const void *in, size_t inl) {
        */
       ret = inl;
     } else {
-      coap_log_debug("*  %s: failed to send %zd bytes (%s) state %d\n",
+      coap_log_debug("*  %s: failed to send %" PRIdS " bytes (%s) state %d\n",
                      coap_session_str(c_session), inl, coap_socket_strerror(),
                      c_session->state);
     }

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -312,7 +312,7 @@ coap_dgram_write(void *ctx, const unsigned char *send_buffer,
     if (result != (ssize_t)send_buffer_length) {
       int keep_errno = errno;
 
-      coap_log_warn("coap_netif_dgrm_write failed (%zd != %zu)\n",
+      coap_log_warn("coap_netif_dgrm_write failed (%" PRIdS " != %" PRIuS ")\n",
                     result, send_buffer_length);
       errno = keep_errno;
       if (result < 0) {
@@ -1821,7 +1821,7 @@ coap_sock_write(void *context, const unsigned char *in, size_t inl) {
       else {
         ret = MBEDTLS_ERR_NET_SEND_FAILED;
       }
-      coap_log_debug("*  %s: failed to send %zd bytes (%s) state %d\n",
+      coap_log_debug("*  %s: failed to send %" PRIdS " bytes (%s) state %d\n",
                      coap_session_str(c_session), inl, coap_socket_strerror(),
                      c_session->state);
     }
@@ -2560,7 +2560,7 @@ coap_dtls_receive(coap_session_t *c_session,
       break;
     default:
       coap_log_warn("coap_dtls_receive: "
-                    "returned -0x%x: '%s' (length %zd)\n",
+                    "returned -0x%x: '%s' (length %" PRIdS ")\n",
                     -ret, get_error_string(ret), data_len);
       break;
     }
@@ -2892,7 +2892,7 @@ coap_tls_read(coap_session_t *c_session, uint8_t *data, size_t data_len) {
         break;
       default:
         coap_log_warn("coap_tls_read: "
-                      "returned -0x%x: '%s' (length %zd)\n",
+                      "returned -0x%x: '%s' (length %" PRIdS ")\n",
                       -ret, get_error_string(ret), data_len);
         ret = -1;
         break;

--- a/src/coap_mem.c
+++ b/src/coap_mem.c
@@ -423,7 +423,7 @@ coap_malloc_type(coap_memory_tag_t type, size_t size) {
 
   if (size > container->size) {
     coap_log_warn("coap_malloc_type: Requested memory exceeds maximum object "
-                  "size (type %d, size %zu, max %zd)\n",
+                  "size (type %d, size %" PRIuS ", max %" PRIdS ")\n",
                   type, size, container->size);
     return NULL;
   }
@@ -465,7 +465,7 @@ coap_realloc_type(coap_memory_tag_t type, void *p, size_t size) {
   if (p) {
     if (size > container->size) {
       coap_log_warn("coap_realloc_type: Requested memory exceeds maximum object "
-                    "size (type %d, size %zu, max %zd)\n",
+                    "size (type %d, size %" PRIuS ", max %" PRIdS ")\n",
                     type, size, container->size);
       return NULL;
     }

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -1544,7 +1544,7 @@ coap_send_lkd(coap_session_t *session, coap_pdu_t *pdu) {
    */
   if (COAP_PDU_IS_REQUEST(pdu) &&
       pdu->actual_token.length > session->max_token_size) {
-    coap_log_warn("coap_send: PDU dropped as token too long (%zu > %" PRIu32 ")\n",
+    coap_log_warn("coap_send: PDU dropped as token too long (%" PRIuS " > %" PRIu32 ")\n",
                   pdu->actual_token.length, session->max_token_size);
     goto error;
   }
@@ -1915,7 +1915,7 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
           return (coap_mid_t)COAP_DROPPED_RESPONSE;
         } else if (hop_limit < 1 || hop_limit > 255) {
           /* Something is bad - need to drop this pdu (TODO or delete option) */
-          coap_log_warn("Proxy return has bad hop limit count '%zu'\n",
+          coap_log_warn("Proxy return has bad hop limit count '%" PRIuS "'\n",
                         hop_limit);
           coap_delete_pdu_lkd(pdu);
           return (coap_mid_t)COAP_DROPPED_RESPONSE;
@@ -2606,7 +2606,7 @@ coap_read_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now)
             size_t size = coap_pdu_parse_size(session->proto, session->read_header,
                                               hdr_size + tok_ext_bytes);
             if (size > COAP_DEFAULT_MAX_PDU_RX_SIZE) {
-              coap_log_warn("** %s: incoming PDU length too large (%zu > %lu)\n",
+              coap_log_warn("** %s: incoming PDU length too large (%" PRIuS " > %lu)\n",
                             coap_session_str(session),
                             size, COAP_DEFAULT_MAX_PDU_RX_SIZE);
               bytes_read = -1;
@@ -3279,7 +3279,7 @@ hnd_get_wellknown_lkd(coap_resource_t *resource,
          * Data does not fit into a packet and no libcoap block support
          * +1 for end of options marker
          */
-        coap_log_debug(".well-known/core: truncating data length to %zu from %zu\n",
+        coap_log_debug(".well-known/core: truncating data length to %" PRIuS " from %" PRIuS "\n",
                        len, response->max_size  - response->used_size - 1);
         len = response->max_size - response->used_size - 1;
       }
@@ -5538,7 +5538,7 @@ coap_mcast_set_hops(coap_session_t *session, size_t hops) {
     case AF_INET:
       if (setsockopt(session->sock.fd, IPPROTO_IP, IP_MULTICAST_TTL,
                      (const char *)&hops, sizeof(hops)) < 0) {
-        coap_log_info("coap_mcast_set_hops: %zu: setsockopt: %s\n",
+        coap_log_info("coap_mcast_set_hops: %" PRIuS ": setsockopt: %s\n",
                       hops, coap_socket_strerror());
         return 0;
       }
@@ -5548,7 +5548,7 @@ coap_mcast_set_hops(coap_session_t *session, size_t hops) {
     case AF_INET6:
       if (setsockopt(session->sock.fd, IPPROTO_IPV6, IPV6_MULTICAST_HOPS,
                      (const char *)&hops, sizeof(hops)) < 0) {
-        coap_log_info("coap_mcast_set_hops: %zu: setsockopt: %s\n",
+        coap_log_info("coap_mcast_set_hops: %" PRIuS ": setsockopt: %s\n",
                       hops, coap_socket_strerror());
         return 0;
       }

--- a/src/coap_netif.c
+++ b/src/coap_netif.c
@@ -76,7 +76,7 @@ coap_netif_dgrm_read(coap_session_t *session, coap_packet_t *packet) {
   bytes_read = coap_socket_recv(&session->sock, packet);
   keep_errno = errno;
   if (bytes_read == -1) {
-    coap_log_debug("*  %s: netif: failed to read %zd bytes (%s (%d)) state %d\n",
+    coap_log_debug("*  %s: netif: failed to read % " PRIdS " bytes (%s (%d)) state %d\n",
                    coap_session_str(session), packet->length,
                    coap_socket_strerror(), keep_errno, session->state);
     errno = keep_errno;
@@ -106,7 +106,7 @@ coap_netif_dgrm_read_ep(coap_endpoint_t *endpoint, coap_packet_t *packet) {
   keep_errno = errno;
   if (bytes_read == -1) {
     if (errno != EAGAIN) {
-      coap_log_debug("*  %s: netif: failed to read %zd bytes (%s)\n",
+      coap_log_debug("*  %s: netif: failed to read % " PRIdS " bytes (%s)\n",
                      coap_endpoint_str(endpoint), packet->length,
                      coap_socket_strerror());
       errno = keep_errno;
@@ -140,7 +140,7 @@ coap_netif_dgrm_write(coap_session_t *session, const uint8_t *data,
   bytes_written = coap_socket_send(sock, session, data, datalen);
   keep_errno = errno;
   if (bytes_written <= 0) {
-    coap_log_debug("*  %s: netif: failed to send %zd bytes (%s (%d)) state %d\n",
+    coap_log_debug("*  %s: netif: failed to send % " PRIdS " bytes (%s (%d)) state %d\n",
                    coap_session_str(session), datalen,
                    coap_socket_strerror(), errno, session->state);
     errno = keep_errno;
@@ -247,7 +247,7 @@ coap_netif_strm_write(coap_session_t *session, const uint8_t *data,
   int keep_errno = errno;
 
   if (bytes_written <= 0) {
-    coap_log_debug("*  %s: netif: failed to send %zd bytes (%s) state %d\n",
+    coap_log_debug("*  %s: netif: failed to send % " PRIdS " bytes (%s) state %d\n",
                    coap_session_str(session), datalen,
                    coap_socket_strerror(), session->state);
     errno = keep_errno;

--- a/src/coap_option.c
+++ b/src/coap_option.c
@@ -325,7 +325,7 @@ coap_opt_setheader(coap_opt_t *opt, size_t maxlen,
     opt[0] |= length & 0x0f;
   } else if (length < 269) {
     if (maxlen < skip + 2) {
-      coap_log_debug("insufficient space to encode option length %zu\n",
+      coap_log_debug("insufficient space to encode option length %" PRIuS "\n",
                      length);
       return 0;
     }
@@ -516,7 +516,7 @@ coap_new_optlist(uint16_t number,
 
 #if defined(WITH_LWIP) && MEMP_USE_CUSTOM_POOLS
   if (length > MEMP_LEN_COAPOPTLIST) {
-    coap_log_crit("coap_new_optlist: size too large (%zu > MEMP_LEN_COAPOPTLIST)\n",
+    coap_log_crit("coap_new_optlist: size too large (%" PRIuS " > MEMP_LEN_COAPOPTLIST)\n",
                   length);
     return NULL;
   }

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -178,7 +178,7 @@ coap_new_pdu_lkd(coap_pdu_type_t type, coap_pdu_code_t code,
   pdu = coap_pdu_init(type, code, coap_new_message_id_lkd(session),
                       coap_session_max_pdu_size_lkd(session));
   if (!pdu)
-    coap_log_crit("coap_new_pdu: cannot allocate memory for new PDU (size = %zu)\n",
+    coap_log_crit("coap_new_pdu: cannot allocate memory for new PDU (size = %" PRIuS ")\n",
                   coap_session_max_pdu_size_lkd(session));
   return pdu;
 }

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -531,7 +531,7 @@ retry:
 
       coap_proxy_cleanup_entry(proxy_entry, send_failure);
       ongoing = proxy_entry->ongoing;
-      coap_log_debug("*  %s: proxy_entry %p released (rem count = %zd)\n",
+      coap_log_debug("*  %s: proxy_entry %p released (rem count = % " PRIdS ")\n",
                      coap_session_str(ongoing),
                      (void *)proxy_entry,
                      session->context->proxy_list_count - 1);
@@ -707,7 +707,7 @@ coap_proxy_get_ongoing_session(coap_session_t *session,
       return NULL;
     }
     if (proxy_entry_created) {
-      coap_log_debug("*  %s: proxy_entry %p created (tot count = %zd)\n",
+      coap_log_debug("*  %s: proxy_entry %p created (tot count = % " PRIdS ")\n",
                      coap_session_str(proxy_entry->ongoing),
                      (void *)proxy_entry,
                      session->context->proxy_list_count);

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -1352,7 +1352,7 @@ coap_endpoint_get_session(coap_endpoint_t *endpoint,
     const uint8_t *payload = (const uint8_t *)packet->payload;
     size_t length = packet->length;
     if (length < (OFF_HANDSHAKE_TYPE + 1)) {
-      coap_log_debug("coap_dtls_hello: ContentType %d Short Packet (%zu < %d) dropped\n",
+      coap_log_debug("coap_dtls_hello: ContentType %d Short Packet (%" PRIuS " < %d) dropped\n",
                      payload[OFF_CONTENT_TYPE], length,
                      OFF_HANDSHAKE_TYPE + 1);
       return NULL;

--- a/src/coap_str.c
+++ b/src/coap_str.c
@@ -22,7 +22,7 @@ coap_new_string(size_t size) {
   coap_string_t *s;
 #if defined(WITH_LWIP) && MEMP_USE_CUSTOM_POOLS
   if (size >= MEMP_LEN_COAPSTRING) {
-    coap_log_crit("coap_new_string: size too large (%zu +1 > MEMP_LEN_COAPSTRING)\n",
+    coap_log_crit("coap_new_string: size too large (%" PRIuS " +1 > MEMP_LEN_COAPSTRING)\n",
                   size);
     return NULL;
   }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -526,7 +526,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
       goto error;
     }
     if (psk_identity->length > result_length) {
-      coap_log_warn("psk_identity too large, truncated to %zd bytes\n",
+      coap_log_warn("psk_identity too large, truncated to % " PRIdS " bytes\n",
                     result_length);
     } else {
       /* Reduce to match */
@@ -548,7 +548,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
         goto error;
       }
       if (psk_key->length > result_length) {
-        coap_log_warn("psk_key too large, truncated to %zd bytes\n",
+        coap_log_warn("psk_key too large, truncated to % " PRIdS " bytes\n",
                       result_length);
       } else {
         /* Reduce to match */
@@ -588,7 +588,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
       if (setup_sdata->validate_id_call_back)
         coap_session_refresh_psk_key(coap_session, psk_key);
       if (psk_key->length > result_length) {
-        coap_log_warn("psk_key too large, truncated to %zd bytes\n",
+        coap_log_warn("psk_key too large, truncated to % " PRIdS " bytes\n",
                       result_length);
       } else {
         /* Reduce to match */
@@ -606,7 +606,7 @@ get_psk_info(struct dtls_context_t *dtls_context,
     if (psk_hint == NULL)
       return 0;
     if (psk_hint->length > result_length) {
-      coap_log_warn("psk_hint too large, truncated to %zd bytes\n",
+      coap_log_warn("psk_hint too large, truncated to % " PRIdS " bytes\n",
                     result_length);
     } else {
       /* Reduce to match */

--- a/src/coap_ws.c
+++ b/src/coap_ws.c
@@ -695,13 +695,13 @@ coap_ws_read(coap_session_t *session, uint8_t *data, size_t datalen) {
     session->ws->data_size = bytes_size;
     if ((size_t)bytes_size > datalen) {
       coap_log_err("coap_ws_read: packet size bigger than provided data space"
-                   " (%zu > %zu)\n", bytes_size, datalen);
+                   " (%" PRIuS " > %" PRIuS ")\n", bytes_size, datalen);
       coap_handle_event_lkd(session->context, COAP_EVENT_WS_PACKET_SIZE, session);
       session->ws->close_reason = 1009;
       coap_ws_close(session);
       return 0;
     }
-    coap_log_debug("*  %s: Packet size %zu\n", coap_session_str(session),
+    coap_log_debug("*  %s: Packet size %" PRIuS "\n", coap_session_str(session),
                    bytes_size);
 
     /* Handle any data read in as a part of the header */
@@ -774,7 +774,8 @@ coap_ws_read(coap_session_t *session, uint8_t *data, size_t datalen) {
     return session->ws->data_size;
   }
   /* Need to get in all of the data */
-  coap_log_debug("*  %s: Waiting Packet size %zu (got %zu)\n", coap_session_str(session),
+  coap_log_debug("*  %s: Waiting Packet size %" PRIuS " (got %" PRIuS ")\n",
+                 coap_session_str(session),
                  session->ws->data_size, session->ws->data_ofs);
   return 0;
 }


### PR DESCRIPTION
PRIdS or PRIuS need to be defined for a format specification that compilers / libraries (e.g. nano) understand rather than the default of %zd and %zu.

Addresses #1837.