### PR TITLE
coap_resource.c: Update .well-known/core query matching

### DIFF
--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -4139,6 +4139,10 @@ handle_request(coap_context_t *context, coap_session_t *session, coap_pdu_t *pdu
                    (int)resource->uri_path->length, (int)resource->uri_path->length,
                    resource->uri_path->s);
     h(resource, session, pdu, query, response);
+    if (COAP_RESPONSE_CLASS(response->code) == 2 && response->data == NULL &&
+        coap_is_mcast(&session->addr_info.local)) {
+      goto drop_it_debug;
+    }
   } else {
     coap_log_debug("call custom handler for resource '%*.*s' (3)\n",
                    (int)resource->uri_path->length, (int)resource->uri_path->length,
@@ -4296,6 +4300,7 @@ skip_handler:
               COAP_PROTO_RELIABLE(session->proto))) {
     coap_delete_pdu_lkd(response);
   } else {
+drop_it_debug:
     coap_log_debug("   %s: mid=0x%04x: response dropped\n",
                    coap_session_str(session),
                    response->mid);

--- a/src/coap_resource.c
+++ b/src/coap_resource.c
@@ -64,42 +64,40 @@
     }                                                                        \
   }
 
+#ifndef WITHOUT_QUERY_FILTER
 static int
 match(const coap_str_const_t *text, const coap_str_const_t *pattern,
-      int match_prefix, int match_substring) {
+      int match_prefix) {
+  const uint8_t *next_token = text->s;
+  size_t remaining_length = text->length;
   assert(text);
   assert(pattern);
 
   if (text->length < pattern->length || !pattern->s)
     return 0;
 
-  if (match_substring) {
-    const uint8_t *next_token = text->s;
-    size_t remaining_length = text->length;
-    while (remaining_length) {
-      size_t token_length;
-      const uint8_t *token = next_token;
-      next_token = (unsigned char *)memchr(token, ' ', remaining_length);
+  while (remaining_length) {
+    size_t token_length;
+    const uint8_t *token = next_token;
+    next_token = (unsigned char *)memchr(token, ' ', remaining_length);
 
-      if (next_token) {
-        token_length = next_token - token;
-        remaining_length -= (token_length + 1);
-        next_token++;
-      } else {
-        token_length = remaining_length;
-        remaining_length = 0;
-      }
-
-      if ((match_prefix || pattern->length == token_length) &&
-          memcmp(token, pattern->s, pattern->length) == 0)
-        return 1;
+    if (next_token) {
+      token_length = next_token - token;
+      remaining_length -= (token_length + 1);
+      next_token++;
+    } else {
+      token_length = remaining_length;
+      remaining_length = 0;
     }
-    return 0;
-  }
 
-  return (match_prefix || pattern->length == text->length) &&
-         memcmp(text->s, pattern->s, pattern->length) == 0;
+    if (token_length >= pattern->length &&
+        (match_prefix || pattern->length == token_length) &&
+        memcmp(token, pattern->s, pattern->length) == 0)
+      return 1;
+  }
+  return 0;
 }
+#endif /* WITHOUT_QUERY_FILTER */
 
 COAP_API coap_print_status_t
 coap_print_wellknown(coap_context_t *context, unsigned char *buf,
@@ -120,7 +118,7 @@ static coap_str_const_t coap_default_uri_wellknown = {
 coap_print_status_t
 coap_print_wellknown_lkd(coap_context_t *context, unsigned char *buf,
                          size_t *buflen, size_t offset,
-                         const coap_string_t *query_filter) {
+                         const coap_string_t *query_filterm) {
   coap_print_status_t output_length = 0;
   unsigned char *p = buf;
   const uint8_t *bufend = buf + *buflen;
@@ -129,121 +127,168 @@ coap_print_wellknown_lkd(coap_context_t *context, unsigned char *buf,
   const size_t old_offset = offset;
   int subsequent_resource = 0;
 #ifdef WITHOUT_QUERY_FILTER
-  (void)query_filter;
-#else
-  coap_str_const_t resource_param = { 0, NULL }, query_pattern = { 0, NULL };
-  int flags = 0; /* MATCH_SUBSTRING, MATCH_PREFIX, MATCH_URI */
-#define MATCH_URI       0x01
-#define MATCH_PREFIX    0x02
-#define MATCH_SUBSTRING 0x04
-  static const coap_str_const_t _rt_attributes[] = {
-    {2, (const uint8_t *)"rt"},
-    {2, (const uint8_t *)"if"},
-    {3, (const uint8_t *)"rel"},
-    {0, NULL}
-  };
+  (void)query_filterm;
 #endif /* WITHOUT_QUERY_FILTER */
 
   coap_lock_check_locked();
 #ifndef WITHOUT_QUERY_FILTER
   /* split query filter, if any */
-  if (query_filter) {
-    resource_param.s = query_filter->s;
-    while (resource_param.length < query_filter->length &&
-           resource_param.s[resource_param.length] != '=')
-      resource_param.length++;
+  if (query_filterm) {
+    unsigned char *next_query = (unsigned char *)memchr(query_filterm->s, '&', query_filterm->length);
+    size_t query_filterm_rem;
+    coap_string_t query_filter;
 
-    if (resource_param.length < query_filter->length) {
-      const coap_str_const_t *rt_attributes;
-      if (resource_param.length == 4 &&
-          memcmp(resource_param.s, "href", 4) == 0)
-        flags |= MATCH_URI;
+    /* There could be multiple queries */
+    query_filter.s = query_filterm->s;
+    if (next_query) {
+      query_filter.length = next_query - query_filter.s;
+      next_query++;
+      query_filterm_rem = query_filterm->length - query_filter.length - 1;
+    } else {
+      query_filter.length = query_filterm->length;
+      query_filterm_rem = 0;
+    }
 
-      for (rt_attributes = _rt_attributes; rt_attributes->s; rt_attributes++) {
-        if (resource_param.length == rt_attributes->length &&
-            memcmp(resource_param.s, rt_attributes->s, rt_attributes->length) == 0) {
-          flags |= MATCH_SUBSTRING;
+    while (query_filter.length) {
+      coap_str_const_t resource_param = { 0, NULL }, query_pattern = { 0, NULL };
+      /*
+       * If query starts with href=, then MATCH_URI is set in flags.
+       * If query value contains a '*', then MATCH_PREFIX is set in flags to
+       * match up to the *.
+       */
+      int flags = 0; /* MATCH_PREFIX, MATCH_URI */
+#define MATCH_URI       0x01
+#define MATCH_PREFIX    0x02
+
+      resource_param.s = query_filter.s;
+      while (resource_param.length < query_filter.length &&
+             resource_param.s[resource_param.length] != '=')
+        resource_param.length++;
+
+      if (resource_param.length < query_filter.length) {
+        if (resource_param.length == 4 &&
+            memcmp(resource_param.s, "href", 4) == 0)
+          flags |= MATCH_URI;
+
+        /* rest is query-pattern (resource may have multiple values to match */
+        query_pattern.s =
+            query_filter.s + resource_param.length + 1;
+
+        assert((resource_param.length + 1) <= query_filter.length);
+        query_pattern.length =
+            query_filter.length - (resource_param.length + 1);
+
+        if (query_pattern.length &&
+            (query_pattern.s[0] == '/') && ((flags & MATCH_URI) == MATCH_URI)) {
+          query_pattern.s++;
+          query_pattern.length--;
+        }
+
+        if (query_pattern.length &&
+            query_pattern.s[query_pattern.length-1] == '*') {
+          query_pattern.length--;
+          flags |= MATCH_PREFIX;
+        }
+      }
+
+      RESOURCES_ITER(context->resources, r) {
+
+        if (coap_string_equal(r->uri_path, &coap_default_uri_wellknown)) {
+          /* server app has defined a resource for .well-known/core - ignore */
+          continue;
+        }
+        if (r->flags & COAP_RESOURCE_HIDE_WELLKNOWN_CORE) {
+          continue;
+        }
+        if (resource_param.length) { /* there is a query filter */
+
+          if (flags & MATCH_URI) {        /* match resource URI */
+            if (!match(r->uri_path, &query_pattern, (flags & MATCH_PREFIX) != 0))
+              continue;
+          } else {                        /* match attribute */
+            coap_attr_t *attr;
+            coap_str_const_t unquoted_val;
+            attr = coap_find_attr(r, &resource_param);
+            if (!attr || !attr->value)
+              continue;
+            unquoted_val = *attr->value;
+            /* if attribute has a quoted value, remove double quotes */
+            if (attr->value->length >= 2 && attr->value->s[0] == '"') {
+              unquoted_val.length -= 2;
+              unquoted_val.s += 1;
+            }
+            if (!match(&unquoted_val, &query_pattern, (flags & MATCH_PREFIX) != 0))
+              continue;
+          }
+        }
+
+        if (!subsequent_resource) {        /* this is the first resource  */
+          subsequent_resource = 1;
+        } else {
+          PRINT_COND_WITH_OFFSET(p, bufend, offset, ',', written);
+        }
+
+        left = bufend - p; /* calculate available space */
+        result = coap_print_link(r, p, &left, &offset);
+
+        if (result & COAP_PRINT_STATUS_ERROR) {
           break;
         }
+
+        /* coap_print_link() returns the number of characters that
+         * where actually written to p. Now advance to its end. */
+        p += COAP_PRINT_OUTPUT_LENGTH(result);
+        written += left;
       }
-
-      /* rest is query-pattern */
-      query_pattern.s =
-          query_filter->s + resource_param.length + 1;
-
-      assert((resource_param.length + 1) <= query_filter->length);
-      query_pattern.length =
-          query_filter->length - (resource_param.length + 1);
-
-      if (query_pattern.length &&
-          (query_pattern.s[0] == '/') && ((flags & MATCH_URI) == MATCH_URI)) {
-        query_pattern.s++;
-        query_pattern.length--;
-      }
-
-      if (query_pattern.length &&
-          query_pattern.s[query_pattern.length-1] == '*') {
-        query_pattern.length--;
-        flags |= MATCH_PREFIX;
+      query_filter.s = next_query;
+      if (next_query) {
+        next_query = (unsigned char *)memchr(next_query, '&', query_filterm_rem);
+        if (next_query) {
+          query_filter.length = next_query - query_filter.s;
+          next_query++;
+          query_filterm_rem = query_filterm_rem - query_filter.length - 1;
+        } else {
+          query_filter.length = query_filterm_rem;
+          query_filterm_rem = 0;
+        }
+      } else {
+        query_filter.length = query_filterm_rem;
+        query_filterm_rem = 0;
       }
     }
-  }
+  } else {
 #endif /* WITHOUT_QUERY_FILTER */
+    RESOURCES_ITER(context->resources, r) {
 
-  RESOURCES_ITER(context->resources, r) {
+      if (coap_string_equal(r->uri_path, &coap_default_uri_wellknown)) {
+        /* server app has defined a resource for .well-known/core - ignore */
+        continue;
+      }
+      if (r->flags & COAP_RESOURCE_HIDE_WELLKNOWN_CORE) {
+        continue;
+      }
 
-    if (coap_string_equal(r->uri_path, &coap_default_uri_wellknown)) {
-      /* server app has defined a resource for .well-known/core - ignore */
-      continue;
-    }
-    if (r->flags & COAP_RESOURCE_HIDE_WELLKNOWN_CORE) {
-      continue;
+      if (!subsequent_resource) {        /* this is the first resource  */
+        subsequent_resource = 1;
+      } else {
+        PRINT_COND_WITH_OFFSET(p, bufend, offset, ',', written);
+      }
+
+      left = bufend - p; /* calculate available space */
+      result = coap_print_link(r, p, &left, &offset);
+
+      if (result & COAP_PRINT_STATUS_ERROR) {
+        break;
+      }
+
+      /* coap_print_link() returns the number of characters that
+       * where actually written to p. Now advance to its end. */
+      p += COAP_PRINT_OUTPUT_LENGTH(result);
+      written += left;
     }
 #ifndef WITHOUT_QUERY_FILTER
-    if (resource_param.length) { /* there is a query filter */
-
-      if (flags & MATCH_URI) {        /* match resource URI */
-        if (!match(r->uri_path, &query_pattern, (flags & MATCH_PREFIX) != 0,
-                   (flags & MATCH_SUBSTRING) != 0))
-          continue;
-      } else {                        /* match attribute */
-        coap_attr_t *attr;
-        coap_str_const_t unquoted_val;
-        attr = coap_find_attr(r, &resource_param);
-        if (!attr || !attr->value)
-          continue;
-        unquoted_val = *attr->value;
-        /* if attribute has a quoted value, remove double quotes */
-        if (attr->value->length >= 2 && attr->value->s[0] == '"') {
-          unquoted_val.length -= 2;
-          unquoted_val.s += 1;
-        }
-        if (!(match(&unquoted_val, &query_pattern,
-                    (flags & MATCH_PREFIX) != 0,
-                    (flags & MATCH_SUBSTRING) != 0)))
-          continue;
-      }
-    }
-#endif /* WITHOUT_QUERY_FILTER */
-
-    if (!subsequent_resource) {        /* this is the first resource  */
-      subsequent_resource = 1;
-    } else {
-      PRINT_COND_WITH_OFFSET(p, bufend, offset, ',', written);
-    }
-
-    left = bufend - p; /* calculate available space */
-    result = coap_print_link(r, p, &left, &offset);
-
-    if (result & COAP_PRINT_STATUS_ERROR) {
-      break;
-    }
-
-    /* coap_print_link() returns the number of characters that
-     * where actually written to p. Now advance to its end. */
-    p += COAP_PRINT_OUTPUT_LENGTH(result);
-    written += left;
   }
+#endif /* WITHOUT_QUERY_FILTER */
 
   *buflen = written;
   output_length = (coap_print_status_t)(p - buf);

--- a/tests/test_wellknown.c
+++ b/tests/test_wellknown.c
@@ -191,6 +191,88 @@ t_wellknown4(void) {
   coap_delete_string(query);
 }
 
+static void
+t_wellknown5(void) {
+  coap_resource_t *r;
+  coap_print_status_t result;
+  coap_string_t *query;
+  unsigned char buf[80];
+  size_t buflen = sizeof(buf);
+  char teststr[] = {  /* ,</abcd>;rt="bbbbbb a";obs (27 chars) */
+    '<', '/', 'a', 'b', 'c', 'd', 'e', '>', ';',
+    'r', 't', '=', '"', 'b', 'b', 'b', 'b', 'b', 'b', ' ', 'a', '"',
+    ';', 'o', 'b', 's'
+  };
+
+  /* Need to release all the built up resources */
+  coap_free_context(ctx);
+  ctx = coap_new_context(NULL);
+  ReturnIf_CU_ASSERT_PTR_NOT_NULL(ctx);
+
+  r = coap_resource_init(coap_make_str_const("abcde"), 0);
+  coap_add_attr(r, coap_make_str_const("rt"), coap_make_str_const("\"bbbbbb a\""), 0);
+  coap_resource_set_get_observable(r, 1);
+
+  coap_add_resource(ctx, r);
+
+  query = coap_new_string(sizeof("rt=cccc*")-1);
+  ReturnIf_CU_ASSERT_PTR_NOT_NULL(query);
+  memcpy(query->s, "rt=cccc*", sizeof("rt=cccc*")-1);
+  result = coap_print_wellknown(ctx, buf, &buflen, 0, query);
+  CU_ASSERT(result == 0);
+  coap_delete_string(query);
+
+  query = coap_new_string(sizeof("rt=aa*")-1);
+  ReturnIf_CU_ASSERT_PTR_NOT_NULL(query);
+  memcpy(query->s, "rt=aa*", sizeof("rt=aa*")-1);
+  result = coap_print_wellknown(ctx, buf, &buflen, 0, query);
+  CU_ASSERT(result == 0);
+  coap_delete_string(query);
+
+  query = coap_new_string(sizeof("rt=bbb*")-1);
+  ReturnIf_CU_ASSERT_PTR_NOT_NULL(query);
+  memcpy(query->s, "rt=bbb*", sizeof("rt=bbb*")-1);
+  buflen = sizeof(buf);
+  result = coap_print_wellknown(ctx, buf, &buflen, 0, query);
+  CU_ASSERT((result & COAP_PRINT_STATUS_ERROR) == 0);
+  CU_ASSERT(COAP_PRINT_OUTPUT_LENGTH(result) == sizeof(teststr));
+  CU_ASSERT(buflen == sizeof(teststr));
+  CU_ASSERT(memcmp(buf, teststr, buflen) == 0);
+  coap_delete_string(query);
+
+  query = coap_new_string(sizeof("rt=bbbbbb")-1);
+  ReturnIf_CU_ASSERT_PTR_NOT_NULL(query);
+  memcpy(query->s, "rt=bbbbbb", sizeof("rt=bbbbbb")-1);
+  buflen = sizeof(buf);
+  result = coap_print_wellknown(ctx, buf, &buflen, 0, query);
+  CU_ASSERT((result & COAP_PRINT_STATUS_ERROR) == 0);
+  CU_ASSERT(COAP_PRINT_OUTPUT_LENGTH(result) == sizeof(teststr));
+  CU_ASSERT(buflen == sizeof(teststr));
+  CU_ASSERT(memcmp(buf, teststr, buflen) == 0);
+  coap_delete_string(query);
+
+  query = coap_new_string(sizeof("rt=a*")-1);
+  ReturnIf_CU_ASSERT_PTR_NOT_NULL(query);
+  memcpy(query->s, "rt=a*", sizeof("rt=a*")-1);
+  buflen = sizeof(buf);
+  result = coap_print_wellknown(ctx, buf, &buflen, 0, query);
+  CU_ASSERT((result & COAP_PRINT_STATUS_ERROR) == 0);
+  CU_ASSERT(COAP_PRINT_OUTPUT_LENGTH(result) == sizeof(teststr));
+  CU_ASSERT(buflen == sizeof(teststr));
+  CU_ASSERT(memcmp(buf, teststr, buflen) == 0);
+  coap_delete_string(query);
+
+  query = coap_new_string(sizeof("rt=a")-1);
+  ReturnIf_CU_ASSERT_PTR_NOT_NULL(query);
+  memcpy(query->s, "rt=a", sizeof("rt=a")-1);
+  buflen = sizeof(buf);
+  result = coap_print_wellknown(ctx, buf, &buflen, 0, query);
+  CU_ASSERT((result & COAP_PRINT_STATUS_ERROR) == 0);
+  CU_ASSERT(COAP_PRINT_OUTPUT_LENGTH(result) == sizeof(teststr));
+  CU_ASSERT(buflen == sizeof(teststr));
+  CU_ASSERT(memcmp(buf, teststr, buflen) == 0);
+  coap_delete_string(query);
+}
 
 static int
 t_wkc_tests_create(void) {
@@ -209,39 +291,6 @@ t_wkc_tests_create(void) {
   session = coap_new_client_session(ctx, NULL, &addr, COAP_PROTO_UDP);
 
   pdu = coap_pdu_init(0, 0, 0, TEST_PDU_SIZE);
-#if 0
-  /* add resources to coap context */
-  if (ctx && pdu) {
-    coap_resource_t *r;
-    static char _buf[2 * 1024];
-    unsigned char *buf = (unsigned char *)_buf;
-    int i;
-
-    /* </>;title="some attribute";ct=0 (31 chars) */
-    r = coap_resource_init(NULL, 0, 0);
-
-    coap_add_attr(r, coap_make_str_const("ct"), coap_make_str_const("0"), 0);
-    coap_add_attr(r, coap_make_str_const("title"), coap_make_str_const("\"some attribute\""), 0);
-    coap_add_resource(ctx, r);
-
-    /* ,</abcd>;if="one";obs (21 chars) */
-    r = coap_resource_init((const uint8_t *)"abcd", 4, 0);
-    r->observable = 1;
-    coap_add_attr(r, coap_make_str_const("if"), coap_make_str_const("\"one\""), 0);
-
-    coap_add_resource(ctx, r);
-
-    /* ,</0000> (TEST_URI_LEN + 4 chars) */
-    for (i = 0; i < sizeof(_buf) / (TEST_URI_LEN + 4); i++) {
-      int len = snprintf((char *)buf, TEST_URI_LEN + 1,
-                         "%0*d", TEST_URI_LEN, i);
-      r = coap_resource_init(buf, len, 0);
-      coap_add_resource(ctx, r);
-      buf += TEST_URI_LEN + 1;
-    }
-
-  }
-#endif
   return ctx == NULL || pdu == NULL;
 }
 
@@ -274,6 +323,7 @@ t_init_wellknown_tests(void) {
   WKC_TEST(suite, t_wellknown2);
   WKC_TEST(suite, t_wellknown3);
   WKC_TEST(suite, t_wellknown4);
+  WKC_TEST(suite, t_wellknown5);
 
   return suite;
 }


### PR DESCRIPTION
Support matching multiple, space separated, values, not limited to if=, rt= and rel=.

Fix OOB read if the last space separated value is shorter than the query.

Support matching against multiple queries.

Do not sent back empty 2.05 response if multicast.