### PR TITLE
coap_mem: fix -Werror=return-type in coap_malloc() lwIP stub

### DIFF
--- a/include/coap3/coap_mem.h
+++ b/include/coap3/coap_mem.h
@@ -176,6 +176,7 @@ COAP_STATIC_INLINE void *
 coap_malloc(size_t size) {
   (void)size;
   LWIP_ASSERT("coap_malloc must not be used in lwIP", 0);
+  return NULL;
 }
 
 COAP_STATIC_INLINE void


### PR DESCRIPTION
coap_malloc() under WITH_LWIP calls LWIP_ASSERT() but has no return statement, causing -Werror=return-type with GCC on embedded targets. Added return NULL; after the assert to satisfy the compiler.