### PR TITLE
Delayqueue: Add delayqueue_tail to coap_session to avoid scanning long queues

### DIFF
--- a/include/coap3/coap_net_internal.h
+++ b/include/coap3/coap_net_internal.h
@@ -368,10 +368,51 @@ coap_mid_t coap_retransmit(coap_context_t *context, coap_queue_t *node);
 int coap_handle_dgram(coap_context_t *ctx, coap_session_t *session, uint8_t *data, size_t data_len);
 
 /**
- * This function removes the element with given @p id from the list given list.
- * If @p id was found, @p node is updated to point to the removed element. Note
+ * This function removes the node with given @p mid from the delayqueue.
+ * Note that the storage allocated by the returned node entry is @b not released.
+ * The caller must do this manually using coap_delete_node_lkd().
+ *
+ * @param session The session to process.
+ * @param mid   The message id to look for.
+ *
+ * @return      The found queue entry or NULL.
+ */
+coap_queue_t *coap_remove_mid_from_delayq(coap_session_t *session, coap_mid_t mid);
+
+/**
+ * This function adds the node to the head of the delayqueue.
+ *
+ * @param session The session to process.
+ * @param node   The queue entry node.
+ *
+ */
+void coap_add_to_head_delayq(coap_session_t *session, coap_queue_t *node);
+
+/**
+ * This function adds the node to the tail of the delayqueue.
+ *
+ * @param session The session to process.
+ * @param node   The queue entry node.
+ *
+ */
+void coap_add_to_tail_delayq(coap_session_t *session, coap_queue_t *node);
+
+/**
+ * This function removes the first node from the delayqueue.
+ * Note that the storage allocated by the returned node entry is @b not released.
+ * The caller must do this manually using coap_delete_node_lkd().
+ *
+ * @param session The session to process.
+ *
+ * @return      The found queue entry or NULL.
+ */
+coap_queue_t *coap_remove_first_from_delayq(coap_session_t *session);
+
+/**
+ * This function removes the element with given @p mid from the list given list.
+ * If @p mid was found, @p node is updated to point to the removed element. Note
  * that the storage allocated by @p node is @b not released. The caller must do
- * this manually using coap_delete_node(). This function returns @c 1 if the
+ * this manually using coap_delete_node_lkd(). This function returns @c 1 if the
  * element with id @p id was found, @c 0 otherwise. For a return value of @c 0,
  * the contents of @p node is undefined.
  *
@@ -382,7 +423,7 @@ int coap_handle_dgram(coap_context_t *ctx, coap_session_t *session, uint8_t *dat
  * @param node  If found, @p node is updated to point to the removed node. You
  *              must release the storage pointed to by @p node manually.
  *
- * @return      @c 1 if @p id was found, @c 0 otherwise.
+ * @return      @c 1 if @p mid was found, @c 0 otherwise.
  */
 int coap_remove_from_queue(coap_queue_t **queue,
                            coap_session_t *session,

--- a/include/coap3/coap_session_internal.h
+++ b/include/coap3/coap_session_internal.h
@@ -109,6 +109,7 @@ struct coap_session_t {
                                          used in this session */
   coap_queue_t *delayqueue;         /**< list of delayed messages waiting to
                                          be sent */
+  coap_queue_t *delayqueue_tail;    /**< tail of delayqueue for O(1) append */
   coap_lg_xmit_t *lg_xmit;          /**< list of large transmissions */
 #if COAP_CLIENT_SUPPORT
   coap_lg_crcv_t *lg_crcv;       /**< Client list of expected large receives */

--- a/src/coap_io.c
+++ b/src/coap_io.c
@@ -662,9 +662,7 @@ release_1:
       } else {
         /* Session set up has failed */
         coap_queue_t *sent;
-        coap_queue_t *p = NULL;
         coap_queue_t *q;
-        coap_queue_t *tmp;
 
         if (s->state == COAP_SESSION_STATE_CSM) {
           coap_log_debug("** %s: timeout waiting for CSM response\n",
@@ -692,25 +690,17 @@ release_1:
          * The test packet may be in the delayqueue ((D)TLS has not been set up),
          * or in the sendqueue if sent and is pending re-transmission.
          */
-        LL_FOREACH_SAFE(s->delayqueue, q, tmp) {
-          if (q->id == s->remote_test_mid) {
-            if (q->pdu->type==COAP_MESSAGE_CON) {
-              coap_handle_nack(s, q->pdu,
-                               s->proto == COAP_PROTO_DTLS ?
-                               COAP_NACK_TLS_FAILED : COAP_NACK_NOT_DELIVERABLE,
-                               q->id);
-            }
-            coap_log_debug("** %s: mid=0x%04x: removed\n",
-                           coap_session_str(s), q->id);
-            if (p) {
-              p->next = q->next;
-            } else {
-              s->delayqueue = q->next;
-            }
-            coap_delete_node_lkd(q);
-            break;
+        q = coap_remove_mid_from_delayq(s, s->remote_test_mid);
+        if (q) {
+          if (q->pdu->type==COAP_MESSAGE_CON) {
+            coap_handle_nack(s, q->pdu,
+                             s->proto == COAP_PROTO_DTLS ?
+                             COAP_NACK_TLS_FAILED : COAP_NACK_NOT_DELIVERABLE,
+                             q->id);
           }
-          p = q;
+          coap_log_debug("** %s: mid=0x%04x: removed\n",
+                         coap_session_str(s), q->id);
+          coap_delete_node_lkd(q);
         }
         coap_remove_from_queue(&ctx->sendqueue, s, s->remote_test_mid, s->last_token, &sent);
         if (sent) {

--- a/src/coap_net.c
+++ b/src/coap_net.c
@@ -2622,12 +2622,13 @@ coap_connect_session(coap_session_t *session, coap_tick_t now) {
 
 static void
 coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now) {
+  coap_queue_t *q;
+
   (void)ctx;
   assert(session->sock.flags & COAP_SOCKET_CONNECTED);
 
-  while (session->delayqueue) {
+  while ((q = coap_remove_first_from_delayq(session)) != NULL) {
     ssize_t bytes_written;
-    coap_queue_t *q = session->delayqueue;
 
     coap_address_copy(&session->addr_info.remote, &q->remote);
     coap_log_debug("** %s: mid=0x%04x: transmitted after delay (1)\n",
@@ -2642,9 +2643,9 @@ coap_write_session(coap_context_t *ctx, coap_session_t *session, coap_tick_t now
         (size_t)bytes_written < q->pdu->used_size + q->pdu->hdr_size - session->partial_write) {
       if (bytes_written > 0)
         session->partial_write += (size_t)bytes_written;
+      coap_add_to_head_delayq(session, q);
       break;
     }
-    session->delayqueue = q->next;
     session->partial_write = 0;
     coap_delete_node_lkd(q);
   }
@@ -3156,6 +3157,60 @@ error:
   coap_send_rst_lkd(session, pdu);
   coap_delete_pdu_lkd(pdu);
   return -1;
+}
+
+coap_queue_t *
+coap_remove_mid_from_delayq(coap_session_t *session, coap_mid_t mid) {
+  coap_queue_t *p = NULL;
+  coap_queue_t *q;
+
+  LL_FOREACH(session->delayqueue, q) {
+    if (q->id == mid) {
+      if (p) {
+        p->next = q->next;
+      } else {
+        session->delayqueue = q->next;
+      }
+      if (session->delayqueue_tail == q)
+        session->delayqueue_tail = p;
+      q->next = NULL;
+      return q;
+    }
+    p = q;
+  }
+  return NULL;
+}
+
+coap_queue_t *
+coap_remove_first_from_delayq(coap_session_t *session) {
+  coap_queue_t *q = session->delayqueue;
+
+  if (q) {
+    session->delayqueue = q->next;
+    if (session->delayqueue == NULL)
+      session->delayqueue_tail = NULL;
+    q->next = NULL;
+  }
+  return q;
+}
+
+void
+coap_add_to_tail_delayq(coap_session_t *session, coap_queue_t *node) {
+  node->next = NULL;
+  if (session->delayqueue_tail) {
+    session->delayqueue_tail->next = node;
+  } else {
+    session->delayqueue = node;
+  }
+  session->delayqueue_tail = node;
+}
+
+void
+coap_add_to_head_delayq(coap_session_t *session, coap_queue_t *node) {
+  node->next = session->delayqueue;
+  session->delayqueue = node;
+  if (node->next == NULL)
+    session->delayqueue_tail = node;
 }
 
 int

--- a/src/coap_session.c
+++ b/src/coap_session.c
@@ -528,7 +528,7 @@ coap_make_session(coap_proto_t proto, coap_session_type_t type,
 
 void
 coap_session_mfree(coap_session_t *session) {
-  coap_queue_t *q, *tmp;
+  coap_queue_t *q;
   coap_lg_xmit_t *lq, *ltmp;
 
 #if COAP_PROXY_SUPPORT
@@ -563,7 +563,7 @@ coap_session_mfree(coap_session_t *session) {
   }
 #endif /* COAP_CLIENT_SUPPORT */
 
-  LL_FOREACH_SAFE(session->delayqueue, q, tmp) {
+  while ((q = coap_remove_first_from_delayq(session)) != NULL) {
     if (q->pdu->type==COAP_MESSAGE_CON) {
       coap_handle_nack(session, q->pdu,
                        session->proto == COAP_PROTO_DTLS ?
@@ -678,6 +678,7 @@ coap_session_free(coap_session_t *session) {
 void
 coap_session_server_keepalive_failed(coap_session_t *session) {
   int i;
+  coap_queue_t *q;
 
   coap_session_reference_lkd(session);
   coap_handle_event_lkd(session->context, COAP_EVENT_KEEPALIVE_FAILURE, session);
@@ -703,10 +704,7 @@ coap_session_server_keepalive_failed(coap_session_t *session) {
         break;
     }
   }
-  while (session->delayqueue) {
-    coap_queue_t *q = session->delayqueue;
-
-    session->delayqueue = q->next;
+  while ((q = coap_remove_first_from_delayq(session)) != NULL) {
     coap_delete_node_lkd(q);
   }
   /* Force session to go away */
@@ -856,7 +854,7 @@ coap_session_delay_pdu(coap_session_t *session, coap_pdu_t *pdu,
     }
     coap_address_copy(&node->remote, &session->addr_info.remote);
   }
-  LL_APPEND(session->delayqueue, node);
+  coap_add_to_tail_delayq(session, node);
   coap_show_pdu(COAP_LOG_DEBUG, node->pdu);
   coap_log_debug("** %s: mid=0x%04x: delayed\n",
                  coap_session_str(session), node->id);
@@ -987,8 +985,7 @@ coap_session_connected(coap_session_t *session) {
       session->con_active++;
     }
     /* Take entry off the queue */
-    session->delayqueue = q->next;
-    q->next = NULL;
+    q = coap_remove_first_from_delayq(session);
 
     coap_address_copy(&remote, &session->addr_info.remote);
     coap_address_copy(&session->addr_info.remote, &q->remote);
@@ -1007,8 +1004,7 @@ coap_session_connected(coap_session_t *session) {
         break;
     } else if (q) {
       if (bytes_written <= 0 || (size_t)bytes_written < q->pdu->used_size + q->pdu->hdr_size) {
-        q->next = session->delayqueue;
-        session->delayqueue = q;
+        coap_add_to_head_delayq(session, q);
         if (bytes_written > 0)
           session->partial_write = (size_t)bytes_written;
         break;
@@ -1113,10 +1109,7 @@ coap_session_disconnected_lkd(coap_session_t *session, coap_nack_reason_t reason
     q = q->next;
   }
 
-  while (session->delayqueue) {
-    q = session->delayqueue;
-    session->delayqueue = q->next;
-    q->next = NULL;
+  while ((q = coap_remove_first_from_delayq(session)) != NULL) {
     coap_log_debug("** %s: mid=0x%04x: not transmitted after disconnect\n",
                    coap_session_str(session), q->id);
     if (q->pdu->type == COAP_MESSAGE_CON) {
@@ -1161,10 +1154,7 @@ coap_session_disconnected_lkd(coap_session_t *session, coap_nack_reason_t reason
   session->partial_read = 0;
 
   /* Not done if nack handler called above */
-  while (session->delayqueue) {
-    q = session->delayqueue;
-    session->delayqueue = q->next;
-    q->next = NULL;
+  while ((q = coap_remove_first_from_delayq(session)) != NULL) {
     coap_log_debug("** %s: mid=0x%04x: not transmitted after disconnect\n",
                    coap_session_str(session), q->id);
 #if COAP_CLIENT_SUPPORT


### PR DESCRIPTION
Alternative to #2136 using the principles set up in #2136, but using functions instead for readability.