### PR TITLE
OSS-FUZZ: Stop actual packet transmissions

### DIFF
--- a/tests/oss-fuzz/persist_target.c
+++ b/tests/oss-fuzz/persist_target.c
@@ -83,6 +83,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   coap_startup();
   coap_set_log_level(COAP_LOG_EMERG);
+  coap_debug_set_packet_loss("100%");
 
   coap_context_t *ctx = coap_new_context(NULL);
   if (!ctx)


### PR DESCRIPTION
Make sure all packets are dropped in persist_target.c.