### PR TITLE
Stalling Q-Block transfers under packet loss

### DIFF
--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -136,6 +136,7 @@ typedef struct coap_rblock_t {
 #if COAP_Q_BLOCK_SUPPORT
   uint32_t processing_payload_set;
   uint32_t latest_payload_set;
+  uint32_t highest_seen;
 #endif /* COAP_Q_BLOCK_SUPPORT */
   struct coap_lg_range range[COAP_RBLOCK_CNT];
   coap_tick_t last_seen;

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -117,6 +117,16 @@ struct coap_lg_range {
 #error COAP_RBLOCK_CNT too small
 #endif
 
+#if COAP_Q_BLOCK_SUPPORT
+/*
+ * Maximum bytes used by exact Q-Block1 receive tracking per transfer.
+ * Set to 0 at build time to disable bitmap tracking on constrained devices.
+ */
+#ifndef COAP_Q_BLOCK1_BITMAP_MAX_BYTES
+#define COAP_Q_BLOCK1_BITMAP_MAX_BYTES (128U * 1024U)
+#endif
+#endif /* COAP_Q_BLOCK_SUPPORT */
+
 /**
  * Structure to keep track of received blocks
  */
@@ -255,6 +265,15 @@ struct coap_lg_srcv_t {
   coap_resource_t *resource; /**< associated resource */
   coap_str_const_t *uri_path; /** set to uri_path if unknown resource */
   coap_rblock_t rec_blocks; /** < list of received blocks */
+#if COAP_Q_BLOCK_SUPPORT
+  uint32_t recovery_blocks[COAP_DEFAULT_MAX_PAYLOADS];
+  uint8_t recovery_blocks_used; /**< outstanding Q-Block1 recovery blocks */
+#endif /* COAP_Q_BLOCK_SUPPORT */
+#if COAP_Q_BLOCK_SUPPORT && COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0
+  uint8_t *q_block1_bitmap; /**< exact Q-Block1 received-block tracking */
+  uint32_t q_block1_bitmap_blocks; /**< number of blocks in bitmap */
+  uint32_t q_block1_bitmap_received; /**< number of received blocks */
+#endif /* COAP_Q_BLOCK_SUPPORT && COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0 */
   coap_bin_const_t *last_token; /**< last used token */
   uint32_t ref;          /**< Reference count */
 };

--- a/include/coap3/coap_block_internal.h
+++ b/include/coap3/coap_block_internal.h
@@ -189,7 +189,8 @@ struct coap_lg_xmit_t {
   coap_tick_t last_obs; /**< Last time used (Observe tracking) or 0 */
 #if COAP_Q_BLOCK_SUPPORT
   coap_tick_t non_timeout_random_ticks; /** Used for Q-Block */
-  coap_rblock_t send_blocks; /**< list of blocks still to send */
+  coap_rblock_t send_blocks; /**< forward blocks still to send */
+  coap_rblock_t recovery_blocks; /**< Q-Block1 blocks requested by 4.08 */
 #endif /* COAP_Q_BLOCK_SUPPORT */
   uint32_t ref;          /**< Reference count */
 };

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -1904,6 +1904,100 @@ check_all_blocks_in(coap_rblock_t *rec_blocks) {
   return 1;
 }
 
+#if COAP_SERVER_SUPPORT && COAP_Q_BLOCK_SUPPORT && \
+    COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0
+static int
+q_block1_bitmap_has_block(const coap_lg_srcv_t *lg_srcv, uint32_t block_num) {
+  return lg_srcv->q_block1_bitmap &&
+         block_num < lg_srcv->q_block1_bitmap_blocks &&
+         (lg_srcv->q_block1_bitmap[block_num / 8] &
+          (uint8_t)(1U << (block_num % 8)));
+}
+
+static int
+q_block1_bitmap_set_block(coap_lg_srcv_t *lg_srcv, uint32_t block_num) {
+  if (!lg_srcv->q_block1_bitmap ||
+      block_num >= lg_srcv->q_block1_bitmap_blocks)
+    return 0;
+  if (q_block1_bitmap_has_block(lg_srcv, block_num))
+    return 0;
+  lg_srcv->q_block1_bitmap[block_num / 8] |=
+      (uint8_t)(1U << (block_num % 8));
+  lg_srcv->q_block1_bitmap_received++;
+  return 1;
+}
+
+static int
+q_block1_bitmap_all_blocks_in(const coap_lg_srcv_t *lg_srcv) {
+  return lg_srcv->q_block1_bitmap &&
+         lg_srcv->q_block1_bitmap_received ==
+         lg_srcv->q_block1_bitmap_blocks;
+}
+
+static int
+q_block1_bitmap_missing_previous_payload_set(const coap_session_t *session,
+                                             const coap_lg_srcv_t *lg_srcv,
+                                             uint32_t block_num) {
+  uint32_t block;
+  uint32_t payload_set = block_num / COAP_MAX_PAYLOADS(session);
+  uint32_t first_block;
+  uint32_t last_block;
+
+  if (payload_set == 0)
+    return 0;
+  first_block = (payload_set - 1) * COAP_MAX_PAYLOADS(session);
+  last_block = first_block + COAP_MAX_PAYLOADS(session);
+  if (last_block > lg_srcv->q_block1_bitmap_blocks)
+    last_block = lg_srcv->q_block1_bitmap_blocks;
+  for (block = first_block; block < last_block; block++) {
+    if (!q_block1_bitmap_has_block(lg_srcv, block))
+      return 1;
+  }
+  return 0;
+}
+#endif /* COAP_SERVER_SUPPORT && COAP_Q_BLOCK_SUPPORT &&
+          COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0 */
+
+#if COAP_SERVER_SUPPORT && COAP_Q_BLOCK_SUPPORT
+static int
+q_block1_all_blocks_in(coap_lg_srcv_t *lg_srcv) {
+#if COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0
+  if (lg_srcv->q_block1_bitmap)
+    return q_block1_bitmap_all_blocks_in(lg_srcv);
+#endif /* COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0 */
+  return check_all_blocks_in(&lg_srcv->rec_blocks);
+}
+#endif /* COAP_SERVER_SUPPORT && COAP_Q_BLOCK_SUPPORT */
+
+#if COAP_SERVER_SUPPORT && COAP_Q_BLOCK_SUPPORT
+static int
+q_block1_recovery_remove(coap_lg_srcv_t *lg_srcv, uint32_t block_num) {
+  uint8_t i;
+
+  for (i = 0; i < lg_srcv->recovery_blocks_used; i++) {
+    if (lg_srcv->recovery_blocks[i] == block_num) {
+      if (i + 1 < lg_srcv->recovery_blocks_used) {
+        memmove(&lg_srcv->recovery_blocks[i],
+                &lg_srcv->recovery_blocks[i + 1],
+                (lg_srcv->recovery_blocks_used - i - 1) *
+                sizeof(lg_srcv->recovery_blocks[0]));
+      }
+      lg_srcv->recovery_blocks_used--;
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static void
+q_block1_recovery_add(coap_lg_srcv_t *lg_srcv, uint32_t block_num) {
+  assert(lg_srcv->recovery_blocks_used <
+         sizeof(lg_srcv->recovery_blocks) /
+         sizeof(lg_srcv->recovery_blocks[0]));
+  lg_srcv->recovery_blocks[lg_srcv->recovery_blocks_used++] = block_num;
+}
+#endif /* COAP_SERVER_SUPPORT && COAP_Q_BLOCK_SUPPORT */
+
 #if COAP_CLIENT_SUPPORT
 #if COAP_Q_BLOCK_SUPPORT
 static int
@@ -3532,6 +3626,25 @@ coap_handle_request_put_block(coap_context_t *context,
       lg_srcv->szx = block.szx;
     }
     lg_srcv->block_option = block_option;
+#if COAP_Q_BLOCK_SUPPORT && COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0
+    if (block_option == COAP_OPTION_Q_BLOCK1 && total) {
+      size_t block_size = (size_t)1 << (lg_srcv->szx + 4);
+      size_t bitmap_blocks = total / block_size + !!(total % block_size);
+      size_t bitmap_bytes = (bitmap_blocks + 7) / 8;
+
+      if (bitmap_blocks <= UINT32_MAX &&
+          bitmap_bytes <= COAP_Q_BLOCK1_BITMAP_MAX_BYTES) {
+        lg_srcv->q_block1_bitmap =
+            coap_malloc_type(COAP_STRING, bitmap_bytes);
+        if (lg_srcv->q_block1_bitmap) {
+          memset(lg_srcv->q_block1_bitmap, 0, bitmap_bytes);
+          lg_srcv->q_block1_bitmap_blocks = (uint32_t)bitmap_blocks;
+        } else {
+          coap_log_warn("Q-Block1 bitmap allocation failed; using range tracking\n");
+        }
+      }
+    }
+#endif /* COAP_Q_BLOCK_SUPPORT && COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0 */
     if (observe) {
       lg_srcv->observe_length = min(coap_opt_length(observe), 3);
       memcpy(lg_srcv->observe, coap_opt_value(observe), lg_srcv->observe_length);
@@ -3644,16 +3757,32 @@ coap_handle_request_put_block(coap_context_t *context,
   }
 
   if (block.m ||
-      !check_all_blocks_in(&lg_srcv->rec_blocks)) {
+#if COAP_Q_BLOCK_SUPPORT
+      (block_option == COAP_OPTION_Q_BLOCK1 ?
+       !q_block1_all_blocks_in(lg_srcv) :
+#endif /* COAP_Q_BLOCK_SUPPORT */
+       !check_all_blocks_in(&lg_srcv->rec_blocks)
+#if COAP_Q_BLOCK_SUPPORT
+      )
+#endif /* COAP_Q_BLOCK_SUPPORT */
+      ) {
     /* Not all the payloads of the body have arrived */
     if (block.m) {
       uint8_t buf[4];
 
 #if COAP_Q_BLOCK_SUPPORT
       if (block_option == COAP_OPTION_Q_BLOCK1) {
-        if (check_all_blocks_in(&lg_srcv->rec_blocks)) {
+        if (q_block1_all_blocks_in(lg_srcv)) {
           goto give_app_data;
         }
+#if COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0
+        if (lg_srcv->q_block1_bitmap &&
+            q_block1_bitmap_missing_previous_payload_set(session, lg_srcv,
+                                                          block.num)) {
+          request_missing_blocks(session, lg_srcv, block.num);
+          goto skip_app_handler;
+        }
+#endif /* COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0 */
         if (lg_srcv->rec_blocks.used == 1 &&
             (lg_srcv->rec_blocks.range[0].end % COAP_MAX_PAYLOADS(session)) + 1
             == COAP_MAX_PAYLOADS(session)) {
@@ -3670,6 +3799,19 @@ coap_handle_request_put_block(coap_context_t *context,
           /*
            * Current MAX_PAYLOAD chunk is different to last MAX_PAYLOAD chunk
            * with some missing packets in last MAX_PAYLOAD chunk
+           */
+          request_missing_blocks(session, lg_srcv, block.num);
+          goto skip_app_handler;
+        } else if (lg_srcv->rec_blocks.highest_seen >
+                   lg_srcv->rec_blocks.range[0].end &&
+                   (lg_srcv->rec_blocks.range[0].end %
+                    COAP_MAX_PAYLOADS(session)) + 1 ==
+                   COAP_MAX_PAYLOADS(session) &&
+                   block.num == lg_srcv->rec_blocks.range[0].end) {
+          /*
+           * A recovery payload set completed while later blocks have been
+           * observed. Request the next earliest gap immediately instead of
+           * waiting for another NON receive timeout.
            */
           request_missing_blocks(session, lg_srcv, block.num);
           goto skip_app_handler;
@@ -3697,7 +3839,16 @@ coap_handle_request_put_block(coap_context_t *context,
        * complete payload to application and acknowledge this current
        * block.
        */
-      if ((total == 0 && block.m) || !check_all_blocks_in(&lg_srcv->rec_blocks)) {
+      if ((total == 0 && block.m) ||
+#if COAP_Q_BLOCK_SUPPORT
+          (block_option == COAP_OPTION_Q_BLOCK1 ?
+           !q_block1_all_blocks_in(lg_srcv) :
+#endif /* COAP_Q_BLOCK_SUPPORT */
+           !check_all_blocks_in(&lg_srcv->rec_blocks)
+#if COAP_Q_BLOCK_SUPPORT
+          )
+#endif /* COAP_Q_BLOCK_SUPPORT */
+         ) {
         /* Ask for the next block */
         coap_insert_option(response, block_option,
                            coap_encode_var_safe(buf, sizeof(buf),

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -1799,32 +1799,33 @@ pdu_408_build(coap_session_t *session, coap_lg_srcv_t *lg_srcv) {
 }
 
 static int
-add_408_block(coap_pdu_t *pdu, int block) {
+add_408_block(coap_pdu_t *pdu, size_t block) {
   size_t len;
   uint8_t val[8];
 
-  assert(block >= 0 && block < (1 << 20));
+  assert(block < (1U << 20));
 
-  if (block < 0 || block >= (1 << 20)) {
+  if (block >= (1U << 20)) {
     return 0;
   } else if (block < 24) {
     len = 1;
-    val[0] = block;
+    val[0] = (uint8_t)block;
   } else if (block < 0x100) {
     len = 2;
     val[0] = 24;
-    val[1] = block;
+    val[1] = (uint8_t)block;
   } else if (block < 0x10000) {
     len = 3;
     val[0] = 25;
-    val[1] = block >> 8;
-    val[2] = block & 0xff;
+    val[1] = (uint8_t)(block >> 8);
+    val[2] = (uint8_t)(block & 0xff);
   } else { /* Largest block number is 2^^20 - 1 */
-    len = 4;
+    len = 5;
     val[0] = 26;
-    val[1] = block >> 16;
-    val[2] = (block >> 8) & 0xff;
-    val[3] = block & 0xff;
+    val[1] = (uint8_t)(block >> 24);
+    val[2] = (uint8_t)((block >> 16) & 0xff);
+    val[3] = (uint8_t)((block >> 8) & 0xff);
+    val[4] = (uint8_t)(block & 0xff);
   }
   if (coap_pdu_check_resize(pdu, pdu->used_size + len)) {
     memcpy(&pdu->token[pdu->used_size], val, len);

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -2164,7 +2164,8 @@ coap_send_q_blocks(coap_session_t *session,
   pdu->lg_xmit = lg_xmit;
   if ((block.m || lg_xmit->send_blocks.used) &&
       COAP_MAX_PAYLOADS(session) &&
-      ((pdu->type == COAP_MESSAGE_NON &&
+      (send_pdu == COAP_SEND_SKIP_PDU ||
+       (pdu->type == COAP_MESSAGE_NON &&
         (lg_xmit->send_blocks.used > 1 ||
          ((block.num + 1) % COAP_MAX_PAYLOADS(session)) + 1 !=
          COAP_MAX_PAYLOADS(session))) ||
@@ -2321,6 +2322,29 @@ coap_send_q_blocks(coap_session_t *session,
   } else
     coap_ticks(&lg_xmit->last_payload);
   coap_lg_xmit_release_lkd(session, lg_xmit);
+  return mid;
+}
+
+/*
+ * Send a 4.08 recovery batch without letting it reorder the forward queue.
+ * coap_send_q_blocks() consumes lg_xmit->send_blocks synchronously.
+ */
+static coap_mid_t
+coap_send_q_recovery_blocks(coap_session_t *session,
+                            coap_lg_xmit_t *lg_xmit,
+                            coap_block_b_t block) {
+  coap_rblock_t forward_blocks = lg_xmit->send_blocks;
+  coap_tick_t forward_last_payload = lg_xmit->last_payload;
+  coap_tick_t forward_last_all_sent = lg_xmit->last_all_sent;
+  coap_mid_t mid;
+
+  lg_xmit->send_blocks = lg_xmit->recovery_blocks;
+  mid = coap_send_q_blocks(session, lg_xmit, block, lg_xmit->sent_pdu,
+                           COAP_SEND_SKIP_PDU);
+  lg_xmit->recovery_blocks = lg_xmit->send_blocks;
+  lg_xmit->send_blocks = forward_blocks;
+  lg_xmit->last_payload = forward_last_payload;
+  lg_xmit->last_all_sent = forward_last_all_sent;
   return mid;
 }
 
@@ -4190,13 +4214,13 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *sent,
           block.m = (block.num + 1) * chunk < lg_xmit->data_info->length;
           block.szx = lg_xmit->blk_size;
 
-          blocks_add_entry(&lg_xmit->send_blocks, block.num, block.m);
+          blocks_add_entry(&lg_xmit->recovery_blocks, block.num, block.m);
         }
-        if (lg_xmit->send_blocks.used) {
+        if (lg_xmit->recovery_blocks.used) {
           /* Flush out the first one */
-          block.num = lg_xmit->send_blocks.range[0].begin;
+          block.num = lg_xmit->recovery_blocks.range[0].begin;
           block.m = (block.num + 1) * chunk < lg_xmit->data_info->length;
-          coap_send_q_blocks(session, lg_xmit, block, lg_xmit->sent_pdu, COAP_SEND_SKIP_PDU);
+          coap_send_q_recovery_blocks(session, lg_xmit, block);
         }
         goto skip_app_handler;
       }

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -29,10 +29,25 @@
 #error COAP_ETAG_MAX_BYTES byte size invalid
 #endif
 
-#define COAP_LG_XMIT_TXT_SCALAR (8)
-
 #if COAP_Q_BLOCK_SUPPORT
 static int blocks_delete_entry(coap_rblock_t *rec_blocks, uint32_t block_num);
+
+static coap_tick_t
+q_block_feedback_timeout(const coap_session_t *session) {
+  coap_tick_t timeout = 0;
+  coap_tick_t retry_timeout = COAP_NON_RECEIVE_TIMEOUT_TICKS(session);
+  uint16_t retry;
+
+  for (retry = 0; retry < COAP_NON_MAX_RETRANSMIT(session); retry++) {
+    if (timeout > COAP_MAX_DELAY_TICKS - retry_timeout)
+      return COAP_MAX_DELAY_TICKS;
+    timeout += retry_timeout;
+    if (retry_timeout > COAP_MAX_DELAY_TICKS / 2)
+      return COAP_MAX_DELAY_TICKS;
+    retry_timeout *= 2;
+  }
+  return timeout;
+}
 #endif /* COAP_Q_BLOCK_SUPPORT */
 
 #if COAP_Q_BLOCK_SUPPORT
@@ -1535,18 +1550,25 @@ coap_block_check_lg_xmit_timeouts(coap_session_t *session, coap_tick_t now,
                                   coap_tick_t *tim_rem) {
   coap_lg_xmit_t *lg_xmit;
   coap_lg_xmit_t *q;
-#if COAP_Q_BLOCK_SUPPORT
-  coap_tick_t idle_timeout = COAP_LG_XMIT_TXT_SCALAR * COAP_NON_TIMEOUT_TICKS(session);
-#else /* ! COAP_Q_BLOCK_SUPPORT */
   coap_tick_t idle_timeout = 8 * COAP_TICKS_PER_SECOND;
-#endif /* ! COAP_Q_BLOCK_SUPPORT */
   coap_tick_t partial_timeout = COAP_MAX_TRANSMIT_WAIT_TICKS(session);
   int ret = 0;
 
   *tim_rem = COAP_MAX_DELAY_TICKS;
 
   LL_FOREACH_SAFE(session->lg_xmit, lg_xmit, q) {
-    if (lg_xmit->last_all_sent) {
+#if COAP_Q_BLOCK_SUPPORT
+    if (lg_xmit->option == COAP_OPTION_Q_BLOCK1)
+      idle_timeout = q_block_feedback_timeout(session);
+    else
+#endif /* COAP_Q_BLOCK_SUPPORT */
+      idle_timeout = 8 * COAP_TICKS_PER_SECOND;
+    if (lg_xmit->last_all_sent
+#if COAP_Q_BLOCK_SUPPORT
+        && (lg_xmit->option != COAP_OPTION_Q_BLOCK1 ||
+            lg_xmit->last_payload == 0)
+#endif /* COAP_Q_BLOCK_SUPPORT */
+       ) {
       if (lg_xmit->last_all_sent + idle_timeout <= now) {
         /* Expire this entry */
         LL_DELETE(session->lg_xmit, lg_xmit);
@@ -2345,16 +2367,16 @@ coap_block_check_q_block1_xmit(coap_session_t *session, coap_tick_t now, coap_ti
           ret = 1;
         }
       }
-    } else if (lg_xmit->last_all_sent) {
-      non_timeout = COAP_NON_TIMEOUT_TICKS(session);
-      if (lg_xmit->last_all_sent + COAP_LG_XMIT_TXT_SCALAR * non_timeout <= now) {
+    } else if (lg_xmit->last_all_sent && lg_xmit->last_payload == 0) {
+      non_timeout = q_block_feedback_timeout(session);
+      if (lg_xmit->last_all_sent + non_timeout <= now) {
         /* Expire this entry */
         LL_DELETE(session->lg_xmit, lg_xmit);
         coap_block_delete_lg_xmit(session, lg_xmit);
       } else {
         /* Delay until the lg_xmit needs to expire */
-        if (*tim_rem > lg_xmit->last_all_sent + COAP_LG_XMIT_TXT_SCALAR * non_timeout - now) {
-          *tim_rem = lg_xmit->last_all_sent + COAP_LG_XMIT_TXT_SCALAR * non_timeout - now;
+        if (*tim_rem > lg_xmit->last_all_sent + non_timeout - now) {
+          *tim_rem = lg_xmit->last_all_sent + non_timeout - now;
           ret = 1;
         }
       }

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -2027,77 +2027,146 @@ check_any_blocks_next_payload_set(coap_session_t *session,
 static int
 request_missing_blocks(coap_session_t *session, coap_lg_srcv_t *lg_srcv, size_t final_block) {
   uint32_t i;
-  int block = -1; /* Last one seen */
-  size_t block_size = (size_t)1 << (lg_srcv->szx + 4);
-  size_t cur_payload;
-  size_t last_payload_block;
+  size_t block = 0;
+  size_t first_missing;
+  size_t last_received;
+  size_t final_body_block;
+  size_t gap_end;
   coap_pdu_t *pdu = NULL;
-  size_t no_blocks = 0;
+  size_t missing_blocks = 0;
 
-  /* Need to count the number of missing blocks */
-  for (i = 0; i < lg_srcv->rec_blocks.used; i++) {
-    if (block < (int)lg_srcv->rec_blocks.range[i].begin &&
-        lg_srcv->rec_blocks.range[i].begin != 0) {
-      block++;
-      no_blocks += lg_srcv->rec_blocks.range[i].begin - block;
-    }
-    if (block < (int)lg_srcv->rec_blocks.range[i].end) {
-      block = lg_srcv->rec_blocks.range[i].end;
-    }
-  }
-  if (no_blocks == 0 && block == (int)final_block)
-    return 0;
+  if (lg_srcv->recovery_blocks_used) {
+    coap_tick_t now;
+    size_t recovery_timeout = COAP_NON_RECEIVE_TIMEOUT_TICKS(session) *
+                              ((size_t)1 << lg_srcv->rec_blocks.retry);
 
-  /* Include missing up to end of current payload or total amount */
-  cur_payload = block / COAP_MAX_PAYLOADS(session);
-  last_payload_block = (cur_payload + 1) * COAP_MAX_PAYLOADS(session) - 1;
-  if (final_block > last_payload_block) {
-    final_block = last_payload_block;
+    coap_ticks(&now);
+    if (lg_srcv->rec_blocks.last_seen + recovery_timeout > now)
+      return 1;
+    lg_srcv->recovery_blocks_used = 0;
   }
-  no_blocks += final_block - block;
-  if (no_blocks == 0) {
-    /* Add in the blocks out of the next payload */
-    final_block = (lg_srcv->total_len + block_size - 1)/block_size - 1;
-    last_payload_block += COAP_MAX_PAYLOADS(session);
-    if (final_block > last_payload_block) {
-      final_block = last_payload_block;
+
+#if COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0
+  if (lg_srcv->q_block1_bitmap) {
+    last_received = lg_srcv->rec_blocks.highest_seen;
+    first_missing = lg_srcv->rec_blocks.used &&
+                    lg_srcv->rec_blocks.range[0].begin == 0 ?
+                    (size_t)lg_srcv->rec_blocks.range[0].end + 1 : 0;
+    for (;
+         first_missing <= last_received &&
+         q_block1_bitmap_has_block(lg_srcv, (uint32_t)first_missing);
+         first_missing++) {
     }
-  }
-  /* Ask for the missing blocks */
-  block = -1;
-  for (i = 0; i < lg_srcv->rec_blocks.used; i++) {
-    if (block < (int)lg_srcv->rec_blocks.range[i].begin &&
-        lg_srcv->rec_blocks.range[i].begin != 0) {
-      /* Report on missing blocks */
+    if (first_missing > last_received && lg_srcv->total_len) {
+      size_t block_size = (size_t)1 << (lg_srcv->szx + 4);
+
+      final_body_block = (lg_srcv->total_len - 1) / block_size;
+      if (first_missing <= final_body_block)
+        last_received = final_body_block;
+    }
+    if (first_missing > last_received) {
+      coap_ticks(&lg_srcv->rec_blocks.last_seen);
+      return 1;
+    }
+
+    for (block = first_missing;
+         block <= last_received &&
+         missing_blocks < COAP_MAX_PAYLOADS(session);
+         block++) {
+      if (q_block1_bitmap_has_block(lg_srcv, (uint32_t)block))
+        continue;
       if (pdu == NULL) {
         pdu = pdu_408_build(session, lg_srcv);
         if (!pdu)
-          continue;
-      }
-      block++;
-      for (; block < (int)lg_srcv->rec_blocks.range[i].begin; block++) {
-        if (!add_408_block(pdu, block)) {
           break;
-        }
       }
+      if (!add_408_block(pdu, block))
+        break;
+      q_block1_recovery_add(lg_srcv, (uint32_t)block);
+      missing_blocks++;
     }
-    if (block < (int)lg_srcv->rec_blocks.range[i].end) {
-      block = lg_srcv->rec_blocks.range[i].end;
+    if (missing_blocks) {
+      coap_send_internal(session, pdu, NULL);
+    } else if (pdu) {
+      coap_delete_pdu_lkd(pdu);
     }
+    lg_srcv->rec_blocks.retry++;
+    coap_ticks(&lg_srcv->rec_blocks.last_seen);
+    return 1;
   }
-  block++;
-  for (; block <= (int)final_block; block++) {
-    if (pdu == NULL) {
-      pdu = pdu_408_build(session, lg_srcv);
-      if (!pdu)
-        continue;
-    }
-    if (!add_408_block(pdu, block)) {
+#endif /* COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0 */
+
+  /* Start recovery at the earliest missing block. */
+  for (i = 0; i < lg_srcv->rec_blocks.used; i++) {
+    if (block < lg_srcv->rec_blocks.range[i].begin)
       break;
-    }
+    block = (size_t)lg_srcv->rec_blocks.range[i].end + 1;
   }
-  if (pdu)
+  first_missing = block;
+  last_received = lg_srcv->rec_blocks.range[lg_srcv->rec_blocks.used - 1].end;
+  if (last_received < lg_srcv->rec_blocks.highest_seen)
+    last_received = lg_srcv->rec_blocks.highest_seen;
+  if (first_missing > last_received && lg_srcv->total_len) {
+    size_t block_size = (size_t)1 << (lg_srcv->szx + 4);
+
+    final_body_block = (lg_srcv->total_len - 1) / block_size;
+    if (first_missing <= final_body_block)
+      final_block = final_body_block;
+    else
+      final_block = last_received;
+  } else {
+    final_block = last_received;
+  }
+  if (first_missing > final_block) {
+    /*
+     * The received payload set is complete.  M indicates that more data is
+     * expected, but it does not make the next, unsent payload set missing.
+     */
+    coap_ticks(&lg_srcv->rec_blocks.last_seen);
+    return 1;
+  }
+
+  i = 0;
+  for (block = first_missing;
+       block <= final_block &&
+       missing_blocks < COAP_MAX_PAYLOADS(session);
+      ) {
+    while (i < lg_srcv->rec_blocks.used &&
+           lg_srcv->rec_blocks.range[i].end < block)
+      i++;
+    if (i < lg_srcv->rec_blocks.used &&
+        lg_srcv->rec_blocks.range[i].begin <= block) {
+      block = (size_t)lg_srcv->rec_blocks.range[i].end + 1;
+      continue;
+    }
+
+    gap_end = final_block;
+    if (i < lg_srcv->rec_blocks.used &&
+        lg_srcv->rec_blocks.range[i].begin <= final_block)
+      gap_end = lg_srcv->rec_blocks.range[i].begin - 1;
+
+    for (; block <= gap_end &&
+         missing_blocks < COAP_MAX_PAYLOADS(session);
+         block++) {
+      if (pdu == NULL) {
+        pdu = pdu_408_build(session, lg_srcv);
+        if (!pdu)
+          break;
+      }
+      if (!add_408_block(pdu, block)) {
+        break;
+      }
+      q_block1_recovery_add(lg_srcv, (uint32_t)block);
+      missing_blocks++;
+    }
+    if (pdu == NULL || block <= gap_end)
+      break;
+  }
+  if (missing_blocks) {
     coap_send_internal(session, pdu, NULL);
+  } else if (pdu) {
+    coap_delete_pdu_lkd(pdu);
+  }
   lg_srcv->rec_blocks.retry++;
   coap_ticks(&lg_srcv->rec_blocks.last_seen);
   return 1;
@@ -2894,6 +2963,9 @@ coap_block_delete_lg_srcv(coap_session_t *session,
 
   coap_delete_str_const(lg_srcv->uri_path);
   coap_delete_bin_const(lg_srcv->last_token);
+#if COAP_Q_BLOCK_SUPPORT && COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0
+  coap_free_type(COAP_STRING, lg_srcv->q_block1_bitmap);
+#endif /* COAP_Q_BLOCK_SUPPORT && COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0 */
   coap_free_type(COAP_STRING, lg_srcv->body_data);
   coap_log_debug("** %s: lg_srcv %p released\n",
                  coap_session_str(session), (void *)lg_srcv);
@@ -3438,6 +3510,9 @@ coap_handle_request_put_block(coap_context_t *context,
   const uint8_t *rtag;
   uint32_t max_block_szx;
   int update_data;
+#if COAP_Q_BLOCK_SUPPORT
+  int q_block1_recovery_progress = 0;
+#endif /* COAP_Q_BLOCK_SUPPORT */
   unsigned int saved_num;
   size_t saved_offset;
   int lg_srcv_is_refed = 0;
@@ -3699,20 +3774,80 @@ coap_handle_request_put_block(coap_context_t *context,
   saved_offset = offset;
 
   while (offset < saved_offset + length) {
-    if (!check_if_received_block(&lg_srcv->rec_blocks, block.num)) {
-      /* Update list of blocks received */
-      if (blocks_add_entry(&lg_srcv->rec_blocks, block.num, block.m)) {
+#if COAP_Q_BLOCK_SUPPORT
+    if (block_option == COAP_OPTION_Q_BLOCK1 &&
+        block.num > lg_srcv->rec_blocks.highest_seen)
+      lg_srcv->rec_blocks.highest_seen = block.num;
+#endif /* COAP_Q_BLOCK_SUPPORT */
+#if COAP_Q_BLOCK_SUPPORT && COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0
+    if (block_option == COAP_OPTION_Q_BLOCK1 &&
+        lg_srcv->q_block1_bitmap) {
+      if (block.num >= lg_srcv->q_block1_bitmap_blocks) {
+        coap_log_info("Q-Block1 block nr %u exceeds Size1\n", block.num);
+        response->code = COAP_RESPONSE_CODE(408);
+        goto skip_app_handler;
+      } else if (q_block1_bitmap_set_block(lg_srcv, block.num)) {
+        /*
+         * Keep range state for Q-Block scheduling, but preserve this payload
+         * in the bitmap even when the bounded range table is full.
+         */
+        blocks_add_entry(&lg_srcv->rec_blocks, block.num, block.m);
         update_data = 1;
+        if (!lg_srcv->recovery_blocks_used ||
+            q_block1_recovery_remove(lg_srcv, block.num)) {
+          lg_srcv->rec_blocks.retry = 0;
+          q_block1_recovery_progress = 1;
+        }
       } else {
-        coap_log_debug("Block nr %u ignored (too many missing blocks)\n", block.num);
+        coap_log_debug("Duplicate block nr %u\n", block.num);
+        coap_ticks(&lg_srcv->rec_blocks.last_seen);
       }
-    } else {
-      coap_log_debug("Duplicate block nr %u\n", block.num);
-    }
+    } else
+#endif /* COAP_Q_BLOCK_SUPPORT && COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0 */
+      if (!check_if_received_block(&lg_srcv->rec_blocks, block.num)) {
+        /* Update list of blocks received */
+        if (blocks_add_entry(&lg_srcv->rec_blocks, block.num, block.m)) {
+          update_data = 1;
+#if COAP_Q_BLOCK_SUPPORT
+          if (block_option == COAP_OPTION_Q_BLOCK1) {
+            lg_srcv->rec_blocks.retry = 0;
+            if (q_block1_recovery_remove(lg_srcv, block.num))
+              q_block1_recovery_progress = 1;
+          }
+#endif /* COAP_Q_BLOCK_SUPPORT */
+#if COAP_Q_BLOCK_SUPPORT
+        } else if (block_option == COAP_OPTION_Q_BLOCK1) {
+          /*
+           * Do not silently lose Q-Block1 state when the bounded range table
+           * is full. Ask the sender to fill the tracked gaps before accepting
+           * another disjoint range.
+           */
+          request_missing_blocks(session, lg_srcv, block.num);
+          goto skip_app_handler;
+#endif /* COAP_Q_BLOCK_SUPPORT */
+        } else {
+          coap_log_debug("Block nr %u ignored (too many missing blocks)\n", block.num);
+        }
+      } else {
+        coap_log_debug("Duplicate block nr %u\n", block.num);
+#if COAP_Q_BLOCK_SUPPORT
+        if (block_option == COAP_OPTION_Q_BLOCK1)
+          coap_ticks(&lg_srcv->rec_blocks.last_seen);
+#endif /* COAP_Q_BLOCK_SUPPORT */
+      }
     block.num++;
     offset = block.num << (block.szx + 4);
   }
   block.num--;
+
+#if COAP_Q_BLOCK_SUPPORT
+  if (block_option == COAP_OPTION_Q_BLOCK1 && update_data) {
+#if COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0
+    if (!lg_srcv->q_block1_bitmap || q_block1_recovery_progress)
+#endif /* COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0 */
+      coap_ticks(&lg_srcv->rec_blocks.last_seen);
+  }
+#endif /* COAP_Q_BLOCK_SUPPORT */
 
   if (update_data) {
     /* Update saved data */
@@ -3765,7 +3900,7 @@ coap_handle_request_put_block(coap_context_t *context,
 #if COAP_Q_BLOCK_SUPPORT
       )
 #endif /* COAP_Q_BLOCK_SUPPORT */
-      ) {
+     ) {
     /* Not all the payloads of the body have arrived */
     if (block.m) {
       uint8_t buf[4];
@@ -3778,7 +3913,7 @@ coap_handle_request_put_block(coap_context_t *context,
 #if COAP_Q_BLOCK1_BITMAP_MAX_BYTES > 0
         if (lg_srcv->q_block1_bitmap &&
             q_block1_bitmap_missing_previous_payload_set(session, lg_srcv,
-                                                          block.num)) {
+                                                         block.num)) {
           request_missing_blocks(session, lg_srcv, block.num);
           goto skip_app_handler;
         }

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -2143,6 +2143,7 @@ coap_send_q_blocks(coap_session_t *session,
         mid = coap_send_internal(session, pdu, NULL);
         if (mid != COAP_INVALID_MID) {
           blocks_delete_entry(&lg_xmit->send_blocks, l_block.num);
+          coap_ticks(&lg_xmit->last_sent);
         }
       } else {
         return coap_send_internal(session, pdu, NULL);
@@ -2203,6 +2204,7 @@ coap_send_q_blocks(coap_session_t *session,
       mid = coap_send_internal(session, pdu, NULL);
       if (mid != COAP_INVALID_MID) {
         blocks_delete_entry(&lg_xmit->send_blocks, l_block.num);
+        coap_ticks(&lg_xmit->last_sent);
       }
     } else {
       mid = coap_send_internal(session, pdu, NULL);
@@ -2212,6 +2214,7 @@ coap_send_q_blocks(coap_session_t *session,
       coap_delete_pdu_lkd(block_pdu);
       return COAP_INVALID_MID;
     }
+    coap_ticks(&lg_xmit->last_sent);
   }
   /* Unsafe to use pdu in later code */
 
@@ -2306,6 +2309,7 @@ coap_send_q_blocks(coap_session_t *session,
       coap_delete_pdu_lkd(t_pdu);
       return COAP_INVALID_MID;
     }
+    coap_ticks(&lg_xmit->last_sent);
     /* This block has now been transmitted */
     blocks_delete_entry(&lg_xmit->send_blocks, block.num);
     block_pdu = t_pdu;

--- a/src/coap_block.c
+++ b/src/coap_block.c
@@ -3993,7 +3993,7 @@ coap_handle_response_send_block(coap_session_t *session, coap_pdu_t *sent,
       }
       track_echo(session, rcvd);
 #if COAP_Q_BLOCK_SUPPORT
-      if (rcvd->code == COAP_RESPONSE_CLASS(231) &&
+      if (rcvd->code == COAP_RESPONSE_CODE(231) &&
           lg_xmit->option == COAP_OPTION_Q_BLOCK1) {
         coap_send_q_blocks(session, lg_xmit, block, lg_xmit->sent_pdu, COAP_SEND_SKIP_PDU);
         goto skip_app_handler;


### PR DESCRIPTION
Hello,

we are using Q-Block transfers to send files with up to 100 MB to our device. The device is sometimes connected via Wifi. We noticed that if the Wifi signal is weak, the transfers get very slow or even stall completely although other (CoAP) communication is still possible.

We reproduced this behaviour on a Linux system using artificial packet loss. We used the "tc" tool to configure the system to drop packets with an (arbitrary) 10% probability. So almost every batch of blocks is missing one block and recovery is required frequently.

With the help of AI, I was able to fix the hanging and even improve the transfer speed a bit again during packet loss. I must admit that I lack the knowledge about libcoap internals to truly assess the AI patches here. However, this is the result of several hours of testing and trying different approaches so even with AI coming to these results was not easy. Hence, if something looks odd, let me know and I try to come up with something better.

One commit introduces a bitmap that can be used to track all received blocks. This bitmap can be at most 128 KB large but I do not know if this is acceptable for the embedded systems supported by libcoap. Hence, the commit introduces a macro `COAP_Q_BLOCK1_BITMAP_MAX_BYTES` that can be set to limit the acceptable size or even set it to zero. If this is acceptable, let me know if this should be enabled/disabled by default and I wire it into configure and CMake.

I tried to split the changes into multiple commits to ease the review but I can merge them later if you want. I did not test each commit individually.

I asked AI to describe the commits:

52055ff8 Encode large missing Q-Block numbers
----------------------------------------------

Large missing block numbers were encoded as a truncated CBOR uint32, causing the sender to decode and retransmit the wrong block.

* **Encode all uint32 bytes.** Emit the CBOR uint32 marker plus all four big-endian bytes for block numbers at and above 65536.

513f31e4 Keep Q-Block state during recovery
--------------------------------------------

The sender could expire while the receiver was still permitted to send delayed NON 4.08 recovery feedback.

* **Extend the Q-Block state lifetime.** Use the complete NON feedback retry window instead of the ordinary idle timeout.
* **Retain active transfers.** Do not expire Q-Block state while payload work remains active.

12499547 Refresh Q-Block send activity
---------------------------------------

Long Q-Block transfers could appear idle because successful individual payload sends did not update last_sent.

* **Refresh send activity for every payload.** Update last_sent after every successful Q-Block send, preventing an active transfer from expiring.

c76fb64a Handle Q-Block 2.31 Continue responses
------------------------------------------------

The client compared a response code with COAP_RESPONSE_CLASS(231), so valid RFC 9177 2.31 Continue feedback was ignored and the next set waited for a timeout.

* **Compare full response codes.** Use COAP_RESPONSE_CODE(231), allowing valid Continue responses to start the next payload set immediately.

1a851b00 Separate Q-Block recovery transmissions
-------------------------------------------------

Recovery retransmissions previously entered the forward-send queue. They could then reorder or delay new payload sets.

* **Use a dedicated recovery queue.** Keep 4.08-requested blocks separate from forward blocks and restore forward scheduling after recovery flushes.
* **Flush a single recovery block.** A one-block request at a payload-set boundary could remain queued. Treat the recovery path as an explicit send request.

d17a2851 Track Q-Block receives with bitmap
--------------------------------------------

Bounded ranges cannot represent every received block under heavy loss, causing unnecessary retransmissions and preventing exact completion checks.

* **Add optional exact receive tracking.** Use a size-limited bitmap for duplicate, completion, and missing-block checks, with range tracking as a fallback.
* **Release bitmap storage with the transfer.** Free the per-transfer bitmap when receive state is deleted.
* **Detect prior-set gaps immediately.** When later-set traffic arrives, inspect the preceding set and issue 4.08 feedback for real gaps instead of waiting for another timeout.

7e12189f Improve Q-Block missing-block recovery
------------------------------------------------

Range overflow and repeated recovery checks could either lose forward progress or repeatedly send ineffective feedback.

* **Bound missing-block feedback.** Request the earliest real gap and fill remaining feedback capacity with later observed gaps, up to COAP_MAX_PAYLOADS(), without requesting unsent future blocks.
* **Preserve highest-seen receive progress.** Record the largest observed block so recovery can continue after bounded range tracking overflows.
* **Suppress duplicate recovery feedback.** Record outstanding 4.08 requests, clear them only on relevant progress, and retry after the receive timeout.

Thank you!