### PR TITLE
LwIP: Allocate semaphores per context for NO_SYS == 0

### DIFF
--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -97,6 +97,9 @@ struct coap_context_t {
   uint8_t timer_configured;       /**< Set to 1 when a retransmission is
                                    *   scheduled using lwIP timers for this
                                    *   context, otherwise 0. */
+#if NO_SYS == 0
+  sys_sem_t coap_io_timeout_sem; /**< Semaphore to wait on for input activity */
+#endif /* NO_SYS == 0 */
 #endif /* WITH_LWIP */
 #ifdef RIOT_VERSION
   thread_t *selecting_thread;

--- a/src/coap_dgrm_lwip.c
+++ b/src/coap_dgrm_lwip.c
@@ -27,7 +27,6 @@
 #endif /* !COAP_DISABLE_TCP */
 
 #if NO_SYS == 0
-extern sys_sem_t coap_io_timeout_sem;
 extern uint32_t coap_lwip_in_call_back_ref;
 #endif /* NO_SYS == 0 */
 
@@ -110,7 +109,7 @@ coap_recvc(void *arg, struct udp_pcb *upcb, struct pbuf *p,
         coap_delete_pdu_lkd(pdu);
         coap_lock_unlock();
 #if NO_SYS == 0
-        sys_sem_signal(&coap_io_timeout_sem);
+        sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
         return;
       } else {
@@ -126,7 +125,7 @@ coap_recvc(void *arg, struct udp_pcb *upcb, struct pbuf *p,
 #endif /* NO_SYS == 0 */
   }
 #if NO_SYS == 0
-  sys_sem_signal(&coap_io_timeout_sem);
+  sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
   coap_delete_pdu_lkd(pdu);
   coap_lock_unlock();
@@ -142,7 +141,7 @@ error:
   coap_delete_pdu_lkd(pdu);
   coap_lock_unlock();
 #if NO_SYS == 0
-  sys_sem_signal(&coap_io_timeout_sem);
+  sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
   return;
 }
@@ -251,7 +250,7 @@ coap_udp_recvs(void *arg, struct udp_pcb *upcb, struct pbuf *p,
   coap_free_packet(packet);
   coap_lock_unlock();
 #if NO_SYS == 0
-  sys_sem_signal(&coap_io_timeout_sem);
+  sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
   return;
 
@@ -270,7 +269,7 @@ cleanup:
   coap_free_packet(packet);
   coap_lock_unlock();
 #if NO_SYS == 0
-  sys_sem_signal(&coap_io_timeout_sem);
+  sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
   return;
 }

--- a/src/coap_io_lwip.c
+++ b/src/coap_io_lwip.c
@@ -24,7 +24,6 @@
 #include <lwip/tcpip.h>
 
 #if NO_SYS == 0
-sys_sem_t coap_io_timeout_sem;
 uint32_t coap_lwip_in_call_back_ref = 0; /* Used if in LwIP call back, under
                                             protection of global lock if
                                             thread safe libcoap code */
@@ -40,24 +39,18 @@ coap_lwip_set_input_wait_handler(coap_context_t *context,
 
 void
 coap_io_lwip_init(void) {
-#if NO_SYS == 0
-  if (sys_sem_new(&coap_io_timeout_sem, 0) != ERR_OK)
-    coap_log_warn("coap_io_lwip_init: Failed to set up semaphore\n");
-#endif /* NO_SYS == 0 */
 }
 
 void
 coap_io_lwip_cleanup(void) {
-#if NO_SYS == 0
-  sys_sem_free(&coap_io_timeout_sem);
-#endif /* NO_SYS == 0 */
 }
 
 void
 coap_io_process_timeout(void *arg) {
   (void)arg;
 #if NO_SYS == 0
-  sys_sem_signal(&coap_io_timeout_sem);
+  coap_context_t *context = (coap_context_t *)arg;
+  sys_sem_signal(&context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
 }
 
@@ -116,7 +109,7 @@ coap_io_process_lkd(coap_context_t *context, uint32_t timeout_ms) {
                                return 0);
 #if NO_SYS == 0
   } else {
-    coap_lock_callback_release(sys_arch_sem_wait(&coap_io_timeout_sem, timeout),
+    coap_lock_callback_release(sys_arch_sem_wait(&context->coap_io_timeout_sem, timeout),
                                return 0);
 #endif /* NO_SYS == 0 */
   }

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -805,6 +805,12 @@ coap_new_context(const coap_address_t *listen_addr) {
 
   c->max_token_size = COAP_TOKEN_DEFAULT_MAX; /* RFC8974 */
 
+#if defined(WITH_LWIP)
+#if NO_SYS == 0
+  if (sys_sem_new(&c->coap_io_timeout_sem, 0) != ERR_OK)
+    coap_log_warn("coap_new_context: Failed to set up semaphore\n");
+#endif /* NO_SYS == 0 */
+#endif /* ! WITH_LWIP */
   coap_lock_unlock();
   return c;
 
@@ -933,6 +939,11 @@ coap_free_context_lkd(coap_context_t *context) {
   if (context->app_cb) {
     coap_lock_callback(context->app_cb(context->app_data));
   }
+#if defined(WITH_LWIP)
+#if NO_SYS == 0
+  sys_sem_free(&context->coap_io_timeout_sem);
+#endif /* NO_SYS == 0 */
+#endif /* ! WITH_LWIP */
 #if COAP_THREAD_SAFE && !WITH_LWIP
   coap_io_process_remove_threads_lkd(context);
 #endif /* COAP_THREAD_SAFE && !WITH_LWIP */

--- a/src/coap_strm_lwip.c
+++ b/src/coap_strm_lwip.c
@@ -31,7 +31,6 @@ coap_tcp_is_supported(void) {
 #include <lwip/tcp.h>
 
 #if NO_SYS == 0
-extern sys_sem_t coap_io_timeout_sem;
 extern uint32_t coap_lwip_in_call_back_ref;
 #endif /* NO_SYS == 0 */
 
@@ -68,7 +67,7 @@ do_tcp_err(void *arg, err_t err) {
 #endif /* NO_SYS == 0 */
   coap_lock_unlock();
 #if NO_SYS == 0
-  sys_sem_signal(&coap_io_timeout_sem);
+  sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
 }
 
@@ -97,7 +96,7 @@ coap_tcp_recv(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err) {
     coap_session_disconnected_lkd(session, COAP_NACK_NOT_DELIVERABLE);
     coap_lock_unlock();
 #if NO_SYS == 0
-    sys_sem_signal(&coap_io_timeout_sem);
+    sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
     return ERR_OK;
   } else if (err != ERR_OK) {
@@ -107,7 +106,7 @@ coap_tcp_recv(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err) {
     }
     tcp_recved(sock->tcp_pcb, p->tot_len);
 #if NO_SYS == 0
-    sys_sem_signal(&coap_io_timeout_sem);
+    sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
     return err;
   }
@@ -124,7 +123,7 @@ coap_tcp_recv(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err) {
 #endif /* NO_SYS == 0 */
   coap_lock_unlock();
 #if NO_SYS == 0
-  sys_sem_signal(&coap_io_timeout_sem);
+  sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
   return ERR_OK;
 }
@@ -153,7 +152,7 @@ do_tcp_connected(void *arg, struct tcp_pcb *tpcb, err_t err) {
 #endif /* NO_SYS == 0 */
   coap_lock_unlock();
 #if NO_SYS == 0
-  sys_sem_signal(&coap_io_timeout_sem);
+  sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
   return ERR_OK;
 }
@@ -263,7 +262,7 @@ do_tcp_accept(void *arg, struct tcp_pcb *newpcb, err_t err) {
 #endif /* NO_SYS == 0 */
   coap_lock_unlock();
 #if NO_SYS == 0
-  sys_sem_signal(&coap_io_timeout_sem);
+  sys_sem_signal(&session->context->coap_io_timeout_sem);
 #endif /* NO_SYS == 0 */
   return ret_err;
 }
@@ -342,7 +341,7 @@ coap_lwip_tcp_write(void *ctx) {
     }
     pbuf_free(cb_ctx->pbuf);
     coap_free_type(COAP_STRING, cb_ctx);
-    sys_sem_signal(&coap_io_timeout_sem);
+    sys_sem_signal(&cb_ctx->session->context->coap_io_timeout_sem);
   }
 }
 #endif /* NO_SYS == 0 */


### PR DESCRIPTION
Each LwIP coap_context_t must now periodically call coap_io_process().