### PR TITLE
oscore_cbor: fix infinite loop on large CBOR array/map counts

### DIFF
--- a/src/oscore/oscore_cbor.c
+++ b/src/oscore/oscore_cbor.c
@@ -384,6 +384,7 @@ static size_t
 oscore_cbor_skip_value(const uint8_t **data, size_t *buf_len) {
   uint8_t elem = oscore_cbor_get_next_element(data, buf_len);
   uint8_t control = get_byte(data, buf_len) & 0x1f;
+  uint64_t count = 0; /* number of elements in array or map */
   size_t nb = 0;   /* number of elements in array or map */
   size_t num = 0;  /* number of bytes of length or number */
   size_t size = 0; /* size of value to be skipped */
@@ -414,17 +415,38 @@ oscore_cbor_skip_value(const uint8_t **data, size_t *buf_len) {
     (*data) = (*data) + size - num;
     break;
   case CBOR_ARRAY:
-    nb = oscore_cbor_get_element_size(data, buf_len);
+    count = oscore_cbor_get_element_size(data, buf_len);
     size = num;
-    for (uint16_t qq = 0; qq < nb; qq++)
-      size += oscore_cbor_skip_value(data, buf_len);
+    /* Every CBOR array element consumes at least one byte. */
+    if (count > *buf_len)
+      return 0;
+    nb = (size_t)count;
+    for (size_t qq = 0; qq < nb; qq++) {
+      size_t value_size = oscore_cbor_skip_value(data, buf_len);
+
+      if (value_size == 0)
+        return 0;
+      size += value_size;
+    }
     break;
   case CBOR_MAP:
-    nb = oscore_cbor_get_element_size(data, buf_len);
+    count = oscore_cbor_get_element_size(data, buf_len);
     size = num;
-    for (uint16_t qq = 0; qq < nb; qq++) {
-      size += oscore_cbor_skip_value(data, buf_len);
-      size += oscore_cbor_skip_value(data, buf_len);
+    /* Every CBOR map pair consumes at least two bytes. */
+    if (count > *buf_len / 2)
+      return 0;
+    nb = (size_t)count;
+    for (size_t qq = 0; qq < nb; qq++) {
+      size_t key_size = oscore_cbor_skip_value(data, buf_len);
+      size_t value_size;
+
+      if (key_size == 0)
+        return 0;
+      size += key_size;
+      value_size = oscore_cbor_skip_value(data, buf_len);
+      if (value_size == 0)
+        return 0;
+      size += value_size;
     }
     break;
   case CBOR_TAG:
@@ -449,9 +471,23 @@ oscore_cbor_skip_value(const uint8_t **data, size_t *buf_len) {
 uint8_t
 oscore_cbor_strip_value(const uint8_t **data, size_t *buf_len, uint8_t **result, size_t *len) {
   const uint8_t *st_data = *data;
+  size_t st_buf_len = *buf_len;
   size_t size = oscore_cbor_skip_value(data, buf_len);
+
+  *result = NULL;
+  *len = 0;
+  if (size == 0) {
+    *data = st_data;
+    *buf_len = st_buf_len;
+    return 1;
+  }
   *result = coap_malloc_type(COAP_STRING, size);
-  for (uint16_t qq = 0; qq < size; qq++)
+  if (*result == NULL) {
+    *data = st_data;
+    *buf_len = st_buf_len;
+    return 1;
+  }
+  for (size_t qq = 0; qq < size; qq++)
     (*result)[qq] = st_data[qq];
   *len = size;
   return 0;

--- a/tests/test_oscore.c
+++ b/tests/test_oscore.c
@@ -1804,6 +1804,68 @@ fail:
   oscore_free_contexts(ctx);
 }
 
+static void
+t_cbor_large_container_count(void) {
+  static const uint8_t large_array[] = {
+    0x9a, 0x00, 0x01, 0x00, 0x00
+  };
+  static const uint8_t large_map[] = {
+    0xba, 0x00, 0x01, 0x00, 0x00
+  };
+  const uint8_t *data = large_array;
+  size_t buf_len = sizeof(large_array);
+  uint8_t *result = NULL;
+  size_t len = 0;
+
+  CU_ASSERT(oscore_cbor_strip_value(&data, &buf_len, &result, &len) == 1);
+  CU_ASSERT_PTR_NULL(result);
+  CU_ASSERT(len == 0);
+  CU_ASSERT(data == large_array);
+  CU_ASSERT(buf_len == sizeof(large_array));
+
+  data = large_map;
+  buf_len = sizeof(large_map);
+  CU_ASSERT(oscore_cbor_strip_value(&data, &buf_len, &result, &len) == 1);
+  CU_ASSERT_PTR_NULL(result);
+  CU_ASSERT(len == 0);
+  CU_ASSERT(data == large_map);
+  CU_ASSERT(buf_len == sizeof(large_map));
+}
+
+static void
+t_cbor_large_value(void) {
+  const size_t payload_len = 0x10000;
+  const size_t cbor_len = payload_len + 5;
+  uint8_t *cbor = malloc(cbor_len);
+  const uint8_t *data;
+  size_t buf_len;
+  uint8_t *result = NULL;
+  size_t len = 0;
+
+  CU_ASSERT_PTR_NOT_NULL(cbor);
+  if (cbor == NULL)
+    return;
+  cbor[0] = 0x5a;
+  cbor[1] = 0x00;
+  cbor[2] = 0x01;
+  cbor[3] = 0x00;
+  cbor[4] = 0x00;
+  memset(&cbor[5], 0xa5, payload_len);
+  data = cbor;
+  buf_len = cbor_len;
+
+  CU_ASSERT(oscore_cbor_strip_value(&data, &buf_len, &result, &len) == 0);
+  CU_ASSERT_PTR_NOT_NULL(result);
+  CU_ASSERT(len == cbor_len);
+  CU_ASSERT(data == cbor + cbor_len);
+  CU_ASSERT(buf_len == 0);
+  if (result != NULL) {
+    CU_ASSERT(memcmp(result, cbor, cbor_len) == 0);
+    coap_free_type(COAP_STRING, result);
+  }
+  free(cbor);
+}
+
 /************************************************************************
  ** initialization
  ************************************************************************/
@@ -1879,6 +1941,9 @@ t_init_oscore_tests(void) {
     OSCORE_TEST(t_propagate_flat);
     OSCORE_TEST(t_propagate_complex);
     OSCORE_TEST(t_propagate_no_state);
+
+    OSCORE_TEST(t_cbor_large_container_count);
+    OSCORE_TEST(t_cbor_large_value);
   }
 
   return suite[0];


### PR DESCRIPTION
CBOR array and map counts can exceed UINT16_MAX. The uint16_t loop counters then wrap and never reach the advertised count, causing a CWE-835 denial of service.

Use size_t loop counters and reject counts that cannot fit in the remaining buffer at the minimum encoding size of one byte per array element or two bytes per map pair. Propagate malformed-value errors and cover large malformed containers and valid values over 64 KiB with regression tests.