### PR TITLE
Proxy: Check for non-safe options

### DIFF
--- a/include/coap3/coap_debug_internal.h
+++ b/include/coap3/coap_debug_internal.h
@@ -37,6 +37,16 @@ int coap_debug_send_packet(void);
  */
 void coap_debug_reset(void);
 
+/**
+ * Output ascii representation of option number, if known.
+ *
+ * @param code The PDU code.
+ * @param number The option number.
+ *
+ * @return Ascii representation or numeric value in ascii.
+ */
+const char *coap_option_string(coap_pdu_code_t code, coap_option_num_t number);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -243,6 +243,12 @@ struct coap_context_t {
   uint64_t rl_ticks_per_packet;    /**< If not 0, rate limit NON to ticks per packet */
 };
 
+typedef enum {
+  COAP_CRIT_UNKNOWN,
+  COAP_CRIT_NOT_PROXY,
+  COAP_CRIT_PROXY,
+} coap_crit_type_t;
+
 /**
  * Adds @p node to given @p queue, ordered by variable t in @p node.
  *
@@ -414,12 +420,14 @@ void coap_dispatch(coap_context_t *context, coap_session_t *session,
  * @param pdu      The PDU to check.
  * @param unknown  The output filter that will be updated to indicate the
  *                 unknown critical/duplicated/reserved options found in @p pdu.
+ * @param is_proxy The type of the critical search.
  *
  * @return         @c 1 if everything was ok, @c 0 otherwise.
  */
 int coap_option_check_critical(coap_session_t *session,
                                coap_pdu_t *pdu,
-                               coap_opt_filter_t *unknown);
+                               coap_opt_filter_t *unknown,
+                               coap_crit_type_t is_proxy);
 
 /**
  * Creates a new response for given @p request with the contents of @c

--- a/include/coap3/coap_option.h
+++ b/include/coap3/coap_option.h
@@ -36,6 +36,111 @@ extern "C" {
 
 typedef uint16_t coap_option_num_t;
 
+/*
+ * CoAP option numbers (be sure to update coap_option_check_critical()
+ * and coap_option_check_repeatable() when adding options).
+ */
+
+/*
+ * The C, U, and N flags indicate the properties
+ * Critical, Unsafe, and NoCacheKey, respectively.
+ * If U is set, then N has no meaning as per
+ * https://rfc-editor.org/rfc/rfc7252#section-5.10
+ * and is set to a -.
+ *
+ * Separately, R is for the options that can be repeated
+ *
+ * The least significant byte of the option is set as followed
+ * as per https://rfc-editor.org/rfc/rfc7252#section-5.4.6
+ *
+ *   0   1   2   3   4   5   6   7
+ * --+---+---+---+---+---+---+---+
+ *           | NoCacheKey| U | C |
+ * --+---+---+---+---+---+---+---+
+ *
+ * https://rfc-editor.org/rfc/rfc8613#section-4 goes on to define E, I and U
+ * properties Encrypted and Integrity Protected, Integrity Protected Only, and
+ * Unprotected respectively.  Integrity Protected Only is not currently used.
+ *
+ * An Option is tagged with CUNREIU with any of the letters replaced with _ if
+ * not set, or - for N if U is set (see above) for aiding understanding of the
+ * Option.
+ */
+
+typedef enum coap_code_opt_num_t {
+  COAP_OPTION_IF_MATCH      =   1, /* C__RE__, opaque,      0-8 B, none, RFC7252 */
+  COAP_OPTION_URI_HOST      =   3, /* CU-___U, String,    1-255 B, none, RFC7252 */
+  COAP_OPTION_ETAG          =   4, /* ___RE__, opaque,      1-8 B, none, RFC7252 */
+  COAP_OPTION_IF_NONE_MATCH =   5, /* C___E__, empty,         0 B, none, RFC7252 */
+  COAP_OPTION_OBSERVE       =   6, /* _U-_E_U, empty/uint,0/0-3 B, none, RFC7641 */
+  COAP_OPTION_URI_PORT      =   7, /* CU-___U, uint,        0-2 B, none, RFC7252 */
+  COAP_OPTION_LOCATION_PATH =   8, /* ___RE__, String,    0-255 B, none, RFC7252 */
+  COAP_OPTION_OSCORE        =   9, /* C_____U, *,         0-255 B, none, RFC8613 */
+  COAP_OPTION_URI_PATH      =  11, /* CU-RE__, String,    0-255 B, none, RFC7252 */
+  COAP_OPTION_CONTENT_FORMAT=  12, /* ____E__, uint,        0-2 B, none, RFC7252 */
+  COAP_OPTION_URI_PATH_ABB  =  13, /* C___E__, uint,        0-4 B, none, RFC TBD */
+  /* COAP_OPTION_MAXAGE default 60 seconds if not set */
+  COAP_OPTION_MAXAGE        =  14, /* _U-_E_U, uint,        0-4 B, 60,   RFC7252 */
+  COAP_OPTION_URI_QUERY     =  15, /* CU-RE__, String,    1-255 B, none, RFC7252 */
+  COAP_OPTION_HOP_LIMIT     =  16, /* ______U, uint,          1 B, none, RFC8768 */
+  COAP_OPTION_ACCEPT        =  17, /* C___E__, uint,        0-2 B, none, RFC7252 */
+  COAP_OPTION_Q_BLOCK1      =  19, /* CU__E_U, uint,        0-3 B, none, RFC9177 */
+  COAP_OPTION_LOCATION_QUERY=  20, /* ___RE__, String,    0-255 B, none, RFC7252 */
+  COAP_OPTION_EDHOC         =  21, /* C_____U, empty,         0 B, none, RFC9668 */
+  COAP_OPTION_BLOCK2        =  23, /* CU-_E_U, uint,        0-3 B, none, RFC7959 */
+  COAP_OPTION_BLOCK1        =  27, /* CU-_E_U, uint,        0-3 B, none, RFC7959 */
+  COAP_OPTION_SIZE2         =  28, /* __N_E_U, uint,        0-4 B, none, RFC7959 */
+  COAP_OPTION_Q_BLOCK2      =  31, /* CU_RE_U, uint,        0-3 B, none, RFC9177 */
+  COAP_OPTION_PROXY_URI     =  35, /* CU-___U, String,   1-1034 B, none, RFC7252 */
+  COAP_OPTION_PROXY_SCHEME  =  39, /* CU-___U, String,    1-255 B, none, RFC7252 */
+  COAP_OPTION_SIZE1         =  60, /* __N_E_U, uint,        0-4 B, none, RFC7252 */
+  COAP_OPTION_ECHO          = 252, /* __N_E_U, opaque,     0-40 B, none, RFC9175 */
+  COAP_OPTION_NORESPONSE    = 258, /* _U-_E_U, uint,        0-1 B, none, RFC7967 */
+  COAP_OPTION_RTAG          = 292, /* ___RE_U, opaque,      0-8 B, none, RFC9175 */
+} coap_code_opt_num_t;
+
+#define  COAP_OPTION_CONTENT_TYPE COAP_OPTION_CONTENT_FORMAT
+
+#if (UINT_MAX > 65535)
+#define COAP_MAX_OPT 65535 /**< the highest option number we know */
+#else /* UINT_MAX <= 65535 */
+#define COAP_MAX_OPT 65534 /**< the highest option number we know */
+#endif /* UINT_MAX <= 65535 */
+
+/* Signaling options */
+
+/* Applies to COAP_SIGNALING_CSM (7.01) */
+typedef enum coap_sig_csm_opt_t {
+  COAP_SIG_OPT_MAX_MESSAGE_SIZE      = 2, /* ____E_U, uint,     0-4 B, 1152, RFC8323 */
+  COAP_SIG_OPT_BLOCK_WISE_TRANSFER   = 4, /* ____E_U, empty,      0 B, none, RFC8323 */
+  COAP_SIG_OPT_EXTENDED_TOKEN_LENGTH = 6, /* ____E_U, uint,     0-3 B, 8,    RFC8974 */
+} coap_sig_csm_opt_t;
+
+/* Applies to COAP_SIGNALING_PING / COAP_SIGNALING_PONG (7.02 / 7.03) */
+typedef enum coap_sig_ping_opt_t {
+  COAP_SIG_OPT_CUSTODY               = 2, /* ____E_U, empty,      0 B, none, RFC8323 */
+} coap_sig_ping_opt_t;
+
+/* Applies to COAP_SIGNALING_RELEASE (7.04) */
+typedef enum coap_sig_release_opt_t {
+  COAP_SIG_OPT_ALTERNATIVE_ADDRESS   = 2, /* ___RE_U, String, 1-255 B, none, RFC8323 */
+  COAP_SIG_OPT_HOLD_OFF              = 4, /* ____E_U, uint,     0-3 B, none, RFC8323 */
+} coap_sig_release_opt_t;
+
+/* Applies to COAP_SIGNALING_ABORT (7.05 )*/
+typedef enum coap_sig_abort_opt_t {
+  COAP_SIG_OPT_BAD_CSM_OPTION        = 2, /* ____E_U, uint,     0-2 B, none, RFC8323 */
+} coap_sig_abort_opt_t;
+
+/* Backward Application compatability */
+#define COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE      COAP_SIG_OPT_MAX_MESSAGE_SIZE
+#define COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER   COAP_SIG_OPT_BLOCK_WISE_TRANSFER
+#define COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH COAP_SIG_OPT_EXTENDED_TOKEN_LENGTH
+#define COAP_SIGNALING_OPTION_CUSTODY               COAP_SIG_OPT_CUSTODY
+#define COAP_SIGNALING_OPTION_ALTERNATIVE_ADDRESS   COAP_SIG_OPT_ALTERNATIVE_ADDRESS
+#define COAP_SIGNALING_OPTION_HOLD_OFF              COAP_SIG_OPT_HOLD_OFF
+#define COAP_SIGNALING_OPTION_BAD_CSM_OPTION        COAP_SIG_OPT_BAD_CSM_OPTION
+
 /**
  * Use byte-oriented access methods here because sliding a complex struct
  * coap_opt_t over the data buffer may cause bus error on certain platforms.
@@ -341,7 +446,7 @@ const uint8_t *coap_opt_value(const coap_opt_t *opt);
  */
 typedef struct coap_optlist_t {
   struct coap_optlist_t *next;  /**< next entry in the optlist chain */
-  uint16_t number;              /**< the option number (no delta coding) */
+  coap_option_num_t number;     /**< the option number (no delta coding) */
   size_t length;                /**< the option value length */
   uint8_t *data;                /**< the option data */
 } coap_optlist_t;
@@ -361,7 +466,7 @@ typedef struct coap_optlist_t {
  *
  * @return          A pointer to the new optlist entry, or @c NULL if error
  */
-coap_optlist_t *coap_new_optlist(uint16_t number,
+coap_optlist_t *coap_new_optlist(coap_option_num_t number,
                                  size_t length,
                                  const uint8_t *data);
 
@@ -423,7 +528,7 @@ void coap_delete_optlist(coap_optlist_t *optlist_chain);
  * @return       @c 1 if bit was set, @c -1 otherwise.
  */
 COAP_STATIC_INLINE COAP_DEPRECATED int
-coap_option_setb(coap_opt_filter_t *filter, uint16_t type) {
+coap_option_setb(coap_opt_filter_t *filter, coap_option_num_t type) {
   return coap_option_filter_set(filter, type) ? 1 : -1;
 }
 
@@ -439,7 +544,7 @@ coap_option_setb(coap_opt_filter_t *filter, uint16_t type) {
  * @return       @c 1 if bit was set, @c -1 otherwise.
  */
 COAP_STATIC_INLINE COAP_DEPRECATED int
-coap_option_clrb(coap_opt_filter_t *filter, uint16_t type) {
+coap_option_clrb(coap_opt_filter_t *filter, coap_option_num_t type) {
   return coap_option_filter_unset(filter, type) ? 1 : -1;
 }
 
@@ -455,7 +560,7 @@ coap_option_clrb(coap_opt_filter_t *filter, uint16_t type) {
  * @return       @c 1 if bit was set, @c 0 if not.
  */
 COAP_STATIC_INLINE COAP_DEPRECATED int
-coap_option_getb(coap_opt_filter_t *filter, uint16_t type) {
+coap_option_getb(coap_opt_filter_t *filter, coap_option_num_t type) {
   return coap_option_filter_get(filter, type);
 }
 

--- a/include/coap3/coap_pdu.h
+++ b/include/coap3/coap_pdu.h
@@ -87,74 +87,6 @@ typedef enum coap_request_t {
   COAP_REQUEST_IPATCH,    /* 7 RFC 8132 */
 } coap_request_t;
 
-/*
- * CoAP option numbers (be sure to update coap_option_check_critical() and
- * coap_add_option() when adding options
- */
-
-/*
- * The C, U, and N flags indicate the properties
- * Critical, Unsafe, and NoCacheKey, respectively.
- * If U is set, then N has no meaning as per
- * https://rfc-editor.org/rfc/rfc7252#section-5.10
- * and is set to a -.
- *
- * Separately, R is for the options that can be repeated
- *
- * The least significant byte of the option is set as followed
- * as per https://rfc-editor.org/rfc/rfc7252#section-5.4.6
- *
- *   0   1   2   3   4   5   6   7
- * --+---+---+---+---+---+---+---+
- *           | NoCacheKey| U | C |
- * --+---+---+---+---+---+---+---+
- *
- * https://rfc-editor.org/rfc/rfc8613#section-4 goes on to define E, I and U
- * properties Encrypted and Integrity Protected, Integrity Protected Only, and
- * Unprotected respectively.  Integrity Protected Only is not currently used.
- *
- * An Option is tagged with CUNREIU with any of the letters replaced with _ if
- * not set, or - for N if U is set (see above) for aiding understanding of the
- * Option.
- */
-
-#define COAP_OPTION_IF_MATCH        1 /* C__RE__, opaque,    0-8 B, RFC7252 */
-#define COAP_OPTION_URI_HOST        3 /* CU-___U, String,  1-255 B, RFC7252 */
-#define COAP_OPTION_ETAG            4 /* ___RE__, opaque,    1-8 B, RFC7252 */
-#define COAP_OPTION_IF_NONE_MATCH   5 /* C___E__, empty,       0 B, RFC7252 */
-#define COAP_OPTION_OBSERVE         6 /* _U-_E_U, empty/uint,0/0-3 B, RFC7641 */
-#define COAP_OPTION_URI_PORT        7 /* CU-___U, uint,      0-2 B, RFC7252 */
-#define COAP_OPTION_LOCATION_PATH   8 /* ___RE__, String,  0-255 B, RFC7252 */
-#define COAP_OPTION_OSCORE          9 /* C_____U, *,       0-255 B, RFC8613 */
-#define COAP_OPTION_URI_PATH       11 /* CU-RE__, String,  0-255 B, RFC7252 */
-#define COAP_OPTION_CONTENT_FORMAT 12 /* ____E__, uint,      0-2 B, RFC7252 */
-#define COAP_OPTION_URI_PATH_ABB   13 /* C___E__, uint,      0-4 B, RFC TBD */
-#define COAP_OPTION_CONTENT_TYPE COAP_OPTION_CONTENT_FORMAT
-/* COAP_OPTION_MAXAGE default 60 seconds if not set */
-#define COAP_OPTION_MAXAGE         14 /* _U-_E_U, uint,      0-4 B, RFC7252 */
-#define COAP_OPTION_URI_QUERY      15 /* CU-RE__, String,  1-255 B, RFC7252 */
-#define COAP_OPTION_HOP_LIMIT      16 /* ______U, uint,        1 B, RFC8768 */
-#define COAP_OPTION_ACCEPT         17 /* C___E__, uint,      0-2 B, RFC7252 */
-#define COAP_OPTION_Q_BLOCK1       19 /* CU__E_U, uint,      0-3 B, RFC9177 */
-#define COAP_OPTION_LOCATION_QUERY 20 /* ___RE__, String,  0-255 B, RFC7252 */
-#define COAP_OPTION_EDHOC          21 /* C_____U, empty,       0 B, RFC9668 */
-#define COAP_OPTION_BLOCK2         23 /* CU-_E_U, uint,      0-3 B, RFC7959 */
-#define COAP_OPTION_BLOCK1         27 /* CU-_E_U, uint,      0-3 B, RFC7959 */
-#define COAP_OPTION_SIZE2          28 /* __N_E_U, uint,      0-4 B, RFC7959 */
-#define COAP_OPTION_Q_BLOCK2       31 /* CU_RE_U, uint,      0-3 B, RFC9177 */
-#define COAP_OPTION_PROXY_URI      35 /* CU-___U, String, 1-1034 B, RFC7252 */
-#define COAP_OPTION_PROXY_SCHEME   39 /* CU-___U, String,  1-255 B, RFC7252 */
-#define COAP_OPTION_SIZE1          60 /* __N_E_U, uint,      0-4 B, RFC7252 */
-#define COAP_OPTION_ECHO          252 /* _N__E_U, opaque,   0-40 B, RFC9175 */
-#define COAP_OPTION_NORESPONSE    258 /* _U-_E_U, uint,      0-1 B, RFC7967 */
-#define COAP_OPTION_RTAG          292 /* ___RE_U, opaque,    0-8 B, RFC9175 */
-
-#if (UINT_MAX > 65535)
-#define COAP_MAX_OPT            65535 /**< the highest option number we know */
-#else /* UINT_MAX <= 65535 */
-#define COAP_MAX_OPT            65534 /**< the highest option number we know */
-#endif /* UINT_MAX <= 65535 */
-
 /* CoAP result codes (HTTP-Code / 100 * 40 + HTTP-Code % 100) */
 
 /* As of draft-ietf-core-coap-04, response codes are encoded to base
@@ -196,21 +128,6 @@ typedef enum coap_pdu_signaling_proto_t {
   COAP_SIGNALING_RELEASE = COAP_SIGNALING_CODE(704),
   COAP_SIGNALING_ABORT =   COAP_SIGNALING_CODE(705),
 } coap_pdu_signaling_proto_t;
-
-/* Applies to COAP_SIGNALING_CSM */
-#define COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE 2
-#define COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER 4
-#define COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH 6
-
-/* Applies to COAP_SIGNALING_PING / COAP_SIGNALING_PONG */
-#define COAP_SIGNALING_OPTION_CUSTODY 2
-
-/* Applies to COAP_SIGNALING_RELEASE */
-#define COAP_SIGNALING_OPTION_ALTERNATIVE_ADDRESS 2
-#define COAP_SIGNALING_OPTION_HOLD_OFF 4
-
-/* Applies to COAP_SIGNALING_ABORT */
-#define COAP_SIGNALING_OPTION_BAD_CSM_OPTION 2
 
 /* CoAP media type encoding */
 
@@ -283,7 +200,7 @@ typedef int coap_mid_t;
  * structure (see macro COAP_OPTION_DATA).
  */
 COAP_DEPRECATED typedef struct {
-  uint16_t key;           /* the option key (no delta coding) */
+  coap_option_num_t key;           /* the option key (no delta coding) */
   unsigned int length;
 } coap_option;
 

--- a/include/coap3/coap_pdu_internal.h
+++ b/include/coap3/coap_pdu_internal.h
@@ -373,11 +373,12 @@ int coap_update_token(coap_pdu_t *pdu,
  * Check whether the option is allowed to be repeated or not.
  * This function returns @c 0 if not repeatable or @c 1 if repeatable
  *
+ * @param pdu    The PDU being checked.
  * @param number The option number to check for repeatability.
  *
  * @return     @c 0 if not repeatable or @c 1 if repeatable.
  */
-int coap_option_check_repeatable(coap_option_num_t number);
+int coap_option_check_repeatable(coap_pdu_t *pdu, coap_option_num_t number);
 
 /**
  * Check the length / data (if appropriate) of an option.

--- a/src/coap_debug.c
+++ b/src/coap_debug.c
@@ -610,10 +610,10 @@ msg_code_string(uint16_t c) {
 }
 
 /** Returns a textual description of the option name. */
-static const char *
-msg_option_string(uint8_t code, uint16_t option_type) {
+const char *
+coap_option_string(coap_pdu_code_t code, coap_option_num_t number) {
   struct option_desc_t {
-    uint16_t type;
+    uint16_t value;
     const char *name;
   };
 
@@ -648,61 +648,61 @@ msg_option_string(uint8_t code, uint16_t option_type) {
   };
 
   static struct option_desc_t options_csm[] = {
-    { COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE, "Max-Message-Size" },
-    { COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER, "Block-Wise-Transfer" },
-    { COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH, "Extended-Token-Length" }
+    { COAP_SIG_OPT_MAX_MESSAGE_SIZE, "Max-Message-Size" },
+    { COAP_SIG_OPT_BLOCK_WISE_TRANSFER, "Block-Wise-Transfer" },
+    { COAP_SIG_OPT_EXTENDED_TOKEN_LENGTH, "Extended-Token-Length" }
   };
 
   static struct option_desc_t options_pingpong[] = {
-    { COAP_SIGNALING_OPTION_CUSTODY, "Custody" }
+    { COAP_SIG_OPT_CUSTODY, "Custody" }
   };
 
   static struct option_desc_t options_release[] = {
-    { COAP_SIGNALING_OPTION_ALTERNATIVE_ADDRESS, "Alternative-Address" },
-    { COAP_SIGNALING_OPTION_HOLD_OFF, "Hold-Off" }
+    { COAP_SIG_OPT_ALTERNATIVE_ADDRESS, "Alternative-Address" },
+    { COAP_SIG_OPT_HOLD_OFF, "Hold-Off" }
   };
 
   static struct option_desc_t options_abort[] = {
-    { COAP_SIGNALING_OPTION_BAD_CSM_OPTION, "Bad-CSM-Option" }
+    { COAP_SIG_OPT_BAD_CSM_OPTION, "Bad-CSM-Option" }
   };
 
   static char buf[6];
   size_t i;
 
-  if (code == COAP_SIGNALING_CSM) {
+  if (code == COAP_SIGNALING_CODE_CSM) {
     for (i = 0; i < sizeof(options_csm)/sizeof(struct option_desc_t); i++) {
-      if (option_type == options_csm[i].type) {
+      if (number == options_csm[i].value) {
         return options_csm[i].name;
       }
     }
-  } else if (code == COAP_SIGNALING_PING || code == COAP_SIGNALING_PONG) {
+  } else if (code == COAP_SIGNALING_CODE_PING || code == COAP_SIGNALING_CODE_PONG) {
     for (i = 0; i < sizeof(options_pingpong)/sizeof(struct option_desc_t); i++) {
-      if (option_type == options_pingpong[i].type) {
+      if (number == options_pingpong[i].value) {
         return options_pingpong[i].name;
       }
     }
-  } else if (code == COAP_SIGNALING_RELEASE) {
+  } else if (code == COAP_SIGNALING_CODE_RELEASE) {
     for (i = 0; i < sizeof(options_release)/sizeof(struct option_desc_t); i++) {
-      if (option_type == options_release[i].type) {
+      if (number == options_release[i].value) {
         return options_release[i].name;
       }
     }
-  } else if (code == COAP_SIGNALING_ABORT) {
+  } else if (code == COAP_SIGNALING_CODE_ABORT) {
     for (i = 0; i < sizeof(options_abort)/sizeof(struct option_desc_t); i++) {
-      if (option_type == options_abort[i].type) {
+      if (number == options_abort[i].value) {
         return options_abort[i].name;
       }
     }
   } else {
     /* search option_type in list of known options */
     for (i = 0; i < sizeof(options)/sizeof(struct option_desc_t); i++) {
-      if (option_type == options[i].type) {
+      if (number == options[i].value) {
         return options[i].name;
       }
     }
   }
   /* unknown option type, just print to buf */
-  snprintf(buf, sizeof(buf), "%u", option_type);
+  snprintf(buf, sizeof(buf), "%u", number);
   return buf;
 }
 
@@ -821,7 +821,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
   char outbuf[COAP_DEBUG_BUF_SIZE];
 #endif /* ! COAP_CONSTRAINED_STACK */
   size_t buf_len = 0; /* takes the number of bytes written to buf */
-  int encode = 0, have_options = 0;
+  int have_options = 0;
   uint32_t i;
   coap_opt_iterator_t opt_iter;
   coap_opt_t *option;
@@ -882,28 +882,33 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
     }
 
     if (pdu->code == COAP_SIGNALING_CODE_CSM) {
-      switch (opt_iter.number) {
-      case COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH:
-      case COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE:
+      switch ((coap_sig_csm_opt_t)opt_iter.number) {
+      case COAP_SIG_OPT_EXTENDED_TOKEN_LENGTH:
+      case COAP_SIG_OPT_MAX_MESSAGE_SIZE:
         buf_len = snprintf((char *)buf, sizeof(buf), "%u",
                            coap_decode_var_bytes(coap_opt_value(option),
                                                  coap_opt_length(option)));
         break;
+      case COAP_SIG_OPT_BLOCK_WISE_TRANSFER:
       default:
         buf_len = 0;
         break;
       }
     } else if (pdu->code == COAP_SIGNALING_CODE_PING ||
                pdu->code == COAP_SIGNALING_CODE_PONG) {
-      buf_len = 0;
+      switch ((coap_sig_ping_opt_t)opt_iter.number) {
+      case COAP_SIG_OPT_CUSTODY:
+      default:
+        buf_len = 0;
+      }
     } else if (pdu->code == COAP_SIGNALING_CODE_RELEASE) {
-      switch (opt_iter.number) {
-      case COAP_SIGNALING_OPTION_ALTERNATIVE_ADDRESS:
+      switch ((coap_sig_release_opt_t)opt_iter.number) {
+      case COAP_SIG_OPT_ALTERNATIVE_ADDRESS:
         buf_len = print_readable(coap_opt_value(option),
                                  coap_opt_length(option),
                                  buf, sizeof(buf), 0);
         break;
-      case COAP_SIGNALING_OPTION_HOLD_OFF:
+      case COAP_SIG_OPT_HOLD_OFF:
         buf_len = snprintf((char *)buf, sizeof(buf), "%u",
                            coap_decode_var_bytes(coap_opt_value(option),
                                                  coap_opt_length(option)));
@@ -913,8 +918,8 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
         break;
       }
     } else if (pdu->code == COAP_SIGNALING_CODE_ABORT) {
-      switch (opt_iter.number) {
-      case COAP_SIGNALING_OPTION_BAD_CSM_OPTION:
+      switch ((coap_sig_abort_opt_t)opt_iter.number) {
+      case COAP_SIG_OPT_BAD_CSM_OPTION:
         buf_len = snprintf((char *)buf, sizeof(buf), "%u",
                            coap_decode_var_bytes(coap_opt_value(option),
                                                  coap_opt_length(option)));
@@ -924,7 +929,7 @@ coap_show_pdu(coap_log_t level, const coap_pdu_t *pdu) {
         break;
       }
     } else {
-      switch (opt_iter.number) {
+      switch ((coap_code_opt_num_t)opt_iter.number) {
       case COAP_OPTION_CONTENT_FORMAT:
       case COAP_OPTION_ACCEPT:
         content_format = (int)coap_decode_var_bytes(coap_opt_value(option),
@@ -1066,27 +1071,28 @@ no_more:
         }
         buf_len = strlen((char *)buf);
         break;
-      default:
-        /* generic output function for all other option types */
-        if (opt_iter.number == COAP_OPTION_URI_PATH ||
-            opt_iter.number == COAP_OPTION_PROXY_URI ||
-            opt_iter.number == COAP_OPTION_URI_HOST ||
-            opt_iter.number == COAP_OPTION_LOCATION_PATH ||
-            opt_iter.number == COAP_OPTION_LOCATION_QUERY ||
-            opt_iter.number == COAP_OPTION_PROXY_SCHEME ||
-            opt_iter.number == COAP_OPTION_URI_QUERY) {
-          encode = 0;
-        } else {
-          encode = 1;
-        }
+      case COAP_OPTION_URI_PATH:
+      case COAP_OPTION_PROXY_URI:
+      case COAP_OPTION_URI_HOST:
+      case COAP_OPTION_LOCATION_PATH:
+      case COAP_OPTION_LOCATION_QUERY:
+      case COAP_OPTION_PROXY_SCHEME:
+      case COAP_OPTION_URI_QUERY:
         buf_len = print_readable(coap_opt_value(option),
                                  coap_opt_length(option),
-                                 buf, sizeof(buf), encode);
+                                 buf, sizeof(buf), 0);
+        break;
+      case COAP_OPTION_IF_NONE_MATCH:
+      case COAP_OPTION_EDHOC:
+      default:
+        buf_len = print_readable(coap_opt_value(option),
+                                 coap_opt_length(option),
+                                 buf, sizeof(buf), 1);
       }
     }
     outbuflen = strlen(outbuf);
     snprintf(&outbuf[outbuflen], sizeof(outbuf)-outbuflen,
-             " %s:%.*s", msg_option_string(pdu->code, opt_iter.number),
+             " %s:%.*s", coap_option_string(pdu->code, opt_iter.number),
              (int)buf_len, buf);
   }
 

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -951,10 +951,80 @@ coap_free_context_lkd(coap_context_t *context) {
   coap_dump_memory_type_counts(COAP_LOG_DEBUG);
 }
 
+static coap_crit_type_t
+coap_is_session_proxy(coap_session_t *session, coap_pdu_t *pdu) {
+#if COAP_SERVER_SUPPORT
+  coap_opt_iterator_t t_iter;
+  coap_opt_t *proxy_uri = NULL;
+  coap_opt_t *proxy_scheme = NULL;
+
+  if (session->proxy_session) {
+    return COAP_CRIT_PROXY;
+  } else if (COAP_PDU_IS_REQUEST(pdu) && session->context->unknown_resource &&
+             session->context->unknown_resource->is_reverse_proxy) {
+    return COAP_CRIT_PROXY;
+  } else if (COAP_PDU_IS_REQUEST(pdu) && session->context->proxy_uri_resource &&
+             ((proxy_uri = coap_check_option(pdu, COAP_OPTION_PROXY_URI, &t_iter)) ||
+              (proxy_scheme = coap_check_option(pdu, COAP_OPTION_PROXY_SCHEME, &t_iter)))) {
+    if (proxy_uri || proxy_scheme) {
+      coap_uri_t uri;
+
+      /* Duplicates some of the code in handle_request() */
+      if (proxy_uri) {
+        if (coap_split_proxy_uri(coap_opt_value(proxy_uri),
+                                 coap_opt_length(proxy_uri), &uri) < 0) {
+          return COAP_CRIT_PROXY;
+        }
+      } else {
+        coap_opt_t *opt;
+        coap_resource_t *resource;
+
+        memset(&uri, 0, sizeof(uri));
+        opt = coap_check_option(pdu, COAP_OPTION_URI_HOST, &t_iter);
+        if (opt) {
+          uri.host.length = coap_opt_length(opt);
+          uri.host.s = coap_opt_value(opt);
+        } else {
+          uri.host.length = 0;
+        }
+        /* See if we are the endpoint */
+        resource = session->context->proxy_uri_resource;
+        if (uri.host.length && resource->proxy_name_count &&
+            resource->proxy_name_list) {
+          size_t i;
+
+          if (resource->proxy_name_count == 1 &&
+              resource->proxy_name_list[0]->length == 0) {
+            /* If proxy_name_list[0] is zero length, then this is the endpoint */
+            i = 0;
+          } else {
+            for (i = 0; i < resource->proxy_name_count; i++) {
+              if (coap_string_equal(&uri.host, resource->proxy_name_list[i])) {
+                break;
+              }
+            }
+          }
+          if (i != resource->proxy_name_count) {
+            return COAP_CRIT_NOT_PROXY;
+          }
+        }
+      }
+      return COAP_CRIT_PROXY;
+    }
+  }
+  return COAP_CRIT_NOT_PROXY;
+#else /* ! COAP_SERVER_SUPPORT */
+#endif /* ! COAP_SERVER_SUPPORT */
+  (void)session;
+  (void)pdu;
+  return COAP_CRIT_NOT_PROXY;
+}
+
 int
 coap_option_check_critical(coap_session_t *session,
                            coap_pdu_t *pdu,
-                           coap_opt_filter_t *unknown) {
+                           coap_opt_filter_t *unknown,
+                           coap_crit_type_t is_proxy) {
   coap_context_t *ctx = session->context;
   coap_opt_iterator_t opt_iter;
   int ok = 1;
@@ -972,7 +1042,7 @@ coap_option_check_critical(coap_session_t *session,
     case 136:
     case 140:
       if (coap_option_filter_get(&ctx->known_options, opt_iter.number) <= 0) {
-        coap_log_debug("unknown reserved option %d\n", opt_iter.number);
+        coap_log_debug("Unknown reserved option %d\n", opt_iter.number);
         ok = 0;
 
         /* When opt_iter.number cannot be set in unknown, all of the appropriate
@@ -993,8 +1063,8 @@ coap_option_check_critical(coap_session_t *session,
       case COAP_OPTION_Q_BLOCK1:
       case COAP_OPTION_Q_BLOCK2:
         if (!(ctx->block_mode & COAP_BLOCK_TRY_Q_BLOCK)) {
-          coap_log_debug("disabled support for critical option %u\n",
-                         opt_iter.number);
+          coap_log_debug("Critical option '%s' (%d) disabled - not supported\n",
+                         coap_option_string(pdu->code, opt_iter.number), opt_iter.number);
           ok = 0;
           /* When opt_iter.number cannot be set in unknown, all of the appropriate
            * slots have been used up and no more options can be tracked.
@@ -1013,10 +1083,10 @@ coap_option_check_critical(coap_session_t *session,
       case COAP_OPTION_URI_PATH_ABB:
       case COAP_OPTION_URI_QUERY:
       case COAP_OPTION_ACCEPT:
-      case COAP_OPTION_PROXY_URI:
-      case COAP_OPTION_PROXY_SCHEME:
       case COAP_OPTION_BLOCK2:
       case COAP_OPTION_BLOCK1:
+      case COAP_OPTION_PROXY_URI:
+      case COAP_OPTION_PROXY_SCHEME:
         break;
       case COAP_OPTION_OSCORE:
         /* Valid critical if doing OSCORE */
@@ -1030,25 +1100,51 @@ coap_option_check_critical(coap_session_t *session,
         if (coap_option_filter_get(&ctx->known_options, opt_iter.number) <= 0) {
 #if COAP_SERVER_SUPPORT
           if ((opt_iter.number & 0x02) == 0) {
-            coap_opt_iterator_t t_iter;
-
-            /* Safe to forward  - check if proxy pdu */
-            if (session->proxy_session)
-              break;
-            if (COAP_PDU_IS_REQUEST(pdu) && ctx->proxy_uri_resource &&
-                (coap_check_option(pdu, COAP_OPTION_PROXY_URI, &t_iter) ||
-                 coap_check_option(pdu, COAP_OPTION_PROXY_SCHEME, &t_iter))) {
-              pdu->crit_opt = 1;
-              break;
+            /* Safe to forward critical? - check if proxy pdu */
+            if (is_proxy == COAP_CRIT_UNKNOWN) {
+              is_proxy = coap_is_session_proxy(session, pdu);
             }
-            if (COAP_PDU_IS_REQUEST(pdu) && ctx->unknown_resource &&
-                ctx->unknown_resource->is_reverse_proxy) {
+            if (is_proxy == COAP_CRIT_PROXY) {
               pdu->crit_opt = 1;
               break;
             }
           }
 #endif /* COAP_SERVER_SUPPORT */
-          coap_log_debug("unknown critical option %d\n", opt_iter.number);
+          coap_log_debug("Critical option %u dropped\n", opt_iter.number);
+          ok = 0;
+
+          /* When opt_iter.number cannot be set in unknown, all of the appropriate
+           * slots have been used up and no more options can be tracked.
+           * Safe to break out of this loop as ok is already set. */
+          if (coap_option_filter_set(unknown, opt_iter.number) == 0) {
+            goto overflow;
+          }
+        }
+      }
+    }
+    if (opt_iter.number & 0x02) {
+      /* Check for safe to forward for a proxy */
+      if (is_proxy == COAP_CRIT_UNKNOWN) {
+        is_proxy = coap_is_session_proxy(session, pdu);
+      }
+      if (is_proxy == COAP_CRIT_PROXY) {
+        switch (opt_iter.number) {
+        case COAP_OPTION_URI_HOST:
+        case COAP_OPTION_OBSERVE:
+        case COAP_OPTION_URI_PORT:
+        case COAP_OPTION_URI_PATH:
+        case COAP_OPTION_MAXAGE:
+        case COAP_OPTION_URI_QUERY:
+        case COAP_OPTION_Q_BLOCK1:
+        case COAP_OPTION_BLOCK2:
+        case COAP_OPTION_BLOCK1:
+        case COAP_OPTION_Q_BLOCK2:
+        case COAP_OPTION_PROXY_URI:
+        case COAP_OPTION_PROXY_SCHEME:
+          break;
+        default:
+          coap_log_debug("Not Safe option %u cannot be forwarded - dropped\n",
+                         opt_iter.number);
           ok = 0;
 
           /* When opt_iter.number cannot be set in unknown, all of the appropriate
@@ -1062,7 +1158,7 @@ coap_option_check_critical(coap_session_t *session,
     }
     if (last_number == opt_iter.number) {
       /* Check for duplicated option RFC 5272 5.4.5 */
-      if (!coap_option_check_repeatable(opt_iter.number)) {
+      if (!coap_option_check_repeatable(pdu, opt_iter.number)) {
         if (coap_option_filter_get(&ctx->known_options, opt_iter.number) <= 0) {
           ok = 0;
           if (coap_option_filter_set(unknown, opt_iter.number) == 0) {
@@ -4459,9 +4555,11 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
       session->max_token_size = COAP_TOKEN_DEFAULT_MAX;
     }
     while ((option = coap_option_next(&opt_iter))) {
-      if (opt_iter.number == COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE) {
-        unsigned max_recv = coap_decode_var_bytes(coap_opt_value(option), coap_opt_length(option));
+      unsigned max_recv;
 
+      switch ((coap_sig_csm_opt_t)opt_iter.number) {
+      case COAP_SIG_OPT_MAX_MESSAGE_SIZE:
+        max_recv = coap_decode_var_bytes(coap_opt_value(option), coap_opt_length(option));
         if (max_recv > COAP_DEFAULT_MAX_PDU_RX_SIZE) {
           max_recv = COAP_DEFAULT_MAX_PDU_RX_SIZE;
           coap_log_debug("*  %s: Restricting CSM Max-Message-Size size to %u\n",
@@ -4469,9 +4567,11 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
         }
         coap_session_set_mtu(session, max_recv);
         set_mtu = 1;
-      } else if (opt_iter.number == COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER) {
+        break;
+      case COAP_SIG_OPT_BLOCK_WISE_TRANSFER:
         session->csm_block_supported = 1;
-      } else if (opt_iter.number == COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH) {
+        break;
+      case COAP_SIG_OPT_EXTENDED_TOKEN_LENGTH:
         session->max_token_size =
             coap_decode_var_bytes(coap_opt_value(option),
                                   coap_opt_length(option));
@@ -4480,6 +4580,9 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
         else if (session->max_token_size > COAP_TOKEN_EXT_MAX)
           session->max_token_size = COAP_TOKEN_EXT_MAX;
         session->max_token_checked = COAP_EXT_T_CHECKED;
+        break;
+      default:
+        break;
       }
     }
     if (set_mtu) {
@@ -4496,7 +4599,8 @@ handle_signaling(coap_context_t *context, coap_session_t *session,
       coap_lock_callback(context->ping_cb(session, pdu, pdu->mid));
     }
     if (pong) {
-      coap_add_option_internal(pong, COAP_SIGNALING_OPTION_CUSTODY, 0, NULL);
+      coap_add_option_internal(pong, (coap_option_num_t)COAP_SIG_OPT_CUSTODY,
+                               0, NULL);
       coap_send_internal(session, pong, NULL);
     }
   } else if (pdu->code == COAP_SIGNALING_CODE_PONG) {
@@ -4617,7 +4721,7 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
   }
 #if COAP_OSCORE_SUPPORT
   if (!COAP_PDU_IS_SIGNALING(pdu) &&
-      coap_option_check_critical(session, pdu, &opt_filter) == 0) {
+      coap_option_check_critical(session, pdu, &opt_filter, COAP_CRIT_UNKNOWN) == 0) {
     if (pdu->type == COAP_MESSAGE_CON || pdu->type == COAP_MESSAGE_NON) {
       if (COAP_PDU_IS_REQUEST(pdu)) {
         response =
@@ -4720,7 +4824,8 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
         /* Flush out any entries on session->delayqueue */
         coap_session_connected(session);
     }
-    if (oscore_invalid || coap_option_check_critical(session, pdu, &opt_filter) == 0) {
+    if (oscore_invalid ||
+        coap_option_check_critical(session, pdu, &opt_filter, COAP_CRIT_UNKNOWN) == 0) {
       packet_is_bad = 1;
       goto cleanup;
     }
@@ -4914,7 +5019,8 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
 
   case COAP_MESSAGE_NON:
     /* check for oscore issue or unknown critical options */
-    if (oscore_invalid || coap_option_check_critical(session, pdu, &opt_filter) == 0) {
+    if (oscore_invalid ||
+        coap_option_check_critical(session, pdu, &opt_filter, COAP_CRIT_UNKNOWN) == 0) {
       packet_is_bad = 1;
       if (COAP_PDU_IS_REQUEST(pdu)) {
         response =
@@ -4944,7 +5050,8 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
 
     /* check for oscore issue or unknown critical options in non-signaling messages */
     if (oscore_invalid ||
-        (!COAP_PDU_IS_SIGNALING(pdu) && coap_option_check_critical(session, pdu, &opt_filter) == 0)) {
+        (!COAP_PDU_IS_SIGNALING(pdu) &&
+         coap_option_check_critical(session, pdu, &opt_filter, COAP_CRIT_UNKNOWN) == 0)) {
       packet_is_bad = 1;
       if (COAP_PDU_IS_REQUEST(pdu)) {
         response =
@@ -5423,14 +5530,14 @@ coap_register_dynamic_resource_handler(coap_context_t *context,
 }
 
 COAP_API void
-coap_register_option(coap_context_t *ctx, uint16_t type) {
+coap_register_option(coap_context_t *ctx, coap_option_num_t type) {
   coap_lock_lock(return);
   coap_register_option_lkd(ctx, type);
   coap_lock_unlock();
 }
 
 void
-coap_register_option_lkd(coap_context_t *ctx, uint16_t type) {
+coap_register_option_lkd(coap_context_t *ctx, coap_option_num_t type) {
   coap_option_filter_set(&ctx->known_options, type);
 }
 

--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -614,11 +614,12 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
   /* Copy across the Outer/Inner Options to respective PDUs */
   coap_option_iterator_init(pdu, &opt_iter, COAP_OPT_ALL);
   while ((option = coap_option_next(&opt_iter))) {
-    switch (opt_iter.number) {
+    switch ((coap_code_opt_num_t)opt_iter.number) {
     case COAP_OPTION_URI_HOST:
     case COAP_OPTION_URI_PORT:
     case COAP_OPTION_PROXY_SCHEME:
     case COAP_OPTION_HOP_LIMIT:
+    case COAP_OPTION_EDHOC:
       /* Outer only */
       if (!coap_insert_option(osc_pdu,
                               opt_iter.number,
@@ -660,6 +661,29 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
        */
       assert(0);
       break;
+    case COAP_OPTION_OSCORE:
+      /* Dealt with separately */
+      break;
+    case COAP_OPTION_IF_MATCH:
+    case COAP_OPTION_ETAG:
+    case COAP_OPTION_IF_NONE_MATCH:
+    case COAP_OPTION_LOCATION_PATH:
+    case COAP_OPTION_URI_PATH:
+    case COAP_OPTION_URI_PATH_ABB:
+    case COAP_OPTION_CONTENT_FORMAT:
+    case COAP_OPTION_MAXAGE:
+    case COAP_OPTION_URI_QUERY:
+    case COAP_OPTION_ACCEPT:
+    case COAP_OPTION_Q_BLOCK1:
+    case COAP_OPTION_LOCATION_QUERY:
+    case COAP_OPTION_BLOCK2:
+    case COAP_OPTION_BLOCK1:
+    case COAP_OPTION_SIZE2:
+    case COAP_OPTION_Q_BLOCK2:
+    case COAP_OPTION_SIZE1:
+    case COAP_OPTION_NORESPONSE:
+    case COAP_OPTION_ECHO:
+    case COAP_OPTION_RTAG:
     default:
       /* Make as Inner option */
       if (!coap_insert_option(plain_pdu,
@@ -980,7 +1004,7 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
    */
   coap_option_iterator_init(pdu, &opt_iter, COAP_OPT_ALL);
   while ((opt = coap_option_next(&opt_iter))) {
-    switch (opt_iter.number) {
+    switch ((coap_code_opt_num_t)opt_iter.number) {
     /* 'E' options skipped */
     case COAP_OPTION_IF_MATCH:
     case COAP_OPTION_ETAG:
@@ -988,14 +1012,17 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
     case COAP_OPTION_OBSERVE:
     case COAP_OPTION_LOCATION_PATH:
     case COAP_OPTION_URI_PATH:
+    case COAP_OPTION_URI_PATH_ABB:
     case COAP_OPTION_CONTENT_FORMAT:
     case COAP_OPTION_MAXAGE:
     case COAP_OPTION_URI_QUERY:
     case COAP_OPTION_ACCEPT:
+    case COAP_OPTION_Q_BLOCK1:
     case COAP_OPTION_LOCATION_QUERY:
     case COAP_OPTION_BLOCK2:
     case COAP_OPTION_BLOCK1:
     case COAP_OPTION_SIZE2:
+    case COAP_OPTION_Q_BLOCK2:
     case COAP_OPTION_SIZE1:
     case COAP_OPTION_NORESPONSE:
     case COAP_OPTION_ECHO:
@@ -1003,6 +1030,13 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
     /* OSCORE does not get copied across */
     case COAP_OPTION_OSCORE:
       break;
+    /* 'U' options included */
+    case COAP_OPTION_URI_HOST:
+    case COAP_OPTION_URI_PORT:
+    case COAP_OPTION_HOP_LIMIT:
+    case COAP_OPTION_EDHOC:
+    case COAP_OPTION_PROXY_URI:
+    case COAP_OPTION_PROXY_SCHEME:
     default:
       if (!coap_add_option_internal(decrypt_pdu,
                                     opt_iter.number,

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -41,6 +41,8 @@
 #define max(a,b) ((a) > (b) ? (a) : (b))
 #endif
 
+static int coap_pdu_parse_opt_csm(coap_pdu_code_t code, coap_option_num_t option, uint16_t len);
+
 void
 coap_pdu_clear(coap_pdu_t *pdu, size_t size) {
   assert(pdu);
@@ -635,12 +637,17 @@ coap_remove_option(coap_pdu_t *pdu, coap_option_num_t number) {
 }
 
 int
-coap_option_check_repeatable(coap_option_num_t number) {
+coap_option_check_repeatable(coap_pdu_t *pdu, coap_option_num_t number) {
   /* Validate that the option is repeatable */
-  switch (number) {
+  switch ((coap_code_opt_num_t)number) {
+  case COAP_OPTION_ETAG:
+    if (!COAP_PDU_IS_REQUEST(pdu)) {
+      coap_log_info("Option 'Echo' (4) cannot be repeated on a Response - dropped\n");
+      return 0;
+    }
+    break;
   /* Ignore list of genuine repeatable */
   case COAP_OPTION_IF_MATCH:
-  case COAP_OPTION_ETAG:
   case COAP_OPTION_LOCATION_PATH:
   case COAP_OPTION_URI_PATH:
   case COAP_OPTION_URI_QUERY:
@@ -654,8 +661,8 @@ coap_option_check_repeatable(coap_option_num_t number) {
   case COAP_OPTION_OBSERVE:
   case COAP_OPTION_URI_PORT:
   case COAP_OPTION_OSCORE:
-  case COAP_OPTION_URI_PATH_ABB:
   case COAP_OPTION_CONTENT_FORMAT:
+  case COAP_OPTION_URI_PATH_ABB:
   case COAP_OPTION_MAXAGE:
   case COAP_OPTION_HOP_LIMIT:
   case COAP_OPTION_ACCEPT:
@@ -669,8 +676,8 @@ coap_option_check_repeatable(coap_option_num_t number) {
   case COAP_OPTION_SIZE1:
   case COAP_OPTION_ECHO:
   case COAP_OPTION_NORESPONSE:
-    coap_log_info("Option number %d is not defined as repeatable - dropped\n",
-                  number);
+    coap_log_info("Option '%s' (%d) is not defined as repeatable - dropped\n",
+                  coap_option_string(pdu->code, number), number);
     return 0;
   default:
     coap_log_info("Option number %d is not defined as repeatable\n",
@@ -718,7 +725,7 @@ coap_insert_option(coap_pdu_t *pdu, coap_option_num_t number, size_t len,
     return 0;
   opt_delta = opt_iter.number - number;
   if (opt_delta == 0) {
-    if (!coap_option_check_repeatable(number))
+    if (!coap_option_check_repeatable(pdu, number))
       return 0;
   }
 
@@ -849,7 +856,7 @@ coap_add_option_internal(coap_pdu_t *pdu, coap_option_num_t number, size_t len,
   assert(pdu);
 
   if (number == pdu->max_opt) {
-    if (!coap_option_check_repeatable(number))
+    if (!coap_option_check_repeatable(pdu, number))
       return 0;
   }
 
@@ -1197,67 +1204,67 @@ bad_ext_token:
 }
 
 static int
-coap_pdu_parse_opt_csm(coap_pdu_t *pdu, uint16_t len) {
-  switch ((coap_pdu_signaling_proto_t)pdu->code) {
+coap_pdu_parse_opt_csm(coap_pdu_code_t code, coap_option_num_t option, uint16_t len) {
+  switch ((coap_pdu_signaling_proto_t)code) {
   case COAP_SIGNALING_CSM:
-    switch (pdu->max_opt) {
-    case COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE:
+    switch ((coap_sig_csm_opt_t)option) {
+    case COAP_SIG_OPT_MAX_MESSAGE_SIZE:
       if (len > 4)
         goto bad;
       break;
-    case COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER:
+    case COAP_SIG_OPT_BLOCK_WISE_TRANSFER:
       if (len > 0)
         goto bad;
       break;
-    case COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH:
+    case COAP_SIG_OPT_EXTENDED_TOKEN_LENGTH:
       if (len > 3)
         goto bad;
       break;
     default:
-      if (pdu->max_opt & 0x01)
+      if (option & 0x01)
         goto bad; /* Critical */
     }
     break;
   case COAP_SIGNALING_PING:
   case COAP_SIGNALING_PONG:
-    switch (pdu->max_opt) {
-    case COAP_SIGNALING_OPTION_CUSTODY:
+    switch ((coap_sig_ping_opt_t)option) {
+    case COAP_SIG_OPT_CUSTODY:
       if (len > 0)
         goto bad;
       break;
     default:
-      if (pdu->max_opt & 0x01)
+      if (option & 0x01)
         goto bad; /* Critical */
     }
     break;
   case COAP_SIGNALING_RELEASE:
-    switch (pdu->max_opt) {
-    case COAP_SIGNALING_OPTION_ALTERNATIVE_ADDRESS:
+    switch ((coap_sig_release_opt_t)option) {
+    case COAP_SIG_OPT_ALTERNATIVE_ADDRESS:
       if (len < 1 || len > 255)
         goto bad;
       break;
-    case COAP_SIGNALING_OPTION_HOLD_OFF:
+    case COAP_SIG_OPT_HOLD_OFF:
       if (len > 3)
         goto bad;
       break;
     default:
-      if (pdu->max_opt & 0x01)
+      if (option & 0x01)
         goto bad; /* Critical */
     }
     break;
   case COAP_SIGNALING_ABORT:
-    switch (pdu->max_opt) {
-    case COAP_SIGNALING_OPTION_BAD_CSM_OPTION:
+    switch ((coap_sig_abort_opt_t)option) {
+    case COAP_SIG_OPT_BAD_CSM_OPTION:
       if (len > 2)
         goto bad;
       break;
     default:
-      if (pdu->max_opt & 0x01)
+      if (option & 0x01)
         goto bad; /* Critical */
     }
     break;
   default:
-    ;
+    goto bad;
   }
   return 1;
 bad:
@@ -1268,7 +1275,7 @@ int
 coap_pdu_parse_opt_base(coap_option_num_t number, size_t len, const uint8_t *opt_val) {
   int res = 1;
 
-  switch (number) {
+  switch ((coap_code_opt_num_t)number) {
   case COAP_OPTION_IF_MATCH:
     if (len > 8)
       res = 0;
@@ -1307,6 +1314,10 @@ coap_pdu_parse_opt_base(coap_option_num_t number, size_t len, const uint8_t *opt
     break;
   case COAP_OPTION_CONTENT_FORMAT:
     if (len > 2)
+      res = 0;
+    break;
+  case COAP_OPTION_URI_PATH_ABB:
+    if (len > 4)
       res = 0;
     break;
   case COAP_OPTION_MAXAGE:
@@ -1464,7 +1475,7 @@ coap_pdu_parse_opt(coap_pdu_t *pdu, coap_opt_filter_t *error_opts) {
       len = coap_opt_length((const uint8_t *)opt - optsize);
       opt_val = coap_opt_value((const uint8_t *)opt - optsize);
       if (COAP_PDU_IS_SIGNALING(pdu) ?
-          !coap_pdu_parse_opt_csm(pdu, len) :
+          !coap_pdu_parse_opt_csm(pdu->code, pdu->max_opt, len) :
           !coap_pdu_parse_opt_base(pdu->max_opt, len, opt_val)) {
         coap_log_warn("coap_pdu_parse: %d.%02d: offset %u option %u has bad length %" PRIu32 " or value\n",
                       pdu->code >> 5, pdu->code & 0x1F,
@@ -1508,7 +1519,7 @@ coap_pdu_parse_opt(coap_pdu_t *pdu, coap_opt_filter_t *error_opts) {
               optsize ?  coap_opt_value((const uint8_t *)opt - optsize) : 0;
 
           if (!optsize || (COAP_PDU_IS_SIGNALING(pdu) ?
-                           !coap_pdu_parse_opt_csm(pdu, len) :
+                           !coap_pdu_parse_opt_csm(pdu->code, pdu->max_opt, len) :
                            !coap_pdu_parse_opt_base(pdu->max_opt, len, opt_val))) {
             ok = ok && write_prefix(&obp, &outbuflen, "*", 1);
             if (!optsize) {

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -797,6 +797,14 @@ coap_proxy_call_response_handler(coap_session_t *session, const coap_pdu_t *sent
   size_t total;
   const uint8_t *data;
   coap_string_t *l_query = NULL;
+  coap_opt_filter_t opt_filter;
+
+  coap_option_filter_clear(&opt_filter);
+  if (!coap_option_check_critical(session, rcvd, &opt_filter, COAP_CRIT_PROXY)) {
+    /* Need to send back a 5.02 response */
+    coap_send_error_lkd(session, rcvd, COAP_RESPONSE_CODE(502), &opt_filter);
+    return COAP_RESPONSE_FAIL;
+  }
 
   if (remove_observe) {
     coap_opt_filter_t drop_options;

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -870,15 +870,15 @@ coap_session_send_csm(coap_session_t *session) {
     coap_session_set_mtu(session, COAP_DEFAULT_MTU);  /* base value */
   pdu = coap_pdu_init(COAP_MESSAGE_CON, COAP_SIGNALING_CODE_CSM, 0, 20);
   if (pdu == NULL
-      || coap_add_option_internal(pdu, COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE,
+      || coap_add_option_internal(pdu, (coap_option_num_t)COAP_SIG_OPT_MAX_MESSAGE_SIZE,
                                   coap_encode_var_safe(buf, sizeof(buf),
                                                        session->context->csm_max_message_size), buf) == 0
-      || coap_add_option_internal(pdu, COAP_SIGNALING_OPTION_BLOCK_WISE_TRANSFER,
+      || coap_add_option_internal(pdu, (coap_option_num_t)COAP_SIG_OPT_BLOCK_WISE_TRANSFER,
                                   coap_encode_var_safe(buf, sizeof(buf),
                                                        0), buf) == 0
       || (session->max_token_size > COAP_TOKEN_DEFAULT_MAX &&
           coap_add_option_internal(pdu,
-                                   COAP_SIGNALING_OPTION_EXTENDED_TOKEN_LENGTH,
+                                   (coap_option_num_t)COAP_SIG_OPT_EXTENDED_TOKEN_LENGTH,
                                    coap_encode_var_safe(buf, sizeof(buf),
                                                         session->max_token_size),
                                    buf) == 0)

--- a/tests/oss-fuzz/network_message_target.c
+++ b/tests/oss-fuzz/network_message_target.c
@@ -87,7 +87,7 @@ test_reliable_transport(coap_context_t *ctx, coap_session_t *session,
                             (uint32_t)data[3];
     if (max_msg_size >= 64) {
       uint8_t buf[4];
-      coap_insert_option(pdu, COAP_SIGNALING_OPTION_MAX_MESSAGE_SIZE,
+      coap_insert_option(pdu, (coap_option_num_t)COAP_SIG_OPT_MAX_MESSAGE_SIZE,
                          coap_encode_var_safe(buf, sizeof(buf), max_msg_size),
                          buf);
     }

--- a/tests/test_pdu.c
+++ b/tests/test_pdu.c
@@ -275,6 +275,7 @@ t_parse_pdu15(void) {
 
   CU_ASSERT(pdu->data == NULL);
 
+  coap_set_log_level(COAP_LOG_CRIT);
   result = coap_pdu_parse(COAP_PROTO_UDP, teststr, sizeof(teststr), pdu);
   CU_ASSERT(result == 0);
 }


### PR DESCRIPTION
Generally re-organize option handling, making use of enums etc.

This also updates critical options checks, and well as repeatable options.