### PR TITLE
Fix data race in coap_resolve_address_info()

### DIFF
--- a/include/coap3/coap_address.h
+++ b/include/coap3/coap_address.h
@@ -256,6 +256,9 @@ typedef enum coap_resolve_type_t {
  * Resolve the specified @p address into a set of coap_address_t that can
  * be used to bind() (local) or connect() (remote) to.
  *
+ * Note: coap_startup() must have been called first, otherwise @c NULL
+ *       is returned.
+ *
  * @param address The Address to resolve.
  * @param port    The unsecured protocol port to use.
  * @param secure_port The secured protocol port to use.
@@ -268,14 +271,14 @@ typedef enum coap_resolve_type_t {
  *
  * @return One or more linked sets of coap_addr_info_t or @c NULL if error.
  */
-coap_addr_info_t *coap_resolve_address_info(const coap_str_const_t *address,
-                                            uint16_t port,
-                                            uint16_t secure_port,
-                                            uint16_t ws_port,
-                                            uint16_t ws_secure_port,
-                                            int ai_hints_flags,
-                                            int scheme_hint_bits,
-                                            coap_resolve_type_t type);
+COAP_API coap_addr_info_t *coap_resolve_address_info(const coap_str_const_t *address,
+                                                     uint16_t port,
+                                                     uint16_t secure_port,
+                                                     uint16_t ws_port,
+                                                     uint16_t ws_secure_port,
+                                                     int ai_hints_flags,
+                                                     int scheme_hint_bits,
+                                                     coap_resolve_type_t type);
 
 /**
  * Free off the one or more linked sets of coap_addr_info_t returned from

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -276,6 +276,33 @@ COAP_API int coap_delete_node(coap_queue_t *node);
 int coap_delete_node_lkd(coap_queue_t *node);
 
 /**
+ * Resolve the specified @p address into a set of coap_address_t that can
+ * be used to bind() (local) or connect() (remote) to.
+ *
+ * Note: This function must be called in the locked state.
+ *
+ * @param address The Address to resolve.
+ * @param port    The unsecured protocol port to use.
+ * @param secure_port The secured protocol port to use.
+ * @param ws_port The unsecured WebSockets port to use.
+ * @param ws_secure_port The secured WebSockets port to use.
+ * @param ai_hints_flags AI_* Hint flags to use for internal getaddrinfo().
+ * @param scheme_hint_bits Which schemes to return information for. One or
+ *                         more of COAP_URI_SCHEME_*_BIT or'd together.
+ * @param type COAP_ADDRESS_TYPE_LOCAL or COAP_ADDRESS_TYPE_REMOTE
+ *
+ * @return One or more linked sets of coap_addr_info_t or @c NULL if error.
+ */
+coap_addr_info_t *coap_resolve_address_info_lkd(const coap_str_const_t *address,
+                                                uint16_t port,
+                                                uint16_t secure_port,
+                                                uint16_t ws_port,
+                                                uint16_t ws_secure_port,
+                                                int ai_hints_flags,
+                                                int scheme_hint_bits,
+                                                coap_resolve_type_t type);
+
+/**
  * Removes all items from given @p queue and frees the allocated storage.
  *
  * Internal function.

--- a/src/coap_address.c
+++ b/src/coap_address.c
@@ -666,14 +666,14 @@ update_coap_addr_port(coap_uri_scheme_t scheme, coap_addr_info_t *info,
 #if defined(WITH_LWIP) && !(LWIP_DNS)
 
 coap_addr_info_t *
-coap_resolve_address_info(const coap_str_const_t *address,
-                          uint16_t port,
-                          uint16_t secure_port,
-                          uint16_t ws_port,
-                          uint16_t ws_secure_port,
-                          int ai_hints_flags,
-                          int scheme_hint_bits,
-                          coap_resolve_type_t type) {
+coap_resolve_address_info_lkd(const coap_str_const_t *address,
+                              uint16_t port,
+                              uint16_t secure_port,
+                              uint16_t ws_port,
+                              uint16_t ws_secure_port,
+                              int ai_hints_flags,
+                              int scheme_hint_bits,
+                              coap_resolve_type_t type) {
   ip_addr_t addr_ip;
   coap_addr_info_t *info = NULL;
   coap_addr_info_t *info_prev = NULL;
@@ -681,6 +681,8 @@ coap_resolve_address_info(const coap_str_const_t *address,
   coap_uri_scheme_t scheme;
 
   (void)ai_hints_flags;
+
+  coap_lock_check_locked();
 
   if (address == NULL || address->length == 0) {
     memset(&addr_ip, 0, sizeof(addr_ip));
@@ -718,24 +720,30 @@ coap_resolve_address_info(const coap_str_const_t *address,
 #elif !defined(RIOT_VERSION) && !defined(WITH_CONTIKI)
 
 coap_addr_info_t *
-coap_resolve_address_info(const coap_str_const_t *address,
-                          uint16_t port,
-                          uint16_t secure_port,
-                          uint16_t ws_port,
-                          uint16_t ws_secure_port,
-                          int ai_hints_flags,
-                          int scheme_hint_bits,
-                          coap_resolve_type_t type) {
+coap_resolve_address_info_lkd(const coap_str_const_t *address,
+                              uint16_t port,
+                              uint16_t secure_port,
+                              uint16_t ws_port,
+                              uint16_t ws_secure_port,
+                              int ai_hints_flags,
+                              int scheme_hint_bits,
+                              coap_resolve_type_t type) {
 
   struct addrinfo *res, *ainfo;
   struct addrinfo hints;
+#if COAP_CONSTRAINED_STACK
   static char addrstr[256];
+#else /* ! COAP_CONSTRAINED_STACK */
+  char addrstr[256];
+#endif /* ! COAP_CONSTRAINED_STACK */
   int error;
   coap_addr_info_t *info = NULL;
   coap_addr_info_t *info_prev = NULL;
   coap_addr_info_t *info_list = NULL;
   coap_addr_info_t *info_tmp;
   coap_uri_scheme_t scheme;
+
+  coap_lock_check_locked();
 
 #if COAP_AF_UNIX_SUPPORT
   if (address && coap_host_is_unix_domain(address)) {
@@ -915,14 +923,14 @@ coap_resolve_address_info(const coap_str_const_t *address,
 #include "net/utils.h"
 
 coap_addr_info_t *
-coap_resolve_address_info(const coap_str_const_t *address,
-                          uint16_t port,
-                          uint16_t secure_port,
-                          uint16_t ws_port,
-                          uint16_t ws_secure_port,
-                          int ai_hints_flags,
-                          int scheme_hint_bits,
-                          coap_resolve_type_t type) {
+coap_resolve_address_info_lkd(const coap_str_const_t *address,
+                              uint16_t port,
+                              uint16_t secure_port,
+                              uint16_t ws_port,
+                              uint16_t ws_secure_port,
+                              int ai_hints_flags,
+                              int scheme_hint_bits,
+                              coap_resolve_type_t type) {
 #if COAP_IPV6_SUPPORT
   ipv6_addr_t addr_ipv6;
 #endif /* COAP_IPV6_SUPPORT */
@@ -936,6 +944,8 @@ coap_resolve_address_info(const coap_str_const_t *address,
   coap_uri_scheme_t scheme;
   (void)ai_hints_flags;
   int family = AF_UNSPEC;
+
+  coap_lock_check_locked();
 
   if (address == NULL || address->length == 0) {
     memset(&addr_ipv6, 0, sizeof(addr_ipv6));
@@ -1009,14 +1019,14 @@ coap_resolve_address_info(const coap_str_const_t *address,
 #include <os/net/ipv6/uiplib.h>
 
 coap_addr_info_t *
-coap_resolve_address_info(const coap_str_const_t *address,
-                          uint16_t port,
-                          uint16_t secure_port,
-                          uint16_t ws_port,
-                          uint16_t ws_secure_port,
-                          int ai_hints_flags,
-                          int scheme_hint_bits,
-                          coap_resolve_type_t type) {
+coap_resolve_address_info_lkd(const coap_str_const_t *address,
+                              uint16_t port,
+                              uint16_t secure_port,
+                              uint16_t ws_port,
+                              uint16_t ws_secure_port,
+                              int ai_hints_flags,
+                              int scheme_hint_bits,
+                              coap_resolve_type_t type) {
   uip_ipaddr_t addr_ip;
   coap_addr_info_t *info = NULL;
   coap_addr_info_t *info_prev = NULL;
@@ -1025,6 +1035,8 @@ coap_resolve_address_info(const coap_str_const_t *address,
   int parsed_ip = 0;
 
   (void)ai_hints_flags;
+
+  coap_lock_check_locked();
 
   if (address == NULL || address->length == 0) {
     memset(&addr_ip, 0, sizeof(addr_ip));
@@ -1075,6 +1087,20 @@ coap_resolve_address_info(const coap_str_const_t *address,
 #error "OS type not supported"
 
 coap_addr_info_t *
+coap_resolve_address_info_lkd(const coap_str_const_t *address,
+                              uint16_t port,
+                              uint16_t secure_port,
+                              uint16_t ws_port,
+                              uint16_t ws_secure_port,
+                              int ai_hints_flags,
+                              int scheme_hint_bits,
+                              coap_resolve_type_t type) {
+  return NULL;
+}
+
+#endif
+
+COAP_API coap_addr_info_t *
 coap_resolve_address_info(const coap_str_const_t *address,
                           uint16_t port,
                           uint16_t secure_port,
@@ -1083,10 +1109,15 @@ coap_resolve_address_info(const coap_str_const_t *address,
                           int ai_hints_flags,
                           int scheme_hint_bits,
                           coap_resolve_type_t type) {
-  return NULL;
-}
+  coap_addr_info_t *info_list;
 
-#endif
+  coap_lock_lock(return NULL);
+  info_list = coap_resolve_address_info_lkd(address, port, secure_port, ws_port,
+                                            ws_secure_port, ai_hints_flags,
+                                            scheme_hint_bits, type);
+  coap_lock_unlock();
+  return info_list;
+}
 
 void
 coap_free_address_info(coap_addr_info_t *info) {

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -602,14 +602,14 @@ coap_proxy_get_ongoing_session(coap_session_t *session,
     coap_address_t *local_addr = NULL;
 
     /* resolve destination address where data should be sent */
-    info_list = coap_resolve_address_info(&server_use.uri.host,
-                                          server_use.uri.port,
-                                          server_use.uri.port,
-                                          server_use.uri.port,
-                                          server_use.uri.port,
-                                          0,
-                                          1 << server_use.uri.scheme,
-                                          COAP_RESOLVE_TYPE_REMOTE);
+    info_list = coap_resolve_address_info_lkd(&server_use.uri.host,
+                                              server_use.uri.port,
+                                              server_use.uri.port,
+                                              server_use.uri.port,
+                                              server_use.uri.port,
+                                              0,
+                                              1 << server_use.uri.scheme,
+                                              COAP_RESOLVE_TYPE_REMOTE);
 
     if (info_list == NULL) {
       response->code = COAP_RESPONSE_CODE(502);
@@ -1644,10 +1644,10 @@ coap_new_client_session_proxy_lkd(coap_context_t *ctx,
 #endif /* !COAP_IPV6_SUPPORT && ! COAP_IPV4_SUPPORT */
   remote.length = strlen((const char *)remote.s);
   /* resolve internal remote address where proxy session is 'connecting' to */
-  info_list = coap_resolve_address_info(&remote, 0, 0, 0, 0,
-                                        0,
-                                        1 << COAP_URI_SCHEME_COAP,
-                                        COAP_RESOLVE_TYPE_REMOTE);
+  info_list = coap_resolve_address_info_lkd(&remote, 0, 0, 0, 0,
+                                            0,
+                                            1 << COAP_URI_SCHEME_COAP,
+                                            COAP_RESOLVE_TYPE_REMOTE);
   if (!info_list) {
     coap_log_warn("coap_new_client_session_proxy: Unable to resolve IP address\n");
     return NULL;


### PR DESCRIPTION
Steps to reproduce:

```sh
./autogen.sh

CFLAGS="-fsanitize=thread -g -O0" LDFLAGS="-fsanitize=thread" \
  ./configure --enable-thread-safe \
              --disable-doxygen --disable-manpages \
              --disable-dtls --disable-examples

make -j"$(nproc)"
```

`race.c`:
```c
#include <coap3/coap.h>
#include <pthread.h>
#include <stdint.h>
#include <string.h>

static void *worker(void *arg) {
    const char *host = (const char *)arg;
    for (int i = 0; i < 5000; ++i) {
        coap_str_const_t h = {strlen(host), (const uint8_t *)host};
        coap_addr_info_t *info = coap_resolve_address_info(
            &h, 5683, 5683, 0, 0, 0, 1 << COAP_URI_SCHEME_COAP, COAP_RESOLVE_TYPE_REMOTE);
        if (info) coap_free_address_info(info);
    }
    return NULL;
}
int main(void) {
    coap_startup();
    pthread_t a, b;
    pthread_create(&a, NULL, worker, (void *)"127.0.0.1");
    pthread_create(&b, NULL, worker, (void *)"127.0.0.2");
    pthread_join(a, NULL); pthread_join(b, NULL);
    coap_cleanup();
    return 0;
}
```

```sh
cc -fsanitize=thread -g race.c \
   -Iinclude .libs/libcoap-3-notls.a -lpthread -o race
./race
```

This should result in a ThreadSanitizer: data race.