### PR TITLE
DTLS: Do not call coap_session_disconnected_lkd() for writes

### DIFF
--- a/src/coap_gnutls.c
+++ b/src/coap_gnutls.c
@@ -2447,7 +2447,6 @@ coap_dtls_send(coap_session_t *c_session,
     coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
-      coap_session_disconnected_lkd(c_session, COAP_NACK_TLS_FAILED);
       ret = -1;
     }
   }
@@ -2588,9 +2587,7 @@ coap_dtls_receive(coap_session_t *c_session, const uint8_t *data,
   }
 
   if (c_session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
+    coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected_lkd(c_session, COAP_NACK_TLS_FAILED);
@@ -2911,12 +2908,9 @@ coap_tls_write(coap_session_t *c_session, const uint8_t *data,
   }
 
   if (c_session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
+    coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
-      coap_session_disconnected_lkd(c_session, COAP_NACK_TLS_FAILED);
       ret = -1;
     }
   }
@@ -2992,9 +2986,7 @@ coap_tls_read(coap_session_t *c_session, uint8_t *data, size_t data_len) {
   }
 
   if (c_session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
+    coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected_lkd(c_session, COAP_NACK_TLS_FAILED);

--- a/src/coap_mbedtls.c
+++ b/src/coap_mbedtls.c
@@ -2857,12 +2857,9 @@ coap_dtls_send(coap_session_t *c_session,
   }
 
   if (c_session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
+    coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
-      coap_session_disconnected_lkd(c_session, COAP_NACK_TLS_FAILED);
       ret = -1;
     }
   }
@@ -2985,6 +2982,10 @@ coap_dtls_receive(coap_session_t *c_session,
       coap_log_debug("*  %s: dtls:  recv %4d bytes\n",
                      coap_session_str(c_session), ret);
       ret = coap_handle_dgram(c_session->context, c_session, pdu, (size_t)ret);
+      if (!c_session->tls) {
+        /* Possible there was a DTLS error */
+        ssl_data = NULL;
+      }
       goto finish;
     }
     switch (ret) {
@@ -3020,9 +3021,7 @@ coap_dtls_receive(coap_session_t *c_session,
     }
   }
   if (c_session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
+    coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected_lkd(c_session, COAP_NACK_TLS_FAILED);
@@ -3259,12 +3258,9 @@ coap_tls_write(coap_session_t *c_session, const uint8_t *data,
   }
 
   if (c_session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
+    coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
-      coap_session_disconnected_lkd(c_session, COAP_NACK_TLS_FAILED);
       ret = -1;
     }
   }
@@ -3340,9 +3336,7 @@ coap_tls_read(coap_session_t *c_session, uint8_t *data, size_t data_len) {
   }
 
   if (c_session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (c_session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
+    coap_handle_event_lkd(c_session->context, c_session->dtls_event, c_session);
     if (c_session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         c_session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected_lkd(c_session, COAP_NACK_TLS_FAILED);

--- a/src/coap_openssl.c
+++ b/src/coap_openssl.c
@@ -597,9 +597,9 @@ coap_dgram_destroy(BIO *a) {
   if (a == NULL)
     return 0;
   data = (coap_ssl_data *)BIO_get_data(a);
+  BIO_set_data(a, NULL);
   if (data != NULL)
     free(data);
-  BIO_set_data(a, NULL);
   return 1;
 }
 
@@ -3701,6 +3701,8 @@ coap_dtls_send(coap_session_t *session,
   }
 
   session->dtls_event = -1;
+  coap_log_debug("*  %s: dtls:  sent %4d bytes\n",
+                 coap_session_str(session), (int)data_len);
   ERR_clear_error();
   r = SSL_write(ssl, data, (int)data_len);
 
@@ -3727,24 +3729,13 @@ coap_dtls_send(coap_session_t *session,
   }
 
   if (session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(session->context, session->dtls_event, session);
+    coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
-      coap_session_disconnected_lkd(session, COAP_NACK_TLS_FAILED);
       r = -1;
     }
   }
 
-  if (r > 0) {
-    if (r == (ssize_t)data_len)
-      coap_log_debug("*  %s: dtls:  sent %4d bytes\n",
-                     coap_session_str(session), r);
-    else
-      coap_log_debug("*  %s: dtls:  sent %4d of %4" PRIdS " bytes\n",
-                     coap_session_str(session), r, data_len);
-  }
   return r;
 }
 
@@ -3874,6 +3865,8 @@ retry:
     coap_log_debug("*  %s: dtls:  recv %4d bytes\n",
                    coap_session_str(session), r);
     r =  coap_handle_dgram(session->context, session, pdu, (size_t)r);
+    /* Possible there was a DTLS error */
+    ssl_data = (coap_ssl_data *)BIO_get_data(rbio);
     goto finished;
   } else {
     int err = SSL_get_error(ssl, r);
@@ -3910,11 +3903,10 @@ retry:
       r = -1;
     }
     if (session->dtls_event >= 0) {
-      /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-      if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-        coap_handle_event_lkd(session->context, session->dtls_event, session);
+      coap_handle_event_lkd(session->context, session->dtls_event, session);
       if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
           session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
+        /* Cause disconnect on a read */
         coap_session_disconnected_lkd(session, COAP_NACK_TLS_FAILED);
         ssl_data = NULL;
         r = -1;
@@ -4207,12 +4199,9 @@ coap_tls_write(coap_session_t *session, const uint8_t *data, size_t data_len) {
   }
 
   if (session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(session->context, session->dtls_event, session);
+    coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
-      coap_session_disconnected_lkd(session, COAP_NACK_TLS_FAILED);
       r = -1;
     }
   }
@@ -4293,11 +4282,10 @@ coap_tls_read(coap_session_t *session, uint8_t *data, size_t data_len) {
   }
 
   if (session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(session->context, session->dtls_event, session);
+    coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
+      /* Cause disconnect on a read */
       coap_session_disconnected_lkd(session, COAP_NACK_TLS_FAILED);
       r = -1;
     }

--- a/src/coap_tinydtls.c
+++ b/src/coap_tinydtls.c
@@ -908,9 +908,7 @@ coap_dtls_send(coap_session_t *session,
     coap_log_warn("coap_dtls_send: cannot send PDU\n");
 
   if (coap_event_dtls >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (coap_event_dtls != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(session->context, coap_event_dtls, session);
+    coap_handle_event_lkd(session->context, coap_event_dtls, session);
     if (coap_event_dtls == COAP_EVENT_DTLS_CONNECTED) {
 #if (DTLS_MAX_CID_LENGTH > 0) && COAP_CLIENT_SUPPORT
       if (session->type == COAP_SESSION_TYPE_CLIENT) {
@@ -927,7 +925,7 @@ coap_dtls_send(coap_session_t *session,
 #endif /* DTLS_MAX_CID_LENGTH > 0 && COAP_CLIENT_SUPPORT */
       coap_session_connected(session);
     } else if (coap_event_dtls == COAP_EVENT_DTLS_CLOSED || coap_event_dtls == COAP_EVENT_DTLS_ERROR) {
-      coap_session_disconnected_lkd(session, COAP_NACK_TLS_FAILED);
+      res = -1;
     }
   }
 
@@ -991,9 +989,7 @@ coap_dtls_receive(coap_session_t *session,
   }
 
   if (coap_event_dtls >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (coap_event_dtls != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(session->context, coap_event_dtls, session);
+    coap_handle_event_lkd(session->context, coap_event_dtls, session);
     if (coap_event_dtls == COAP_EVENT_DTLS_CONNECTED) {
       coap_session_connected(session);
 #if (DTLS_MAX_CID_LENGTH > 0) && COAP_CLIENT_SUPPORT

--- a/src/coap_wolfssl.c
+++ b/src/coap_wolfssl.c
@@ -2315,12 +2315,9 @@ coap_dtls_send(coap_session_t *session,
   }
 
   if (session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(session->context, session->dtls_event, session);
+    coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
-      coap_session_disconnected_lkd(session, COAP_NACK_TLS_FAILED);
       r = -1;
     }
   }
@@ -2497,9 +2494,7 @@ coap_dtls_receive(coap_session_t *session, const uint8_t *data, size_t data_len)
       r = -1;
     }
     if (session->dtls_event >= 0) {
-      /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-      if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-        coap_handle_event_lkd(session->context, session->dtls_event, session);
+      coap_handle_event_lkd(session->context, session->dtls_event, session);
       if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
           session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
         coap_session_disconnected_lkd(session, COAP_NACK_TLS_FAILED);
@@ -2844,12 +2839,9 @@ coap_tls_write(coap_session_t *session, const uint8_t *data, size_t data_len) {
   }
 
   if (session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(session->context, session->dtls_event, session);
+    coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
-      coap_session_disconnected_lkd(session, COAP_NACK_TLS_FAILED);
       r = -1;
     }
   }
@@ -2934,9 +2926,7 @@ coap_tls_read(coap_session_t *session, uint8_t *data, size_t data_len) {
   }
 
   if (session->dtls_event >= 0) {
-    /* COAP_EVENT_DTLS_CLOSED event reported in coap_session_disconnected_lkd() */
-    if (session->dtls_event != COAP_EVENT_DTLS_CLOSED)
-      coap_handle_event_lkd(session->context, session->dtls_event, session);
+    coap_handle_event_lkd(session->context, session->dtls_event, session);
     if (session->dtls_event == COAP_EVENT_DTLS_ERROR ||
         session->dtls_event == COAP_EVENT_DTLS_CLOSED) {
       coap_session_disconnected_lkd(session, COAP_NACK_TLS_FAILED);


### PR DESCRIPTION
Let the upper calling layer do the coap_session_disconnected_lkd() on detection of write error.