### PR TITLE
[main] Backport CVE-2026-29013: cache-entry NULL-data guard in coap_get_data

### DIFF
--- a/src/coap_cache.c
+++ b/src/coap_cache.c
@@ -203,7 +203,8 @@ coap_new_cache_entry_lkd(coap_session_t *session, const coap_pdu_t *pdu,
       memcpy(entry->pdu, pdu, offsetof(coap_pdu_t, token));
       memcpy(entry->pdu->token, pdu->token, pdu->used_size);
       /* And adjust all the pointers etc. */
-      entry->pdu->data = entry->pdu->token + (pdu->data - pdu->token);
+      if (pdu->data)
+        entry->pdu->data = entry->pdu->token + (pdu->data - pdu->token);
     }
   }
   entry->cache_key = coap_cache_derive_key(session, pdu, session_based);

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -280,10 +280,12 @@ fail:
 int
 coap_pdu_resize(coap_pdu_t *pdu, size_t new_size) {
   if (new_size > pdu->alloc_size) {
+    /* Expanding the PDU usage */
 #if !defined(WITH_LWIP)
     uint8_t *new_hdr;
     size_t offset;
 #endif
+
     if (pdu->max_size && new_size > pdu->max_size) {
       coap_log_warn("coap_pdu_resize: pdu too big\n");
       return 0;
@@ -314,8 +316,8 @@ coap_pdu_resize(coap_pdu_t *pdu, size_t new_size) {
     else
       pdu->actual_token.s = &pdu->token[2];
 #endif
+    pdu->alloc_size = new_size;
   }
-  pdu->alloc_size = new_size;
   return 1;
 }
 
@@ -629,7 +631,12 @@ coap_insert_option(coap_pdu_t *pdu, coap_option_num_t number, size_t len,
     }
     prev_number = opt_iter.number;
   }
-  assert(option != NULL);
+  if (option == NULL) {
+    /* Code is broken somewhere */
+    coap_log_warn("coap_insert_option: Broken max_opt\n");
+    return 0;
+  }
+
   /* size of option inc header to insert */
   shift = coap_opt_encode_size(number - prev_number, len);
 


### PR DESCRIPTION
backports `b7847c4dbb0d` to `main` for CVE-2026-29013 (refs #2025).

context: see #2025 for Docker A/B evidence — pre-fix ASan SEGV at 0x180 → exit 1; post-fix `coap_get_data rc=0 ptr=(nil)` → exit 0.

upstream: https://github.com/obgm/libcoap/commit/b7847c4dbb0d
CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-29013

clean cherry-pick with `-x`. test suite not run locally.