### PR TITLE
OSS-Fuzz: Fix Makefile for fuzzer to include CFLAGS from OSS-Fuzz

### DIFF
--- a/tests/oss-fuzz/Makefile.ci.in
+++ b/tests/oss-fuzz/Makefile.ci.in
@@ -15,7 +15,7 @@ WARNING_CFLAGS?=@WARNING_CFLAGS@
 DTLS_CFLAGS?=@DTLS_CFLAGS@
 DTLS_LIBS?=@DTLS_LIBS@
 CPPFLAGS=-I$(top_builddir)/include -I$(top_srcdir)/include -I$(top_srcdir)
-CFLAGS=$(WARNING_CFLAGS) $(DTLS_CFLAGS) -std=c99
+CFLAGS+=$(WARNING_CFLAGS) $(DTLS_CFLAGS) -std=c99
 CFLAGS+=-Wno-missing-prototypes -Wno-missing-declarations
 
 SOURCES:=$(wildcard *_target.c)


### PR DESCRIPTION
This PR fixes the Makefile for OSS-Fuzz fuzzers to preserve the CFLAGS from OSS-Fuzz which includes coverage instrumentation flags to allow coverage tracing for fuzzer code.