### PR TITLE
multi-threading: Lock resource structure when calling request handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ include/coap3/coap_defines.h
 tests/.deps
 tests/Makefile
 tests/oss-fuzz/Makefile.ci
+tests/oss-fuzz/*.o
 tests/testdriver
 tests/*.o
 

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1073,7 +1073,9 @@ dyn_create_handler(coap_session_t *session, const coap_pdu_t *request) {
 
   /*
    * Create a resource to handle the new URI
-   * uri_path will get deleted when the resource is removed
+   * uri_path will get deleted when the resource is removed.
+   * Not safe to set COAP_RESOURCE_SAFE_REQUEST_HANDLER here as
+   * hnd_put_post() manipulates resource associated information..
    */
   r = coap_resource_init((coap_str_const_t *)uri_path,
                          COAP_RESOURCE_FLAGS_RELEASE_URI | resource_flags);
@@ -1185,7 +1187,7 @@ init_resources(coap_context_t *ctx) {
 #if COAP_PROXY_SUPPORT
   if (reverse_proxy.entry_count) {
     /* Create a reverse proxy resource to handle PUTs */
-    r = coap_resource_reverse_proxy_init(hnd_reverse_proxy_uri, 0);
+    r = coap_resource_reverse_proxy_init(hnd_reverse_proxy_uri, COAP_RESOURCE_SAFE_REQUEST_HANDLER);
     if (!r)
       return;
     coap_add_resource(ctx, r);
@@ -1194,7 +1196,8 @@ init_resources(coap_context_t *ctx) {
     coap_register_nack_handler(ctx, proxy_nack_handler);
   } else {
 #endif /* COAP_PROXY_SUPPORT */
-    r = coap_resource_init(NULL, COAP_RESOURCE_FLAGS_HAS_MCAST_SUPPORT);
+    r = coap_resource_init(NULL,
+                           COAP_RESOURCE_FLAGS_HAS_MCAST_SUPPORT | COAP_RESOURCE_SAFE_REQUEST_HANDLER);
     if (!r)
       return;
     coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_index);
@@ -1206,7 +1209,8 @@ init_resources(coap_context_t *ctx) {
     /* store clock base to use in /time */
     my_clock_base = clock_offset;
 
-    r = coap_resource_init(coap_make_str_const("time"), resource_flags);
+    r = coap_resource_init(coap_make_str_const("time"),
+                           COAP_RESOURCE_SAFE_REQUEST_HANDLER | resource_flags);
     if (!r)
       return;
     coap_register_request_handler(r, COAP_REQUEST_GET, hnd_get_fetch_time);
@@ -1261,7 +1265,7 @@ init_resources(coap_context_t *ctx) {
   }
   if (proxy_host_name_count) {
     r = coap_resource_proxy_uri_init2(hnd_forward_proxy_uri, proxy_host_name_count,
-                                      proxy_host_name_list, 0);
+                                      proxy_host_name_list, COAP_RESOURCE_SAFE_REQUEST_HANDLER);
     if (!r)
       return;
     coap_add_resource(ctx, r);

--- a/include/coap3/coap_resource.h
+++ b/include/coap3/coap_resource.h
@@ -172,6 +172,15 @@ typedef void (*coap_method_handler_t)(coap_resource_t *resource,
 #define COAP_RESOURCE_HIDE_WELLKNOWN_CORE 0x2000
 
 /**
+ * Don't lock this resource when calling app call-back handler for requests
+ * as handler will not be manipulating any resource held data.
+ * Not locking the resource (if safe) can save lock contention on a busy system.
+ * Caution: If there is a POST or PUT handler, then it is likely this should
+ * not be set.
+ */
+#define COAP_RESOURCE_SAFE_REQUEST_HANDLER 0x4000
+
+/**
  * Creates a new resource object and initializes the link field to the string
  * @p uri_path. This function returns the new coap_resource_t object.
  *

--- a/include/coap3/coap_resource_internal.h
+++ b/include/coap3/coap_resource_internal.h
@@ -17,6 +17,7 @@
 #ifndef COAP_RESOURCE_INTERNAL_H_
 #define COAP_RESOURCE_INTERNAL_H_
 
+#include "coap_threadsafe_internal.h"
 #include "coap_uthash_internal.h"
 
 #ifdef __cplusplus
@@ -115,6 +116,9 @@ struct coap_resource_t {
    * the coap handler.
    */
   void *user_data;
+#if COAP_THREAD_SAFE
+  coap_lock_t lock;
+#endif /* COAP_THREAD_SAFE */
 
 };
 

--- a/include/coap3/coap_threadsafe_internal.h
+++ b/include/coap3/coap_threadsafe_internal.h
@@ -113,35 +113,37 @@ typedef struct coap_lock_t {
 } coap_lock_t;
 
 /**
- * Unlock the global_lock lock.
+ * Unlock the specific lock.
  *
  * If this is a nested lock (Public API - libcoap - app call-back - Public API),
- * then the lock remains locked, but global_lock.in_callback is decremented.
+ * then the lock remains locked, but lock->in_callback is decremented.
  *
  * Note: Invoked by wrapper macro, not used directly.
  *
+ * @param lock The lock to act on.
  * @param file The file from which coap_lock_unlock_func() is getting called.
  * @param line The line no from which coap_lock_unlock_func() is getting called.
  */
-void coap_lock_unlock_func(const char *file, int line);
+void coap_lock_unlock_func(coap_lock_t *lock, const char *file, int line);
 
 /**
- * Lock the global_lock lock.
+ * Lock the specfic lock.
  *
  * If this is a nested lock (Public API - libcoap - app call-back - Public API),
- * then increment the global_lock.in_callback.
+ * then increment the lock->in_callback.
  *
  * Note: Invoked by wrapper macro, not used directly.
  *
+ * @param lock The lock to act on.
  * @param file The file from which coap_lock_lock_func() is getting called.
  * @param line The line no from which coap_lock_lock_func() is getting called.
  *
  * @return @c 0 if libcoap has not started (coap_startup() not called), else @c 1.
  */
-int coap_lock_lock_func(const char *file, int line);
+int coap_lock_lock_func(coap_lock_t *lock, const char *file, int line);
 
 /**
- * libcoap library code. Lock The global_lock.
+ * libcoap library code. Lock the global_lock.
  *
  * Invoked when
  *   Not locked at all
@@ -156,20 +158,56 @@ int coap_lock_lock_func(const char *file, int line);
  *
  */
 #define coap_lock_lock(failed) do { \
-    if (!coap_lock_lock_func(__FILE__, __LINE__)) { \
+    if (!coap_lock_lock_func(&global_lock, __FILE__, __LINE__)) { \
       failed; \
     } \
   } while (0)
 
 /**
- * libcoap library code. Unlock The global_lock.
+ * libcoap library code. Unlock the global_lock.
  *
  * Unlocked when
  *   Same thread locked context
  *   Not when called from app call-back
  */
 #define coap_lock_unlock() do { \
-    coap_lock_unlock_func(__FILE__, __LINE__); \
+    coap_lock_unlock_func(&global_lock, __FILE__, __LINE__); \
+  } while (0)
+
+/**
+ * libcoap library code. Lock a specific lock.
+ *
+ * Invoked when
+ *   Not locked at all
+ *   Locked, app call-back, call from app call-back
+ *   Locked, app call-back, call from app call-back, app call-back, call from app call-back
+ * Result
+ *   global_lock locked.
+ *   global_lock not locked if libcoap not started and @p failed is executed. @p failed must
+ *   be code that skips doing the lock protected code.
+ *
+ * @param lock The specifc lock to lock.
+ * @param failed Code to execute on lock failure.
+ *
+ */
+#define coap_lock_specific_lock(lock, failed) do { \
+    if (!coap_lock_lock_func(lock, __FILE__, __LINE__)) { \
+      failed; \
+    } \
+  } while (0)
+
+/**
+ * libcoap library code. Unlock a specific lock.
+ *
+ * Unlocked when
+ *   Same thread locked context
+ *   Not when called from app call-back
+ *
+ * @param lock The specifc lock to unlock.
+ *
+ */
+#define coap_lock_specific_unlock(lock) do { \
+    coap_lock_unlock_func(lock, __FILE__, __LINE__); \
   } while (0)
 
 /**
@@ -243,6 +281,32 @@ int coap_lock_lock_func(const char *file, int line);
     coap_lock_check_locked(); \
     coap_lock_unlock(); \
     (r) = func; \
+    coap_lock_lock(failed); \
+  } while (0)
+
+/**
+ * libcoap library code. Invoke an app callback, unlocking global_lock first,
+ * followed by locking specified lock, and after callback unlock specified lock
+ * and lock global_lock..
+ *
+ * Called when
+ *   Locked
+ *
+ * @param lock lock to lock before callback.
+ * @param func app call-back function to invoke.
+ * @param failed Code to execute on (re-)lock failure.
+ *
+ */
+#define coap_lock_specific_callback_release(lock,func,failed) do { \
+    coap_lock_check_locked(); \
+    coap_lock_unlock(); \
+    coap_lock_specific_lock(lock, failed); \
+    (lock)->in_callback++; \
+    (lock)->callback_file = __FILE__; \
+    (lock)->callback_line = __LINE__; \
+    func; \
+    (lock)->in_callback--; \
+    coap_lock_specific_unlock(lock); \
     coap_lock_lock(failed); \
   } while (0)
 
@@ -268,8 +332,10 @@ typedef struct coap_lock_t {
  *
  * Note: Invoked by wrapper macro, not used directly.
  *
+ * @param lock The lock to act on.
+ *
  */
-void coap_lock_unlock_func(void);
+void coap_lock_unlock_func(coap_lock_t *lock);
 
 /**
  * Lock the global_lock lock.
@@ -279,12 +345,14 @@ void coap_lock_unlock_func(void);
  *
  * Note: Invoked by wrapper macro, not used directly.
  *
+ * @param lock The lock to act on.
+ *
  * @return @c 0 if libcoap has not started (coap_startup() not called), else @c 1.
  */
-int coap_lock_lock_func(void);
+int coap_lock_lock_func(coap_lock_t *lock);
 
 /**
- * libcoap library code. Lock The global_lock.
+ * libcoap library code. Lock the global_lock.
  *
  * Invoked when
  *   Not locked at all
@@ -299,20 +367,56 @@ int coap_lock_lock_func(void);
  *
  */
 #define coap_lock_lock(failed) do { \
-    if (!coap_lock_lock_func()) { \
+    if (!coap_lock_lock_func(&global_lock)) { \
       failed; \
     } \
   } while (0)
 
 /**
- *  libcoap library code. Unlock The global_lock.
+ * libcoap library code. Lock the specific lock.
+ *
+ * Invoked when
+ *   Not locked at all
+ *   Locked, app call-back, call from app call-back
+ *   Locked, app call-back, call from app call-back, app call-back, call from app call-back
+ * Result
+ *   global_lock locked.
+ *   global not locked if libcoap not started and @p failed is executed. @p failed must
+ *   be code that skips doing the lock protected code.
+ *
+ * @param lock The specifc lock to lock.
+ * @param failed Code to execute on lock failure
+ *
+ */
+#define coap_lock_specific_lock(lock, failed) do { \
+    if (!coap_lock_lock_func(lock)) { \
+      failed; \
+    } \
+  } while (0)
+
+/**
+ *  libcoap library code. Unlock the global_lock.
  *
  * Unlocked when
  *   Same thread locked context.
  *   Not when called from app call-back.
  */
 #define coap_lock_unlock() do { \
-    coap_lock_unlock_func(); \
+    coap_lock_unlock_func(&global_lock); \
+  } while (0)
+
+/**
+ *  libcoap library code. Unlock the specific lock..
+ *
+ * Unlocked when
+ *   Same thread locked context.
+ *   Not when called from app call-back.
+ *
+ * @param lock The specifc lock to unlock.
+ *
+ */
+#define coap_lock_specific_unlock(lock) do { \
+    coap_lock_unlock_func(lock); \
   } while (0)
 
 /**
@@ -367,6 +471,30 @@ int coap_lock_lock_func(void);
   } while (0)
 
 /**
+ * libcoap library code. Invoke an app callback, unlocking global_lock first,
+ * followed by locking specified lock, and after callback unlock specified lock
+ * and lock global_lock..
+ *
+ * Called when
+ *   Locked (need to unlock over app call-back)
+ *
+ * @param lock lock to lock before callback.
+ * @param func app call-back function to invoke.
+ * @param failed Code to execute on (re-)lock failure.
+ *
+ */
+#define coap_lock_specific_callback_release(lock,func,failed) do { \
+    coap_lock_check_locked(); \
+    coap_lock_unlock(); \
+    coap_lock_specific_lock(lock, failed); \
+    (lock)->in_callback++; \
+    func; \
+    (lock)->in_callback--; \
+    coap_lock_specific_unlock(lock); \
+    coap_lock_lock(failed); \
+  } while (0)
+
+/**
  * libcoap library code. Invoke an app callback that has a return value,
  * unlocking global_lock first.
  *
@@ -388,11 +516,11 @@ int coap_lock_lock_func(void);
 # endif /* ! COAP_THREAD_RECURSIVE_CHECK */
 
 /**
- * libcoap library code. Initialize the global_lock.
+ * libcoap library code. Initialize the specified lock.
  */
-#define coap_lock_init() do { \
-    memset(&global_lock.mutex, 0, sizeof(global_lock.mutex)); \
-    coap_mutex_init(&global_lock.mutex); \
+#define coap_lock_init(lock) do { \
+    memset(&(lock)->mutex, 0, sizeof((lock)->mutex)); \
+    coap_mutex_init(&(lock)->mutex); \
   } while (0)
 
 /**
@@ -433,7 +561,7 @@ typedef coap_mutex_t coap_lock_t;
 /**
  * Dummy for no thread-safe code
  *
- * libcoap library code. Lock The global_lock.
+ * libcoap library code. Lock the global_lock.
  *
  * Invoked when
  *   Not locked at all
@@ -452,7 +580,27 @@ typedef coap_mutex_t coap_lock_t;
 /**
  * Dummy for no thread-safe code
  *
- * libcoap library code. Unlock The global_lock.
+ * libcoap library code. Lock the specific lock.
+ *
+ * Invoked when
+ *   Not locked at all
+ *   Locked, app call-back, call from app call-back
+ *   Locked, app call-back, call from app call-back, app call-back, call from app call-back
+ * Result
+ *   global_lock locked.
+ *   global_lock not locked if libcoap not started and @p failed is executed. @p failed must
+ *   be code that skips doing the lock protected code.
+ *
+ * @param lock The specifc lock to lock.
+ * @param failed Code to execute on lock failure.
+ *
+ */
+#define coap_lock_specific_lock(lock,failed)
+
+/**
+ * Dummy for no thread-safe code
+ *
+ * libcoap library code. Unlock the global_lock.
  *
  * Unlocked when
  *   Same thread locked context
@@ -462,9 +610,21 @@ typedef coap_mutex_t coap_lock_t;
 /**
  * Dummy for no thread-safe code
  *
+ * libcoap library code. Unlock the specific lock.
+ *
+ * Unlocked when
+ *   Same thread locked context
+ *
+ * @param lock The specifc lock to unlock.
+ */
+#define coap_lock_specific_unlock(lock)
+
+/**
+ * Dummy for no thread-safe code
+ *
  * libcoap library code. Initialize the global_lock.
  */
-#define coap_lock_init()
+#define coap_lock_init(lock)
 
 /**
  * Dummy for no thread-safe code
@@ -514,6 +674,18 @@ typedef coap_mutex_t coap_lock_t;
  *
  */
 #define coap_lock_callback_release(func,failed) func
+
+/**
+ * Dummy for no thread-safe code
+ *
+ * libcoap library code. Invoke an app callback.
+ *
+ * @param lock lock to unlock before callback.
+ * @param func app call-back function to invoke.
+ * @param failed Code to execute on (re-)lock failure.
+ *
+ */
+#define coap_lock_specific_callback_release(lock,func,failed) func
 
 /**
  * Dummy for no thread-safe code

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -161,6 +161,9 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_io.3" > coap_socket_set_flags.3
 	@echo ".so man3/coap_locking.3" > coap_lock_callback_ret_release.3
 	@echo ".so man3/coap_locking.3" > coap_lock_invert.3
+	@echo ".so man3/coap_locking.3" > coap_lock_specific_lock.3
+	@echo ".so man3/coap_locking.3" > coap_lock_specific_unlock.3
+	@echo ".so man3/coap_locking.3" > coap_lock_specific_callback_release.3
 	@echo ".so man3/coap_logging.3" > coap_log_info.3
 	@echo ".so man3/coap_logging.3" > coap_log_debug.3
 	@echo ".so man3/coap_logging.3" > coap_log_oscore.3

--- a/man/coap_locking.txt.in
+++ b/man/coap_locking.txt.in
@@ -19,35 +19,44 @@ coap_lock_callback,
 coap_lock_callback_release,
 coap_lock_callback_ret,
 coap_lock_callback_ret_release,
-coap_lock_invert
+coap_lock_invert,
+coap_lock_specific_lock,
+coap_lock_specific_unlock,
+coap_lock_specific_callback_release
 - Work with CoAP thread safe locking
 
 SYNOPSIS
 --------
 *#include <coap@LIBCOAP_API_VERSION@/coap.h>*
 
-*void coap_lock_init(void);*
+*void coap_lock_init(coap_lock_t *_lock_);*
 
-*void coap_lock_lock(coap_context_t *_context_, coap_code_t _failed_statement_);*
+*void coap_lock_lock(coap_code_t _failed_statement_);*
 
-*void coap_lock_unlock(coap_context_t *_context_);*
+*void coap_lock_unlock(void);*
 
-*void coap_lock_check_locked(coap_context_t *_context_);*
+*void coap_lock_check_locked(void);*
 
-*void coap_lock_callback(coap_context_t *_context_,
-coap_func_t _callback_function_);*
+*void coap_lock_callback(coap_func_t _callback_function_);*
 
-*void coap_lock_callback_ret(void *_return_value_, coap_context_t *_context_,
+*void coap_lock_callback_ret(void *_return_value_,
 coap_func_t _callback_function_, coap_code_t _failed_statement_);*
 
-*void coap_lock_callback_release(coap_context_t *_context_,
+*void coap_lock_callback_release(
 coap_func_t _callback_function__, coap_code_t _failed_statement_);*
 
-*void coap_lock_callback_ret_release(void *_return_value_, coap_context_t *_context_,
+*void coap_lock_callback_ret_release(void *_return_value_,
 coap_func_t _callback_function_, coap_code_t _failed_statement_);*
 
-*void coap_lock_invert(coap_context_t *_context_, coap_func_t _locking_function_,
+*void coap_lock_invert(coap_func_t _locking_function_,
 coap_code_t _failed_statement_);*
+
+*void coap_lock_specific_lock(coap_lock_t *_lock_, coap_code_t _failed_statement_);*
+
+*void coap_lock_specific_unlock(coap_lock_t *_lock_);*
+
+*void coap_lock_specific_callback_release(coap_lock_t *lock,
+coap_func_t _callback_function__, coap_code_t _failed_statement_);*
 
 For specific (D)TLS library support, link with
 *-lcoap-@LIBCOAP_API_VERSION@-notls*, *-lcoap-@LIBCOAP_API_VERSION@-gnutls*,
@@ -72,20 +81,21 @@ execution of the following code that would have been under the lock protection
 and certainly not cause the corresponding *coap_lock_unlock*() function to be
 called.
 
-Likewise, _callback_function_ is the callback handler function with all of
+Likewise, _callback_function_ is the call-back handler function with all of
 its parameters.
 
 Several definitions can be defined with configure or cmake.  These are
 
-COAP_THREAD_SAFE If set, simply does locking at the appropriate places. If
+COAP_THREAD_SAFE If set, libcoap does internal locking at the appropriate places. If
 not set, then no locking takes place, the code is faster (no locking code), but
 not multi-thread access safe.
 
 COAP_THREAD_RECURSIVE_CHECK If set, and COAP_THREAD_SAFE is set, checks that
 if a lock is locked, it reports that the same lock is being (re-)locked.
 
-Currently, locking is only done at the *global_lock* level for the Public API
-functions where appropriate.
+Normally locking is done at the *global_lock* level for the Public API
+functions where appropriate, apart from call-backs to request handler functions
+where specific structures may get locked to make the call-back thread safe.
 
 In principal, libcoap code internally should only unlock *global_lock* when waiting
 on a *select*() or equivalent, or when calling a request handler, and then lock
@@ -100,8 +110,12 @@ call a Public API when in the locked state.
 
 *coap_lock_callback_release*() (or *coap_lock_callback_ret_release*()) unlocks
 *global_lock* when calling app call-back. The allows the app call-back to go off
-and do other slow/blocking activity.  Any calls to a Public API then locks up
-*global_lock* before preceding.
+and do other slow/blocking activity.  Any app call-back calls to a Public API then
+locks up *global_lock* before proceding.
+
+*coap_lock_specific_callback_release*() acts as *coap_lock_callback_release*(),
+but allows additional locks to be set before doing the call-back, and then
+unlocking them after the call-back return.
 
 Any libcoap code that runs with *global_lock* locked should not call a Public API,
 but call the _lkd equivalent (if available).
@@ -111,7 +125,7 @@ FUNCTIONS
 
 *Function: coap_lock_init()*
 
-The *coap_lock_init*() function is used to initialize the *global_lock* lock
+The *coap_lock_init*() function is used to initialize the specified _lock_
 structure.
 
 *Function: coap_lock_lock()*
@@ -128,39 +142,39 @@ thread can access libcoap and the underlying structures.
 *Function: coap_lock_check_lock()*
 
 The *coap_lock_check_lock*() function is used to check the internal version
-(potentially has __lkd_ appended in the name) of a public AP is getting called
+(potentially has __lkd_ appended in the name) of a public API is getting called
 with *global_lock* locked.
 
 *Function: coap_lock_callback()*
 
-The *coap_lock_callback*() function is used whenever a callback handler is
+The *coap_lock_callback*() function is used whenever a call-back handler is
 getting called, instead of calling the function directly. The lock information
-in *global_lock* is updated  so that if a public API is called from within the handler,
+in *global_lock* is updated so that if a public API is called from within the handler,
 recursive locking is enabled for that particular thread.  On return from the
-callback, the lock in *global_lock* is suitably restored. _callback_function_ is the
-callback handler to be called, along with all of the appropriate parameters.
+call-back, the lock in *global_lock* is suitably restored. _callback_function_ is the
+call-back handler to be called, along with all of the appropriate parameters.
 
 *Function: coap_lock_callback_ret()*
 
 The *coap_lock_callback_ret*() function is similar to *coap_lock_callback*(),
-but in addition, it updates the return value from the callback handler function
+but in addition, it updates the return value from the call-back handler function
 in _return_value_.
 
 *Function: coap_lock_callback_release()*
 
-The *coap_lock_callback_release*() function is used whenever a callback handler is
+The *coap_lock_callback_release*() function is used whenever a call-back handler is
 getting called, instead of calling the function directly. The lock information
 in *global_lock* is released so that if a public API is called from within the handler,
 it can do its own lock. The intent here is to reduce lock contention.  On return
-from the callback, the lock in *global_lock* is re-locked, but if there is a failure in
+from the call-back, the lock in *global_lock* is re-locked, but if there is a failure in
 re-locking, _failed_statement_ is executed. _callback_function_ is the
-callback handler to be called, along with all of the appropriate parameters.
+call-back handler to be called, along with all of the appropriate parameters.
 
 *Function: coap_lock_callback_ret_release()*
 
 The *coap_lock_callback_ret_release*() function is similar to
 *coap_lock_callback_release*(), but in addition, it updates the return value from the
-callback handler function in _return_value_.
+call-back handler function in _return_value_.
 
 *Function: coap_lock_invert()*
 
@@ -171,6 +185,30 @@ then libcoap code locked. *global_lock* already needs to be locked before callin
 get unlocked, _locking_function_ with all of its parameters called, and then
 *global_lock* re-locked.  If for any reason locking fails, then _failed_statement_
 will get executed.
+
+*Function: coap_lock_specific_lock()*
+
+The *coap_lock_specific_lock*() function is used to lock the specified _lock_ in the
+appropriate structue from multiple thread access. If the locking fails for any reason,
+then _failed_statement_ will get
+executed.
+
+*Function: coap_lock_specific_unlock()*
+
+The *coap_lock_specific_unlock*() function is used to unlock the specified _lock_
+so that another thread can access the apprpriate structure.
+
+*Function: coap_lock_specific_callback_release()*
+
+The *coap_lock_specific_callback_release*() function is used whenever a call-back
+handler is getting called, instead of calling the function directly. The lock information
+in *global_lock* is released so that if a public API is called from within the handler,
+it can do its own lock. The intent here is to reduce lock contention.  On return
+from the call-back, the lock in *global_lock* is re-locked, but if there is a failure in
+re-locking, _failed_statement_ is executed. _callback_function_ is the
+call-back handler to be called, along with all of the appropriate parameters.
+_lock_ will get locked before entry to the call-cack and unlocked on return. _lock_
+can be recursively locked by the same thread.
 
 SEE ALSO
 --------

--- a/man/coap_threads.txt.in
+++ b/man/coap_threads.txt.in
@@ -59,6 +59,9 @@ library. There are several things that can cause thread interaction issues.
 Any application thread that is not executing in the libcoap library or in
 a libcoap call-back function must not modify any libcoap structure other
 than by calling a libcoap Public API as there is no locking protection.
+Furthermore, if a reference to some libcoap held data item is obtained, and then
+data associated with reference is modified (even with a Public API call) then
+this is not thread safe.
 
 There are two types of libcoap call-back.
 
@@ -67,9 +70,10 @@ and so changes can safely be made to any structure that libcoap is using includi
 invoking any libcoap Public API calls.
 
 The second type of call-back is executing without the libcoap lock protections and
-so no mofications must take place other than by using the libcoap Public API. The
-second type is used when there is a likelyhood that the call-back may block on an
-external event and libcoap in general should not be blocked.
+so no modications must take place other than by using the libcoap Public API that
+is not modifying a determined reference. The second type is used when there is a
+likelyhood that the call-back may block on an external event and libcoap in general
+should not be blocked.
 
 The list of the second type of call-backs are set up by the following functions:
 

--- a/man/examples-code-check.c
+++ b/man/examples-code-check.c
@@ -101,6 +101,9 @@ const char *define_list[] = {
   "coap_lock_callback_ret(",
   "coap_lock_callback_ret_release(",
   "coap_lock_invert(",
+  "coap_lock_specific_lock(",
+  "coap_lock_specific_unlock(",
+  "coap_lock_specific_callback_release(",
 };
 
 /* xxx *function */

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4013,9 +4013,16 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
     coap_log_debug("call custom handler for resource '%*.*s' (3)\n",
                    (int)resource->uri_path->length, (int)resource->uri_path->length,
                    resource->uri_path->s);
-    coap_lock_callback_release(h(resource, session, pdu, query, response),
-                               /* context is being freed off */
-                               goto finish);
+    if (resource->flags & COAP_RESOURCE_SAFE_REQUEST_HANDLER) {
+      coap_lock_callback_release(h(resource, session, pdu, query, response),
+                                 /* context is being freed off */
+                                 goto finish);
+    } else {
+      coap_lock_specific_callback_release(&resource->lock,
+                                          h(resource, session, pdu, query, response),
+                                          /* context is being freed off */
+                                          goto finish);
+    }
   }
 
   /* Check validity of response code */
@@ -5209,7 +5216,7 @@ coap_startup(void) {
   coap_started = 1;
 
 #if COAP_THREAD_SAFE
-  coap_lock_init();
+  coap_lock_init(&global_lock);
   coap_mutex_init(&m_show_pdu);
   coap_mutex_init(&m_log_impl);
   coap_mutex_init(&m_io_threads);

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -268,6 +268,9 @@ coap_resource_init(coap_str_const_t *uri_path, int flags) {
   r = (coap_resource_t *)coap_malloc_type(COAP_RESOURCE, sizeof(coap_resource_t));
   if (r) {
     memset(r, 0, sizeof(coap_resource_t));
+#if COAP_THREAD_SAFE
+    coap_lock_init(&r->lock);
+#endif /* COAP_THREAD_SAFE */
 
     if (!(flags & COAP_RESOURCE_FLAGS_RELEASE_URI)) {
       /* Need to take a copy if caller is not providing a release request */
@@ -302,6 +305,9 @@ coap_resource_unknown_init2(coap_method_handler_t put_handler, int flags) {
   r = (coap_resource_t *)coap_malloc_type(COAP_RESOURCE, sizeof(coap_resource_t));
   if (r) {
     memset(r, 0, sizeof(coap_resource_t));
+#if COAP_THREAD_SAFE
+    coap_lock_init(&r->lock);
+#endif /* COAP_THREAD_SAFE */
     r->is_unknown = 1;
     /* Something unlikely to be used, but it shows up in the logs */
     r->uri_path = coap_new_str_const(coap_unknown_resource_uri, sizeof(coap_unknown_resource_uri)-1);
@@ -332,6 +338,9 @@ coap_resource_proxy_uri_init2(coap_method_handler_t handler,
   if (r) {
     size_t i;
     memset(r, 0, sizeof(coap_resource_t));
+#if COAP_THREAD_SAFE
+    coap_lock_init(&r->lock);
+#endif /* COAP_THREAD_SAFE */
     r->is_proxy_uri = 1;
     /* Something unlikely to be used, but it shows up in the logs */
     r->uri_path = coap_new_str_const(coap_proxy_resource_uri, sizeof(coap_proxy_resource_uri)-1);
@@ -384,6 +393,9 @@ coap_resource_reverse_proxy_init(coap_method_handler_t handler, int flags) {
   r = (coap_resource_t *)coap_malloc_type(COAP_RESOURCE, sizeof(coap_resource_t));
   if (r) {
     memset(r, 0, sizeof(coap_resource_t));
+#if COAP_THREAD_SAFE
+    coap_lock_init(&r->lock);
+#endif /* COAP_THREAD_SAFE */
     r->is_unknown = 1;
     r->is_reverse_proxy = 1;
     /* Something unlikely to be used, but it shows up in the logs */
@@ -1246,15 +1258,28 @@ coap_notify_observers(coap_context_t *context, coap_resource_t *r,
                        r->uri_path->s);
 
         /* obs may get deleted during callback (potentially by another thread) */
-        coap_lock_callback_release(h(r, obs->session, obs->pdu, query, response),
-                                   /* context is being freed off */
-                                   coap_delete_string(query);
-                                   coap_delete_pdu_lkd(response);
-                                   coap_session_release_lkd(obs_session);
-                                   coap_pdu_release_lkd(obs_pdu);
-                                   r->list_being_traversed = 0;
-                                   coap_resource_release_lkd(r);
-                                   return);
+        if (r->flags & COAP_RESOURCE_SAFE_REQUEST_HANDLER) {
+          coap_lock_callback_release(h(r, obs->session, obs->pdu, query, response),
+                                     /* context is being freed off */
+                                     coap_delete_string(query);
+                                     coap_delete_pdu_lkd(response);
+                                     coap_session_release_lkd(obs_session);
+                                     coap_pdu_release_lkd(obs_pdu);
+                                     r->list_being_traversed = 0;
+                                     coap_resource_release_lkd(r);
+                                     return);
+        } else {
+          coap_lock_specific_callback_release(&r->lock,
+                                              h(r, obs->session, obs->pdu, query, response),
+                                              /* context is being freed off */
+                                              coap_delete_string(query);
+                                              coap_delete_pdu_lkd(response);
+                                              coap_session_release_lkd(obs_session);
+                                              coap_pdu_release_lkd(obs_pdu);
+                                              r->list_being_traversed = 0;
+                                              coap_resource_release_lkd(r);
+                                              return);
+        }
 
         /* Check validity of response code */
         if (!coap_check_code_class(obs_session, response)) {

--- a/src/coap_subscribe.c
+++ b/src/coap_subscribe.c
@@ -989,11 +989,20 @@ coap_op_dyn_resource_load_disk(coap_context_t *ctx) {
         goto fail;
       query = coap_get_query(request);
       /* Call the application handler to set up this dynamic resource */
-      coap_lock_callback_release(r->handler[request->code-1](r,
-                                                             session, request,
-                                                             query, response),
-                                 /* context is being freed off */
-                                 goto fail);
+      if (r->flags & COAP_RESOURCE_SAFE_REQUEST_HANDLER) {
+        coap_lock_callback_release(r->handler[request->code-1](r,
+                                                               session, request,
+                                                               query, response),
+                                   /* context is being freed off */
+                                   goto fail);
+      } else {
+        coap_lock_specific_callback_release(&r->lock,
+                                            r->handler[request->code-1](r,
+                                                session, request,
+                                                query, response),
+                                            /* context is being freed off */
+                                            goto fail);
+      }
       coap_delete_string(query);
       query = NULL;
       coap_delete_pdu_lkd(response);

--- a/src/coap_threadsafe.c
+++ b/src/coap_threadsafe.c
@@ -18,66 +18,66 @@
 #if COAP_THREAD_SAFE
 #if COAP_THREAD_RECURSIVE_CHECK
 void
-coap_lock_unlock_func(const char *file, int line) {
-  assert(coap_thread_pid == global_lock.pid);
-  if (global_lock.in_callback) {
-    assert(global_lock.lock_count > 0);
-    global_lock.lock_count--;
+coap_lock_unlock_func(coap_lock_t *lock, const char *file, int line) {
+  assert(coap_thread_pid == lock->pid);
+  if (lock->in_callback) {
+    assert(lock->lock_count > 0);
+    lock->lock_count--;
   } else {
-    global_lock.pid = 0;
-    global_lock.unlock_file = file;
-    global_lock.unlock_line = line;
-    coap_mutex_unlock(&global_lock.mutex);
+    lock->pid = 0;
+    lock->unlock_file = file;
+    lock->unlock_line = line;
+    coap_mutex_unlock(&lock->mutex);
   }
 }
 
 int
-coap_lock_lock_func(const char *file, int line) {
+coap_lock_lock_func(coap_lock_t *lock, const char *file, int line) {
   if (!coap_started) {
     /* libcoap not initialized with coap_startup() */
     return 0;
   }
-  if (coap_mutex_trylock(&global_lock.mutex)) {
-    if (coap_thread_pid == global_lock.pid) {
+  if (coap_mutex_trylock(&lock->mutex)) {
+    if (coap_thread_pid == lock->pid) {
       /* This thread locked the mutex */
-      if (global_lock.in_callback) {
+      if (lock->in_callback) {
         /* This is called from within an app callback */
-        global_lock.lock_count++;
-        assert(global_lock.in_callback == global_lock.lock_count);
+        lock->lock_count++;
+        assert(lock->in_callback == lock->lock_count);
         return 1;
       } else {
         coap_log_alert("Thread Deadlock: Last %s: %u, this %s: %u\n",
-                       global_lock.lock_file, global_lock.lock_line, file, line);
+                       lock->lock_file, lock->lock_line, file, line);
         assert(0);
       }
     }
     /* Wait for the other thread to unlock */
-    coap_mutex_lock(&global_lock.mutex);
+    coap_mutex_lock(&lock->mutex);
   }
   /* Just got the lock, so should not be in a locked callback */
-  assert(!global_lock.in_callback);
-  global_lock.pid = coap_thread_pid;
-  global_lock.lock_file = file;
-  global_lock.lock_line = line;
+  assert(!lock->in_callback);
+  lock->pid = coap_thread_pid;
+  lock->lock_file = file;
+  lock->lock_line = line;
   return 1;
 }
 
 #else /* ! COAP_THREAD_RECURSIVE_CHECK */
 
 void
-coap_lock_unlock_func(void) {
-  assert(coap_thread_pid == global_lock.pid);
-  if (global_lock.in_callback) {
-    assert(global_lock.lock_count > 0);
-    global_lock.lock_count--;
+coap_lock_unlock_func(coap_lock_t *lock) {
+  assert(coap_thread_pid == lock->pid);
+  if (lock->in_callback) {
+    assert(lock->lock_count > 0);
+    lock->lock_count--;
   } else {
-    global_lock.pid = 0;
-    coap_mutex_unlock(&global_lock.mutex);
+    lock->pid = 0;
+    coap_mutex_unlock(&lock->mutex);
   }
 }
 
 int
-coap_lock_lock_func(void) {
+coap_lock_lock_func(coap_lock_t *lock) {
   if (!coap_started) {
     /* libcoap not initialized with coap_startup() */
     return 0;
@@ -86,15 +86,15 @@ coap_lock_lock_func(void) {
    * Some OS do not have support for coap_mutex_trylock() so
    * cannot use that here and have to rely on lock-pid being stable
    */
-  if (global_lock.in_callback && coap_thread_pid == global_lock.pid) {
-    global_lock.lock_count++;
-    assert(global_lock.in_callback == global_lock.lock_count);
+  if (lock->in_callback && coap_thread_pid == lock->pid) {
+    lock->lock_count++;
+    assert(lock->in_callback == lock->lock_count);
     return 1;
   }
-  coap_mutex_lock(&global_lock.mutex);
+  coap_mutex_lock(&lock->mutex);
   /* Just got the lock, so should not be in a locked callback */
-  assert(!global_lock.in_callback);
-  global_lock.pid = coap_thread_pid;
+  assert(!lock->in_callback);
+  lock->pid = coap_thread_pid;
   return 1;
 }
 #endif /* ! COAP_THREAD_RECURSIVE_CHECK */


### PR DESCRIPTION
If an app request call-back modifies any data associated with a resource, then multiple threads can attempt to unsafely modify the data at the same time.

Lock the resource when calling the app request handler (as global_lock is unlocked) to prevent concurrent changes to the resource information.

If the app request handler is definately known to not modify the resource information, then COAP_RESOURCE_SAFE_REQUEST_HANDLER can be set in the flags for coap_resource_init().  Usually if there is a PUT, POST, PATCH or IPATCH handler it is unsafe to set this. Setting this will reduce lock contention on a resource lock.