### PR TITLE
add coap_endpoint_join_mcast_group_intf

### DIFF
--- a/include/coap3/coap_net.h
+++ b/include/coap3/coap_net.h
@@ -765,6 +765,22 @@ COAP_API int coap_join_mcast_group_intf(coap_context_t *ctx, const char *groupna
   (coap_join_mcast_group_intf(ctx, groupname, NULL))
 
 /**
+ * Function interface for joining a multicast group for listening on a single
+ * UDP endpoint.
+ *
+ * @param endpoint  The endpoint to join the multicast group on.
+ * @param groupname The name of the group that is to be joined for listening.
+ * @param ifname    Network interface to join the group on, or NULL if the
+ *                  endpoint's bound interface should be used where possible,
+ *                  otherwise the O/S will choose an appropriate interface.
+ *
+ * @return       0 on success, -1 on error
+ */
+COAP_API int coap_endpoint_join_mcast_group_intf(coap_endpoint_t *endpoint,
+                                                 const char *groupname,
+                                                 const char *ifname);
+
+/**
  * Function interface for defining the hop count (ttl) for sending
  * multicast traffic.  The default is 1 so that the ttl expires after
  * decrementing if the packet is trying to pass out of the local network.

--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -598,13 +598,17 @@ int coap_can_exit_lkd(coap_context_t *context);
  * Note: This function must be called in the locked state.
  *
  * @param ctx       The current context.
+ * @param endpoint  The specific endpoint to join on, or NULL to consider
+ *                  all UDP endpoints in @p ctx.
  * @param groupname The name of the group that is to be joined for listening.
  * @param ifname    Network interface to join the group on, or NULL if first
  *                  appropriate interface is to be chosen by the O/S.
  *
  * @return       0 on success, -1 on error
  */
-int coap_join_mcast_group_intf_lkd(coap_context_t *ctx, const char *groupname,
+int coap_join_mcast_group_intf_lkd(coap_context_t *ctx,
+                                   coap_endpoint_t *endpoint,
+                                   const char *groupname,
                                    const char *ifname);
 
 /**

--- a/libcoap-3.map
+++ b/libcoap-3.map
@@ -110,6 +110,7 @@ global:
   coap_encode_var_safe8;
   coap_encode_var_safe;
   coap_endpoint_get_app_data;
+  coap_endpoint_join_mcast_group_intf;
   coap_endpoint_set_app_data;
   coap_endpoint_set_default_mtu;
   coap_endpoint_str;

--- a/libcoap-3.sym
+++ b/libcoap-3.sym
@@ -108,6 +108,7 @@ coap_enable_pdu_data_output
 coap_encode_var_safe
 coap_encode_var_safe8
 coap_endpoint_get_app_data
+coap_endpoint_join_mcast_group_intf
 coap_endpoint_set_app_data
 coap_endpoint_set_default_mtu
 coap_endpoint_str

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -118,6 +118,7 @@ install-man: install-man3 install-man5 install-man7
 	@echo ".so man3/coap_address.3" > coap_is_bcast.3
 	@echo ".so man3/coap_address.3" > coap_is_mcast.3
 	@echo ".so man3/coap_address.3" > coap_is_af_unix.3
+	@echo ".so man3/coap_endpoint_server.3" > coap_endpoint_join_mcast_group_intf.3
 	@echo ".so man3/coap_block.3" > coap_q_block_is_supported.3
 	@echo ".so man3/coap_block.3" > coap_register_block_data_handler.3
 	@echo ".so man3/coap_cache.3" > coap_cache_get_pdu.3

--- a/man/coap_endpoint_server.txt.in
+++ b/man/coap_endpoint_server.txt.in
@@ -17,6 +17,7 @@ coap_new_endpoint,
 coap_free_endpoint,
 coap_endpoint_set_default_mtu,
 coap_join_mcast_group_intf,
+coap_endpoint_join_mcast_group_intf,
 coap_mcast_per_resource
 - Work with CoAP server endpoints
 
@@ -39,6 +40,9 @@ const coap_address_t *_listen_addr_, coap_proto_t _proto_);*
 unsigned _mtu_);*
 
 *int coap_join_mcast_group_intf(coap_context_t *_context_,
+const char *_groupname_, const char *_ifname_);*
+
+*int coap_endpoint_join_mcast_group_intf(coap_endpoint_t *_endpoint_,
 const char *_groupname_, const char *_ifname_);*
 
 *void coap_mcast_per_resource(coap_context_t *_context_);*
@@ -178,6 +182,14 @@ ff05::fd (Site-Local).
 
 *NOTE:* multicast is not supported for address family type AF_UNIX.
 
+*Function: coap_endpoint_join_mcast_group_intf()*
+
+The *coap_endpoint_join_mcast_group_intf*() function is used to join the
+specified UDP _endpoint_ to the defined multicast group _groupname_. If
+_ifname_ is not NULL, then the multicast group is associated with this
+interface, otherwise the endpoint's bound interface is used where possible.
+When the endpoint is freed off, the associated multicast group will be removed.
+
 *Function: coap_mcast_per_resource()*
 
 The *coap_mcast_per_resource*() function enables mcast to be controlled on a
@@ -193,7 +205,8 @@ RETURN VALUES
 *coap_new_endpoint*() returns a newly created endpoint or
 NULL if there is a creation failure.
 
-*coap_join_mcast_group_intf*() returns 0 on success, -1 on failure.
+*coap_join_mcast_group_intf*() and
+*coap_endpoint_join_mcast_group_intf*() return 0 on success, -1 on failure.
 
 EXAMPLES
 --------

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -5518,13 +5518,15 @@ coap_join_mcast_group_intf(coap_context_t *ctx, const char *group_name,
   int ret;
 
   coap_lock_lock(return -1);
-  ret = coap_join_mcast_group_intf_lkd(ctx, group_name, ifname);
+  ret = coap_join_mcast_group_intf_lkd(ctx, NULL, group_name, ifname);
   coap_lock_unlock();
   return ret;
 }
 
 int
-coap_join_mcast_group_intf_lkd(coap_context_t *ctx, const char *group_name,
+coap_join_mcast_group_intf_lkd(coap_context_t *ctx,
+                               coap_endpoint_t *single_endpoint,
+                               const char *group_name,
                                const char *ifname) {
 #if COAP_IPV4_SUPPORT
   struct ip_mreq mreq4;
@@ -5535,12 +5537,26 @@ coap_join_mcast_group_intf_lkd(coap_context_t *ctx, const char *group_name,
   struct addrinfo *resmulti = NULL, hints, *ainfo;
   int result = -1;
   coap_endpoint_t *endpoint;
+#if !defined(ESPIDF_VERSION) && COAP_IPV6_SUPPORT && !defined(HAVE_IF_NAMETOINDEX) && !defined(__QNXNTO__)
+  coap_endpoint_t *lookup_endpoint;
+#endif /* !ESPIDF_VERSION && COAP_IPV6_SUPPORT && !HAVE_IF_NAMETOINDEX && !__QNXNTO__ */
   int mgroup_setup = 0;
 
-  /* Need to have at least one endpoint! */
-  assert(ctx->endpoint);
-  if (!ctx->endpoint)
-    return -1;
+  if (single_endpoint) {
+    if (single_endpoint->proto != COAP_PROTO_UDP)
+      return -1;
+#if !defined(ESPIDF_VERSION) && COAP_IPV6_SUPPORT && !defined(HAVE_IF_NAMETOINDEX) && !defined(__QNXNTO__)
+    lookup_endpoint = single_endpoint;
+#endif /* !ESPIDF_VERSION && COAP_IPV6_SUPPORT && !HAVE_IF_NAMETOINDEX && !__QNXNTO__ */
+  } else {
+    /* Need to have at least one endpoint! */
+    assert(ctx->endpoint);
+    if (!ctx->endpoint)
+      return -1;
+#if !defined(ESPIDF_VERSION) && COAP_IPV6_SUPPORT && !defined(HAVE_IF_NAMETOINDEX) && !defined(__QNXNTO__)
+    lookup_endpoint = ctx->endpoint;
+#endif /* !ESPIDF_VERSION && COAP_IPV6_SUPPORT && !HAVE_IF_NAMETOINDEX && !__QNXNTO__ */
+  }
 
   /* Default is let the kernel choose */
 #if COAP_IPV6_SUPPORT
@@ -5609,7 +5625,7 @@ coap_join_mcast_group_intf_lkd(coap_context_t *ctx, const char *group_name,
         }
 #elif defined(__QNXNTO__)
 #else /* !HAVE_IF_NAMETOINDEX */
-        result = ioctl(ctx->endpoint->sock.fd, SIOCGIFINDEX, &ifr);
+        result = ioctl(lookup_endpoint->sock.fd, SIOCGIFINDEX, &ifr);
         if (result != 0) {
           coap_log_warn("coap_join_mcast_group_intf: "
                         "cannot get interface index for '%s': %s\n",
@@ -5678,7 +5694,9 @@ coap_join_mcast_group_intf_lkd(coap_context_t *ctx, const char *group_name,
 
   /* Add in mcast address(es) to appropriate interface */
   for (ainfo = resmulti; ainfo != NULL; ainfo = ainfo->ai_next) {
-    LL_FOREACH(ctx->endpoint, endpoint) {
+    for (endpoint = single_endpoint ? single_endpoint : ctx->endpoint;
+         endpoint != NULL;
+         endpoint = single_endpoint ? NULL : endpoint->next) {
       /* Only UDP currently supported */
       if (endpoint->proto == COAP_PROTO_UDP) {
         coap_address_t gaddr;
@@ -5764,6 +5782,21 @@ finish:
   return result;
 }
 
+COAP_API int
+coap_endpoint_join_mcast_group_intf(coap_endpoint_t *endpoint,
+                                    const char *group_name,
+                                    const char *ifname) {
+  int ret;
+
+  if (!endpoint || !endpoint->context)
+    return -1;
+
+  coap_lock_lock(return -1);
+  ret = coap_join_mcast_group_intf_lkd(endpoint->context, endpoint, group_name, ifname);
+  coap_lock_unlock();
+  return ret;
+}
+
 void
 coap_mcast_per_resource(coap_context_t *context) {
   context->mcast_per_resource = 1;
@@ -5809,6 +5842,13 @@ COAP_API int
 coap_join_mcast_group_intf(coap_context_t *ctx COAP_UNUSED,
                            const char *group_name COAP_UNUSED,
                            const char *ifname COAP_UNUSED) {
+  return -1;
+}
+
+COAP_API int
+coap_endpoint_join_mcast_group_intf(coap_endpoint_t *endpoint COAP_UNUSED,
+                                    const char *group_name COAP_UNUSED,
+                                    const char *ifname COAP_UNUSED) {
   return -1;
 }
 


### PR DESCRIPTION
Hello,

I have an application that meticulously tracks interface states and IPs (v4&v6) and creates/deletes endpoints for a specific selection dynamically. As we also use multicast communication, the existing `coap_join_mcast_group_intf` often causes issues like: 

```
setsockopt: Protocol not available
setsockopt: Address already in use
```
as it operates on all registered endpoints of a context.

This commit modifies the existing `coap_join_mcast_group_intf` to enable a new function `coap_endpoint_join_mcast_group_intf` that only sets up multicast for a specific endpoint.

Thank you!