### PR TITLE
oss-fuzz: Fix undefined-behavior

### DIFF
--- a/include/coap3/coap_uthash_internal.h
+++ b/include/coap3/coap_uthash_internal.h
@@ -640,15 +640,15 @@ do {                                                                            
 
 #define HASH_JEN_MIX(a,b,c)                                                      \
 do {                                                                             \
-  a -= b; a -= c; a ^= ( c >> 13 );                                              \
-  b -= c; b -= a; b ^= ( a << 8 );                                               \
-  c -= a; c -= b; c ^= ( b >> 13 );                                              \
-  a -= b; a -= c; a ^= ( c >> 12 );                                              \
-  b -= c; b -= a; b ^= ( a << 16 );                                              \
-  c -= a; c -= b; c ^= ( b >> 5 );                                               \
-  a -= b; a -= c; a ^= ( c >> 3 );                                               \
-  b -= c; b -= a; b ^= ( a << 10 );                                              \
-  c -= a; c -= b; c ^= ( b >> 15 );                                              \
+  a = (int64_t)a - b; a = (int64_t)a - c; a ^= ( c >> 13 );                      \
+  b = (int64_t)b - c; b = (int64_t)b - a; b ^= ( a << 8 );                       \
+  c = (int64_t)c - a; c = (int64_t)c - b; c ^= ( b >> 13 );                      \
+  a = (int64_t)a - b; a = (int64_t)a - c; a ^= ( c >> 12 );                      \
+  b = (int64_t)b - c; b = (int64_t)b - a; b ^= ( a << 16 );                      \
+  c = (int64_t)c - a; c = (int64_t)c - b; c ^= ( b >> 5 );                       \
+  a = (int64_t)a - b; a = (int64_t)a - c; a ^= ( c >> 3 );                       \
+  b = (int64_t)b - c; b = (int64_t)b - a; b ^= ( a << 10 );                      \
+  c = (int64_t)c - a; c = (int64_t)c - b; c ^= ( b >> 15 );                      \
 } while (0)
 
 #define HASH_JEN(key,keylen,hashv)                                               \
@@ -659,13 +659,13 @@ do {                                                                            
   _hj_i = _hj_j = 0x9e3779b9u;                                                   \
   _hj_k = (uint32_t)(keylen);                                                    \
   while (_hj_k >= 12U) {                                                         \
-    _hj_i +=    (_hj_key[0] + ( (uint32_t)_hj_key[1] << 8 )                      \
+    _hj_i = (int64_t)_hj_i + (_hj_key[0] + ( (uint32_t)_hj_key[1] << 8 )         \
         + ( (uint32_t)_hj_key[2] << 16 )                                         \
         + ( (uint32_t)_hj_key[3] << 24 ) );                                      \
-    _hj_j +=    (_hj_key[4] + ( (uint32_t)_hj_key[5] << 8 )                      \
+    _hj_j = (int64_t)_hj_j + (_hj_key[4] + ( (uint32_t)_hj_key[5] << 8 )         \
         + ( (uint32_t)_hj_key[6] << 16 )                                         \
         + ( (uint32_t)_hj_key[7] << 24 ) );                                      \
-    hashv += (_hj_key[8] + ( (uint32_t)_hj_key[9] << 8 )                         \
+    hashv = (int64_t)hashv + (_hj_key[8] + ( (uint32_t)_hj_key[9] << 8 )         \
         + ( (uint32_t)_hj_key[10] << 16 )                                        \
         + ( (uint32_t)_hj_key[11] << 24 ) );                                     \
                                                                                  \
@@ -676,17 +676,17 @@ do {                                                                            
   }                                                                              \
   hashv += (uint32_t)(keylen);                                                   \
   switch ( _hj_k ) {                                                             \
-    case 11: hashv += ( (uint32_t)_hj_key[10] << 24 ); /* FALLTHROUGH */         \
-    case 10: hashv += ( (uint32_t)_hj_key[9] << 16 );  /* FALLTHROUGH */         \
-    case 9:  hashv += ( (uint32_t)_hj_key[8] << 8 );   /* FALLTHROUGH */         \
-    case 8:  _hj_j += ( (uint32_t)_hj_key[7] << 24 );  /* FALLTHROUGH */         \
-    case 7:  _hj_j += ( (uint32_t)_hj_key[6] << 16 );  /* FALLTHROUGH */         \
-    case 6:  _hj_j += ( (uint32_t)_hj_key[5] << 8 );   /* FALLTHROUGH */         \
-    case 5:  _hj_j += _hj_key[4];                      /* FALLTHROUGH */         \
-    case 4:  _hj_i += ( (uint32_t)_hj_key[3] << 24 );  /* FALLTHROUGH */         \
-    case 3:  _hj_i += ( (uint32_t)_hj_key[2] << 16 );  /* FALLTHROUGH */         \
-    case 2:  _hj_i += ( (uint32_t)_hj_key[1] << 8 );   /* FALLTHROUGH */         \
-    case 1:  _hj_i += _hj_key[0];                      /* FALLTHROUGH */         \
+    case 11: hashv = (int64_t)hashv + ( (uint32_t)_hj_key[10] << 24 ); /* FALLTHROUGH */ \
+    case 10: hashv = (int64_t)hashv + ( (uint32_t)_hj_key[9] << 16 );  /* FALLTHROUGH */ \
+    case 9:  hashv = (int64_t)hashv + ( (uint32_t)_hj_key[8] << 8 );   /* FALLTHROUGH */ \
+    case 8:  _hj_j = (int64_t)_hj_j + ( (uint32_t)_hj_key[7] << 24 );  /* FALLTHROUGH */ \
+    case 7:  _hj_j = (int64_t)_hj_j + ( (uint32_t)_hj_key[6] << 16 );  /* FALLTHROUGH */ \
+    case 6:  _hj_j = (int64_t)_hj_j + ( (uint32_t)_hj_key[5] << 8 );   /* FALLTHROUGH */ \
+    case 5:  _hj_j = (int64_t)_hj_j + _hj_key[4];                      /* FALLTHROUGH */ \
+    case 4:  _hj_i = (int64_t)_hj_i + ( (uint32_t)_hj_key[3] << 24 );  /* FALLTHROUGH */ \
+    case 3:  _hj_i = (int64_t)_hj_i + ( (uint32_t)_hj_key[2] << 16 );  /* FALLTHROUGH */ \
+    case 2:  _hj_i = (int64_t)_hj_i + ( (uint32_t)_hj_key[1] << 8 );   /* FALLTHROUGH */ \
+    case 1:  _hj_i = (int64_t)_hj_i + _hj_key[0];                      /* FALLTHROUGH */ \
     default: ;                                                                   \
   }                                                                              \
   HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \

--- a/src/coap_asn1.c
+++ b/src/coap_asn1.c
@@ -72,7 +72,7 @@ asn1_tag_c(const uint8_t **ptr, size_t *plen, int *constructed, int *cls) {
     tag = (tag << 7) + (byte & 0x7F);
     (*plen)--;
     (*ptr)++;
-    if (*plen == 0)
+    if (*plen == 0 || tag > (INT_MAX >> 7))
       return COAP_ASN1_FAIL;
     byte = (**ptr);
   }

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -3611,7 +3611,7 @@ derive_cbor_value(const uint8_t **bp, size_t rem_len) {
   }
   if (rem_len < 4)
     return (uint32_t)-1;
-  value = **bp << 24;
+  value = (uint32_t)(**bp) << 24;
   (*bp)++;
   value |= **bp << 16;
   (*bp)++;

--- a/src/coap_encode.c
+++ b/src/coap_encode.c
@@ -58,7 +58,8 @@ coap_encode_var_safe(uint8_t *buf, size_t length, unsigned int val) {
     return 0;
   }
   i = n;
-  while (i--) {
+  while (i) {
+    i--;
     buf[i] = val & 0xff;
     val >>= 8;
   }
@@ -92,7 +93,8 @@ coap_encode_var_safe8(uint8_t *buf, size_t length, uint64_t val) {
     return 0;
   }
   i = n;
-  while (i--) {
+  while (i) {
+    i--;
     buf[i] = val & 0xff;
     val >>= 8;
   }

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -116,12 +116,12 @@ coap_free_node(coap_queue_t *node) {
 unsigned int
 coap_adjust_basetime(coap_context_t *ctx, coap_tick_t now) {
   unsigned int result = 0;
-  coap_tick_diff_t delta = now - ctx->sendqueue_basetime;
+  coap_tick_diff_t delta = (coap_tick_diff_t)now - (coap_tick_diff_t)ctx->sendqueue_basetime;
 
   if (ctx->sendqueue) {
     /* delta < 0 means that the new time stamp is before the old. */
     if (delta <= 0) {
-      ctx->sendqueue->t -= delta;
+      ctx->sendqueue->t = (coap_tick_diff_t)ctx->sendqueue->t - delta;
     } else {
       /* This case is more complex: The time must be advanced forward,
        * thus possibly leading to timed out elements at the queue's
@@ -145,7 +145,7 @@ coap_adjust_basetime(coap_context_t *ctx, coap_tick_t now) {
   }
 
   /* adjust basetime */
-  ctx->sendqueue_basetime += delta;
+  ctx->sendqueue_basetime = (coap_tick_diff_t)ctx->sendqueue_basetime + delta;
 
   return result;
 }

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -1452,7 +1452,8 @@ coap_pdu_parse_opt(coap_pdu_t *pdu, coap_opt_filter_t *error_opts) {
             ok = ok && write_prefix(&obp, &outbuflen, " ", 1);
           }
           tlen = opt - opt_last;
-          while (tlen--) {
+          while (tlen) {
+            tlen--;
             ok = ok && write_char(&obp, &outbuflen, *opt_last, i);
             opt_last++;
           }

--- a/src/coap_uri.c
+++ b/src/coap_uri.c
@@ -439,9 +439,12 @@ coap_host_is_unix_domain(const coap_str_const_t *host) {
 static void
 decode_segment(const uint8_t *seg, size_t length, unsigned char *buf) {
 
-  while (length--) {
+  while (length) {
+    length--;
 
     if (*seg == '%') {
+      if (length < 2)
+        return;
       *buf = (hexchar_to_dec(seg[1]) << 4) + hexchar_to_dec(seg[2]);
 
       seg += 2;

--- a/tests/oss-fuzz/network_message_target.c
+++ b/tests/oss-fuzz/network_message_target.c
@@ -91,14 +91,14 @@ test_context_config(coap_context_t *ctx, const uint8_t *data, size_t size) {
   coap_context_set_max_token_size(ctx, token_size);
 
   if (size >= 20) {
-    size_t csm_max_message_size = (data[16] << 24) | (data[17] << 16) |
+    size_t csm_max_message_size = ((uint32_t)data[16] << 24) | (data[17] << 16) |
                                   (data[18] << 8) | data[19];
     /* CSM max message size must be >= 64 per spec */
     if (csm_max_message_size >= 64) {
       coap_context_set_csm_max_message_size(ctx, csm_max_message_size);
     }
 
-    uint32_t timeout = (data[12] << 24) | (data[13] << 16) |
+    uint32_t timeout = ((uint32_t)data[12] << 24) | (data[13] << 16) |
                        (data[14] << 8) | data[15];
     coap_context_set_csm_timeout_ms(ctx, timeout);
   }

--- a/tests/test_sendqueue.c
+++ b/tests/test_sendqueue.c
@@ -36,7 +36,8 @@ coap_queue_t *node[5];
 static coap_tick_t
 add_timestamps(coap_queue_t *queue, size_t num) {
   coap_tick_t t = 0;
-  while (queue && num--) {
+  while (queue && num) {
+    num--;
     t += queue->t;
     queue = queue->next;
   }
@@ -133,7 +134,7 @@ t_sendqueue5(void) {
   coap_ticks(&now);
   ctx->sendqueue_basetime = now;
 
-  now -= delta1;
+  now = (coap_tick_diff_t)now - (coap_tick_diff_t)delta1;
   result = coap_adjust_basetime(ctx, now);
 
   CU_ASSERT(result == 0);
@@ -141,7 +142,7 @@ t_sendqueue5(void) {
   CU_ASSERT(ctx->sendqueue_basetime == now);
   CU_ASSERT(ctx->sendqueue->t == timestamp[3] + delta1);
 
-  now += delta2;
+  now = (coap_tick_diff_t)now + (coap_tick_diff_t)delta2;
   result = coap_adjust_basetime(ctx, now);
   CU_ASSERT(result == 2);
   CU_ASSERT(ctx->sendqueue_basetime == now);


### PR DESCRIPTION
Analyzer run time does not like A -= B or A +=B even if A and B are uint32_t as there is potential for overflow.

Analyzer run time does not like overflow when doing coap_tick_t - coap_tick_t.

Analyzer run time does not like (uint8_t << 24) as uint8_t is promoted as int, not u_int.

Analyzer run time does not like while(A--) {} even if A is uint32_t, as A is always decremented on the test, even if the value of A is 0.

Fix potential overflow when analyzing an asn.1 tag.

Fix potential overflow when doing decode_segment() on a % hex value.