### PR TITLE
Proxy: Report 5.04 on proxy gateway timeout

### DIFF
--- a/include/coap3/coap_proxy.h
+++ b/include/coap3/coap_proxy.h
@@ -70,8 +70,8 @@ typedef enum {
   /* Start of additional optional bit mask mapping */
   COAP_PROXY_BIT_STRIP = (1 << 6),
   /**<
-   * If COAP_PROXY_BIT_STRIP set, then remove any Proxy-Uri or Proxy-Scheme,
-   * else leave them.
+   * If COAP_PROXY_BIT_STRIP set, then remove any Proxy-Uri or Proxy-Scheme
+   * as the PDU is forwarded, else leave them.
    */
   COAP_PROXY_BIT_MCAST = (1 << 7),
   /**<
@@ -110,7 +110,8 @@ typedef struct coap_proxy_server_list_t {
   unsigned int idle_timeout_secs; /**< Proxy upstream session idle timeout
                                        (0 is no timeout). Timeout is ignored
                                        if there are any active upstream Observe
-                                       requests */
+                                       requests or a CON upstream request has
+                                       been sent with no response so far */
 } coap_proxy_server_list_t;
 
 /**

--- a/include/coap3/coap_proxy_internal.h
+++ b/include/coap3/coap_proxy_internal.h
@@ -63,6 +63,9 @@ struct coap_proxy_entry_t {
   int track_client_session;   /**< If 1, track individual connections to upstream
                                    server, else 0 for all clients to be multiplexed
                                    over the same upstream session */
+  coap_mid_t mid;             /** Mid of last transmitted ongoing PDU */
+  coap_tick_t req_start_ticks; /**< Set to request time if upstream CON request sent
+                                    and response not received */
   coap_tick_t idle_timeout_ticks; /**< Idle timeout (0 == no timeout). Timeout
                                        is ignored if there are any active
                                        upstream Observe requests */
@@ -98,12 +101,13 @@ int coap_proxy_check_timeouts(coap_context_t *context, coap_tick_t now,
 /**
  * Remove the upstream proxy connection from list for session.
  *
- * @param session Either incoming or ongoiing session.
- * @param send_failure Indicate to incoming session proxy issues.
+ * @param session Either incoming or ongoing session.
+ * @param failure_code If not 0, if ongoing session, send code to
+ *                     incoming sessions.
  *
  * @return Return 1 if proxy_entry deleted.
  */
-int coap_proxy_remove_association(coap_session_t *session, int send_failure);
+int coap_proxy_remove_association(coap_session_t *session, coap_pdu_code_t failure_code);
 
 /**
  * Forward incoming request upstream to the next proxy/server.

--- a/man/coap_proxy.txt.in
+++ b/man/coap_proxy.txt.in
@@ -163,8 +163,8 @@ typedef enum {
   /* Start of additional optional bit mask mapping */
   COAP_PROXY_BIT_STRIP = (1 << 6),
   /**<
-   * If COAP_PROXY_BIT_STRIP set, then remove any Proxy-Uri or Proxy-Scheme,
-   * else leave them.
+   * If COAP_PROXY_BIT_STRIP set, then remove any Proxy-Uri or Proxy-Scheme
+   * as the PDU is forwarded else leave them.
    */
   COAP_PROXY_BIT_MCAST = (1 << 7),
   /**<
@@ -200,7 +200,8 @@ typedef struct coap_proxy_server_list_t {
   unsigned int idle_timeout_secs; /* Proxy upstream session idle timeout
                                      (0 is no timeout). Timeout is ignored
                                      if there are any active upstream Observe
-                                     requests */
+                                     requests or a CON upstream request has
+                                     been sent with no response so far */
 } coap_proxy_server_list_t;
 ----
 
@@ -212,17 +213,21 @@ generated from the _request_ PDU or (usually) NULL.  This _cache_key_ will get
 passed into *coap_proxy_forward_response*() or the response handler set up
 using *coap_register_proxy_response_handler*() when handling the response.
 _server_list_ defines the characteristics of zero or more of the upstream
-servers to connect to. The definitions can cover the following
+servers to connect to.
 
 *NOTE:* _cache_key_ is associated with the D-Client _req_session_ and gets
 deleted when _req_session_ is disconnected.
+
+The _server_list_ type definition can be one of the following
 
 [source, c]
 ----
 Acting as a reverse proxy - connect to defined internal server
  (possibly round robin load balancing over multiple servers).
+
 Acting as a forward-dynamic proxy - connect to host defined in Proxy-Uri
  or Proxy-Scheme with Uri-Host (and maybe Uri-Port).
+
 Acting as a forward-static proxy - connect to defined upstream server
  (possibly round robin load balancing over multiple servers).
 ----

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -711,9 +711,12 @@ release_1:
           p = q;
         }
         coap_remove_from_queue(&ctx->sendqueue, s, s->remote_test_mid, s->last_token, &sent);
-        if (sent && sent->pdu && sent->pdu->type == COAP_MESSAGE_CON && COAP_PROTO_NOT_RELIABLE(s->proto)) {
-          if (s->con_active)
-            s->con_active--;
+        if (sent) {
+          if (sent->pdu && sent->pdu->type == COAP_MESSAGE_CON && COAP_PROTO_NOT_RELIABLE(s->proto)) {
+            if (s->con_active)
+              s->con_active--;
+          }
+          coap_delete_node_lkd(sent);
         }
         coap_reset_doing_first(s);
         if (s->state == COAP_SESSION_STATE_ESTABLISHED) {

--- a/src/coap_proxy.c
+++ b/src/coap_proxy.c
@@ -116,19 +116,19 @@ coap_proxy_del_req(coap_proxy_entry_t *proxy_entry, coap_proxy_req_t *proxy_req)
 }
 
 static void
-coap_proxy_cleanup_entry(coap_proxy_entry_t *proxy_entry, int send_failure) {
+coap_proxy_cleanup_entry(coap_proxy_entry_t *proxy_entry, coap_pdu_code_t failure_code) {
   coap_proxy_req_t *proxy_req, *treq;
 
   LL_FOREACH_SAFE(proxy_entry->proxy_req, proxy_req, treq) {
-    if (send_failure) {
+    if (failure_code) {
       coap_pdu_t *response;
       coap_bin_const_t l_token;
 
-      /* Need to send back a gateway failure */
+      /* Need to send back a gateway failure as per failure_code */
       response = coap_pdu_init(proxy_req->pdu->type,
-                               COAP_RESPONSE_CODE(502),
-                               coap_new_message_id_lkd(proxy_entry->incoming),
-                               coap_session_max_pdu_size_lkd(proxy_entry->incoming));
+                               failure_code,
+                               coap_new_message_id_lkd(proxy_req->incoming),
+                               coap_session_max_pdu_size_lkd(proxy_req->incoming));
       if (!response) {
         coap_log_info("PDU creation issue\n");
         goto cleanup;
@@ -140,8 +140,9 @@ coap_proxy_cleanup_entry(coap_proxy_entry_t *proxy_entry, int send_failure) {
         coap_log_debug("Cannot add token to incoming proxy response PDU\n");
       }
 
-      if (coap_send_lkd(proxy_entry->incoming, response) == COAP_INVALID_MID) {
-        coap_log_info("Failed to send PDU with 5.02 gateway issue\n");
+      if (coap_send_lkd(proxy_req->incoming, response) == COAP_INVALID_MID) {
+        coap_log_info("Failed to send PDU with %u.%02u proxy issue\n",
+                      COAP_RESPONSE_CLASS(failure_code), failure_code & 0x1f);
       }
     }
 cleanup:
@@ -195,15 +196,40 @@ coap_proxy_check_timeouts(coap_context_t *context, coap_tick_t now,
     if (coap_proxy_check_observe(proxy_entry))
       continue;
 
-    if (proxy_entry->ongoing && proxy_entry->idle_timeout_ticks) {
-      if (proxy_entry->last_used + proxy_entry->idle_timeout_ticks <= now) {
-        /* Drop session to upstream server (which may remove proxy entry) */
-        if (coap_proxy_remove_association(proxy_entry->ongoing, 0))
-          i--;
-      } else {
-        if (*tim_rem > proxy_entry->last_used + proxy_entry->idle_timeout_ticks - now) {
-          *tim_rem = proxy_entry->last_used + proxy_entry->idle_timeout_ticks - now;
-          ret = 1;
+    if (proxy_entry->ongoing) {
+      if (proxy_entry->req_start_ticks) {
+        coap_tick_t timeout_time;
+
+        timeout_time = proxy_entry->req_start_ticks + COAP_MAX_TRANSMIT_WAIT_TICKS(proxy_entry->ongoing);
+        if (timeout_time <= now) {
+          /* Forward request has timed out */
+          coap_queue_t *sent = NULL;
+
+          coap_remove_from_queue(&context->sendqueue, proxy_entry->ongoing,
+                                 proxy_entry->mid, NULL, &sent);
+          if (sent) {
+            coap_delete_node_lkd(sent);
+          }
+          if (coap_proxy_remove_association(proxy_entry->ongoing, COAP_RESPONSE_CODE(504))) {
+            i--;
+          }
+        } else {
+          if (*tim_rem > timeout_time - now) {
+            *tim_rem = timeout_time - now;
+            ret = 1;
+          }
+        }
+      } else if (proxy_entry->idle_timeout_ticks) {
+        if (proxy_entry->last_used + proxy_entry->idle_timeout_ticks <= now) {
+          /* Drop session to upstream server (which may remove proxy entry) */
+          if (coap_proxy_remove_association(proxy_entry->ongoing, 0)) {
+            i--;
+          }
+        } else {
+          if (*tim_rem > proxy_entry->last_used + proxy_entry->idle_timeout_ticks - now) {
+            *tim_rem = proxy_entry->last_used + proxy_entry->idle_timeout_ticks - now;
+            ret = 1;
+          }
         }
       }
     }
@@ -525,7 +551,7 @@ coap_proxy_get_session(coap_session_t *session, const coap_pdu_t *request,
 }
 
 int
-coap_proxy_remove_association(coap_session_t *session, int send_failure) {
+coap_proxy_remove_association(coap_session_t *session, coap_pdu_code_t failure_code) {
 
   size_t i;
   coap_proxy_entry_t *proxy_list = session->context->proxy_list;
@@ -556,7 +582,7 @@ retry:
     if (proxy_entry->ongoing == session) {
       coap_session_t *ongoing;
 
-      coap_proxy_cleanup_entry(proxy_entry, send_failure);
+      coap_proxy_cleanup_entry(proxy_entry, failure_code);
       ongoing = proxy_entry->ongoing;
       coap_log_debug("*  %s: proxy_entry %p released (rem count = % " PRIdS ")\n",
                      coap_session_str(ongoing),
@@ -1192,10 +1218,14 @@ coap_proxy_forward_request_lkd(coap_session_t *session,
   }
 
   coap_proxy_log_entry(proxy_req->incoming, proxy_req->pdu, proxy_req->token_used,  "fwd");
-  if (coap_send_lkd(proxy_entry->ongoing, pdu) == COAP_INVALID_MID) {
+  proxy_entry->mid = coap_send_lkd(proxy_entry->ongoing, pdu);
+  if (proxy_entry->mid == COAP_INVALID_MID) {
     pdu = NULL;
     coap_log_debug("proxy: upstream PDU send error\n");
     goto failed;
+  }
+  if (request->type == COAP_MESSAGE_CON && COAP_PROTO_NOT_RELIABLE(proxy_entry->ongoing->proto)) {
+    proxy_entry->req_start_ticks = now;
   }
 
   /*
@@ -1333,6 +1363,7 @@ coap_proxy_forward_response_lkd(coap_session_t *session,
     return COAP_RESPONSE_OK;
   }
 
+  proxy_entry->req_start_ticks = 0;
   req_pdu = proxy_req->pdu;
   req_token = coap_pdu_get_token(req_pdu);
   resource = proxy_req->resource;
@@ -1785,6 +1816,7 @@ coap_proxy_fwd_add_client_session_lkd(coap_session_t *session, const char *use_i
                    (void *)proxy_entry,
                    session->context->proxy_list_count);
     proxy_entry->idle_timeout_ticks = 0;
+    proxy_entry->req_start_ticks = 0;
     proxy_entry->track_client_session = 0;
     coap_session_set_type_client_lkd(session, 1);
     return proxy_entry;


### PR DESCRIPTION
Timeout is set to MAX_TRANSMIT_WAIT for CON Non-Reliable requests.

If request is active, idle timeout is ignored.