### PR TITLE
coap_resource.c: harden coap_print_wellknown_lkd against zero-length query-pattern

### DIFF
--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -175,7 +175,8 @@ coap_print_wellknown_lkd(coap_context_t *context, unsigned char *buf,
       query_pattern.length =
           query_filter->length - (resource_param.length + 1);
 
-      if ((query_pattern.s[0] == '/') && ((flags & MATCH_URI) == MATCH_URI)) {
+      if (query_pattern.length &&
+          (query_pattern.s[0] == '/') && ((flags & MATCH_URI) == MATCH_URI)) {
         query_pattern.s++;
         query_pattern.length--;
       }


### PR DESCRIPTION
## Summary

`coap_print_wellknown` is a public, exported `COAP_API`. When called with a
tightly-allocated `coap_string_t` whose value ends in `=` (e.g. `"rt="`),
`coap_print_wellknown_lkd` performs a **1-byte heap-buffer-overflow read**
at `src/coap_resource.c:178`: it computes `query_pattern.length == 0` but
then unconditionally dereferences `query_pattern.s[0]` to test for a
leading `/`.

In libcoap's own `.well-known/core` dispatch (`coap_net.c:3375` →
`coap_get_query` → `coap_new_string`), the buffer is over-allocated by 1
byte for a NUL terminator, so the OOB read lands on the NUL slot and is
benign. **The bug is not reachable via `coap-server` / `coap-client`.**

It is reachable from any external API consumer that passes a tight
`coap_string_t` (e.g. wrapping a `recvfrom`-style buffer without copying,
or any caller that does not go through `coap_new_string`). The man page
(`man/coap_resource.txt:358`) does not document any required allocation
slack on `query_filter`, so this is an API-contract footgun rather than
only an internal invariant violation.

## Reproduction

Self-contained PoC against HEAD (`e3f8cd0`), saved as `poc_public_api.c`,
built with `clang -fsanitize=address`:

```c
#include <coap3/coap.h>
#include <stdint.h>
#include <stdlib.h>
#include <string.h>

int main(void) {
    coap_startup();
    coap_context_t *ctx = coap_new_context(NULL);
    coap_str_const_t path = { 4, (const uint8_t *)"test" };
    coap_resource_t *res = coap_resource_init(&path, 0);
    coap_add_attr(res, coap_make_str_const("rt"),
                  coap_make_str_const("\"x\""), 0);
    coap_add_resource(ctx, res);

    /* Tight 3-byte buffer ending in '='. resource_param.length=2,
     * query_pattern.s = filter+3 (one past end), length=0.
     * coap_resource.c:178 then reads query_pattern.s[0] -> OOB. */
    uint8_t *filter = malloc(3);
    memcpy(filter, "rt=", 3);
    coap_string_t qf = { .length = 3, .s = filter };

    unsigned char out[1024];
    size_t out_buflen = sizeof(out);
    coap_print_wellknown(ctx, out, &out_buflen, 0, &qf);

    free(filter); coap_free_context(ctx); coap_cleanup();
    return 0;
}
```

ASan output before the fix (full trace from a local run):

```
=================================================================
==10==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b47b97e0013 at pc 0x557db703b02e bp 0x7fff0bd01330 sp 0x7fff0bd01328
READ of size 1 at 0x7b47b97e0013 thread T0
    #0 0x557db703b02d in coap_print_wellknown_lkd /work/libcoap/src/coap_resource.c:178:12
    #1 0x557db703a8f5 in coap_print_wellknown /work/libcoap/src/coap_resource.c:110:12
    #2 0x557db6fdd898 in main /work/poc_public_api.c:31:5
    #3 0x7f27ba5ec082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
    #4 0x557db6ef757d in _start (/work/poc+0x4957d)

0x7b47b97e0013 is located 0 bytes after 3-byte region [0x7b47b97e0010,0x7b47b97e0013)
allocated by thread T0 here:
    #0 0x557db6f9ad04 in malloc /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:67:3
    #1 0x557db6fdd819 in main /work/poc_public_api.c:25:23
    #2 0x7f27ba5ec082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)

SUMMARY: AddressSanitizer: heap-buffer-overflow /work/libcoap/src/coap_resource.c:178:12 in coap_print_wellknown_lkd
Shadow bytes around the buggy address:
  0x7b47b97dff80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7b47b97e0000: fa fa[03]fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7b47b97e0080: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
==10==ABORTING
```

(Build path appears as `/work` because the local build was run inside an
oss-fuzz `base-builder` container with the libcoap source bind-mounted at
`/work/libcoap`. PoC line numbers reflect the file as written above.)

After the fix the PoC exits 0 cleanly. A sanity case `"rt=x"`
(length > 0, exercising the same `if`) is unchanged.

## Fix

Guard the leading-`/` check on `query_pattern.length > 0`. This mirrors
the existing guard on the trailing-`*` check 5 lines below
(`coap_resource.c:183`):

```c
if (query_pattern.length &&
    query_pattern.s[query_pattern.length-1] == '*') {
```

so the two adjacent conditions now have the same shape, and the
downstream code path for `length == 0` (falling through to `match()`
with an empty pattern) is the same one the trailing-`*` guard has been
delegating to for years.

The assertion at `coap_resource.c:174` is intentionally **not** changed:
filters legitimately ending in `=` (e.g. an attribute-name probe with
empty value) satisfy `resource_param.length + 1 == query_filter->length`,
so the existing `<=` is correct. The runtime guard is the load-bearing
fix.

## Severity / disclosure

Latent / hardening. The bug is **not** reachable via the libcoap network
stack (allocator slack masks it; verified against an ASan-built
`coap-server`). External API consumers passing tight buffers can hit
it; the read is 1 byte and not attacker-controllable in any useful way.
Reported as a defensive fix; no CVE / advisory recommended.

## Testing

- Built libcoap HEAD with `clang -fsanitize=address -g -O0`,
  `--without-{openssl,gnutls,mbedtls,tinydtls,wolfssl}`,
  `--enable-shared=no`.
- PoC above:
  - **before patch** → ASan trace shown above, exit 134
  - **after patch** → exit 0, ASan clean
- Sanity case `"rt=x"` (length > 0, hits the same `if`):
  exit 0, ASan clean, behavior unchanged.
- The upstream `tests/test_wellknown` cunit suite was **not** run in this
  verification: the `gcr.io/oss-fuzz-base/base-builder` image's
  `libcunit1-dev` ships without a `cunit.pc` file, so `./configure
  --enable-tests` aborts on the cunit pkg-config probe. All existing test
  cases in `tests/test_wellknown.c` construct `query_filter` via
  `coap_new_string()` (which always allocates `length + 1`), so
  `query_pattern.length` is non-zero for every existing case and this
  guard does not change their behavior. Happy to re-run the cunit suite
  locally if a maintainer can point me at a known-good build env.
