### PR TITLE
coap_session.c: Fix token generation when no token is provided

### DIFF
--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -2258,11 +2258,15 @@ void
 coap_session_init_token(coap_session_t *session, size_t len,
                         const uint8_t *data) {
   session->tx_token = coap_decode_var_bytes8(data, len);
-  /*
-   * Decrement as when first used by coap_session_new_token() it will
-   * get incremented
-   */
-  session->tx_token--;
+  if (session->tx_token > 0) {
+    /*
+     * If the token was populated from coap-client CLI option (-T) decrement it here as
+     * when first used by coap_session_new_token() it will get incremented.
+     * As 0 is a special value for empty token (Token Length = 0) we want to avoid
+     * starting at -1.
+     */
+    session->tx_token--;
+  }
 }
 
 void


### PR DESCRIPTION
When `coap_session_t::tx_token` is initialized to zero, the resulting request token has zero length. Some request types, such as Observe, require a non‑empty token. Avoiding initializing `tx_token` to -1 prevents generation of empty tokens and restores the behavior from before commits #1276 and #1329, while still ensuring that user‑provided tokens are no longer incremented before transmission.