### PR TITLE
Restore the request's local address when a triggered async fires

### DIFF
--- a/include/coap3/coap_async_internal.h
+++ b/include/coap3/coap_async_internal.h
@@ -42,6 +42,8 @@ struct coap_async_t {
   void *app_data;                   /**< User definable data pointer */
   coap_app_data_free_callback_t app_cb; /**< callback to call when async is
                                              being released (or NULL) */
+  coap_address_t local_if;         /**< local address the request was
+                                        received on */
 };
 
 /**

--- a/src/coap_async.c
+++ b/src/coap_async.c
@@ -103,6 +103,9 @@ coap_register_async_lkd(coap_session_t *session,
 
   s->session = coap_session_reference_lkd(session);
 
+  /* Snapshot local address; addr_info.local may change before the async fires (multicast). */
+  coap_address_copy(&s->local_if, &session->addr_info.local);
+
   coap_async_set_delay_lkd(s, delay);
 
   return s;

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -5397,6 +5397,8 @@ coap_check_async(coap_context_t *context, coap_tick_t now, coap_tick_t *tim_rem)
   LL_FOREACH_SAFE(context->async_state, async, tmp) {
     if (async->delay != 0 && !async->session->is_rate_limiting) {
       if (async->delay <= now) {
+        /* Restore the local address the request was received on */
+        coap_address_copy(&async->session->addr_info.local, &async->local_if);
         /* Send off the request to the application */
         coap_log_debug("Async PDU presented to app.\n");
         coap_show_pdu(COAP_LOG_DEBUG, async->pdu);


### PR DESCRIPTION
Server sessions are keyed on (remote address, local port) only, and session->addr_info.local is overwritten by the destination of every received packet. When a unicast CON request is parked in a coap_async_t for a separate response and a multicast packet from the same peer arrives before the async fires, the re-invoked handle_request() sees a multicast local address, drops the CON per RFC7252 8.1 ("Invalid multicast packet received"), and coap_check_async() frees the async: the response is silently never sent.

Snapshot the local address in coap_register_async() and restore it on the session before the async fires, so the deferred request is handled (and its response source selected) against the address it actually arrived on.

Seen in the field with a CoAP remote control whose GET /endpoint was answered via the async path while it also multicast periodic announcements from the same source port: the device received the empty ACK and then never got the response.