### PR TITLE
coap_resource.c: harden coap_print_wellknown_lkd() against short attribute values

### DIFF
--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -213,7 +213,8 @@ coap_print_wellknown_lkd(coap_context_t *context, unsigned char *buf,
         if (!attr || !attr->value)
           continue;
         unquoted_val = *attr->value;
-        if (attr->value->s[0] == '"') {          /* if attribute has a quoted value, remove double quotes */
+        /* if attribute has a quoted value, remove double quotes */
+        if (attr->value->length >= 2 && attr->value->s[0] == '"') {
           unquoted_val.length -= 2;
           unquoted_val.s += 1;
         }


### PR DESCRIPTION
## Summary

In the "match attribute" branch of `coap_print_wellknown_lkd()` (`src/coap_resource.c`), an attribute value shorter than 2 bytes causes a `size_t` underflow:

```c
unquoted_val = *attr->value;
if (attr->value->s[0] == '"') {          /* remove double quotes */
  unquoted_val.length -= 2;
  unquoted_val.s += 1;
}
```

If `attr->value->length` is 0 or 1, this both reads `s[0]` out of bounds on a zero-length value and, if the single byte happens to be `"`, underflows `unquoted_val.length` to `SIZE_MAX` (since `coap_str_const_t.length` is `size_t`). The resulting bogus `coap_str_const_t` is then passed straight into `match()` a few lines below, which dereferences memory far outside the original allocation.

`coap_add_attr()` performs no validation on the attribute value's content or length, so an application calling e.g. `coap_add_attr(resource, name, coap_make_str_const("\""), 0)` (a lone double-quote, length 1) is legal, uncaught API usage that reaches this code path whenever a query filter triggers the "match attribute" branch (e.g. `.well-known/core?rt=foo`).

This is the same class of issue already fixed for `query_pattern` a few lines above in #1977 (zero-length guard before dereferencing `s[0]`).

## Fix

Guard the quote check on `length >= 2` before touching `s[0]`, mirroring the `query_pattern.length && ...` guard style used in #1977:

```c
if (attr->value->length >= 2 && attr->value->s[0] == '"') {
```

## Testing

- Reproduced with a standalone harness (mingw gcc, no ASan available on this toolchain) that places a 1-byte attribute value at the end of a guard-paged memory region:
  - **Before fix**: `unquoted_val.length` becomes `SIZE_MAX`, and calling `match()` with the corrupted string crashes (access violation) when it dereferences the guard page.
  - **After fix**: `unquoted_val.length` stays at 1 (no underflow), `match()` safely short-circuits on the length comparison and returns without touching the guard page.
- A regression check confirms a normal well-formed value `"foo"` (5 bytes) still strips correctly to `foo` (3 bytes), unchanged by this guard.
- `src/coap_resource.c` was syntax/type-checked standalone against the generated `coap_config.h` (clean, no new warnings). A full library build on this Windows/MinGW environment hits an unrelated pre-existing `CMSG_*` macro portability issue in `coap_dgrm_posix.c` (unaffected by this change).

## Notes

- No CVE / advisory suggested; this is a defensive hardening fix in the same spirit as #1977, mirroring its guard style for consistency.