### PR TITLE
OSS-FUZZ: Reduce unnecessary logging during runs

### DIFF
--- a/src/coap_dgrm_contiki.c
+++ b/src/coap_dgrm_contiki.c
@@ -120,7 +120,7 @@ coap_socket_send(coap_socket_t *sock, coap_session_t *session, const uint8_t *da
   }
 
   if (bytes_written < 0) {
-    coap_log_crit("coap_socket_send: %s\n", coap_socket_strerror());
+    coap_log_warn("coap_socket_send: %s\n", coap_socket_strerror());
   }
 
   return bytes_written;

--- a/src/coap_dgrm_posix.c
+++ b/src/coap_dgrm_posix.c
@@ -657,7 +657,7 @@ coap_socket_send(coap_socket_t *sock, coap_session_t *session,
   }
 
   if (bytes_written < 0)
-    coap_log_crit("coap_socket_send: %s\n", coap_socket_strerror());
+    coap_log_warn("coap_socket_send: %s\n", coap_socket_strerror());
 
   return bytes_written;
 }

--- a/src/coap_dgrm_riot.c
+++ b/src/coap_dgrm_riot.c
@@ -57,7 +57,7 @@ coap_socket_send(coap_socket_t *sock,
   if (bytes_written < 0) {
     errno = -bytes_written;
     bytes_written = -1;
-    coap_log_crit("coap_socket_send: %s\n", coap_socket_strerror());
+    coap_log_warn("coap_socket_send: %s\n", coap_socket_strerror());
   }
 
   return bytes_written;

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -1094,7 +1094,7 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
       coap_log_oscore("Appendix B.2 server finished\n");
     }
     if (!osc_ctx) {
-      coap_log_crit("OSCORE: Security Context not found\n");
+      coap_log_err("OSCORE: Security Context not found\n");
       oscore_log_hex_value(COAP_LOG_OSCORE, "key_id", &cose->key_id);
       oscore_log_hex_value(COAP_LOG_OSCORE, "kid_context", &cose->kid_context);
       build_and_send_error_pdu(session,


### PR DESCRIPTION
No need to log socket or OSCORE issues at critical level.