### PR TITLE
fix: do not override sequence counter after window processing

### DIFF
--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -1122,10 +1122,11 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
                                0);
       goto error_no_ack;
     }
-
-    incoming_seq =
-        coap_decode_var_bytes8(cose->partial_iv.s, cose->partial_iv.length);
-    rcp_ctx->last_seq = incoming_seq;
+    if (rcp_ctx->initial_state == 1) {
+      incoming_seq =
+          coap_decode_var_bytes8(cose->partial_iv.s, cose->partial_iv.length);
+      rcp_ctx->last_seq = incoming_seq;
+    }
   } else { /* !coap_request */
     /*
      * 8.4 Step 2


### PR DESCRIPTION
During testing it seemed that libcoap is overriding the rcp_ctx->last_seq, which is previously set by `oscore_validate_sender_seq`. My best guess, this should only occure if the window is not initialized, or maybe never?

This leads to strange behavior, that message maybe can be replayed:
1. GET PIV=10 | last_seq = 10
2. GET PIV=7   | (allowed due to PIV window) but sets last_seq = 7
3. GET PIV=10 | is allowed, since last_seq (7) < PIV (10), expected to fail
