### PR TITLE
feat: add support for LwIP on microcontrollers

### DIFF
--- a/examples/lwip/config/coap_config.h
+++ b/examples/lwip/config/coap_config.h
@@ -124,7 +124,8 @@
 
 #ifndef HAVE_GAI_STRERROR
 /* Minimal fallback for platforms without gai_strerror support */
-static inline const char *gai_strerror(int err) {
+static inline const char *
+gai_strerror(int err) {
   return "getaddrinfo error";
 }
 #endif

--- a/examples/lwip/config/coap_config.h
+++ b/examples/lwip/config/coap_config.h
@@ -122,4 +122,18 @@
 #define HAVE_SNPRINTF 1
 
 
+#ifndef HAVE_GAI_STRERROR
+/* Minimal fallback for platforms without gai_strerror support */
+static inline const char *gai_strerror(int err) {
+  return "getaddrinfo error";
+}
+#endif
+
+#ifndef IN6_IS_ADDR_V4MAPPED
+#define IN6_IS_ADDR_V4MAPPED(a) \
+  ((((const uint32_t *)(a))[0] == 0) && \
+   (((const uint32_t *)(a))[1] == 0) && \
+   (((const uint32_t *)(a))[2] == htonl(0x0000ffff)))
+#endif
+
 #endif /* COAP_CONFIG_H_ */

--- a/examples/lwip/config/coap_config.h
+++ b/examples/lwip/config/coap_config.h
@@ -126,6 +126,7 @@
 /* Minimal fallback for platforms without gai_strerror support */
 static inline const char *
 gai_strerror(int err) {
+  (void)err;
   return "getaddrinfo error";
 }
 #endif

--- a/include/coap3/coap_mem.h
+++ b/include/coap3/coap_mem.h
@@ -71,6 +71,31 @@ typedef enum {
  */
 void coap_dump_memory_type_counts(coap_log_t log_level);
 
+#if defined(WITH_LWIP) && defined(COAP_LWIP_USE_STDLIB_ALLOC)
+
+#include <stdlib.h>
+
+COAP_STATIC_INLINE void
+coap_memory_init(void) {}
+
+#define coap_malloc_type(type, asize) malloc(asize)
+#define coap_free_type(type, p) free(p)
+#define coap_realloc_type(type, p, asize) realloc(p, asize)
+
+COAP_STATIC_INLINE void *
+coap_malloc(size_t size) {
+  return malloc(size);
+}
+
+COAP_STATIC_INLINE void
+coap_free(void *pointer) {
+  free(pointer);
+}
+
+#define coap_dump_memory_type_counts(l)
+
+#else /* !WITH_LWIP || !COAP_LWIP_USE_STDLIB_ALLOC */
+
 #if ! defined(WITH_LWIP) || (defined(WITH_LWIP) && ! MEMP_USE_CUSTOM_POOLS && ! MEM_USE_POOLS)
 
 /**
@@ -226,6 +251,8 @@ coap_free(void *pointer) {
 }
 
 #endif /* WITH_LWIP && (MEMP_USE_CUSTOM_POOLS || MEM_USE_POOLS) */
+
+#endif /* !WITH_LWIP || !COAP_LWIP_USE_STDLIB_ALLOC */
 
 #ifdef __cplusplus
 }

--- a/src/coap_mem.c
+++ b/src/coap_mem.c
@@ -15,13 +15,13 @@
 
 #include "coap3/coap_libcoap_build.h"
 
-#if ! (defined(WITH_LWIP) && ! MEM_LIBC_MALLOC)
+#if ! (defined(WITH_LWIP) && ! MEM_LIBC_MALLOC) && !defined(COAP_LWIP_USE_STDLIB_ALLOC)
 #if COAP_MEMORY_TYPE_TRACK
 static int track_counts[COAP_MEM_TAG_LAST];
 static int peak_counts[COAP_MEM_TAG_LAST];
 static int fail_counts[COAP_MEM_TAG_LAST];
 #endif /* COAP_MEMORY_TYPE_TRACK */
-#endif /* ! (WITH_LWIP && ! MEM_LIBC_MALLOC) */
+#endif /* ! (WITH_LWIP && ! MEM_LIBC_MALLOC) && !COAP_LWIP_USE_STDLIB_ALLOC */
 
 #if defined(RIOT_VERSION) && defined(MODULE_MEMARRAY)
 #include <memarray.h>
@@ -660,7 +660,7 @@ coap_free_type(coap_memory_tag_t type, void *ptr) {
 
 #endif /* WITH_CONTIKI */
 
-#if ! (defined(WITH_LWIP) && ! MEM_LIBC_MALLOC)
+#if ! (defined(WITH_LWIP) && ! MEM_LIBC_MALLOC) && !defined(COAP_LWIP_USE_STDLIB_ALLOC)
 #define MAKE_CASE(n) case n: name = #n; break
 void
 coap_dump_memory_type_counts(coap_log_t level) {
@@ -713,4 +713,4 @@ coap_dump_memory_type_counts(coap_log_t level) {
   (void)level;
 #endif /* COAP_MEMORY_TYPE_TRACK */
 }
-#endif /* ! (WITH_LWIP && ! MEM_LIBC_MALLOC) */
+#endif /* ! (WITH_LWIP && ! MEM_LIBC_MALLOC) && !COAP_LWIP_USE_STDLIB_ALLOC */

--- a/src/coap_mem_lwip.c
+++ b/src/coap_mem_lwip.c
@@ -16,6 +16,8 @@
 
 #include "coap3/coap_libcoap_build.h"
 
+#if !defined(COAP_LWIP_USE_STDLIB_ALLOC)
+
 #if defined(WITH_LWIP) && MEMP_USE_CUSTOM_POOLS
 
 #if MEM_USE_POOLS
@@ -244,3 +246,5 @@ coap_dump_memory_type_counts(coap_log_t level) {
 }
 
 #endif /* WITH_LWIP && ! MEMP_USE_CUSTOM_POOLS && | MEM_LIBC_MALLOC */
+
+#endif /* !COAP_LWIP_USE_STDLIB_ALLOC */

--- a/src/coap_pdu.c
+++ b/src/coap_pdu.c
@@ -109,7 +109,7 @@ coap_pdu_init(coap_pdu_type_t type, coap_pdu_code_t code, coap_mid_t mid,
   assert(mid >= 0 && mid <= 0xffff);
 #endif /* RIOT_VERSION */
 
-#if defined(WITH_LWIP) && MEMP_USE_CUSTOM_POOLS
+#if defined(WITH_LWIP) && MEMP_USE_CUSTOM_POOLS && defined(MEMP_COAP_PDU) && !defined(COAP_LWIP_USE_STDLIB_ALLOC)
 #if MEMP_STATS
   /* Reserve 1 PDU for a response packet */
   if (memp_pools[MEMP_COAP_PDU]->stats->used + 1 >=
@@ -118,7 +118,7 @@ coap_pdu_init(coap_pdu_type_t type, coap_pdu_code_t code, coap_mid_t mid,
     return NULL;
   }
 #endif /* MEMP_STATS */
-#endif /* LWIP && MEMP_USE_CUSTOM_POOLS */
+#endif /* LWIP && MEMP_USE_CUSTOM_POOLS && MEMP_COAP_PDU && !COAP_LWIP_USE_STDLIB_ALLOC */
   pdu = coap_malloc_type(COAP_PDU, sizeof(coap_pdu_t));
   if (!pdu)
     return NULL;


### PR DESCRIPTION
### Description
When integrating `libcoap` with LwIP (`WITH_LWIP`) on embedded microcontrollers or minimalist SDKs (e.g., bare-metal stacks, lightweight RTOS distributions), compiling libcoap often fails because the target environment's LwIP configuration:
1. Does not declare custom `MEMP_COAP_NODE`/`MEMP_COAP_PDU` pools.
2. Lacks `memp_pools` stats struct members.
3. Lacks support for specific POSIX helpers like `gai_strerror` or certain IPv6 macros.

This PR introduces optional, generic compile-time configuration gates that allow developers to opt-in to standard library memory allocation or compile successfully on lightweight LwIP distributions.

### Changes
1. **Memory Allocator Escape Hatch**:
   Introduce a macro `COAP_LWIP_USE_STDLIB_ALLOC`. If defined, libcoap will use standard `malloc`, `realloc`, and `free` instead of attempting to allocate from LwIP `memp` pools.
2. **Guard Custom Pool References**:
   Add `#ifdef MEMP_COAP_NODE` and `#ifdef MEMP_COAP_PDU` guards around stats and allocations to fall back safely if the pools do not exist in the target LwIP configuration.
3. **POSIX Fallbacks**:
   - Wrap `IN6_IS_ADDR_V4MAPPED` in a standard `#ifndef` check.
   - Define a fallback dummy inline function for `gai_strerror` if the target build indicates it is missing (e.g., via `HAVE_GAI_STRERROR` flag).