### PR TITLE
OSS-FUZZ: Support different architectures and engines

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,9 +240,11 @@ WARNING_CFLAGS="\
 -Wwrite-strings \
 "
 
+CC_BASE_NAME=`basename $CC`
+
 # check whether or not the compiler supports -Wlogical-op (clang does not...)
-# Note oss-fuzz uses clang and adds in option -Wno-error=unknown-warning-option which overrides -Werror
-if test "x$CC" != "xclang"; then
+# Note oss-fuzz uses clang / afl and adds in option -Wno-error=unknown-warning-option which overrides -Werror
+if test "x$CC_BASE_NAME" != "xclang" -a "x$CC_BASE_NAME" != "xafl-clang-fast" ; then
     AX_CHECK_COMPILE_FLAG([-Wlogical-op], [WARNING_CFLAGS="$WARNING_CFLAGS -Wlogical-op"],,[-Werror])
 fi
 AX_CHECK_COMPILE_FLAG([-fdiagnostics-color], [CFLAGS="$CFLAGS -fdiagnostics-color"],,[-Werror])

--- a/tests/oss-fuzz/Makefile.ci.in
+++ b/tests/oss-fuzz/Makefile.ci.in
@@ -13,7 +13,7 @@ OUT?=.
 libcoap?=libcoap-@LIBCOAP_NAME_SUFFIX@
 WARNING_CFLAGS?=@WARNING_CFLAGS@
 DTLS_CFLAGS?=@DTLS_CFLAGS@
-DTLS_LIBS?=@DTLS_LIBS@
+DTLS_LIBS?=-Wl,-Bstatic @DTLS_LIBS@ -Wl,-Bdynamic
 CPPFLAGS=-I$(top_builddir)/include -I$(top_srcdir)/include -I$(top_srcdir)
 CFLAGS+=$(WARNING_CFLAGS) $(DTLS_CFLAGS) -std=c99
 CFLAGS+=-Wno-missing-prototypes -Wno-missing-declarations

--- a/tests/oss-fuzz/Makefile.oss-fuzz
+++ b/tests/oss-fuzz/Makefile.oss-fuzz
@@ -3,7 +3,7 @@
 top_builddir=../..
 top_srcdir=../..
 
-LDLIBS+=-lFuzzingEngine
+LDLIBS+=$(LIB_FUZZING_ENGINE)
 export LDLIBS
 
 .PHONY: oss-fuzz clean

--- a/tests/oss-fuzz/pdu_parse_tcp_target.c
+++ b/tests/oss-fuzz/pdu_parse_tcp_target.c
@@ -7,7 +7,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   coap_startup();
   pdu = coap_pdu_init(0, 0, 0, size);
   if (pdu) {
-    coap_set_log_level(COAP_LOG_ERR);
+    coap_set_log_level(COAP_LOG_EMERG);
     if (coap_pdu_parse(COAP_PROTO_TCP, data, size, pdu)) {
       coap_string_t *query = coap_get_query(pdu);
       coap_string_t *uri_path = coap_get_uri_path(pdu);

--- a/tests/oss-fuzz/pdu_parse_udp_target.c
+++ b/tests/oss-fuzz/pdu_parse_udp_target.c
@@ -7,7 +7,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   coap_startup();
   pdu = coap_pdu_init(0, 0, 0, size);
   if (pdu) {
-    coap_set_log_level(COAP_LOG_ERR);
+    coap_set_log_level(COAP_LOG_EMERG);
     if (coap_pdu_parse(COAP_PROTO_UDP, data, size, pdu)) {
       coap_string_t *query = coap_get_query(pdu);
       coap_string_t *uri_path = coap_get_uri_path(pdu);

--- a/tests/oss-fuzz/pdu_parse_ws_target.c
+++ b/tests/oss-fuzz/pdu_parse_ws_target.c
@@ -7,7 +7,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   coap_startup();
   pdu = coap_pdu_init(0, 0, 0, size);
   if (pdu) {
-    coap_set_log_level(COAP_LOG_ERR);
+    coap_set_log_level(COAP_LOG_EMERG);
     if (coap_pdu_parse(COAP_PROTO_WS, data, size, pdu)) {
       coap_string_t *query = coap_get_query(pdu);
       coap_string_t *uri_path = coap_get_uri_path(pdu);


### PR DESCRIPTION
Additionally, reduce some of the unnecessary logging when fuzzing PDU input.