### PR TITLE
fix(cmake): specify project to only use c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ cmake_minimum_required(VERSION 3.10)
 project(
   libcoap
   VERSION 4.3.5
-  LANGUAGES CXX C)
+  LANGUAGES C)
 
 set(LIBCOAP_API_VERSION 3)
 set(LIBCOAP_ABI_VERSION 3.2.2)


### PR DESCRIPTION
I am not sure if this is a correct move, but I think it is. 

While using a minimal docker image to cross-compile the project I work on (which uses libcoap), I have got a following error:
```
CMake Error at libcoap/CMakeLists.txt:13 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```

This error is raised, because the project requires CXX and C languages in Cmake. While I can workaround this without issues (by using dummy path to CXX and some additional Cmake arguments), I think the correct thing would be to remove dependency on CXX. Since cpp in the whole project is only used for zephyr test, it shouldn't affect anything. I have created before hand a fork and tested things in CI, and everything seems to work as before (why wouldn't it). Functionally, my cross-compiled application turned out fine, without needing CXX and libcoap worked as expected.

I would understand if you want to keep it as it is, but I think removing unnecessary dependencies are always a good solution. In worst case, once libcoap actually uses CXX (if ever), it can just add it back. 

Feel free to close the PR without merging, if you disagree.