### PR TITLE
OSS-Fuzz: Fix bias condition

### DIFF
--- a/tests/oss-fuzz/network_message_target.c
+++ b/tests/oss-fuzz/network_message_target.c
@@ -170,7 +170,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   }
 
   /* Test PSK configuration conditionally */
-  if (size >= 32 && data[0] % 4 == 0) {
+  if (size >= 32) {
     test_psk_config(ctx, data, size);
   }
 


### PR DESCRIPTION
This PR fixes a minor bias condition for one of the testing branch for fuzzer targeting coap_net.