### PR TITLE
Includes: Remove unnecessary include files

### DIFF
--- a/coap_config.h.riot
+++ b/coap_config.h.riot
@@ -296,7 +296,7 @@
 #define HAVE_INTTYPES_H 1
 
 /* Define to 1 if you have the <limits.h> header file. */
-/* #undef HAVE_LIMITS_H */
+#define HAVE_LIMITS_H 1
 
 /* Define to 1 if your system has a GNU libc compatible `malloc' function, and
    to 0 otherwise. */
@@ -319,6 +319,9 @@
 
 /* Define to 1 if you have the `socket' function. */
 /* #undef HAVE_SOCKET */
+
+/* Define to 1 if you have the <stddef.h> header file. */
+#define HAVE_STDDEF_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1

--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -49,6 +49,7 @@ strndup(const char *s1, size_t n) {
 
 #include <coap3/coap.h>
 #include <coap3/coap_defines.h>
+#include <assert.h>
 
 #define MAX_USER 128 /* Maximum length of a user name (i.e., PSK
                       * identity) in bytes. */

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -61,6 +61,7 @@ strndup(const char *s1, size_t n) {
 
 #include <coap3/coap.h>
 #include <coap3/coap_defines.h>
+#include <assert.h>
 
 static coap_context_t *global_context;
 #if COAP_THREAD_SAFE

--- a/examples/contiki/server.c
+++ b/examples/contiki/server.c
@@ -31,8 +31,9 @@
  */
 
 #include "contiki-net.h"
-#include "coap3/coap.h"
 #include <time.h>
+#include <assert.h>
+#include "coap3/coap.h"
 
 static coap_context_t *coap_context;
 

--- a/examples/etsi_iot_01.c
+++ b/examples/etsi_iot_01.c
@@ -23,6 +23,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <signal.h>
+#include <assert.h>
 
 #include <coap3/coap.h>
 

--- a/examples/lwip/client-coap.c
+++ b/examples/lwip/client-coap.c
@@ -10,13 +10,11 @@
  * of use.
  */
 
-#include "coap_config.h"
+#include "client-coap.h"
 
-#include <coap3/coap.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
-#include "client-coap.h"
 
 #ifndef COAP_URI
 #define COAP_URI "coap://libcoap.net"

--- a/examples/lwip/config/coap_config.h
+++ b/examples/lwip/config/coap_config.h
@@ -107,14 +107,19 @@
 /* it's just provided by libc. i hope we don't get too many of those, as
  * actually we'd need autotools again to find out what environment we're
  * building in */
-#define HAVE_STRNLEN 1
+/* Header files */
+#define HAVE_ERRNO_H
 
 #define HAVE_LIMITS_H
 
 #define HAVE_NETDB_H
 
-#define HAVE_SNPRINTF
+#define HAVE_STRING_H
 
-#define HAVE_ERRNO_H
+/* Functions */
+#define HAVE_STRNLEN 1
+
+#define HAVE_SNPRINTF 1
+
 
 #endif /* COAP_CONFIG_H_ */

--- a/examples/lwip/server-coap.c
+++ b/examples/lwip/server-coap.c
@@ -10,9 +10,6 @@
  * of use.
  */
 
-#include "coap_config.h"
-
-#include <coap3/coap.h>
 #include "server-coap.h"
 
 coap_context_t *main_coap_context;

--- a/examples/zephyr/test-cpp-src/src/test.cpp
+++ b/examples/zephyr/test-cpp-src/src/test.cpp
@@ -17,5 +17,5 @@ coap_str_const_t *xxx_libcoap_get_version() {
 int main()
 {
   xxx_libcoap_get_version();
-  exit(0);
+  return 0;
 }

--- a/include/coap3/coap_address.h
+++ b/include/coap3/coap_address.h
@@ -17,12 +17,6 @@
 #ifndef COAP_ADDRESS_H_
 #define COAP_ADDRESS_H_
 
-#include <assert.h>
-#include <stdint.h>
-#include <string.h>
-#include <sys/types.h>
-#include "libcoap.h"
-
 #include "coap3/coap_pdu.h"
 
 #ifdef __cplusplus
@@ -32,6 +26,7 @@ extern "C" {
 #if defined(WITH_LWIP)
 
 #include <lwip/ip_addr.h>
+#include <string.h>
 
 struct coap_address_t {
   uint16_t port;
@@ -114,6 +109,7 @@ coap_address_clr_addr(coap_address_t *addr) {
 
 #include "net/sock.h"
 #include "net/af.h"
+#include <string.h>
 
 #ifndef INET6_ADDRSTRLEN
 #define INET6_ADDRSTRLEN IPV6_ADDR_MAX_STR_LEN
@@ -312,9 +308,9 @@ void coap_address_copy(coap_address_t *dst, const coap_address_t *src);
  */
 COAP_STATIC_INLINE int
 coap_address_equals(const coap_address_t *a, const coap_address_t *b) {
-  assert(a);
-  assert(b);
-  return _coap_address_equals_impl(a, b);
+  if (a && b)
+    return _coap_address_equals_impl(a, b);
+  return 0;
 }
 #endif
 
@@ -325,8 +321,9 @@ coap_address_equals(const coap_address_t *a, const coap_address_t *b) {
  */
 COAP_STATIC_INLINE int
 coap_address_isany(const coap_address_t *a) {
-  assert(a);
-  return _coap_address_isany_impl(a);
+  if (a)
+    return _coap_address_isany_impl(a);
+  return 0;
 }
 
 #if !defined(WITH_CONTIKI) && !defined(RIOT_VERSION)

--- a/include/coap3/coap_asn1_internal.h
+++ b/include/coap3/coap_asn1_internal.h
@@ -17,8 +17,6 @@
 #ifndef COAP_ASN1_INTERNAL_H_
 #define COAP_ASN1_INTERNAL_H_
 
-#include "coap_internal.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_async_internal.h
+++ b/include/coap3/coap_async_internal.h
@@ -17,9 +17,6 @@
 #ifndef COAP_ASYNC_INTERNAL_H_
 #define COAP_ASYNC_INTERNAL_H_
 
-#include "coap_internal.h"
-#include "coap_net.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -19,10 +19,6 @@
 #ifndef COAP_BLOCK_INTERNAL_H_
 #define COAP_BLOCK_INTERNAL_H_
 
-#include "coap_internal.h"
-#include "coap_pdu_internal.h"
-#include "coap_resource.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_cache.h
+++ b/include/coap3/coap_cache.h
@@ -16,8 +16,6 @@
 #ifndef COAP_CACHE_H_
 #define COAP_CACHE_H_
 
-#include "coap_forward_decls.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_cache_internal.h
+++ b/include/coap3/coap_cache_internal.h
@@ -17,8 +17,6 @@
 #ifndef COAP_CACHE_INTERNAL_H_
 #define COAP_CACHE_INTERNAL_H_
 
-#include "coap_internal.h"
-#include "coap_io.h"
 #include "coap_uthash_internal.h"
 
 #ifdef __cplusplus

--- a/include/coap3/coap_dgrm_internal.h
+++ b/include/coap3/coap_dgrm_internal.h
@@ -17,9 +17,6 @@
 #ifndef COAP_DGRM_INTERNAL_H_
 #define COAP_DGRM_INTERNAL_H_
 
-#include "coap_internal.h"
-#include "coap_io.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_dtls_internal.h
+++ b/include/coap3/coap_dtls_internal.h
@@ -19,8 +19,6 @@
 #ifndef COAP_DTLS_INTERNAL_H_
 #define COAP_DTLS_INTERNAL_H_
 
-#include "coap_internal.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_encode.h
+++ b/include/coap3/coap_encode.h
@@ -17,14 +17,6 @@
 #ifndef COAP_ENCODE_H_
 #define COAP_ENCODE_H_
 
-#if (defined(BSD) && (BSD >= 199103)) || defined(_WIN32)
-# include <string.h>
-#else
-# include <strings.h>
-#endif
-
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_event.h
+++ b/include/coap3/coap_event.h
@@ -18,8 +18,6 @@
 #ifndef COAP_EVENT_H_
 #define COAP_EVENT_H_
 
-#include "libcoap.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_hashkey_internal.h
+++ b/include/coap3/coap_hashkey_internal.h
@@ -17,10 +17,6 @@
 #ifndef COAP_HASHKEY_INTERNAL_H_
 #define COAP_HASHKEY_INTERNAL_H_
 
-#include "libcoap.h"
-#include "coap_uthash_internal.h"
-#include "coap_str.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_internal.h
+++ b/include/coap3/coap_internal.h
@@ -35,6 +35,14 @@
 # include <assert.h>
 #endif
 
+#if defined(HAVE_ERRNO_H)
+# include <errno.h>
+#endif
+
+#if defined(HAVE_LIMITS_H)
+# include <limits.h>
+#endif
+
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
 #else /* ! HAVE_INTTYPES_H */
@@ -62,8 +70,32 @@
 #define PRIdS "zd"
 #endif /* PRIdS */
 
-#if defined(HAVE_ERRNO_H)
-# include <errno.h>
+#if defined(HAVE_STDDEF_H)
+# include <stddef.h>
+#endif
+
+#if defined(HAVE_STDLIB_H)
+# include <stdlib.h>
+#endif
+
+#if defined(HAVE_STDINT_H)
+# include <stdint.h>
+#endif
+
+#if defined(HAVE_STDIO_H)
+# include <stdio.h>
+#endif
+
+#if defined(HAVE_STRING_H)
+# include <string.h>
+#endif
+
+#if defined(HAVE_STRINGS_H)
+# include <strings.h>
+#endif
+
+#if defined(HAVE_SYS_TYPES_H)
+# include <sys/types.h>
 #endif
 
 /* By default without either configured, these need to be set */

--- a/include/coap3/coap_io.h
+++ b/include/coap3/coap_io.h
@@ -17,8 +17,6 @@
 #ifndef COAP_IO_H_
 #define COAP_IO_H_
 
-#include <sys/types.h>
-
 #include "coap_address.h"
 
 #ifdef RIOT_VERSION

--- a/include/coap3/coap_io_internal.h
+++ b/include/coap3/coap_io_internal.h
@@ -17,11 +17,7 @@
 #ifndef COAP_IO_INTERNAL_H_
 #define COAP_IO_INTERNAL_H_
 
-#include "coap_internal.h"
 #include "coap_layers_internal.h"
-#include <sys/types.h>
-
-#include "coap_address.h"
 
 #ifdef WITH_CONTIKI
 struct uip_udp_conn;

--- a/include/coap3/coap_layers_internal.h
+++ b/include/coap3/coap_layers_internal.h
@@ -17,8 +17,6 @@
 #ifndef COAP_LAYERS_INTERNAL_H_
 #define COAP_LAYERS_INTERNAL_H_
 
-#include "coap_internal.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_mem.h
+++ b/include/coap3/coap_mem.h
@@ -19,7 +19,6 @@
 
 #include "coap3/coap_oscore.h"
 #include "coap3/coap_proxy.h"
-#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -17,9 +17,6 @@
 #ifndef COAP_NET_H_
 #define COAP_NET_H_
 
-#include <stdlib.h>
-#include <string.h>
-
 #if !defined(WITH_LWIP) && !defined(WITH_CONTIKI) && !defined(RIOT_VERSION) && !defined(_WIN32)
 #include <sys/select.h>
 #endif /* ! WITH_LWIP && ! WITH_CONTIKI && ! RIOT_VERSION && ! _WIN32 */

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -18,9 +18,8 @@
 #ifndef COAP_NET_INTERNAL_H_
 #define COAP_NET_INTERNAL_H_
 
-#include "coap_internal.h"
 #include "coap_subscribe.h"
-#include "coap_threadsafe_internal.h"
+#include "coap_resource.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/coap3/coap_netif_internal.h
+++ b/include/coap3/coap_netif_internal.h
@@ -17,8 +17,6 @@
 #ifndef COAP_NETIF_INTERNAL_H_
 #define COAP_NETIF_INTERNAL_H_
 
-#include "coap_internal.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_option.h
+++ b/include/coap3/coap_option.h
@@ -17,6 +17,19 @@
 #ifndef COAP_OPTION_H_
 #define COAP_OPTION_H_
 
+#if defined(RIOT_VERSION)
+#include <thread.h>
+#endif /* RIOT_VERSION */
+
+#if defined(_WIN32)
+#include <stddef.h>
+#include <stdint.h>
+#endif /* _WIN32 */
+
+#ifndef NULL
+#define NULL 0
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_oscore_internal.h
+++ b/include/coap3/coap_oscore_internal.h
@@ -21,8 +21,6 @@
 #ifndef COAP_OSCORE_INTERNAL_H_
 #define COAP_OSCORE_INTERNAL_H_
 
-#include "oscore/oscore_context.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_pdu.h
+++ b/include/coap3/coap_pdu.h
@@ -25,8 +25,6 @@
 #include <lwip/pbuf.h>
 #endif
 
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -17,21 +17,9 @@
 #ifndef COAP_COAP_PDU_INTERNAL_H_
 #define COAP_COAP_PDU_INTERNAL_H_
 
-#include "coap_internal.h"
-
 #ifdef WITH_LWIP
 #include <lwip/pbuf.h>
 #endif
-
-#ifdef RIOT_VERSION
-#include <limits.h>
-#endif /* RIOT_VERSION */
-
-#ifdef HAVE_LIMITS_H
-#include <limits.h>
-#endif /* HAVE_LIMITS_H */
-
-#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/coap3/coap_proxy_internal.h
+++ b/include/coap3/coap_proxy_internal.h
@@ -17,8 +17,6 @@
 #ifndef COAP_PROXY_INTERNAL_H_
 #define COAP_PROXY_INTERNAL_H_
 
-#include "coap_internal.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_resource_internal.h
+++ b/include/coap3/coap_resource_internal.h
@@ -17,7 +17,6 @@
 #ifndef COAP_RESOURCE_INTERNAL_H_
 #define COAP_RESOURCE_INTERNAL_H_
 
-#include "coap_internal.h"
 #include "coap_uthash_internal.h"
 
 #ifdef __cplusplus

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -18,8 +18,6 @@
 #ifndef COAP_SESSION_INTERNAL_H_
 #define COAP_SESSION_INTERNAL_H_
 
-#include "coap_internal.h"
-#include "coap_io_internal.h"
 #include "coap_ws_internal.h"
 
 #ifdef __cplusplus

--- a/include/coap3/coap_sha1_internal.h
+++ b/include/coap3/coap_sha1_internal.h
@@ -57,8 +57,6 @@
  * @brief Provides SHA1 support for WebSockets
  */
 
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_str.h
+++ b/include/coap3/coap_str.h
@@ -17,8 +17,6 @@
 #ifndef COAP_STR_H_
 #define COAP_STR_H_
 
-#include <string.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_strm_internal.h
+++ b/include/coap3/coap_strm_internal.h
@@ -17,9 +17,6 @@
 #ifndef COAP_STRM_INTERNAL_H_
 #define COAP_STRM_INTERNAL_H_
 
-#include "coap_internal.h"
-#include "coap_io.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_subscribe_internal.h
+++ b/include/coap3/coap_subscribe_internal.h
@@ -18,8 +18,6 @@
 #ifndef COAP_SUBSCRIBE_INTERNAL_H_
 #define COAP_SUBSCRIBE_INTERNAL_H_
 
-#include "coap_internal.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_time.h
+++ b/include/coap3/coap_time.h
@@ -31,8 +31,6 @@
 #include "clock.h"
 #elif defined(RIOT_VERSION)
 #include <xtimer.h>
-#else /* !WITH_LWIP && !WITH_CONTIKI && !RIOT_VERSION */
-#include <stdint.h>
 #endif /* !WITH_LWIP && !WITH_CONTIKI && !RIOT_VERSION */
 
 #ifdef __cplusplus

--- a/include/coap3/coap_uri.h
+++ b/include/coap3/coap_uri.h
@@ -17,8 +17,6 @@
 #ifndef COAP_URI_H_
 #define COAP_URI_H_
 
-#include <stdint.h>
-
 #include "coap_str.h"
 
 #ifdef __cplusplus

--- a/include/coap3/coap_uri_internal.h
+++ b/include/coap3/coap_uri_internal.h
@@ -17,8 +17,6 @@
 #ifndef COAP_URI_INTERNAL_H_
 #define COAP_URI_INTERNAL_H_
 
-#include "coap_internal.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_utlist_internal.h
+++ b/include/coap3/coap_utlist_internal.h
@@ -27,8 +27,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define UTLIST_VERSION 2.3.0
 
-#include <assert.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/coap3/coap_ws_internal.h
+++ b/include/coap3/coap_ws_internal.h
@@ -18,8 +18,6 @@
 #ifndef COAP_WS_INTERNAL_H_
 #define COAP_WS_INTERNAL_H_
 
-#include "coap_internal.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/oscore/oscore.h
+++ b/include/oscore/oscore.h
@@ -47,7 +47,6 @@
 #ifndef _OSCORE_H
 #define _OSCORE_H
 
-#include <coap3/coap_internal.h>
 #include "oscore_cose.h"
 #include "oscore_context.h"
 

--- a/include/oscore/oscore_cbor.h
+++ b/include/oscore/oscore_cbor.h
@@ -46,8 +46,6 @@
 
 #ifndef _OSCORE_CBOR_H
 #define _OSCORE_CBOR_H
-#include <stddef.h>
-#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/oscore/oscore_context.h
+++ b/include/oscore/oscore_context.h
@@ -48,9 +48,7 @@
 #ifndef _OSCORE_CONTEXT_H
 #define _OSCORE_CONTEXT_H
 
-#include "coap3/coap_internal.h"
 #include "coap3/coap_uthash_internal.h"
-#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/oscore/oscore_cose.h
+++ b/include/oscore/oscore_cose.h
@@ -46,8 +46,6 @@
 #ifndef _OSCORE_COSE_H
 #define _OSCORE_COSE_H
 
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/oscore/oscore_crypto.h
+++ b/include/oscore/oscore_crypto.h
@@ -48,8 +48,6 @@
 #ifndef _OSCORE_CRYPTO_H
 #define _OSCORE_CRYPTO_H
 
-#include <coap3/coap_internal.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/man/coap_address.txt.in
+++ b/man/coap_address.txt.in
@@ -273,6 +273,8 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+
 static int
 get_address(coap_uri_t *uri, coap_address_t *dst) {
   coap_addr_info_t *info_list;

--- a/man/coap_block.txt.in
+++ b/man/coap_block.txt.in
@@ -474,6 +474,8 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+
 static int
 build_send_pdu(coap_context_t *context, coap_session_t *session,
                uint8_t msgtype, uint8_t request_code, const char *path,
@@ -594,6 +596,7 @@ main(int argc, char *argv[]) {
 #define __USE_POSIX
 #include <stdio.h>
 #include <sys/stat.h>
+#include <string.h>
 
 static FILE *file_block = NULL;
 static size_t file_size = 0;
@@ -754,6 +757,7 @@ main(int argc, char *argv[]) {
 
 #include <stdio.h>
 #include <time.h>
+#include <string.h>
 
 static void
 hnd_get_time(coap_resource_t *resource, coap_session_t *session,

--- a/man/coap_cache.txt.in
+++ b/man/coap_cache.txt.in
@@ -247,6 +247,8 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+
 static coap_binary_t *example_data_ptr = NULL;
 static int example_data_media_type = COAP_MEDIATYPE_TEXT_PLAIN;
 

--- a/man/coap_call_home.txt.in
+++ b/man/coap_call_home.txt.in
@@ -223,6 +223,9 @@ main(int argc, char **argv) {
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 #include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
 
 static int
 do_call_home(coap_context_t *ctx, coap_str_const_t host, uint16_t port, coap_uri_scheme_t scheme) {

--- a/man/coap_encryption.txt.in
+++ b/man/coap_encryption.txt.in
@@ -1030,6 +1030,9 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+#include <strings.h>
+
 typedef struct valid_cns_t {
   int count;
   char **cn_list;
@@ -1211,6 +1214,9 @@ setup_server_context_pki(const char *public_cert_file,
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+#include <strings.h>
+
 typedef struct id_def_t {
   char *hint_match;
   coap_bin_const_t id;
@@ -1341,6 +1347,7 @@ setup_server_context_psk(const char *hint,
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 #include <stdio.h>
+#include <string.h>
 
 #ifndef min
 #define min(a,b) ((a) < (b) ? (a) : (b))

--- a/man/coap_endpoint_client.txt.in
+++ b/man/coap_endpoint_client.txt.in
@@ -352,6 +352,7 @@ setup_client_session(const char *server_ud) {
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 #include <stdio.h>
+#include <string.h>
 #include <netinet/in.h>
 
 static int
@@ -452,6 +453,7 @@ setup_client_session_pki(const char *host,
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 #include <stdio.h>
+#include <string.h>
 #include <netinet/in.h>
 
 #ifndef min

--- a/man/coap_endpoint_server.txt.in
+++ b/man/coap_endpoint_server.txt.in
@@ -240,6 +240,7 @@ setup_server_context(void) {
 
 #include <stdio.h>
 #include <unistd.h>
+#include <string.h>
 
 /* This need to be unique per endpoint */
 #define UNIX_DOMAIN_LISTEN_DGRAM "/tmp/server.dgram"
@@ -280,6 +281,9 @@ setup_server_context(void) {
 [source, c]
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <string.h>
+#include <strings.h>
 
 typedef struct valid_cns_t {
   size_t count;
@@ -422,6 +426,9 @@ setup_server_context_pki(const char *public_cert_file,
 [source, c]
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <string.h>
+#include <strings.h>
 
 typedef struct id_def_t {
   char *id;

--- a/man/coap_handler.txt.in
+++ b/man/coap_handler.txt.in
@@ -471,6 +471,7 @@ EXAMPLES
 
 #include <stdio.h>
 #include <time.h>
+#include <string.h>
 
 static void
 hnd_get_time(coap_resource_t *resource, coap_session_t *session,

--- a/man/coap_io.txt.in
+++ b/man/coap_io.txt.in
@@ -288,6 +288,8 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <stdlib.h>
+
 int
 main(int argc, char *argv[]) {
 
@@ -337,6 +339,8 @@ main(int argc, char *argv[]) {
 [source, c]
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <stdlib.h>
 
 int
 main(int argc, char *argv[]) {
@@ -396,6 +400,7 @@ main(int argc, char *argv[]) {
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 #include <errno.h>
+#include <stdlib.h>
 
 int
 main(int argc, char *argv[]) {
@@ -463,14 +468,14 @@ main(int argc, char *argv[]) {
 }
 ----
 
-*Method Two - epoll_wait() based on monitorable file descriptor*
+*Method Three - epoll_wait() based on monitorable file descriptor*
 
 [source, c]
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 #include <sys/epoll.h>
-
+#include <stdlib.h>
 #include <errno.h>
 
 #define MAX_EVENTS 10

--- a/man/coap_observe.txt.in
+++ b/man/coap_observe.txt.in
@@ -163,7 +163,9 @@ EXAMPLES
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
+#include <stdlib.h>
 #include <sys/time.h>
 
 coap_resource_t *time_resource = NULL;

--- a/man/coap_pdu_setup.txt.in
+++ b/man/coap_pdu_setup.txt.in
@@ -598,6 +598,8 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+
 static int
 build_send_pdu(coap_context_t *context, coap_session_t *session,
                uint8_t msgtype, uint8_t request_code, const char *path,
@@ -682,6 +684,7 @@ error:
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 
 static void

--- a/man/coap_pdu_transmit.txt.in
+++ b/man/coap_pdu_transmit.txt.in
@@ -123,6 +123,8 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+
 static int
 build_send_pdu(coap_context_t *context, coap_session_t *session,
                uint8_t msgtype, uint8_t request_code, const char *path,
@@ -206,6 +208,8 @@ error:
 [source, c]
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <string.h>
 
 /*
  * SIGINT/SIGTERM handler: terminate any outstanding coap_send_recv().

--- a/man/coap_persist.txt.in
+++ b/man/coap_persist.txt.in
@@ -283,7 +283,9 @@ EXAMPLES
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
+#include <stdlib.h>
 #include <sys/time.h>
 
 coap_resource_t *time_resource = NULL;

--- a/man/coap_proxy.txt.in
+++ b/man/coap_proxy.txt.in
@@ -390,6 +390,8 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+
 static const coap_uri_t uri = {
   .host = {sizeof("1.2.3.4")-1, (const uint8_t *)"1.2.3.4"},
   .port = 5683,
@@ -460,6 +462,9 @@ init_resources(coap_context_t *ctx) {
 [source, c]
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <string.h>
+#include <strings.h>
 
 static const coap_uri_t uri1 = {
   .host = {sizeof("1.2.3.4")-1, (const uint8_t *)"1.2.3.4"},
@@ -575,6 +580,8 @@ init_resources(coap_context_t *ctx) {
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+
 /* List of names / IP addresses that proxy server is known by */
 static const char *proxy_host_name_list[2] = {
   "myservername",
@@ -633,6 +640,9 @@ init_resources(coap_context_t *ctx) {
 [source, c]
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
+
+#include <string.h>
+#include <stdlib.h>
 
 /* List of names / IP addresses that proxy server is known by */
 static const char *proxy_host_name_list[2] = {

--- a/man/coap_resource.txt.in
+++ b/man/coap_resource.txt.in
@@ -387,6 +387,8 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+
 #define INDEX "This is an example server using libcoap\n"
 
 static void

--- a/man/coap_threads.txt.in
+++ b/man/coap_threads.txt.in
@@ -148,6 +148,7 @@ EXAMPLES
 [source, c]
 ----
 #include <inttypes.h>
+#include <string.h>
 #include <stdio.h>
 #include <signal.h>
 #include <time.h>

--- a/man/coap_tls_library.txt.in
+++ b/man/coap_tls_library.txt.in
@@ -156,6 +156,8 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+
 #define ENGINE_CONFIG \
   "engine:pkcs11\n" \
   "enable-methods:0xffff\n" \

--- a/man/coap_uri.txt.in
+++ b/man/coap_uri.txt.in
@@ -168,6 +168,8 @@ EXAMPLES
 ----
 #include <coap@LIBCOAP_API_VERSION@/coap.h>
 
+#include <string.h>
+
 /*
  * Returns 0 failure, 1 success
  */

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -190,6 +190,7 @@ check_synopsis(const char *file) {
     fprintf(fpcode, "#define WITH_LWIP_MAN_CHECK\n");
   }
   fprintf(fpcode, "#include <coap3/coap.h>\n");
+  fprintf(fpcode, "#include <string.h>\n");
   fprintf(fpcode, "#ifdef __GNUC__\n");
   fprintf(fpcode, "#define U __attribute__ ((unused))\n");
   fprintf(fpcode, "#else /* not a GCC */\n");

--- a/src/coap_address.c
+++ b/src/coap_address.c
@@ -47,7 +47,7 @@
   ((((a)->s6_addr32[0]) == 0) && (((a)->s6_addr32[1]) == 0) && \
    (((a)->s6_addr32[2]) == htonl(0xffff)))
 #endif
-#endif /* __ZEPHYR__ */
+#endif /* !__ZEPHYR__ */
 
 #ifdef RIOT_VERSION
 /* FIXME */


### PR DESCRIPTION
Include common system header files in coap_internal.h based on HAVE_*H definitions.

Remove these system header files from include/*/*.h.

Add in system header files where appropriate in various apps.