### PR TITLE
OSCORE: Remove unnecessary CBOR assert()

### DIFF
--- a/src/coap_oscore.c
+++ b/src/coap_oscore.c
@@ -585,6 +585,8 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
                                                NULL,
                                                external_aad_buffer,
                                                sizeof(external_aad_buffer));
+    if (external_aad.length == 0)
+      goto error;
     cose_encrypt0_set_external_aad(cose, &external_aad);
 
     /* AAD */
@@ -593,6 +595,8 @@ coap_oscore_new_pdu_encrypted_lkd(coap_session_t *session,
                                     external_aad.length,
                                     aad_buffer,
                                     sizeof(aad_buffer));
+    if (aad.length == 0)
+      goto error;
     assert(aad.length < AAD_BUF_LEN);
     cose_encrypt0_set_aad(cose, &aad);
   }
@@ -1280,6 +1284,8 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
                                                NULL,
                                                external_aad_buffer,
                                                sizeof(external_aad_buffer));
+    if (external_aad.length == 0)
+      goto error;
     cose_encrypt0_set_external_aad(cose, &external_aad);
 
     /* AAD */
@@ -1288,6 +1294,8 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
                                     external_aad.length,
                                     aad_buffer,
                                     sizeof(aad_buffer));
+    if (aad.length == 0)
+      goto error;
     assert(aad.length < AAD_BUF_LEN);
     cose_encrypt0_set_aad(cose, &aad);
 
@@ -1420,6 +1428,8 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
                                                NULL,
                                                external_aad_buffer,
                                                sizeof(external_aad_buffer));
+    if (external_aad.length == 0)
+      goto error;
     cose_encrypt0_set_external_aad(cose, &external_aad);
 
     /* AAD */
@@ -1428,6 +1438,8 @@ coap_oscore_decrypt_pdu(coap_session_t *session,
                                     external_aad.length,
                                     aad_buffer,
                                     sizeof(aad_buffer));
+    if (aad.length == 0)
+      goto error;
     assert(aad.length < AAD_BUF_LEN);
     cose_encrypt0_set_aad(cose, &aad);
 #ifdef OSCORE_EXTRA_DEBUG

--- a/src/oscore/oscore.c
+++ b/src/oscore/oscore.c
@@ -127,37 +127,58 @@ oscore_prepare_e_aad(oscore_ctx_t *ctx,
                      size_t external_aad_size) {
   size_t external_aad_len = 0;
   size_t rem_size = external_aad_size;
+  size_t len;
 
   (void)oscore_option;
   (void)oscore_option_len;
   (void)sender_public_key;
 
-  external_aad_len += oscore_cbor_put_array(&external_aad_ptr, &rem_size, 5);
+  if ((len = oscore_cbor_put_array(&external_aad_ptr, &rem_size, 5)) == 0)
+    goto fail;
+  external_aad_len += len;
 
   /* oscore_version, always "1" */
-  external_aad_len += oscore_cbor_put_unsigned(&external_aad_ptr, &rem_size, 1);
+  if ((len = oscore_cbor_put_unsigned(&external_aad_ptr, &rem_size, 1)) == 0)
+    goto fail;
+  external_aad_len += len;
 
   /* Algorithms array with one item*/
-  external_aad_len += oscore_cbor_put_array(&external_aad_ptr, &rem_size, 1);
+  if ((len = oscore_cbor_put_array(&external_aad_ptr, &rem_size, 1)) == 0)
+    goto fail;
+  external_aad_len += len;
+
   /* Encryption Algorithm   */
-  external_aad_len +=
-      oscore_cbor_put_number(&external_aad_ptr, &rem_size, ctx->aead_alg);
+  if ((len = oscore_cbor_put_number(&external_aad_ptr, &rem_size, ctx->aead_alg)) == 0)
+    goto fail;
+  external_aad_len += len;
+
   /* request_kid */
-  external_aad_len += oscore_cbor_put_bytes(&external_aad_ptr,
-                                            &rem_size,
-                                            cose->key_id.s,
-                                            cose->key_id.length);
+  if ((len = oscore_cbor_put_bytes(&external_aad_ptr,
+                                   &rem_size,
+                                   cose->key_id.s,
+                                   cose->key_id.length)) == 0)
+    goto fail;
+  external_aad_len += len;
+
   /* request_piv */
-  external_aad_len += oscore_cbor_put_bytes(&external_aad_ptr,
-                                            &rem_size,
-                                            cose->partial_iv.s,
-                                            cose->partial_iv.length);
+  if ((len = oscore_cbor_put_bytes(&external_aad_ptr,
+                                   &rem_size,
+                                   cose->partial_iv.s,
+                                   cose->partial_iv.length)) == 0)
+    goto fail;
+  external_aad_len += len;
+
   /* options */
   /* Put integrity protected options, at present there are none. */
-  external_aad_len +=
-      oscore_cbor_put_bytes(&external_aad_ptr, &rem_size, NULL, 0);
+  if ((len = oscore_cbor_put_bytes(&external_aad_ptr, &rem_size, NULL, 0)) == 0)
+    goto fail;
+  external_aad_len += len;
 
   return external_aad_len;
+
+fail:
+  coap_log_info("oscore_prepare_e_aad: Buffer size too small: %" PRIuS "\n", external_aad_size);
+  return 0;
 }
 
 /*
@@ -322,24 +343,39 @@ oscore_prepare_aad(const uint8_t *external_aad_buffer,
                    uint8_t *aad_buffer,
                    size_t aad_size) {
   size_t ret = 0;
+  size_t len;
   size_t rem_size = aad_size;
   char encrypt0[] = "Encrypt0";
 
   (void)aad_size; /* TODO */
   /* Creating the AAD */
-  ret += oscore_cbor_put_array(&aad_buffer, &rem_size, 3);
+  if ((len = oscore_cbor_put_array(&aad_buffer, &rem_size, 3)) == 0)
+    goto fail;
+  ret += len;
+
   /* 1. "Encrypt0" */
-  ret +=
-      oscore_cbor_put_text(&aad_buffer, &rem_size, encrypt0, strlen(encrypt0));
+  if ((len = oscore_cbor_put_text(&aad_buffer, &rem_size, encrypt0, strlen(encrypt0))) == 0)
+    goto fail;
+  ret += len;
+
   /* 2. Empty h'' entry */
-  ret += oscore_cbor_put_bytes(&aad_buffer, &rem_size, NULL, 0);
+  if ((len = oscore_cbor_put_bytes(&aad_buffer, &rem_size, NULL, 0)) == 0)
+    goto fail;
+  ret += len;
+
   /* 3. External AAD */
-  ret += oscore_cbor_put_bytes(&aad_buffer,
-                               &rem_size,
-                               external_aad_buffer,
-                               external_aad_len);
+  if ((len = oscore_cbor_put_bytes(&aad_buffer,
+                                   &rem_size,
+                                   external_aad_buffer,
+                                   external_aad_len)) == 0)
+    goto fail;
+  ret += len;
 
   return ret;
+
+fail:
+  coap_log_info("oscore_prepare_aad: Buffer size too small: %" PRIuS "\n", aad_size);
+  return 0;
 }
 
 /*

--- a/src/oscore/oscore_cbor.c
+++ b/src/oscore/oscore_cbor.c
@@ -52,7 +52,6 @@
 
 static void
 util_write_byte(uint8_t **buffer, size_t *buf_size, uint8_t value) {
-  assert(*buf_size >= 1);
   if (*buf_size < 1)
     return;
   (*buf_size)--;
@@ -85,7 +84,6 @@ oscore_cbor_put_text(uint8_t **buffer,
                      size_t text_len) {
   uint8_t *pt = *buffer;
   size_t nb = oscore_cbor_put_unsigned(buffer, buf_size, text_len);
-  assert(*buf_size >= text_len);
   if (*buf_size < text_len)
     return nb;
   (*buf_size) -= text_len;
@@ -110,9 +108,8 @@ oscore_cbor_put_bytes(uint8_t **buffer,
                       size_t bytes_len) {
   uint8_t *pt = *buffer;
   size_t nb = oscore_cbor_put_unsigned(buffer, buf_size, bytes_len);
-  assert(*buf_size >= bytes_len);
   if (*buf_size < bytes_len)
-    return nb;
+    return 0;
   (*buf_size) -= bytes_len;
   *pt = (*pt | 0x40);
   if (bytes_len)
@@ -177,7 +174,6 @@ put_b_f(uint8_t **buffer, uint64_t value, uint8_t nr) {
 size_t
 oscore_cbor_put_unsigned(uint8_t **buffer, size_t *buf_size, uint64_t value) {
   if (value < 0x18) { /* small value half a byte */
-    assert(*buf_size >= 1);
     if (*buf_size < 1)
       return 0;
     (*buf_size)--;
@@ -186,7 +182,6 @@ oscore_cbor_put_unsigned(uint8_t **buffer, size_t *buf_size, uint64_t value) {
     return 1;
   } else if ((value > 0x17) && (value < 0x100)) {
     /* one byte uint8_t  */
-    assert(*buf_size >= 2);
     if (*buf_size < 2)
       return 0;
     (*buf_size) -= 2;
@@ -196,7 +191,6 @@ oscore_cbor_put_unsigned(uint8_t **buffer, size_t *buf_size, uint64_t value) {
     return 2;
   } else if ((value > 0xff) && (value < 0x10000)) {
     /* 2 bytes uint16_t     */
-    assert(*buf_size >= 3);
     if (*buf_size < 3)
       return 0;
     (*buf_size) -= 3;
@@ -206,7 +200,6 @@ oscore_cbor_put_unsigned(uint8_t **buffer, size_t *buf_size, uint64_t value) {
     return 3;
   } else if ((value > 0xffff) && (value < 0x100000000)) {
     /* 4 bytes uint32_t   */
-    assert(*buf_size >= 5);
     if (*buf_size < 5)
       return 0;
     (*buf_size) -= 5;
@@ -216,7 +209,6 @@ oscore_cbor_put_unsigned(uint8_t **buffer, size_t *buf_size, uint64_t value) {
     return 5;
   } else { /*if(value > 0xffffffff)*/
     /* 8 bytes uint64_t  */
-    assert(*buf_size >= 9);
     if (*buf_size < 9)
       return 0;
     (*buf_size) -= 9;
@@ -397,7 +389,6 @@ oscore_cbor_skip_value(const uint8_t **data, size_t *buf_len) {
   switch (elem) {
   case CBOR_UNSIGNED_INTEGER:
   case CBOR_NEGATIVE_INTEGER:
-    assert((*buf_len) >= num);
     if (*buf_len < num)
       return 0;
     *buf_len -= num;
@@ -408,7 +399,6 @@ oscore_cbor_skip_value(const uint8_t **data, size_t *buf_len) {
   case CBOR_TEXT_STRING:
     size = num;
     size += oscore_cbor_get_element_size(data, buf_len);
-    assert((*buf_len) >= (size - num));
     if (*buf_len < size - num)
       return 0;
     *buf_len -= (size - num);
@@ -450,7 +440,6 @@ oscore_cbor_skip_value(const uint8_t **data, size_t *buf_len) {
     }
     break;
   case CBOR_TAG:
-    assert((*buf_len) >= 1);
     if (*buf_len < 1)
       return 0;
     *buf_len -= 1;


### PR DESCRIPTION
Report error when creating AAD or External AAD when CBOR fails.