### PR TITLE
examples: server: Fix const qualifier discard

### DIFF
--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -2751,10 +2751,10 @@ uint32_t syslog_pri = 0;
 
 static void
 syslog_handler(coap_log_t level, const char *message) {
-  char *cp = strchr(message, '\n');
+  const char *cp = strchr(message, '\n');
 
   if (cp) {
-    char *lcp = strchr(message, '\r');
+    const char *lcp = strchr(message, '\r');
     if (lcp && lcp < cp)
       cp = lcp;
   }


### PR DESCRIPTION
Compiling with gcc-16.1.1 and glibc-2.43 yields warnings: "initialization discards ‘const’ qualifier from pointer target type".

Indeed, pointer passed to strchr() is `const char *` and memory pointed by return value of strchr() is never modified, so variable to assign return value should be `const char *`.