### PR TITLE
FETCH request with OSCORE option incorrectly rejected with 4.15 when COAP_OSCORE_SUPPORT is disabled

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -3859,11 +3859,13 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
     goto fail_response;
   }
   if (pdu->code == COAP_REQUEST_CODE_FETCH) {
-    opt = coap_check_option(pdu, COAP_OPTION_CONTENT_FORMAT, &opt_iter);
-    if (opt == NULL) {
-      /* RFC 8132 2.3.1 */
-      resp = 415;
-      goto fail_response;
+    if (coap_check_option(pdu, COAP_OPTION_OSCORE, &opt_iter) == NULL) {
+      opt = coap_check_option(pdu, COAP_OPTION_CONTENT_FORMAT, &opt_iter);
+      if (opt == NULL) {
+        /* RFC 8132 2.3.1 */
+        resp = 415;
+        goto fail_response;
+      }
     }
   }
   if (context->mcast_per_resource &&


### PR DESCRIPTION
Fixes #[1936](https://github.com/obgm/libcoap/issues/1936)

## Problem

When `COAP_OSCORE_SUPPORT` is disabled and the server receives an
OSCORE-protected FETCH request, `handle_request()` unconditionally
rejects it with 4.15 because Content-Format is absent from the outer
header. Per RFC 8613 §4.1.3.1, Content-Format is an inner option and
MUST NOT appear in the outer OSCORE message.

## Solution

Guard the RFC 8132 §2.3.1 Content-Format check with a prior check for
the OSCORE option. If OSCORE is present the check is skipped; the
encrypted inner request carries the Content-Format and the outer
validation is not applicable.

## Testing

Verified with a client sending an OSCORE-protected FETCH (CoAP Observe
subscription). Before the fix the server returned 4.15; after the fix
the request reaches the application handler correctly.

## Checklist
- [x] Targets `develop` branch
- [x] Single logical change, atomic commit
- [x] `pre-commit` checks pass
- [x] Builds cleanly (CMake)
- [x] References RFC 8132 §2.3.1 and RFC 8613 §4.1.3.1

## Note
If accepted, please consider backporting to the 4.3.x release branch.