### PR TITLE
SendQueue: Match Mid and Token (if given) to remove entry from queue

### DIFF
--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -377,7 +377,8 @@ int coap_handle_dgram(coap_context_t *ctx, coap_session_t *session, uint8_t *dat
  *
  * @param queue The queue to search for @p id.
  * @param session The session to look for.
- * @param id    The message id to look for.
+ * @param mid   The message id to look for.
+ * @param token The incoming pdu token to look for.
  * @param node  If found, @p node is updated to point to the removed node. You
  *              must release the storage pointed to by @p node manually.
  *
@@ -385,7 +386,8 @@ int coap_handle_dgram(coap_context_t *ctx, coap_session_t *session, uint8_t *dat
  */
 int coap_remove_from_queue(coap_queue_t **queue,
                            coap_session_t *session,
-                           coap_mid_t id,
+                           coap_mid_t mid,
+                           coap_bin_const_t *token,
                            coap_queue_t **node);
 
 coap_mid_t coap_wait_ack(coap_context_t *context, coap_session_t *session,

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -2568,6 +2568,7 @@ coap_block_test_q_block(coap_session_t *session, coap_pdu_t *actual) {
   size_t token_len;
   uint8_t buf[4];
   coap_mid_t mid;
+  coap_bin_const_t *k_token;
 
 #if NDEBUG
   (void)actual;
@@ -2606,11 +2607,16 @@ coap_block_test_q_block(coap_session_t *session, coap_pdu_t *actual) {
                      coap_encode_var_safe(buf, sizeof(buf),
                                           (0 << 4) | (0 << 3) | 0),
                      buf);
+  k_token = coap_new_bin_const(pdu->actual_token.s, pdu->actual_token.length);
   set_block_mode_probe_q(session->block_mode);
   mid = coap_send_internal(session, pdu, NULL);
-  if (mid == COAP_INVALID_MID)
+  if (mid == COAP_INVALID_MID) {
+    coap_delete_bin_const(k_token);
     return COAP_INVALID_MID;
+  }
   session->remote_test_mid = mid;
+  coap_delete_bin_const(session->last_token);
+  session->last_token = k_token;
   return mid;
 }
 #endif /* COAP_Q_BLOCK_SUPPORT */

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -691,7 +691,7 @@ release_1:
          * or in the sendqueue if sent and is pending re-transmission.
          */
         LL_FOREACH_SAFE(s->delayqueue, q, tmp) {
-          if (q->pdu->mid == s->remote_test_mid) {
+          if (q->id == s->remote_test_mid) {
             if (q->pdu->type==COAP_MESSAGE_CON) {
               coap_handle_nack(s, q->pdu,
                                s->proto == COAP_PROTO_DTLS ?
@@ -699,7 +699,7 @@ release_1:
                                q->id);
             }
             coap_log_debug("** %s: mid=0x%04x: removed\n",
-                           coap_session_str(s), q->pdu->mid);
+                           coap_session_str(s), q->id);
             if (p) {
               p->next = q->next;
             } else {
@@ -710,7 +710,7 @@ release_1:
           }
           p = q;
         }
-        coap_remove_from_queue(&ctx->sendqueue, s, s->remote_test_mid, &sent);
+        coap_remove_from_queue(&ctx->sendqueue, s, s->remote_test_mid, s->last_token, &sent);
         if (sent && sent->pdu && sent->pdu->type == COAP_MESSAGE_CON && COAP_PROTO_NOT_RELIABLE(s->proto)) {
           if (s->con_active)
             s->con_active--;

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -192,20 +192,10 @@ coap_insert_node(coap_queue_t **queue, coap_queue_t *node) {
 COAP_API int
 coap_delete_node(coap_queue_t *node) {
   int ret;
-#if COAP_THREAD_SAFE
-  coap_context_t *context;
-#endif /* COAP_THREAD_SAFE */
 
   if (!node)
     return 0;
-  if (!node->session)
-    return coap_delete_node_lkd(node);
 
-#if COAP_THREAD_SAFE
-  /* Keep copy as node will be going away */
-  context = node->session->context;
-  (void)context;
-#endif /* COAP_THREAD_SAFE */
   coap_lock_lock(return 0);
   ret = coap_delete_node_lkd(node);
   coap_lock_unlock();
@@ -2675,7 +2665,7 @@ coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now
 
     coap_address_copy(&session->addr_info.remote, &q->remote);
     coap_log_debug("** %s: mid=0x%04x: transmitted after delay (1)\n",
-                   coap_session_str(session), (int)q->pdu->mid);
+                   coap_session_str(session), (int)q->id);
     assert(session->partial_write < q->pdu->used_size + q->pdu->hdr_size);
     bytes_written = session->sock.lfunc[COAP_LAYER_SESSION].l_write(session,
                     q->pdu->token - q->pdu->hdr_size + session->partial_write,
@@ -3199,8 +3189,8 @@ error:
 }
 
 int
-coap_remove_from_queue(coap_queue_t **queue, coap_session_t *session, coap_mid_t id,
-                       coap_queue_t **node) {
+coap_remove_from_queue(coap_queue_t **queue, coap_session_t *session, coap_mid_t mid,
+                       coap_bin_const_t *token, coap_queue_t **node) {
   coap_queue_t *p, *q;
 
   if (!queue || !*queue) {
@@ -3210,7 +3200,8 @@ coap_remove_from_queue(coap_queue_t **queue, coap_session_t *session, coap_mid_t
 
   /* replace queue head if PDU's time is less than head's time */
 
-  if (session == (*queue)->session && id == (*queue)->id) { /* found message id */
+  if (session == (*queue)->session && mid == (*queue)->id &&
+      (!token || coap_binary_equal(token, &(*queue)->pdu->actual_token))) { /* found message id */
     *node = *queue;
     *queue = (*queue)->next;
     if (*queue) {          /* adjust relative time of new queue head */
@@ -3218,7 +3209,7 @@ coap_remove_from_queue(coap_queue_t **queue, coap_session_t *session, coap_mid_t
     }
     (*node)->next = NULL;
     coap_log_debug("** %s: mid=0x%04x: removed (1)\n",
-                   coap_session_str(session), id);
+                   coap_session_str(session), mid);
     return 1;
   }
 
@@ -3227,7 +3218,8 @@ coap_remove_from_queue(coap_queue_t **queue, coap_session_t *session, coap_mid_t
   do {
     p = q;
     q = q->next;
-  } while (q && (session != q->session || id != q->id));
+  } while (q && (session != q->session || mid != q->id ||
+                 (token && ! coap_binary_equal(token, &q->pdu->actual_token))));
 
   if (q) {                        /* found message id */
     p->next = q->next;
@@ -3237,7 +3229,7 @@ coap_remove_from_queue(coap_queue_t **queue, coap_session_t *session, coap_mid_t
     q->next = NULL;
     *node = q;
     coap_log_debug("** %s: mid=0x%04x: removed (2)\n",
-                   coap_session_str(session), id);
+                   coap_session_str(session), mid);
     return 1;
   }
 
@@ -4716,8 +4708,8 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
     if (pdu->type == COAP_MESSAGE_CON) {
       coap_send_message_type_lkd(session, pdu, COAP_MESSAGE_RST);
     }
-    /* find message id in sendqueue to stop retransmission */
-    coap_remove_from_queue(&context->sendqueue, session, pdu->mid, &sent);
+    /* find message id in sendqueue to stop retransmission (code is not 0.00) */
+    coap_remove_from_queue(&context->sendqueue, session, pdu->mid, &pdu->actual_token, &sent);
     goto cleanup;
   }
 
@@ -4815,8 +4807,8 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
     }
 #endif /* COAP_SERVER_SUPPORT */
     if (decrypt) {
-      /* find message id in sendqueue to stop retransmission and get sent */
-      coap_remove_from_queue(&context->sendqueue, session, pdu->mid, &sent);
+      /* find message id in sendqueue to stop retransmission and get sent (not empty packet) */
+      coap_remove_from_queue(&context->sendqueue, session, pdu->mid, &pdu->actual_token, &sent);
       /* Bump ref so pdu is not freed of, and keep a pointer to it */
       orig_pdu = pdu;
       coap_pdu_reference_lkd(orig_pdu);
@@ -4852,8 +4844,9 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
   switch (pdu->type) {
   case COAP_MESSAGE_ACK:
     if (NULL == sent) {
-      /* find message id in sendqueue to stop retransmission */
-      coap_remove_from_queue(&context->sendqueue, session, pdu->mid, &sent);
+      /* find message id in sendqueue to stop retransmission (no token if empty) */
+      coap_remove_from_queue(&context->sendqueue, session, pdu->mid,
+                             pdu->code == 0 ? NULL : &pdu->actual_token, &sent);
     }
 
     if (sent && session->con_active) {
@@ -5009,8 +5002,8 @@ coap_dispatch(coap_context_t *context, coap_session_t *session,
         coap_session_connected(session);
     }
 
-    /* find message id in sendqueue to stop retransmission */
-    coap_remove_from_queue(&context->sendqueue, session, pdu->mid, &sent);
+    /* find message id in sendqueue to stop retransmission (no token as RST) */
+    coap_remove_from_queue(&context->sendqueue, session, pdu->mid, NULL, &sent);
 
     if (sent) {
       if (!is_ping_rst)

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -820,8 +820,11 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
                        coap_queue_t *node) {
   if (node) {
     coap_queue_t *removed = NULL;
-    coap_remove_from_queue(&session->context->sendqueue, session, node->id, &removed);
+    /* Nodes are per ID, no notion of token */
+    coap_remove_from_queue(&session->context->sendqueue, session, node->id,
+                           NULL, &removed);
     assert(removed == node);
+    /* reuse node */
     coap_session_release_lkd(node->session);
     node->session = NULL;
     node->t = 0;
@@ -987,7 +990,7 @@ coap_session_connected(coap_session_t *session) {
     coap_address_copy(&remote, &session->addr_info.remote);
     coap_address_copy(&session->addr_info.remote, &q->remote);
     coap_log_debug("** %s: mid=0x%04x: transmitted after delay (2)\n",
-                   coap_session_str(session), (int)q->pdu->mid);
+                   coap_session_str(session), (int)q->id);
     bytes_written = coap_session_send_pdu(session, q->pdu);
     if (q->pdu->type == COAP_MESSAGE_CON && COAP_PROTO_NOT_RELIABLE(session->proto)) {
       if (coap_wait_ack(session->context, session, q) >= 0)

--- a/tests/test_sendqueue.c
+++ b/tests/test_sendqueue.c
@@ -210,7 +210,8 @@ t_sendqueue7(void) {
   ReturnIf_CU_ASSERT_PTR_NOT_NULL(ctx->sendqueue->next);
   CU_ASSERT_PTR_EQUAL(ctx->sendqueue->next, node[1]);
 
-  result = coap_remove_from_queue(&ctx->sendqueue, session, 3, &tmp_node);
+  /* Check without token */
+  result = coap_remove_from_queue(&ctx->sendqueue, session, 3, NULL, &tmp_node);
 
   CU_ASSERT(result == 1);
   ReturnIf_CU_ASSERT_PTR_NOT_NULL(tmp_node);
@@ -227,7 +228,9 @@ t_sendqueue8(void) {
   int result;
   coap_queue_t *tmp_node;
 
-  result = coap_remove_from_queue(&ctx->sendqueue, session, 4, &tmp_node);
+  /* Check with token */
+  result = coap_remove_from_queue(&ctx->sendqueue, session, 4, &node[4]->pdu->actual_token,
+                                  &tmp_node);
 
   CU_ASSERT(result == 1);
   ReturnIf_CU_ASSERT_PTR_NOT_NULL(tmp_node);
@@ -359,6 +362,12 @@ t_sendqueue_tests_create(void) {
     node[n]->id = n;
     node[n]->t = timestamp[n];
     node[n]->session = coap_session_reference(session);
+    node[n]->pdu = coap_pdu_init(COAP_MESSAGE_CON, n, n, 0);
+    if (!node[n]->pdu) {
+      error = 1;
+      break;
+    }
+    coap_add_token(node[n]->pdu, sizeof(n), (uint8_t *)&n);
   }
 
   if (error) {


### PR DESCRIPTION
For Empty ACK and RST do not do a token match.