### PR TITLE
fix: OSCORE ACK retransmission handling

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4618,12 +4618,10 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
 
   switch (pdu->type) {
   case COAP_MESSAGE_ACK:
-    if (sent != NULL) {
-      coap_delete_node_lkd(sent);
+    if (NULL == sent) {
+      /* find message id in sendqueue to stop retransmission */
+      coap_remove_from_queue(&context->sendqueue, session, pdu->mid, &sent);
     }
-
-    /* find message id in sendqueue to stop retransmission */
-    coap_remove_from_queue(&context->sendqueue, session, pdu->mid, &sent);
 
     if (sent && session->con_active) {
       session->con_active--;

--- a/tests/test_sendqueue.c
+++ b/tests/test_sendqueue.c
@@ -276,6 +276,49 @@ t_sendqueue10(void) {
   CU_ASSERT(tmp_node->t == timestamp[2]);
 }
 
+/*
+ * Regression guard for ACK handling: exercise the real coap_dispatch()
+ * ACK path and ensure the retransmission node is consumed exactly once.
+ */
+static void
+t_sendqueue11(void) {
+  int result;
+  coap_queue_t *queued = NULL;
+  coap_pdu_t *sent_pdu = NULL;
+  uint8_t ack_data[] = { 0x60, 0x00, 0x12, 0x34 };
+
+  CU_ASSERT_PTR_NULL(ctx->sendqueue);
+
+  queued = coap_new_node();
+  ReturnIf_CU_ASSERT_PTR_NOT_NULL(queued);
+
+  sent_pdu = coap_pdu_init(COAP_MESSAGE_CON,
+                           COAP_REQUEST_CODE_GET,
+                           0x1234,
+                           64);
+  ReturnIf_CU_ASSERT_PTR_NOT_NULL(sent_pdu);
+
+  queued->next = NULL;
+  queued->session = coap_session_reference(session);
+  queued->pdu = sent_pdu;
+  queued->id = 0x1234;
+  queued->t = timestamp[1];
+
+  result = coap_insert_node(&ctx->sendqueue, queued);
+  CU_ASSERT(result > 0);
+  ReturnIf_CU_ASSERT_PTR_NOT_NULL(ctx->sendqueue);
+
+  session->state = COAP_SESSION_STATE_ESTABLISHED;
+  coap_lock_lock(return);
+  coap_handle_dgram(ctx, session, ack_data, sizeof(ack_data));
+  CU_ASSERT_PTR_NULL(ctx->sendqueue);
+
+  /* Re-dispatch another ACK with the same mid to ensure idempotent behavior. */
+  coap_handle_dgram(ctx, session, ack_data, sizeof(ack_data));
+  coap_lock_unlock();
+  CU_ASSERT_PTR_NULL(ctx->sendqueue);
+}
+
 /* This function creates a set of nodes for testing. These nodes
  * will exist for all tests and are modified by coap_insert_node()
  * and coap_remove_from_queue().
@@ -361,6 +404,7 @@ t_init_sendqueue_tests(void) {
   SENDQUEUE_TEST(suite, t_sendqueue8);
   SENDQUEUE_TEST(suite, t_sendqueue9);
   SENDQUEUE_TEST(suite, t_sendqueue10);
+  SENDQUEUE_TEST(suite, t_sendqueue11);
 
   return suite;
 }


### PR DESCRIPTION
Redo #1913 as it creates other problems.

Code verified with the same steps as mentioned in the previous PR:
```
./build/coap-client -v 8 -E ./examples/interop/a_client.conf -m get coap://127.0.0.1/notfound       
Mar 19 12:10:10.947  1 OSC  Start Seq no 0
Mar 19 12:10:10.947  1 DEBG ***127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : session 0xf0c1adbe0580: created outgoing session
Mar 19 12:10:10.947  1 DEBG ***127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : session connected
Mar 19 12:10:10.947  1 OSC  Common context
Mar 19 12:10:10.947  1 OSC      AEAD alg         AES-CCM-16-64-128 (10)
Mar 19 12:10:10.947  1 OSC      HKDF alg         direct+HKDF-SHA-256 (-10)
Mar 19 12:10:10.947  1 OSC      ID Context      
Mar 19 12:10:10.947  1 OSC      Master Secret    01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 
Mar 19 12:10:10.947  1 OSC      Master Salt      9e 7c a9 22 23 78 63 40 
Mar 19 12:10:10.947  1 OSC      Common IV        46 22 d4 dd 6d 94 41 68 ee fb 54 98 7c 
Mar 19 12:10:10.947  1 OSC      Sender ID        <>
Mar 19 12:10:10.947  1 OSC      Sender Key       f0 91 0e d7 29 5e 6a d4 b5 4f c7 93 15 43 02 ff 
Mar 19 12:10:10.947  1 OSC      Recipient ID[0]  01 
Mar 19 12:10:10.947  1 OSC      Recipient Key[0] ff b1 4e 09 3c 94 c9 ca c9 47 16 48 b4 f9 87 10 
Mar 19 12:10:10.947  1 DEBG timeout is set to 90 seconds
Mar 19 12:10:10.947  1 DEBG sending CoAP request:
Mar 19 12:10:10.947  1 DEBG ** 127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : lg_crcv 0xf041adbe0180 initialized - stateless token xxxxx00000000001
Mar 19 12:10:10.948  1 DEBG PDU to encrypt
v:1 t:CON c:GET i:cd46 {} [ Uri-Path:notfound, Request-Tag:0x2e7bf0f5 ]
Mar 19 12:10:10.948  1 OSC  Pre encrypt Cose information
Mar 19 12:10:10.948  1 OSC      alg              AES-CCM-16-64-128 (10)
Mar 19 12:10:10.948  1 OSC      key              f0 91 0e d7 29 5e 6a d4 b5 4f c7 93 15 43 02 ff 
Mar 19 12:10:10.948  1 OSC      partial_iv       00 
Mar 19 12:10:10.948  1 OSC      key_id           <>
Mar 19 12:10:10.948  1 OSC      kid_context      <>
Mar 19 12:10:10.948  1 OSC      oscore_option    09 00 
Mar 19 12:10:10.948  1 OSC      nonce            46 22 d4 dd 6d 94 41 68 ee fb 54 98 7c 
Mar 19 12:10:10.948  1 OSC      external_aad     85 01 81 0a 40 41 00 40 
Mar 19 12:10:10.948  1 OSC      aad              83 68 45 6e 63 72 79 70 74 30 40 48 85 01 81 0a 
Mar 19 12:10:10.948  1 OSC                       40 41 00 40 
Mar 19 12:10:10.948  1 DEBG *  127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : netif: sent   33 bytes
v:1 t:CON c:POST i:cd46 {} [ Oscore:pIV=0x00 ] :: binary data length 25
<<ae81301a658a42e3d0e2327ccecf29b3c44ee612185249c6cc>>
<<. . 0 . e . B . . . 2 | . . ) . . N . . . R I . . >>
Mar 19 12:10:10.948  1 DEBG ** 127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : mid=0xcd46: added to retransmit queue (2531ms)
Mar 19 12:10:10.949  1 DEBG *  127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : netif: recv   27 bytes
v:1 t:ACK c:2.04 i:cd46 {} [ Oscore:pIV=0x00 ] :: binary data length 19
<<896bb4a8c47161953d0ddc7b9dcffd92fb4c31>>
<<. k . . . q a . = . . { . . . . . L 1 >>
Mar 19 12:10:10.949  1 DEBG ** 127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : mid=0xcd46: removed (1)
Mar 19 12:10:10.949  1 OSC  Pre decrypt Cose information
Mar 19 12:10:10.949  1 OSC      alg              AES-CCM-16-64-128 (10)
Mar 19 12:10:10.949  1 OSC      key              ff b1 4e 09 3c 94 c9 ca c9 47 16 48 b4 f9 87 10 
Mar 19 12:10:10.949  1 OSC      partial_iv       00 
Mar 19 12:10:10.949  1 OSC      key_id           <>
Mar 19 12:10:10.949  1 OSC      kid_context      <>
Mar 19 12:10:10.949  1 OSC      oscore_option    01 00 
Mar 19 12:10:10.950  1 OSC      nonce            47 22 d4 dd 6d 94 41 69 ee fb 54 98 7c 
Mar 19 12:10:10.950  1 OSC      external_aad     85 01 81 0a 40 41 00 40 
Mar 19 12:10:10.950  1 OSC      aad              83 68 45 6e 63 72 79 70 74 30 40 48 85 01 81 0a 
Mar 19 12:10:10.950  1 OSC                       40 41 00 40 
Mar 19 12:10:10.950  1 DEBG PDU requesting re-transmit
v:1 t:ACK c:4.01 i:cd46 {} [ Echo:0xab3b99b8c63ed018 ]
Mar 19 12:10:10.950  1 OSC  RFC9175 retransmit pdu
Mar 19 12:10:10.950  1 DEBG PDU to encrypt
v:1 t:CON c:GET i:cd48 {200000000001} [ Uri-Path:notfound, Echo:0xab3b99b8c63ed018, Request-Tag:0x2e7bf0f5 ]
Mar 19 12:10:10.950  1 OSC  Pre encrypt Cose information
Mar 19 12:10:10.950  1 OSC      alg              AES-CCM-16-64-128 (10)
Mar 19 12:10:10.950  1 OSC      key              f0 91 0e d7 29 5e 6a d4 b5 4f c7 93 15 43 02 ff 
Mar 19 12:10:10.950  1 OSC      partial_iv       01 
Mar 19 12:10:10.950  1 OSC      key_id           <>
Mar 19 12:10:10.950  1 OSC      kid_context      <>
Mar 19 12:10:10.950  1 OSC      oscore_option    09 01 
Mar 19 12:10:10.950  1 OSC      nonce            46 22 d4 dd 6d 94 41 68 ee fb 54 98 7d 
Mar 19 12:10:10.950  1 OSC      external_aad     85 01 81 0a 40 41 01 40 
Mar 19 12:10:10.950  1 OSC      aad              83 68 45 6e 63 72 79 70 74 30 40 48 85 01 81 0a 
Mar 19 12:10:10.950  1 OSC                       40 41 01 40 
Mar 19 12:10:10.950  1 DEBG *  127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : netif: sent   48 bytes
v:1 t:CON c:POST i:cd48 {200000000001} [ Oscore:pIV=0x01 ] :: binary data length 34
<<194c2a4cc0d6a93f2fd15dc892b5b4734b4feeb3792468a98bae7016dac0247bfbf6>>
<<. L * L . . . ? / . ] . . . . s K O . . y $ h . . . p . . . $ { . . >>
Mar 19 12:10:10.950  1 DEBG ** 127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : mid=0xcd48: added to retransmit queue (2063ms)
Mar 19 12:10:10.951  1 DEBG *  127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : netif: recv   31 bytes
v:1 t:ACK c:2.04 i:cd48 {200000000001} [ Oscore: ] :: binary data length 19
<<8643342f6654e26dccfa0df30efeaa27dac3dd>>
<<. C 4 / f T . m . . . . . . . ' . . . >>
Mar 19 12:10:10.951  1 DEBG ** 127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : mid=0xcd48: removed (1)
Mar 19 12:10:10.951  1 OSC  Pre decrypt Cose information
Mar 19 12:10:10.951  1 OSC      alg              AES-CCM-16-64-128 (10)
Mar 19 12:10:10.951  1 OSC      key              ff b1 4e 09 3c 94 c9 ca c9 47 16 48 b4 f9 87 10 
Mar 19 12:10:10.951  1 OSC      partial_iv       01 
Mar 19 12:10:10.951  1 OSC      key_id           <>
Mar 19 12:10:10.951  1 OSC      kid_context      <>
Mar 19 12:10:10.951  1 OSC      oscore_option    <>
Mar 19 12:10:10.951  1 OSC      nonce            46 22 d4 dd 6d 94 41 68 ee fb 54 98 7d 
Mar 19 12:10:10.951  1 OSC      external_aad     85 01 81 0a 40 41 01 40 
Mar 19 12:10:10.951  1 OSC      aad              83 68 45 6e 63 72 79 70 74 30 40 48 85 01 81 0a 
Mar 19 12:10:10.951  1 OSC                       40 41 01 40 
Mar 19 12:10:10.951  1 DEBG Decrypted PDU
v:1 t:ACK c:4.04 i:cd48 {} [ ] :: 'Not Found'
Mar 19 12:10:10.951  1 DEBG ** 127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : lg_crcv 0xf041adbe0180 released
Mar 19 12:10:10.951  1 DEBG ** process incoming 4.04 response:
4.04 Not Found
Mar 19 12:10:10.951  1 DEBG ***127.0.0.1:55263 <-> 127.0.0.1:5683 UDP : session 0xf0c1adbe0580: closed
```

Test was artificially created.