### PR TITLE
ignore TRY_Q_BLOCK with reliable protocols

### DIFF
--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -109,6 +109,7 @@ struct coap_session_t {
                                          used in this session */
   coap_queue_t *delayqueue;         /**< list of delayed messages waiting to
                                          be sent */
+  coap_queue_t *delayqueue_tail;    /**< tail of delayqueue for O(1) append */
   coap_lg_xmit_t *lg_xmit;          /**< list of large transmissions */
 #if COAP_CLIENT_SUPPORT
   coap_lg_crcv_t *lg_crcv;       /**< Client list of expected large receives */

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -707,6 +707,8 @@ release_1:
             } else {
               s->delayqueue = q->next;
             }
+            if (s->delayqueue_tail == q)
+              s->delayqueue_tail = p;
             coap_delete_node_lkd(q);
             break;
           }

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -2645,6 +2645,8 @@ coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now
       break;
     }
     session->delayqueue = q->next;
+    if (session->delayqueue == NULL)
+      session->delayqueue_tail = NULL;
     session->partial_write = 0;
     coap_delete_node_lkd(q);
   }

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -572,6 +572,7 @@ coap_session_mfree(coap_session_t *session) {
     }
     coap_delete_node_lkd(q);
   }
+  session->delayqueue_tail = NULL;
 
 #if COAP_CLIENT_SUPPORT
   coap_pdu_t *p, *ptmp;
@@ -707,6 +708,8 @@ coap_session_server_keepalive_failed(coap_session_t *session) {
     coap_queue_t *q = session->delayqueue;
 
     session->delayqueue = q->next;
+    if (session->delayqueue == NULL)
+      session->delayqueue_tail = NULL;
     coap_delete_node_lkd(q);
   }
   /* Force session to go away */
@@ -856,7 +859,13 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
     }
     coap_address_copy(&node->remote, &session->addr_info.remote);
   }
-  LL_APPEND(session->delayqueue, node);
+  node->next = NULL;
+  if (session->delayqueue_tail) {
+    session->delayqueue_tail->next = node;
+  } else {
+    session->delayqueue = node;
+  }
+  session->delayqueue_tail = node;
   coap_show_pdu(COAP_LOG_DEBUG, node->pdu);
   coap_log_debug("** %s: mid=0x%04x: delayed\n",
                  coap_session_str(session), node->id);
@@ -988,6 +997,8 @@ coap_session_connected(coap_session_t *session) {
     }
     /* Take entry off the queue */
     session->delayqueue = q->next;
+    if (session->delayqueue == NULL)
+      session->delayqueue_tail = NULL;
     q->next = NULL;
 
     coap_address_copy(&remote, &session->addr_info.remote);
@@ -1009,6 +1020,8 @@ coap_session_connected(coap_session_t *session) {
       if (bytes_written <= 0 || (size_t)bytes_written < q->pdu->used_size + q->pdu->hdr_size) {
         q->next = session->delayqueue;
         session->delayqueue = q;
+        if (q->next == NULL)
+          session->delayqueue_tail = q;
         if (bytes_written > 0)
           session->partial_write = (size_t)bytes_written;
         break;
@@ -1116,6 +1129,8 @@ coap_session_disconnected_lkd(coap_session_t *session, coap_nack_reason_t reason
   while (session->delayqueue) {
     q = session->delayqueue;
     session->delayqueue = q->next;
+    if (session->delayqueue == NULL)
+      session->delayqueue_tail = NULL;
     q->next = NULL;
     coap_log_debug("** %s: mid=0x%04x: not transmitted after disconnect\n",
                    coap_session_str(session), q->id);
@@ -1164,6 +1179,8 @@ coap_session_disconnected_lkd(coap_session_t *session, coap_nack_reason_t reason
   while (session->delayqueue) {
     q = session->delayqueue;
     session->delayqueue = q->next;
+    if (session->delayqueue == NULL)
+      session->delayqueue_tail = NULL;
     q->next = NULL;
     coap_log_debug("** %s: mid=0x%04x: not transmitted after disconnect\n",
                    coap_session_str(session), q->id);


### PR DESCRIPTION
Hello,

my application uses COAPS with `TRY_Q_BLOCK` enabled for regular communication. For (very) large transfers, I want to open a separate TCP-based session to benefit from TCP's superior performance under packet loss. However, when using TCP in a Q-BLOCK-enabled context, `coap_io_process` blocks up to 30 seconds in my case before the transfer really starts. To avoid opening a separate context and as Q-Block is meant for unreliable protocols only anyways, this commit removes TRY_Q_BLOCK for sessions with reliable protocols.

Thank you!