### PR TITLE
KeepAlive: Make sure sessions timeout after ping failures

### DIFF
--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -66,6 +66,10 @@ typedef enum coap_ext_token_check_t {
   COAP_EXT_T_CHECKING,        /**< Token size check request sent */
 } coap_ext_token_check_t;
 
+#ifndef COAP_MAX_PING_FAILURES
+#define COAP_MAX_PING_FAILURES 3
+#endif
+
 /**
  * Abstraction of virtual session that can be attached to coap_context_t
  * (client) or coap_endpoint_t (server).
@@ -256,6 +260,7 @@ struct coap_session_t {
   uint64_t rl_ticks_per_packet;   /**< If not 0, rate limit NON to ticks per packet */
   coap_tick_t last_tx;            /**< Last time a ratelimited packet is sent */
   uint8_t is_rate_limiting;       /**< Currently NON rate limiting */
+  uint32_t ping_failed;           /**< Ping failure count */
 };
 
 #if COAP_SERVER_SUPPORT

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -506,16 +506,18 @@ release_1:
 
           if ((mid = coap_session_send_ping_lkd(s)) == COAP_INVALID_MID) {
             /* Some issue - not safe to continue processing */
+            s->ping_failed++;
             s->last_rx_tx = now;
 #if COAP_CLIENT_SUPPORT
             if (s->client_initiated && ctx->reconnect_time) {
               coap_session_failed(s);
             }
 #endif /* COAP_CLIENT_SUPPORT */
-            continue;
+            if (s->ping_failed <= COAP_MAX_PING_FAILURES)
+              continue;
           }
           s->last_ping_mid = mid;
-          if (s->last_ping > 0 && s->last_pong < s->last_ping) {
+          if ((s->last_ping > 0 && s->last_pong < s->last_ping) || s->ping_failed > COAP_MAX_PING_FAILURES) {
 #if COAP_CLIENT_SUPPORT
             if (s->client_initiated && ctx->reconnect_time) {
               coap_session_failed(s);
@@ -557,16 +559,37 @@ release_1:
 
         if ((mid = coap_session_send_ping_lkd(s)) == COAP_INVALID_MID) {
           /* Some issue - not safe to continue processing */
+          s->ping_failed++;
           s->last_rx_tx = now;
           coap_session_failed(s);
-          continue;
+          if (s->ping_failed <= COAP_MAX_PING_FAILURES)
+            continue;
         }
         s->last_ping_mid = mid;
         if (s->last_ping > 0 && s->last_pong < s->last_ping) {
           coap_handle_event_lkd(s->context, COAP_EVENT_KEEPALIVE_FAILURE, s);
         }
-        s->last_rx_tx = now;
-        s->last_ping = now;
+        if (s->ping_failed > COAP_MAX_PING_FAILURES) {
+#if COAP_CLIENT_SUPPORT
+          if (s->client_initiated) {
+            if (ctx->reconnect_time) {
+              coap_session_failed(s);
+            } else {
+              coap_session_disconnected_lkd(s, COAP_NACK_NOT_DELIVERABLE);
+            }
+          } else {
+#endif /* COAP_CLIENT_SUPPORT */
+#if COAP_SERVER_SUPPORT
+            coap_session_server_keepalive_failed(s);
+#endif /* COAP_SERVER_SUPPORT */
+#if COAP_CLIENT_SUPPORT
+          }
+#endif /* COAP_CLIENT_SUPPORT */
+          continue;
+        } else {
+          s->last_rx_tx = now;
+          s->last_ping = now;
+        }
       } else {
         /* Always positive due to if() above */
         s_timeout = (s->last_rx_tx + ctx->ping_timeout * COAP_TICKS_PER_SECOND) - now;

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -2151,7 +2151,8 @@ coap_send_internal(coap_session_t *session, coap_pdu_t *pdu, coap_pdu_t *request
     return pdu->mid;
   }
   if (bytes_written < 0) {
-    coap_session_disconnected_lkd(session, COAP_NACK_NOT_DELIVERABLE);
+    if (pdu->code != 0)
+      coap_session_disconnected_lkd(session, COAP_NACK_NOT_DELIVERABLE);
     goto error;
   }
 
@@ -4469,6 +4470,7 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
     }
   } else if (pdu->code == COAP_SIGNALING_CODE_PONG) {
     session->last_pong = session->last_rx_tx;
+    session->ping_failed = 0;
     if (context->pong_cb) {
       coap_lock_callback(context->pong_cb(session, pdu, pdu->mid));
     }
@@ -4845,6 +4847,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
           coap_lock_callback(context->pong_cb(session, pdu, pdu->mid));
         }
         session->last_pong = session->last_rx_tx;
+        session->ping_failed = 0;
         session->last_ping_mid = COAP_INVALID_MID;
       }
     } else {
@@ -4901,7 +4904,8 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
      * same token. Matching on token potentially containing ext length bytes.
      */
     /* find message token in sendqueue to stop retransmission */
-    coap_remove_from_queue_token(&context->sendqueue, session, &pdu->actual_token, &sent);
+    if (pdu->code != 0)
+      coap_remove_from_queue_token(&context->sendqueue, session, &pdu->actual_token, &sent);
 
     /* check for oscore issue or unknown critical options in non-signaling messages */
     if (oscore_invalid ||


### PR DESCRIPTION
Currently set to 3 concurrent ping failures.