### PR TITLE
fix: memory leak if client receives ACK response via OSCORE

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4618,6 +4618,10 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
 
   switch (pdu->type) {
   case COAP_MESSAGE_ACK:
+    if (sent != NULL) {
+      coap_delete_node_lkd(sent);
+    }
+
     /* find message id in sendqueue to stop retransmission */
     coap_remove_from_queue(&context->sendqueue, session, pdu->mid, &sent);
 


### PR DESCRIPTION
Resolve a memory leak for following use case:
send a OSCORE request to a coap server which returns a 404 OSCORE Error. Tested by building default coap-client and coap-server with asan enabled.

<details>
<summary>Verified Test</summary>

To enable ASAN, CMakeLists.txt expanded:

```diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index ae1c3bef..9b2a5ff5 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ project(
   VERSION 4.3.5
   LANGUAGES CXX C)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(LIBCOAP_API_VERSION 3)
 set(LIBCOAP_ABI_VERSION 3.2.1)
 
@@ -68,6 +70,18 @@ add_compile_options(
   $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Werror>)
 endif()
 
+option(ENABLE_ASAN "Enable AddressSanitizer (ASan)" OFF)
+if(ENABLE_ASAN)
+  if(MSVC)
+    add_compile_options(/fsanitize=address)
+    add_link_options(/fsanitize=address)
+  else()
+    add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=address)
+  endif()
+  message(STATUS "AddressSanitizer (ASan) enabled")
+endif()
+
 if(MSVC)
   option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols when compiling to a .dll" ON)
   # add_compile_options(/Wall /wd4100 /wd4820 /wd4668 /wd4061)
```

Built:
```
cmake -B ./build -DENABLE_ASAN=ON ./
```

Start server

```bash
$ libcoap/build/coap-server -v 8 -E ./simple-server.txt
```

Run client GET request to an unknown url

```bash
$ libcoap/build/coap-client -v 8 -T 3 -m GET coap://[::1]/notfound -E ./simple-client.txt,client-seq.txt
Mar 10 15:15:17.764  1 OSC  Start Seq no 2
Mar 10 15:15:17.764  1 DEBG ***[::1]:56061 <-> [::1]:5683 UDP : session 0x519000000580: created outgoing session
Mar 10 15:15:17.764  1 DEBG ***[::1]:56061 <-> [::1]:5683 UDP : session connected
Mar 10 15:15:17.764  1 OSC  Common context
Mar 10 15:15:17.764  1 OSC      AEAD alg         AES-CCM-16-64-128 (10)
Mar 10 15:15:17.764  1 OSC      HKDF alg         direct+HKDF-SHA-256 (-10)
Mar 10 15:15:17.764  1 OSC      ID Context      
Mar 10 15:15:17.764  1 OSC      Master Secret    01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 
Mar 10 15:15:17.764  1 OSC      Master Salt     
Mar 10 15:15:17.764  1 OSC      Common IV        be 35 ae 29 7d 2d ac e9 10 c5 2e 99 f9 
Mar 10 15:15:17.764  1 OSC      Sender ID        01 02 
Mar 10 15:15:17.764  1 OSC      Sender Key       18 b5 a8 0d 6a 90 bd 24 7f 9f 10 0b 25 08 1f 64 
Mar 10 15:15:17.764  1 OSC      Recipient ID[0]  <>
Mar 10 15:15:17.764  1 OSC      Recipient Key[0] 56 14 a7 f8 47 31 6c 69 15 d3 66 b9 35 76 b4 19 
Mar 10 15:15:17.764  1 DEBG timeout is set to 90 seconds
Mar 10 15:15:17.764  1 DEBG sending CoAP request:
Mar 10 15:15:17.764  1 DEBG ** [::1]:56061 <-> [::1]:5683 UDP : lg_crcv 0x511000000040 initialized - stateless token xxxxx00000000034
Mar 10 15:15:17.764  1 DEBG PDU to encrypt
v:1 t:CON c:GET i:fca4 {33} [ Uri-Path:notfound, Request-Tag:0xb0a79b84 ]
Mar 10 15:15:17.764  1 OSC  Pre encrypt Cose information
Mar 10 15:15:17.764  1 OSC      alg              AES-CCM-16-64-128 (10)
Mar 10 15:15:17.764  1 OSC      key              18 b5 a8 0d 6a 90 bd 24 7f 9f 10 0b 25 08 1f 64 
Mar 10 15:15:17.764  1 OSC      partial_iv       02 
Mar 10 15:15:17.764  1 OSC      key_id           01 02 
Mar 10 15:15:17.764  1 OSC      kid_context      <>
Mar 10 15:15:17.764  1 OSC      oscore_option    09 02 01 02 
Mar 10 15:15:17.764  1 OSC      nonce            bc 35 ae 29 7d 2d ad eb 10 c5 2e 99 fb 
Mar 10 15:15:17.764  1 OSC      external_aad     85 01 81 0a 42 01 02 41 02 40 
Mar 10 15:15:17.764  1 OSC      aad              83 68 45 6e 63 72 79 70 74 30 40 4a 85 01 81 0a 
Mar 10 15:15:17.764  1 OSC                       42 01 02 41 02 40 
Mar 10 15:15:17.765  1 DEBG *  [::1]:56061 <-> [::1]:5683 UDP : netif: sent   36 bytes
v:1 t:CON c:POST i:fca4 {33} [ Oscore:pIV=0x02,kid=0x0102 ] :: binary data length 25
<<95e06be2688051c9c462c3b194a9254045d6b1c9c591d416c0>>
<<. . k . h . Q . . b . . . . % @ E . . . . . . . . >>
Mar 10 15:15:17.765  1 DEBG ** [::1]:56061 <-> [::1]:5683 UDP : mid=0xfca4: added to retransmit queue (2531ms)
Mar 10 15:15:17.766  1 DEBG *  [::1]:56061 <-> [::1]:5683 UDP : netif: recv   26 bytes
v:1 t:ACK c:2.04 i:fca4 {33} [ Oscore: ] :: binary data length 19
<<e0fd3116490b7793b891e21c120ef191f8d873>>
<<. . 1 . I . w . . . . . . . . . . . s >>
Mar 10 15:15:17.766  1 DEBG ** [::1]:56061 <-> [::1]:5683 UDP : mid=0xfca4: removed (1)
Mar 10 15:15:17.766  1 OSC  Pre decrypt Cose information
Mar 10 15:15:17.766  1 OSC      alg              AES-CCM-16-64-128 (10)
Mar 10 15:15:17.766  1 OSC      key              56 14 a7 f8 47 31 6c 69 15 d3 66 b9 35 76 b4 19 
Mar 10 15:15:17.766  1 OSC      partial_iv       02 
Mar 10 15:15:17.766  1 OSC      key_id           01 02 
Mar 10 15:15:17.766  1 OSC      kid_context      <>
Mar 10 15:15:17.766  1 OSC      oscore_option    <>
Mar 10 15:15:17.766  1 OSC      nonce            bc 35 ae 29 7d 2d ad eb 10 c5 2e 99 fb 
Mar 10 15:15:17.766  1 OSC      external_aad     85 01 81 0a 42 01 02 41 02 40 
Mar 10 15:15:17.766  1 OSC      aad              83 68 45 6e 63 72 79 70 74 30 40 4a 85 01 81 0a 
Mar 10 15:15:17.766  1 OSC                       42 01 02 41 02 40 
Mar 10 15:15:17.766  1 DEBG Decrypted PDU
v:1 t:ACK c:4.04 i:fca4 {33} [ ] :: 'Not Found'
Mar 10 15:15:17.766  1 DEBG ** [::1]:56061 <-> [::1]:5683 UDP : lg_crcv 0x511000000040 released
Mar 10 15:15:17.766  1 DEBG ** process incoming 4.04 response:
4.04 Not Found
Mar 10 15:15:17.766  1 DEBG ***[::1]:56061 <-> [::1]:5683 UDP : session 0x519000000580: closed

=================================================================
==80096==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7fa8c50f4c57 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x563274016589 in coap_malloc_type /home/z003019s/projects/libcoap/src/coap_mem.c:644
    #2 0x56327401660e in coap_malloc_node /home/z003019s/projects/libcoap/src/coap_net.c:108
    #3 0x56327401708e in coap_new_node /home/z003019s/projects/libcoap/src/coap_net.c:245
    #4 0x563274021893 in coap_send_internal /home/z003019s/projects/libcoap/src/coap_net.c:2130
    #5 0x56327401f90c in coap_send_lkd /home/z003019s/projects/libcoap/src/coap_net.c:1830
    #6 0x563274021fef in coap_send_recv_lkd /home/z003019s/projects/libcoap/src/coap_net.c:2213
    #7 0x563274021bb4 in coap_send_recv /home/z003019s/projects/libcoap/src/coap_net.c:2160
    #8 0x563273fe250f in main /home/z003019s/projects/libcoap/examples/coap-client.c:2318
    #9 0x7fa8c4e34ca7  (/lib/x86_64-linux-gnu/libc.so.6+0x29ca7) (BuildId: fce446c9d4ad48e2b0c90cce1a11722897805281)

Indirect leak of 152 byte(s) in 1 object(s) allocated from:
    #0 0x7fa8c50f4c57 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x563274016589 in coap_malloc_type /home/z003019s/projects/libcoap/src/coap_mem.c:644
    #2 0x5632740489cd in coap_pdu_init /home/z003019s/projects/libcoap/src/coap_pdu.c:122
    #3 0x56327403d646 in coap_oscore_new_pdu_encrypted_lkd /home/z003019s/projects/libcoap/src/coap_oscore.c:427
    #4 0x5632740211d4 in coap_send_internal /home/z003019s/projects/libcoap/src/coap_net.c:2073
    #5 0x56327401f90c in coap_send_lkd /home/z003019s/projects/libcoap/src/coap_net.c:1830
    #6 0x563274021fef in coap_send_recv_lkd /home/z003019s/projects/libcoap/src/coap_net.c:2213
    #7 0x563274021bb4 in coap_send_recv /home/z003019s/projects/libcoap/src/coap_net.c:2160
    #8 0x563273fe250f in main /home/z003019s/projects/libcoap/examples/coap-client.c:2318
    #9 0x7fa8c4e34ca7  (/lib/x86_64-linux-gnu/libc.so.6+0x29ca7) (BuildId: fce446c9d4ad48e2b0c90cce1a11722897805281)

Indirect leak of 44 byte(s) in 1 object(s) allocated from:
    #0 0x7fa8c50f4c57 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x563274016589 in coap_malloc_type /home/z003019s/projects/libcoap/src/coap_mem.c:644
    #2 0x563274048aef in coap_pdu_init /home/z003019s/projects/libcoap/src/coap_pdu.c:147
    #3 0x56327403d646 in coap_oscore_new_pdu_encrypted_lkd /home/z003019s/projects/libcoap/src/coap_oscore.c:427
    #4 0x5632740211d4 in coap_send_internal /home/z003019s/projects/libcoap/src/coap_net.c:2073
    #5 0x56327401f90c in coap_send_lkd /home/z003019s/projects/libcoap/src/coap_net.c:1830
    #6 0x563274021fef in coap_send_recv_lkd /home/z003019s/projects/libcoap/src/coap_net.c:2213
    #7 0x563274021bb4 in coap_send_recv /home/z003019s/projects/libcoap/src/coap_net.c:2160
    #8 0x563273fe250f in main /home/z003019s/projects/libcoap/examples/coap-client.c:2318
    #9 0x7fa8c4e34ca7  (/lib/x86_64-linux-gnu/libc.so.6+0x29ca7) (BuildId: fce446c9d4ad48e2b0c90cce1a11722897805281)

SUMMARY: AddressSanitizer: 276 byte(s) leaked in 3 allocation(s).
```

</details>

Issue is related to `coap_remove_from_queue` to be called after each other.
1. coap_net.c:4589 (find message for decryption)
2. coap_net.c:4622+ (remove message from queue if it is a ACK message) --> sets `sent = NULL` leading to memory leak