### PR TITLE
coap_io_posix.c: Make coap_io_process_remove_threads() thread protected.

### DIFF
--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -1067,7 +1067,7 @@ int coap_io_process_configure_threads(coap_context_t *context,
  *
  * @param context Context.
  */
-void coap_io_process_remove_threads(coap_context_t *context);
+COAP_API void coap_io_process_remove_threads(coap_context_t *context);
 
 /**
  * Get the libcoap internal file descriptor for a socket. This can be used to

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -828,6 +828,15 @@ int coap_io_process_loop_lkd(coap_context_t *context,
                              void *main_loop_code_arg, uint32_t timeout_ms,
                              uint32_t thread_count);
 
+/**
+ * Release the coap_io_process() worker threads.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param context Context.
+ */
+void coap_io_process_remove_threads_lkd(coap_context_t *context);
+
 #if !defined(RIOT_VERSION) && !defined(WITH_CONTIKI)
 /**
  * The main message processing loop with additional fds for internal select.

--- a/src/coap_io_posix.c
+++ b/src/coap_io_posix.c
@@ -627,7 +627,7 @@ coap_io_process_loop_lkd(coap_context_t *context,
     }
   }
 #if COAP_THREAD_SAFE
-  coap_io_process_remove_threads(context);
+  coap_io_process_remove_threads_lkd(context);
 #endif /* COAP_THREAD_SAFE */
   coap_thread_quit = 0;
   return ret;

--- a/src/coap_strm_posix.c
+++ b/src/coap_strm_posix.c
@@ -340,7 +340,11 @@ coap_socket_accept_tcp(coap_socket_t *server,
   new_client->fd = accept(server->fd, &remote_addr->addr.sa,
                           &remote_addr->size);
   if (new_client->fd == COAP_INVALID_SOCKET) {
-    if (errno != EAGAIN) {
+    if (errno != EAGAIN
+#if EAGAIN != EWOULDBLOCK
+        && errno != EWOULDBLOCK
+#endif
+       ) {
       coap_log_warn("coap_socket_accept_tcp: accept: %s\n",
                     coap_socket_strerror());
     }

--- a/src/coap_threadsafe.c
+++ b/src/coap_threadsafe.c
@@ -179,11 +179,18 @@ coap_io_process_configure_threads(coap_context_t *context, uint32_t thread_count
   return 1;
 }
 
+COAP_API void
+coap_io_process_remove_threads(coap_context_t *context) {
+  coap_lock_lock();
+  coap_io_process_remove_threads_lkd(context);
+  coap_lock_unlock();
+}
+
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif /* HAVE_SIGNAL_H */
 void
-coap_io_process_remove_threads(coap_context_t *context) {
+coap_io_process_remove_threads_lkd(coap_context_t *context) {
   uint32_t i;
 
   (void)context;


### PR DESCRIPTION
Don't report

WARN coap_socket_accept_tcp: accept: Resource temporarily unavailable

when multiple threads are trying to process the same incoming TCP connection.