### PR TITLE
impr(security): tracking CVE using CPE

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -3,3 +3,7 @@ name: libcoap
 build:
   cmake: zephyr
   kconfig: zephyr/Kconfig
+
+security:
+  external-references:
+    - cpe:2.3:a:libcoap:libcoap:4.3.5a:*:*:*:*:*:*:*


### PR DESCRIPTION
As security awareness is increasing, I would like to propose changes that will help with tracking CVE within Zephyr environment.

This however is also connected with release process, as CPE reference contains the version.

Any suggestion to improve it is welcomed.