### PR TITLE
OSS-Fuzz: Fix observe fuzzer

### DIFF
--- a/tests/oss-fuzz/observe_target.c
+++ b/tests/oss-fuzz/observe_target.c
@@ -1,6 +1,14 @@
 #include "coap3/coap_internal.h"
+#include "coap_fuzz_helper.h"
 #include <stdint.h>
 #include <string.h>
+
+static int
+fuzz_event_handler(coap_session_t *session, const coap_event_t event) {
+  (void)session;
+  (void)event;
+  return 0;
+}
 
 static void
 fuzz_handler(coap_resource_t *resource, coap_session_t *session,
@@ -26,6 +34,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   coap_context_t *ctx = coap_new_context(NULL);
   if (!ctx)
     goto cleanup;
+  coap_register_event_handler(ctx, fuzz_event_handler);
 
   coap_resource_t *res = coap_resource_init(coap_make_str_const("obs"), 0);
   if (!res)
@@ -73,19 +82,33 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
       coap_touch_observer(ctx, sess, &pdu->actual_token);
 
       /* Test coap_resource_notify_observers*/
-      if (data[offset % size] & 0x01) {
-        coap_resource_notify_observers(res, NULL);
-      }
+      coap_resource_notify_observers(res, NULL);
 
       /* Test coap_delete_observer */
-      if (data[offset % size] & 0x02) {
-        coap_delete_observer(res, sess, &pdu->actual_token);
-      }
+      coap_delete_observer(res, sess, &pdu->actual_token);
     }
 
     coap_delete_pdu(pdu);
     offset += 8;
   }
+
+  /* Dispatch GET+OBSERVE to exercise subscription paths in handle_request */
+  {
+    uint8_t obs_val;
+    for (obs_val = 0; obs_val <= 1; obs_val++) {
+      coap_pdu_t *op = coap_pdu_init(COAP_MESSAGE_CON, COAP_REQUEST_CODE_GET,
+                                     coap_new_message_id(sess), 128);
+      if (op) {
+        coap_add_option(op, COAP_OPTION_OBSERVE, 1, &obs_val);
+        coap_add_option(op, COAP_OPTION_URI_PATH, 3, (const uint8_t *)"obs");
+        coap_dispatch(ctx, sess, op);
+        coap_delete_pdu(op);
+      }
+    }
+  }
+
+  /* Dispatch with programmatic PDU and raw wire format */
+  coap_fuzz_dispatch(ctx, sess, data, size, (const uint8_t *)"obs", 3);
 
 cleanup:
   if (ctx)


### PR DESCRIPTION
This PR improves the observe fuzzer by registering an event callback, adding dispatch via the new coap_fuzz_helper introduced in #1979 to guarantee the registered resource is always reached, and explicitly dispatching GET+Observe PDUs with subscribe and deregister values.

**This PR can only be merged in after #1979 is merged in.**