### PR TITLE
Multi-threading: Correctly lock all callbacks

### DIFF
--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -61,7 +61,7 @@ struct coap_context_t {
                                           unknown resources */
   coap_resource_t *proxy_uri_resource; /**< can be used for handling
                                             proxy URI resources */
-  coap_resource_release_userdata_handler_t release_userdata;
+  coap_resource_release_userdata_handler_t release_userdata_cb;
   /**< function to  release user_data
        when resource is deleted */
 #endif /* COAP_SERVER_SUPPORT */
@@ -92,7 +92,7 @@ struct coap_context_t {
 #endif /* WITH_CONTIKI */
 
 #ifdef WITH_LWIP
-  coap_lwip_input_wait_handler_t input_wait; /** Input wait / timeout handler if set */
+  coap_lwip_input_wait_handler_t input_wait_cb; /** Input wait / timeout handler if set */
   void *input_arg;                /** argument to pass it input handler */
   uint8_t timer_configured;       /**< Set to 1 when a retransmission is
                                    *   scheduled using lwIP timers for this
@@ -106,35 +106,33 @@ struct coap_context_t {
 #endif /* COAP_OSCORE_SUPPORT */
 
 #if COAP_CLIENT_SUPPORT
-  coap_response_handler_t response_handler; /**< Called when a response is
-                                                 received */
+  coap_response_handler_t response_cb; /**< Called when a response is
+                                            received */
 #endif /* COAP_CLIENT_SUPPORT */
 #if COAP_PROXY_SUPPORT
-  coap_proxy_response_handler_t proxy_response_handler; /**< Called when a reponse
-                                                             to proxy logic received */
+  coap_proxy_response_handler_t proxy_response_cb; /**< Called when a reponse
+                                                        to proxy logic received */
 #endif /* COAP_PROXY_SUPPORT */
-  coap_nack_handler_t nack_handler; /**< Called when a response issue has
-                                         occurred */
-  coap_ping_handler_t ping_handler; /**< Called when a CoAP ping is received */
-  coap_pong_handler_t pong_handler; /**< Called when a ping response
-                                         is received */
-  coap_block_data_handler_t block_data_handler; /**< Called with each block data
-                                                     during block transfers */
+  coap_nack_handler_t nack_cb; /**< Called when a response issue has occurred */
+  coap_ping_handler_t ping_cb; /**< Called when a CoAP ping is received */
+  coap_pong_handler_t pong_cb; /**< Called when a ping response is received */
+  coap_block_data_handler_t block_data_cb; /**< Called with each block data
+                                                during block transfers */
 
 #if COAP_SERVER_SUPPORT
-  coap_observe_added_t observe_added; /**< Called when there is a new observe
-                                           subscription request */
-  coap_observe_deleted_t observe_deleted; /**< Called when there is a observe
-                                           subscription de-register request */
+  coap_observe_added_t observe_added_cb; /**< Called when there is a new observe
+                                              subscription request */
+  coap_observe_deleted_t observe_deleted_cb; /**< Called when there is a observe
+                                                  subscription de-register request */
   void *observe_user_data; /**< App provided data for use in observe_added or
                                 observe_deleted */
   uint32_t observe_save_freq; /**< How frequently to update observe value */
-  coap_track_observe_value_t track_observe_value; /**< Callback to save observe
-                                                       value when updated */
-  coap_dyn_resource_added_t dyn_resource_added; /**< Callback to save dynamic
-                                                     resource when created */
-  coap_resource_deleted_t resource_deleted; /**< Invoked when resource
-                                                 is deleted */
+  coap_track_observe_value_t track_observe_value_cb; /**< Callback to save observe
+                                                          value when updated */
+  coap_dyn_resource_added_t dyn_resource_added_cb; /**< Callback to save dynamic
+                                                        resource when created */
+  coap_resource_deleted_t resource_deleted_cb; /**< Invoked when resource
+                                                    is deleted */
 #if COAP_WITH_OBSERVE_PERSIST
   coap_bin_const_t *dyn_resource_save_file; /** Where dynamic resource requests
                                                 that create resources are
@@ -151,7 +149,7 @@ struct coap_context_t {
    * Callback function that is used to signal events to the
    * application.  This field is set by coap_set_event_handler().
    */
-  coap_event_handler_t handle_event;
+  coap_event_handler_t event_cb;
 
   void *dtls_context;
 

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -3355,14 +3355,21 @@ coap_handle_request_put_block(coap_context_t *context,
     if (lg_srcv->total_len < saved_offset + length) {
       lg_srcv->total_len = saved_offset + length;
     }
-    if (context && context->block_data_handler && !resource->is_proxy_uri &&
-        !resource->is_reverse_proxy &&
-        ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) || block.bert) &&
-        (resource->flags & COAP_RESOURCE_USE_BLOCK_DATA_HANDLER)) {
+
+#define USE_BLOCK_DATA_HANDLER (context && context->block_data_cb && \
+                                !resource->is_proxy_uri && \
+                                !resource->is_reverse_proxy && \
+                                ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) || block.bert) && \
+                                (resource->flags & COAP_RESOURCE_USE_BLOCK_DATA_HANDLER))
+
+    if (USE_BLOCK_DATA_HANDLER) {
       coap_response_t resp;
-      resp = context->block_data_handler(session, pdu, resource, &lg_srcv->body_data,
-                                         length, data, saved_offset,
-                                         lg_srcv->total_len);
+
+      coap_lock_callback_ret(resp,
+                             context->block_data_cb(session, pdu, resource,
+                                                    &lg_srcv->body_data,
+                                                    length, data, saved_offset,
+                                                    lg_srcv->total_len));
       if (resp != COAP_RESPONSE_OK) {
         response->code = COAP_RESPONSE_CODE(500);
         goto skip_app_handler;
@@ -3507,10 +3514,7 @@ give_app_data:
   }
   pdu->body_offset = 0;
   pdu->body_total = lg_srcv->total_len;
-  if (context && context->block_data_handler && !resource->is_proxy_uri &&
-      !resource->is_reverse_proxy &&
-      ((session->block_mode & COAP_SINGLE_BLOCK_OR_Q) || block.bert) &&
-      (resource->flags & COAP_RESOURCE_USE_BLOCK_DATA_HANDLER)) {
+  if (USE_BLOCK_DATA_HANDLER) {
     /* Data has already been provided - do not duplicate */
     if (pdu->data) {
       pdu->used_size = pdu->data - pdu->token - 1;
@@ -4004,7 +4008,7 @@ lg_xmit_finished:
 void
 coap_register_block_data_handler(coap_context_t *context,
                                  coap_block_data_handler_t block_data_handler) {
-  context->block_data_handler = block_data_handler;
+  context->block_data_cb = block_data_handler;
 }
 
 /*
@@ -4297,11 +4301,14 @@ reinit:
             if (size2 < saved_offset + length) {
               size2 = saved_offset + length;
             }
-            if (context && context->block_data_handler) {
+            if (context && context->block_data_cb) {
               coap_response_t resp;
-              resp = context->block_data_handler(session, rcvd, 0,
-                                                 &lg_crcv->body_data, length,
-                                                 data, saved_offset, size2);
+
+              coap_lock_callback_ret(resp,
+                                     context->block_data_cb(session, rcvd, 0,
+                                                            &lg_crcv->body_data,
+                                                            length, data,
+                                                            saved_offset, size2));
               if (resp != COAP_RESPONSE_OK) {
                 goto fail_resp;
               }
@@ -4418,7 +4425,7 @@ give_to_app:
             }
             rcvd->body_data = lg_crcv->body_data ? lg_crcv->body_data->s : NULL;
 #if COAP_Q_BLOCK_SUPPORT
-            if (context && context->block_data_handler) {
+            if (context && context->block_data_cb) {
               /* Data has already been provided - do not duplicate */
               if (rcvd->data) {
                 rcvd->used_size = rcvd->data - rcvd->token - 1;

--- a/src/coap_event.c
+++ b/src/coap_event.c
@@ -23,16 +23,16 @@
 void
 coap_register_event_handler(coap_context_t *context,
                             coap_event_handler_t hnd) {
-  context->handle_event = hnd;
+  context->event_cb = hnd;
 }
 
 void
 coap_set_event_handler(coap_context_t *context,
                        coap_event_handler_t hnd) {
-  context->handle_event = hnd;
+  context->event_cb = hnd;
 }
 
 void
 coap_clear_event_handler(coap_context_t *context) {
-  context->handle_event = NULL;
+  context->event_cb = NULL;
 }

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -60,7 +60,7 @@ void
 coap_lwip_set_input_wait_handler(coap_context_t *context,
                                  coap_lwip_input_wait_handler_t handler,
                                  void *input_arg) {
-  context->input_wait = handler;
+  context->input_wait_cb = handler;
   context->input_arg = input_arg;
 }
 
@@ -125,7 +125,7 @@ coap_io_process_lkd(coap_context_t *context, uint32_t timeout_ms) {
                 timeout);
 #endif /* COAP_DEBUG_WAKEUP_TIMES */
 #if NO_SYS == 0
-  if (!context->input_wait) {
+  if (!context->input_wait_cb) {
 #endif /* NO_SYS == 0 */
     if (timeout) {
       sys_timeout(timeout, coap_io_process_timeout, context);
@@ -137,8 +137,8 @@ coap_io_process_lkd(coap_context_t *context, uint32_t timeout_ms) {
 
   UNLOCK_TCPIP_CORE();
 
-  if (context->input_wait) {
-    coap_lock_callback_release(context->input_wait(context->input_arg, timeout),
+  if (context->input_wait_cb) {
+    coap_lock_callback_release(context->input_wait_cb(context->input_arg, timeout),
                                return 0);
 #if NO_SYS == 0
   } else {

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -910,7 +910,7 @@ coap_free_context_lkd(coap_context_t *context) {
 #endif /* COAP_PROXY_SUPPORT */
 
   if (context->app_cb) {
-    context->app_cb(context->app_data);
+    coap_lock_callback(context->app_cb(context->app_data));
   }
   coap_free_type(COAP_CONTEXT, context);
   coap_dump_memory_type_counts(COAP_LOG_DEBUG);
@@ -4191,7 +4191,7 @@ coap_call_response_handler(coap_session_t *session,
   coap_response_t ret;
 
 #if COAP_PROXY_SUPPORT
-  if (context->proxy_response_handler) {
+  if (context->proxy_response_cb) {
     coap_proxy_list_t *proxy_entry;
     coap_proxy_req_t *proxy_req = coap_proxy_map_outgoing_request(session,
                                   rcvd,
@@ -4214,12 +4214,12 @@ coap_call_response_handler(coap_session_t *session,
     coap_send_ack_lkd(session, rcvd);
     session->last_con_handler_res = COAP_RESPONSE_OK;
     return;
-  } else if (context->response_handler) {
+  } else if (context->response_cb) {
     coap_lock_callback_ret_release(ret,
-                                   context->response_handler(session,
-                                                             sent,
-                                                             rcvd,
-                                                             rcvd->mid),
+                                   context->response_cb(session,
+                                                        sent,
+                                                        rcvd,
+                                                        rcvd->mid),
                                    /* context is being freed off */
                                    return);
   } else {
@@ -4394,8 +4394,8 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
       coap_session_connected(session);
   } else if (pdu->code == COAP_SIGNALING_CODE_PING) {
     coap_pdu_t *pong = coap_pdu_init(COAP_MESSAGE_CON, COAP_SIGNALING_CODE_PONG, 0, 1);
-    if (context->ping_handler) {
-      coap_lock_callback(context->ping_handler(session, pdu, pdu->mid));
+    if (context->ping_cb) {
+      coap_lock_callback(context->ping_cb(session, pdu, pdu->mid));
     }
     if (pong) {
       coap_add_option_internal(pong, COAP_SIGNALING_OPTION_CUSTODY, 0, NULL);
@@ -4403,8 +4403,8 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
     }
   } else if (pdu->code == COAP_SIGNALING_CODE_PONG) {
     session->last_pong = session->last_rx_tx;
-    if (context->pong_handler) {
-      coap_lock_callback(context->pong_handler(session, pdu, pdu->mid));
+    if (context->pong_cb) {
+      coap_lock_callback(context->pong_cb(session, pdu, pdu->mid));
     }
   } else if (pdu->code == COAP_SIGNALING_CODE_RELEASE
              || pdu->code == COAP_SIGNALING_CODE_ABORT) {
@@ -4776,8 +4776,8 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
           coap_handle_nack(sent->session, sent->pdu, COAP_NACK_RST, sent->id);
         }
       } else if (is_ping_rst) {
-        if (context->pong_handler) {
-          coap_lock_callback(context->pong_handler(session, pdu, pdu->mid));
+        if (context->pong_cb) {
+          coap_lock_callback(context->pong_cb(session, pdu, pdu->mid));
         }
         session->last_pong = session->last_rx_tx;
         session->last_ping_mid = COAP_INVALID_MID;
@@ -4869,8 +4869,8 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
 #endif /* COAP_CLIENT_SUPPORT */
       {
         if (COAP_PDU_IS_EMPTY(pdu)) {
-          if (context->ping_handler) {
-            coap_lock_callback(context->ping_handler(session, pdu, pdu->mid));
+          if (context->ping_cb) {
+            coap_lock_callback(context->ping_cb(session, pdu, pdu->mid));
           }
         } else {
           packet_is_bad = 1;
@@ -5003,8 +5003,8 @@ coap_handle_event_lkd(coap_context_t *context, coap_event_t event,
 
   coap_log_debug("***EVENT: %s\n", coap_event_name(event));
 
-  if (context->handle_event) {
-    coap_lock_callback_ret(ret, context->handle_event(session, event));
+  if (context->event_cb) {
+    coap_lock_callback_ret(ret, context->event_cb(session, event));
 #if COAP_PROXY_SUPPORT
     if (event == COAP_EVENT_SERVER_SESSION_DEL)
       coap_proxy_remove_association(session, 0);
@@ -5249,7 +5249,7 @@ void
 coap_register_response_handler(coap_context_t *context,
                                coap_response_handler_t handler) {
 #if COAP_CLIENT_SUPPORT
-  context->response_handler = handler;
+  context->response_cb = handler;
 #else /* ! COAP_CLIENT_SUPPORT */
   (void)context;
   (void)handler;
@@ -5260,7 +5260,7 @@ void
 coap_register_proxy_response_handler(coap_context_t *context,
                                      coap_proxy_response_handler_t handler) {
 #if COAP_PROXY_SUPPORT
-  context->proxy_response_handler = handler;
+  context->proxy_response_cb = handler;
 #else /* ! COAP_PROXY_SUPPORT */
   (void)context;
   (void)handler;
@@ -5270,19 +5270,19 @@ coap_register_proxy_response_handler(coap_context_t *context,
 void
 coap_register_nack_handler(coap_context_t *context,
                            coap_nack_handler_t handler) {
-  context->nack_handler = handler;
+  context->nack_cb = handler;
 }
 
 void
 coap_register_ping_handler(coap_context_t *context,
                            coap_ping_handler_t handler) {
-  context->ping_handler = handler;
+  context->ping_cb = handler;
 }
 
 void
 coap_register_pong_handler(coap_context_t *context,
                            coap_pong_handler_t handler) {
-  context->pong_handler = handler;
+  context->pong_cb = handler;
 }
 
 void

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -447,7 +447,7 @@ coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
     if (coap_string_equal(&proxy_list[i].uri.host, &server_use->uri.host) &&
         proxy_list[i].uri.port == server_use->uri.port &&
         proxy_list[i].uri.scheme == server_use->uri.scheme) {
-      if (!server_list->track_client_session && session->context->proxy_response_handler) {
+      if (!server_list->track_client_session && session->context->proxy_response_cb) {
         coap_ticks(&proxy_list[i].last_used);
         return &proxy_list[i];
       } else {
@@ -840,7 +840,7 @@ coap_proxy_call_response_handler(coap_session_t *session, const coap_pdu_t *sent
     }
   }
   coap_lock_callback_ret_release(fwd_pdu,
-                                 session->context->proxy_response_handler(session,
+                                 session->context->proxy_response_cb(session,
                                      sent,
                                      resp_pdu,
                                      proxy_req->cache_key),
@@ -930,7 +930,7 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
   coap_proxy_log_entry(session, request, NULL, "req");
 
   /* Is this a observe cached request? */
-  if (obs_opt && session->context->proxy_response_handler) {
+  if (obs_opt && session->context->proxy_response_cb) {
     coap_cache_key_t *cache_key_l;
 
     cache_key_l = coap_cache_derive_key_w_ignore(session, request,

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -499,12 +499,13 @@ coap_free_resource(coap_resource_t *resource, coap_deleting_resource_t deleting)
     coap_notify_observers(resource->context, resource, deleting);
   }
 
-  if (resource->context->resource_deleted)
-    resource->context->resource_deleted(resource->context, resource->uri_path,
-                                        resource->context->observe_user_data);
+  if (resource->context->resource_deleted_cb)
+    coap_lock_callback(resource->context->resource_deleted_cb(resource->context,
+                                                              resource->uri_path,
+                                                              resource->context->observe_user_data));
 
-  if (resource->context->release_userdata && resource->user_data) {
-    coap_lock_callback(resource->context->release_userdata(resource->user_data));
+  if (resource->context->release_userdata_cb && resource->user_data) {
+    coap_lock_callback(resource->context->release_userdata_cb(resource->user_data));
   }
 
   /* delete registered attributes */
@@ -580,15 +581,17 @@ coap_add_resource_lkd(coap_context_t *context, coap_resource_t *resource) {
     RESOURCES_ADD(context->resources, resource);
 #if COAP_WITH_OBSERVE_PERSIST
     if (context->unknown_pdu && context->dyn_resource_save_file &&
-        context->dyn_resource_added && resource->observable) {
+        context->dyn_resource_added_cb && resource->observable) {
       coap_bin_const_t raw_packet;
 
       raw_packet.s = context->unknown_pdu->token -
                      context->unknown_pdu->hdr_size;
       raw_packet.length = context->unknown_pdu->used_size +
                           context->unknown_pdu->hdr_size;
-      context->dyn_resource_added(context->unknown_session, resource->uri_path,
-                                  &raw_packet, context->observe_user_data);
+      coap_lock_callback(context->dyn_resource_added_cb(context->unknown_session,
+                                                        resource->uri_path,
+                                                        &raw_packet,
+                                                        context->observe_user_data));
     }
 #endif /* COAP_WITH_OBSERVE_PERSIST */
   }
@@ -901,7 +904,7 @@ coap_add_observer(coap_resource_t *resource,
                  (void *)s, s->cache_key->key[0], s->cache_key->key[1],
                  s->cache_key->key[2], s->cache_key->key[3]);
 
-  if (session->context->observe_added && session->proto == COAP_PROTO_UDP &&
+  if (session->context->observe_added_cb && session->proto == COAP_PROTO_UDP &&
       !coap_is_af_unix(&session->addr_info.local)) {
     coap_bin_const_t raw_packet;
     coap_bin_const_t *oscore_info = NULL;
@@ -986,21 +989,21 @@ coap_add_observer(coap_resource_t *resource,
            request->token - request->hdr_size, request->hdr_size);
     raw_packet.s = s->pdu->token - request->hdr_size;
     raw_packet.length = s->pdu->used_size + request->hdr_size;
-    session->context->observe_added(session, s, session->proto,
-                                    &session->endpoint->bind_addr,
-                                    &session->addr_info,
-                                    &raw_packet,
-                                    oscore_info,
-                                    session->context->observe_user_data);
+    coap_lock_callback(session->context->observe_added_cb(session, s, session->proto,
+                                                          &session->endpoint->bind_addr,
+                                                          &session->addr_info,
+                                                          &raw_packet,
+                                                          oscore_info,
+                                                          session->context->observe_user_data));
 #if COAP_OSCORE_SUPPORT
     coap_delete_bin_const(oscore_info);
 #endif /* COAP_OSCORE_SUPPORT */
   }
-  if (resource->context->track_observe_value) {
+  if (resource->context->track_observe_value_cb) {
     /* Track last used observe value (as app handler is called) */
-    resource->context->track_observe_value(resource->context,resource->uri_path,
-                                           resource->observe,
-                                           resource->context->observe_user_data);
+    coap_lock_callback(resource->context->track_observe_value_cb(resource->context,resource->uri_path,
+                       resource->observe,
+                       resource->context->observe_user_data));
   }
 
   return s;
@@ -1050,9 +1053,9 @@ coap_delete_observer_internal(coap_resource_t *resource, coap_session_t *session
     coap_delete_string(uri_path);
     coap_delete_string(uri_query);
   }
-  if (session->context->observe_deleted)
-    session->context->observe_deleted(session, s,
-                                      session->context->observe_user_data);
+  if (session->context->observe_deleted_cb)
+    coap_lock_callback(session->context->observe_deleted_cb(session, s,
+                                                            session->context->observe_user_data));
 
   if (resource->subscribers) {
     LL_DELETE(resource->subscribers, s);
@@ -1118,8 +1121,8 @@ coap_delete_observers(coap_context_t *context, coap_session_t *session) {
     coap_subscription_t *s, *tmp;
     LL_FOREACH_SAFE(resource->subscribers, s, tmp) {
       if (s->session == session) {
-        if (context->observe_deleted)
-          context->observe_deleted(session, s, context->observe_user_data);
+        if (context->observe_deleted_cb)
+          coap_lock_callback(context->observe_deleted_cb(session, s, context->observe_user_data));
         assert(resource->subscribers);
         LL_DELETE(resource->subscribers, s);
         coap_session_release_lkd(session);
@@ -1414,12 +1417,12 @@ coap_resource_notify_observers_lkd(coap_resource_t *r,
 
   assert(r->context);
 
-  if (r->context->track_observe_value) {
+  if (r->context->track_observe_value_cb) {
     /* Track last used observe value */
     if ((r->observe % r->context->observe_save_freq) == 0)
-      r->context->track_observe_value(r->context, r->uri_path,
-                                      r->observe,
-                                      r->context->observe_user_data);
+      coap_lock_callback(r->context->track_observe_value_cb(r->context, r->uri_path,
+                                                            r->observe,
+                                                            r->context->observe_user_data));
   }
 
   r->context->observe_pending = 1;
@@ -1447,7 +1450,7 @@ coap_resource_get_userdata(coap_resource_t *resource) {
 void
 coap_resource_release_userdata_handler(coap_context_t *context,
                                        coap_resource_release_userdata_handler_t callback) {
-  context->release_userdata = callback;
+  context->release_userdata_cb = callback;
 }
 
 void

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -660,7 +660,7 @@ coap_session_free(coap_session_t *session) {
 #endif /* COAP_SERVER_SUPPORT */
 
   if (session->app_cb) {
-    session->app_cb(session->app_data);
+    coap_lock_callback(session->app_cb(session->app_data));
   }
   coap_log_debug("***%s: session %p: closed\n", coap_session_str(session),
                  (void *)session);
@@ -1043,7 +1043,7 @@ coap_handle_nack(coap_session_t *session,
                  coap_pdu_t *sent,
                  const coap_nack_reason_t reason,
                  const coap_mid_t mid) {
-  if (session->context->nack_handler
+  if (session->context->nack_cb
 #if COAP_CLIENT_SUPPORT
       && !session->doing_first_pdu
 #endif /* COAP_CLIENT_SUPPORT */
@@ -1054,7 +1054,7 @@ coap_handle_nack(coap_session_t *session,
       coap_check_update_token(session, sent);
       token = sent->actual_token;
     }
-    coap_lock_callback(session->context->nack_handler(session, sent, reason, mid));
+    coap_lock_callback(session->context->nack_cb(session, sent, reason, mid));
     if (sent) {
       coap_update_token(sent, token.length, token.s);
     }
@@ -2640,7 +2640,7 @@ coap_free_endpoint_lkd(coap_endpoint_t *ep) {
     }
 
     if (ep->app_cb) {
-      ep->app_cb(ep->app_data);
+      coap_lock_callback(ep->app_cb(ep->app_data));
     }
 
     coap_mfree_endpoint(ep);

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -45,13 +45,13 @@ coap_persist_track_funcs(coap_context_t *context,
                          coap_resource_deleted_t resource_deleted,
                          uint32_t save_freq,
                          void *user_data) {
-  context->observe_added = observe_added;
-  context->observe_deleted = observe_deleted;
+  context->observe_added_cb = observe_added;
+  context->observe_deleted_cb = observe_deleted;
   context->observe_user_data = user_data;
   context->observe_save_freq = save_freq ? save_freq : 1;
-  context->track_observe_value = track_observe_value;
-  context->dyn_resource_added = dyn_resource_added;
-  context->resource_deleted = resource_deleted;
+  context->track_observe_value_cb = track_observe_value;
+  context->dyn_resource_added_cb = dyn_resource_added;
+  context->resource_deleted_cb = resource_deleted;
 }
 
 COAP_API coap_subscription_t *
@@ -1195,8 +1195,8 @@ coap_persist_startup_lkd(coap_context_t *context,
     if (!context->dyn_resource_save_file)
       return 0;
     coap_op_dyn_resource_load_disk(context);
-    context->dyn_resource_added = coap_op_dyn_resource_added;
-    context->resource_deleted = coap_op_resource_deleted;
+    context->dyn_resource_added_cb = coap_op_dyn_resource_added;
+    context->resource_deleted_cb = coap_op_resource_deleted;
   }
   if (obs_cnt_save_file) {
     context->obs_cnt_save_file =
@@ -1206,8 +1206,8 @@ coap_persist_startup_lkd(coap_context_t *context,
       return 0;
     context->observe_save_freq = save_freq ? save_freq : 1;
     coap_op_obs_cnt_load_disk(context);
-    context->track_observe_value = coap_op_obs_cnt_track_observe;
-    context->resource_deleted = coap_op_resource_deleted;
+    context->track_observe_value_cb = coap_op_obs_cnt_track_observe;
+    context->resource_deleted_cb = coap_op_resource_deleted;
   }
   if (observe_save_file) {
     context->observe_save_file =
@@ -1216,8 +1216,8 @@ coap_persist_startup_lkd(coap_context_t *context,
     if (!context->observe_save_file)
       return 0;
     coap_op_observe_load_disk(context);
-    context->observe_added = coap_op_observe_added;
-    context->observe_deleted = coap_op_observe_deleted;
+    context->observe_added_cb = coap_op_observe_added;
+    context->observe_deleted_cb = coap_op_observe_deleted;
   }
   return 1;
 }


### PR DESCRIPTION
Make sure all application callbacks are called with a coap_lock_callback*() wrapper.

Rename callback variables within the internal structures with a _cb suffix for ease of review.