### PR TITLE
PSK: Support keys in hex notation in matching files

### DIFF
--- a/examples/coap-client.c
+++ b/examples/coap-client.c
@@ -721,7 +721,8 @@ usage(const char *program, const char *version) {
           "\t       \t\toptions. E.g., per line\n"
           "\t       \t\t hint_to_match,use_user,with_key\n"
           "\t       \t\tNote: -k and -u still need to be defined for the default\n"
-          "\t       \t\tin case there is no match\n"
+          "\t       \t\tin case there is no match.\n"
+          "\t       \t\tNote: with_key can be in hex as defined in -k option\n"
           "\t-k key \t\tPre-shared key for the specified user identityt. If the\n"
           "\t       \t\tkey begins with 0x, then the hex text (two [0-9a-f] per\n"
           "\t       \t\tbyte) is converted to binary data\n"
@@ -1509,11 +1510,22 @@ cmdline_read_hint_check(const char *arg) {
       cp = tcp+1;
       tcp = strchr(cp, ',');
       if (tcp) {
+        size_t len;
+
         valid_ihs.ih_list[valid_ihs.count].new_identity =
             coap_new_bin_const((const uint8_t *)cp, tcp-cp);
         cp = tcp+1;
+        len = strlen(cp);
+        if (len) {
+          /* read hex string alternative when key starts with "0x" */
+          if (len >= 4 && cp[0] == '0' && (cp[1] == 'x' || cp[1] == 'X')) {
+            /* As tmpbuf is part of our environment we can do
+             * the conversion in place. */
+            len = convert_hex_string(cp + 2, (uint8_t *)cp);
+          }
+        }
         valid_ihs.ih_list[valid_ihs.count].new_key =
-            coap_new_bin_const((const uint8_t *)cp, strlen(cp));
+            coap_new_bin_const((const uint8_t *)cp, len);
         valid_ihs.count++;
       } else {
         /* Badly formatted */
@@ -1538,6 +1550,22 @@ verify_cn_callback(const char *cn,
   return 1;
 }
 
+static char *
+print_in_hex(const uint8_t *buf, size_t buflen, char *obuf, size_t obuf_len) {
+  size_t i;
+  size_t ofs = 0;
+  const char hex[] = "0123456789ABCDEF";
+
+  for (i = 0; i < buflen; i++) {
+    if (ofs + 2 >= obuf_len)
+      break;
+    obuf[ofs++] = hex[(buf[i] & 0xf0) >> 4];
+    obuf[ofs++] = hex[(buf[i] & 0x0f)];
+  }
+  obuf[ofs] = '\000';
+  return obuf;
+}
+
 static const coap_dtls_cpsk_info_t *
 verify_ih_callback(coap_str_const_t *hint,
                    coap_session_t *c_session COAP_UNUSED,
@@ -1553,6 +1581,7 @@ verify_ih_callback(coap_str_const_t *hint,
   /* Test for hint to possibly change identity + key */
   for (i = 0; i < valid_ihs.count; i++) {
     if (strcmp(lhint, valid_ihs.ih_list[i].hint_match) == 0) {
+      char obuf[256];
       /* Preset */
       psk_identity_info = *psk_info;
       if (valid_ihs.ih_list[i].new_key) {
@@ -1561,8 +1590,9 @@ verify_ih_callback(coap_str_const_t *hint,
       if (valid_ihs.ih_list[i].new_identity) {
         psk_identity_info.identity = *valid_ihs.ih_list[i].new_identity;
       }
-      coap_log_info("Switching to using '%s' identity + '%s' key\n",
-                    psk_identity_info.identity.s, psk_identity_info.key.s);
+      coap_log_info("Switching to using '%s' identity + '0x%s' key\n",
+                    psk_identity_info.identity.s,
+                    print_in_hex(psk_identity_info.key.s, psk_identity_info.key.length, obuf, sizeof(obuf)));
       return &psk_identity_info;
     }
   }

--- a/examples/coap-server.c
+++ b/examples/coap-server.c
@@ -1517,6 +1517,22 @@ verify_pki_sni_callback(const char *sni,
   return &dtls_key;
 }
 
+static char *
+print_in_hex(const uint8_t *buf, size_t buflen, char *obuf, size_t obuf_len) {
+  size_t i;
+  size_t ofs = 0;
+  const char hex[] = "0123456789ABCDEF";
+
+  for (i = 0; i < buflen; i++) {
+    if (ofs + 2 >= obuf_len)
+      break;
+    obuf[ofs++] = hex[(buf[i] & 0xf0) >> 4];
+    obuf[ofs++] = hex[(buf[i] & 0x0f)];
+  }
+  obuf[ofs] = '\000';
+  return obuf;
+}
+
 static const coap_dtls_spsk_info_t *
 verify_psk_sni_callback(const char *sni,
                         coap_session_t *c_session COAP_UNUSED,
@@ -1533,14 +1549,16 @@ verify_psk_sni_callback(const char *sni,
     size_t i;
     coap_log_info("SNI '%s' requested\n", sni);
     for (i = 0; i < valid_psk_snis.count; i++) {
+      char obuf[256];
+
       /* Test for identity match to change key */
       if (strcasecmp(sni,
                      valid_psk_snis.psk_sni_list[i].sni_match) == 0) {
-        coap_log_info("Switching to using '%.*s' hint + '%.*s' key\n",
+        coap_log_info("Switching to using '%.*s' hint + '0x%s' key\n",
                       (int)valid_psk_snis.psk_sni_list[i].new_hint->length,
                       valid_psk_snis.psk_sni_list[i].new_hint->s,
-                      (int)valid_psk_snis.psk_sni_list[i].new_key->length,
-                      valid_psk_snis.psk_sni_list[i].new_key->s);
+                      print_in_hex(valid_psk_snis.psk_sni_list[i].new_key->s,
+                                   valid_psk_snis.psk_sni_list[i].new_key->length, obuf, sizeof(obuf)));
         psk_info.hint = *valid_psk_snis.psk_sni_list[i].new_hint;
         psk_info.key = *valid_psk_snis.psk_sni_list[i].new_key;
         break;
@@ -1575,9 +1593,10 @@ verify_id_callback(coap_bin_const_t *identity,
     }
     /* Test for identity match to change key */
     if (coap_binary_equal(identity, valid_ids.id_list[i].identity_match)) {
-      coap_log_info("Switching to using '%.*s' key\n",
-                    (int)valid_ids.id_list[i].new_key->length,
-                    valid_ids.id_list[i].new_key->s);
+      char obuf[256];
+      coap_log_info("Switching to using '0x%s' key\n",
+                    print_in_hex(valid_ids.id_list[i].new_key->s,
+                                 valid_ids.id_list[i].new_key->length, obuf, sizeof(obuf)));
       return valid_ids.id_list[i].new_key;
     }
   }
@@ -1945,6 +1964,7 @@ usage(const char *program, const char *version) {
           "\t       \t\tcurrent Identity Hint is different to that defined by -h.\n"
           "\t       \t\tNote: If -h is not defined, the hint from the first line\n"
           "\t       \t\tis used.\n"
+          "\t       \t\tNote: use_key can be in hex as defined in -k option\n."
           "\t       \t\tNote: Using this option disables (D)TLS1.3 negotiation\n"
           "\t-k key \t\tPre-Shared Key. This argument requires (D)TLS with PSK\n"
           "\t       \t\tto be available. This cannot be empty if defined.\n"
@@ -1968,6 +1988,7 @@ usage(const char *program, const char *version) {
           "\t       \t\t-s followed by -i\n"
           "\t       \t\tNote: If -h or -i is not defined, the hint from the first\n"
           "\t       \t\tline is used.\n"
+          "\t       \t\tNote: with_key can be in hex as defined in -k option\n."
           "\t       \t\tNote: Using this option disables (D)TLS1.3 negotiation\n"
           "\t-u user\t\tUser identity for pre-shared key mode (only used if\n"
           "\t       \t\toption -P is set)\n"
@@ -2572,11 +2593,22 @@ cmdline_read_psk_sni_check(char *arg) {
       cp = tcp+1;
       tcp = strchr(cp, ',');
       if (tcp) {
+        size_t len;
+
         valid_psk_snis.psk_sni_list[valid_psk_snis.count].new_hint =
             coap_new_bin_const((const uint8_t *)cp, tcp-cp);
         cp = tcp+1;
+        len = strlen(cp);
+        if (len) {
+          /* read hex string alternative when key starts with "0x" */
+          if (len >= 4 && cp[0] == '0' && (cp[1] == 'x' || cp[1] == 'X')) {
+            /* As tmpbuf is part of our environment we can do
+             * the conversion in place. */
+            len = convert_hex_string(cp + 2, (uint8_t *)cp);
+          }
+        }
         valid_psk_snis.psk_sni_list[valid_psk_snis.count].new_key =
-            coap_new_bin_const((const uint8_t *)cp, strlen(cp));
+            coap_new_bin_const((const uint8_t *)cp, len);
         valid_psk_snis.count++;
       } else {
         free(valid_psk_snis.psk_sni_list[valid_psk_snis.count].sni_match);
@@ -2617,11 +2649,22 @@ cmdline_read_identity_check(char *arg) {
       cp = tcp+1;
       tcp = strchr(cp, ',');
       if (tcp) {
+        size_t len;
+
         valid_ids.id_list[valid_ids.count].identity_match =
             coap_new_bin_const((const uint8_t *)cp, tcp-cp);
         cp = tcp+1;
+        len = strlen(cp);
+        if (len) {
+          /* read hex string alternative when key starts with "0x" */
+          if (len >= 4 && cp[0] == '0' && (cp[1] == 'x' || cp[1] == 'X')) {
+            /* As tmpbuf is part of our environment we can do
+             * the conversion in place. */
+            len = convert_hex_string(cp + 2, (uint8_t *)cp);
+          }
+        }
         valid_ids.id_list[valid_ids.count].new_key =
-            coap_new_bin_const((const uint8_t *)cp, strlen(cp));
+            coap_new_bin_const((const uint8_t *)cp, len);
         valid_ids.count++;
       } else {
         free(valid_ids.id_list[valid_ids.count].hint_match);

--- a/examples/tls_backend_testcases.sh
+++ b/examples/tls_backend_testcases.sh
@@ -136,6 +136,8 @@ while getopts "c:s:h:n:p:L:k:u:H:IB:DPFK" OPTION; do
   esac
 done
 
+PSK_KEY_HEX=0x`echo -n "$PSK_KEY" | od -t x1 -v | sed "s/^[0-9]*$//g ; s/^[0-9]* //g ; s/ //g" | tr -d "\n" | tr '[a-z]' '[A-Z]'`
+
 if [ ! -x "$CLIENT" ]; then
   echo "Client executable not found or not executable: $CLIENT"
   exit 1
@@ -940,7 +942,7 @@ run_psk_identity_hint_callback () {
      assert_contains "$LOGDIR/$case_name.server" "does not support Identity Hint" ; then
     skip_case "Identity Hint not supported"
   elif assert_contains "$LOGDIR/$case_name.client" "Identity Hint '$PSK_HINT' provided" &&
-     assert_contains "$LOGDIR/$case_name.client" "Switching to using '$PSK_IDENTITY' identity \\+ '$PSK_KEY' key" &&
+     assert_contains "$LOGDIR/$case_name.client" "Switching to using '$PSK_IDENTITY' identity \\+ '$PSK_KEY_HEX' key" &&
      assert_contains "$LOGDIR/$case_name.client" "COAP_EVENT_DTLS_CONNECTED" &&
      assert_contains "$LOGDIR/$case_name.client" "2\\.05" &&
      assert_contains "$LOGDIR/$case_name.server" "call handler for pseudo resource '.well-known/core'"; then
@@ -965,7 +967,7 @@ run_psk_identity_callback () {
   run_client "$case_name" "$PSK_KEY" "" "$CLIENT_TIMEOUT"
 
   if assert_contains "$LOGDIR/$case_name.server" "Identity '$PSK_IDENTITY' requested, current hint ''" &&
-     assert_contains "$LOGDIR/$case_name.server" "Switching to using '$PSK_KEY' key" &&
+     assert_contains "$LOGDIR/$case_name.server" "Switching to using '$PSK_KEY_HEX' key" &&
      assert_contains "$LOGDIR/$case_name.client" "COAP_EVENT_DTLS_CONNECTED" &&
      assert_contains "$LOGDIR/$case_name.client" "2\\.05" &&
      assert_contains "$LOGDIR/$case_name.server" "call handler for pseudo resource '.well-known/core'"; then

--- a/man/coap-client.txt.in
+++ b/man/coap-client.txt.in
@@ -271,7 +271,8 @@ OPTIONS - PSK
    hint_to_match,use_user,with_key +
    A line that starts with # is treated as a comment. +
    Note: *-k key* and *-u user* still need to be defined for the default case in
-   case there is no match.
+   case there is no match. +
+   Note: with_key can be in hex as defined in *-k* option.
 
 *-k* key::
    Pre-shared key for the specified user identity (*-u* option also required). +

--- a/man/coap-server.txt.in
+++ b/man/coap-server.txt.in
@@ -266,6 +266,7 @@ OPTIONS - PSK
    Note: A match using the *-s* option may mean that the current Identity Hint
    is different to that defined by *-h*. +
    Note: If *-h* is not defined, the hint from the first line is used. +
+   Note: use_key can be in hex as defined in *-k* option. +
    Note: Using this option disables (D)TLS1.3 negotiation.
 
 *-k* key::
@@ -288,6 +289,7 @@ OPTIONS - PSK
    match. The update checking order is *-s* followed by *-i*.
    Note: If the hint is not defined (by *-h* or *-i*), the hint from the first
    line is used. +
+   Note: with_key can be in hex as defined in *-k* option. +
    Note: Using this option disables (D)TLS1.3 negotiation.
 
 *-u* user ::


### PR DESCRIPTION
coap-server options
-i match_identiity_file
-s match_psk_sni_file

coap-client option
-h match_hint_file

Fixes #2131.